### PR TITLE
Fix a PAL spin lock issue

### DIFF
--- a/src/pal/src/thread/thread.cpp
+++ b/src/pal/src/thread/thread.cpp
@@ -458,7 +458,7 @@ void SPINLOCKAcquire (LONG * lock, unsigned int flags)
 
 void SPINLOCKRelease (LONG * lock)
 {
-    *lock = 0;
+    VolatileStore(lock, 0);
 }
 
 DWORD SPINLOCKTryAcquire (LONG * lock)


### PR DESCRIPTION
Fix for https://github.com/dotnet/coreclr/issues/18486
- Lock release needs to be at least volatile

coreclr master PR: https://github.com/dotnet/coreclr/pull/19604