### PR TITLE
Speed scope

### DIFF
--- a/src/Tools/dotnet-collect/CollectionConfiguration.cs
+++ b/src/Tools/dotnet-collect/CollectionConfiguration.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Diagnostics.Tools.Collect
     {
         public int? ProcessId { get; set; }
         public string OutputPath { get; set; }
+        public string OutputFormat { get; set; }
         public int? CircularMB { get; set; }
         public IList<EventSpec> Providers { get; set; } = new List<EventSpec>();
         public IList<LoggerSpec> Loggers { get; set; } = new List<LoggerSpec>();

--- a/src/Tools/dotnet-collect/EtwCollector.cs
+++ b/src/Tools/dotnet-collect/EtwCollector.cs
@@ -83,7 +83,9 @@ namespace Microsoft.Diagnostics.Tools.Collect
             {
                 var stackSource = new MutableTraceEventStackSource(eventLog);
 
+#pragma warning disable 618 // ThreadTimeStackComputer is not obsolete but experimental, because its interface is likely to change
                 var computer = new ThreadTimeStackComputer(eventLog, symbolReader);
+#pragma warning restore 618
                 computer.GenerateThreadTimeStacks(stackSource);
 
                 return stackSource;

--- a/src/Tools/dotnet-collect/EventCollector.cs
+++ b/src/Tools/dotnet-collect/EventCollector.cs
@@ -1,10 +1,38 @@
+using Microsoft.Diagnostics.Symbols;
+using Microsoft.Diagnostics.Tracing.Stacks;
+using Microsoft.Diagnostics.Tracing.Stacks.Formats;
+using System;
+using System.IO;
 using System.Threading.Tasks;
 
 namespace Microsoft.Diagnostics.Tools.Collect
 {
     public abstract class EventCollector
     {
+        protected CollectionConfiguration Config { get; }
+
+        protected EventCollector(CollectionConfiguration config) => Config = config;
+
         public abstract Task StartCollectingAsync();
         public abstract Task StopCollectingAsync();
+
+        protected abstract StackSource GetStackSource(SymbolReader symbolReader);
+
+        public async Task FormatOutputAsync()
+        {
+            if (!Config.OutputFormat.Equals("SpeedScope", StringComparison.InvariantCultureIgnoreCase))
+            {
+                return;
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(7)); // we need to wait for a moment to make sure the data gets written to the trace file
+
+            var symbolReader = new SymbolReader(Console.Out) { SymbolPath = SymbolPath.MicrosoftSymbolServerPath };
+            var stackSource = GetStackSource(symbolReader);
+
+            var speedScopeFilePath = Path.Combine(Config.OutputPath, $"{Config.ProcessId}.speedscope.json");
+
+            SpeedScopeStackSourceWriter.WriteStackViewAsJson(stackSource, speedScopeFilePath);
+        }
     }
 }

--- a/src/Tools/dotnet-collect/EventPipeCollector.cs
+++ b/src/Tools/dotnet-collect/EventPipeCollector.cs
@@ -58,7 +58,8 @@ namespace Microsoft.Diagnostics.Tools.Collect
 
         private string GetNetPerfFilePath()
         {
-            var processName = Path.GetFileNameWithoutExtension(ConfigPathDetector.TryDetectConfigPath(Config.ProcessId.Value));
+            var processName = Path.GetFileNameWithoutExtension(ConfigPathDetector.TryDetectConfigPath(Config.ProcessId.Value))
+                ?? Path.GetFileNameWithoutExtension(_configPath);
 
             return Path.Combine(Config.OutputPath, $"{processName}.{Config.ProcessId.Value}.netperf");
         }

--- a/src/Tools/dotnet-collect/KnownData.cs
+++ b/src/Tools/dotnet-collect/KnownData.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.Tracing;
 using System.Linq;
+using Microsoft.Diagnostics.Tracing.EventPipe;
 using Microsoft.Diagnostics.Tracing.Parsers;
 
 namespace Microsoft.Diagnostics.Tools.Collect
@@ -25,7 +26,10 @@ namespace Microsoft.Diagnostics.Tools.Collect
                 CollectionProfile.DefaultProfileName,
                 "A default set of event providers useful for diagosing problems in any .NET application.",
                 new[] {
-                    new EventSpec(ClrTraceEventParser.ProviderName, (ulong)ClrTraceEventParser.Keywords.Default, EventLevel.Informational)
+                    new EventSpec(ClrTraceEventParser.ProviderName, (ulong)ClrTraceEventParser.Keywords.Default, EventLevel.Informational),
+                    new EventSpec(SampleProfilerTraceEventParser.ProviderName, ulong.MaxValue, EventLevel.Verbose),
+                    new EventSpec("Microsoft-Windows-DotNETRuntimeRundown", ulong.MaxValue, EventLevel.Verbose),
+                    new EventSpec("Microsoft-Windows-DotNETRuntimePrivate", ulong.MaxValue, EventLevel.Verbose)
                 },
                 Array.Empty<LoggerSpec>());
 

--- a/src/Tools/dotnet-collect/Program.cs
+++ b/src/Tools/dotnet-collect/Program.cs
@@ -28,6 +28,9 @@ namespace Microsoft.Diagnostics.Tools.Collect
         [Option("-o|--output <OUTPUT_DIRECTORY>", Description = "The directory to write the trace to. Defaults to the current working directory.")]
         public string OutputDir { get; set; }
 
+        [Option("--format <FORMAT_NAME>", Description = "The format of the output file: Trace (default) or SpeedScope.")]
+        public string OutputFormat { get; set; } = "Trace";
+
         [Option("--buffer <BUFFER_SIZE_IN_MB>", Description = "The size of the in-memory circular buffer in megabytes.")]
         public int? CircularMB { get; set; }
 
@@ -77,7 +80,8 @@ namespace Microsoft.Diagnostics.Tools.Collect
             {
                 ProcessId = ProcessId,
                 CircularMB = CircularMB,
-                OutputPath = string.IsNullOrEmpty(OutputDir) ? Directory.GetCurrentDirectory() : OutputDir
+                OutputPath = string.IsNullOrEmpty(OutputDir) ? Directory.GetCurrentDirectory() : OutputDir,
+                OutputFormat = OutputFormat
             };
 
             if (Profiles != null && Profiles.Count > 0)
@@ -142,7 +146,10 @@ namespace Microsoft.Diagnostics.Tools.Collect
             await console.WaitForCtrlCAsync();
 
             await collector.StopCollectingAsync();
-            console.WriteLine($"Tracing stopped. Trace files written to {config.OutputPath}");
+
+            await collector.FormatOutputAsync();
+
+            console.WriteLine($"Tracing stopped. Output files written to {config.OutputPath}");
 
             return 0;
         }

--- a/src/Tools/dotnet-collect/Program.cs
+++ b/src/Tools/dotnet-collect/Program.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Diagnostics.Tools.Collect
                 return ExecuteKeywordsForAsync(console);
             }
 
-            if(string.IsNullOrEmpty(ConfigPath))
+            if (string.IsNullOrEmpty(ConfigPath) && !Etw)
             {
                 ConfigPath = ConfigPathDetector.TryDetectConfigPath(ProcessId);
                 if(string.IsNullOrEmpty(ConfigPath))

--- a/src/Tools/dotnet-collect/dotnet-collect.csproj
+++ b/src/Tools/dotnet-collect/dotnet-collect.csproj
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.2.5" />
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.30" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.34" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
@vancem  I decided to add the new argument `--format` to the dotnet-collect tool. IMHO output format of the collect command is more natural to me than new analysis command (we don't analyze anything here). Also the dotnet-collect has the concept of ETW/EventPipe and it was simply very easy to add it there.

If the user specifies `--format speedscope` I load the trace file and export it to a `*.speedsope.json` format. The default is just "trace" (does not change existing behavior)

Sample usage:

```cmd
dotnet run -- --profile Default --format SpeedScope --config-path /Projects/SomeApp/bin/Release/netcoreapp3.0/SomeApp.eventpipeconfig --process-id 792
```

I added few provider names to the "default" profile. I needed to that to be able to get stack samples and symbols (rundown).

I tested it on macOS and Windows with .NET Core 3.0 and it works.

I am open to any ideas/suggestions/changes. 