### PR TITLE
Add ConfigPath detection mechanism on OSX

### DIFF
--- a/src/Tools/dotnet-collect/ConfigPathDetector.cs
+++ b/src/Tools/dotnet-collect/ConfigPathDetector.cs
@@ -67,7 +67,6 @@ namespace Microsoft.Diagnostics.Tools.Collect
                 int result = 0;
                 byte* pBuffer = stackalloc byte[PROC_PIDPATHINFO_MAXSIZE];
                 int _pid = getpid();
-                Console.WriteLine("About to pinvoke proc_pidpath on " + _pid);
                 result = proc_pidpath(pid, pBuffer, (uint)(PROC_PIDPATHINFO_MAXSIZE * sizeof(byte)));
                 if (result <= 0)
                 {

--- a/src/Tools/dotnet-collect/ConfigPathDetector.cs
+++ b/src/Tools/dotnet-collect/ConfigPathDetector.cs
@@ -53,9 +53,6 @@ namespace Microsoft.Diagnostics.Tools.Collect
                 byte* buffer, 
                 uint bufferSize);
 
-            [DllImport("libSystem.dylib")]
-            private static extern int getpid();
-
             /// <summary>
             /// Gets the full path to the executable file identified by the specified PID
             /// </summary>
@@ -66,7 +63,10 @@ namespace Microsoft.Diagnostics.Tools.Collect
                 // The path is a fixed buffer size, so use that and trim it after
                 int result = 0;
                 byte* pBuffer = stackalloc byte[PROC_PIDPATHINFO_MAXSIZE];
-                int _pid = getpid();
+
+                // WARNING - Despite its name, don't try to pass in a smaller size than specified by PROC_PIDPATHINFO_MAXSIZE.
+                // For some reason libproc returns -1 if you specify something that's NOT EQUAL to PROC_PIDPATHINFO_MAXSIZE
+                // even if you declare your buffer to be smaller/larger than this size. 
                 result = proc_pidpath(pid, pBuffer, (uint)(PROC_PIDPATHINFO_MAXSIZE * sizeof(byte)));
                 if (result <= 0)
                 {

--- a/src/Tools/dotnet-collect/ConfigPathDetector.cs
+++ b/src/Tools/dotnet-collect/ConfigPathDetector.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Diagnostics.Tools.Collect
                 result = proc_pidpath(pid, pBuffer, (uint)(PROC_PIDPATHINFO_MAXSIZE * sizeof(byte)));
                 if (result <= 0)
                 {
-                    throw new Exception("Could not find procpath using libproc.");
+                    throw new ArgumentException("Could not find procpath using libproc.");
                 }
 
                 // OS X uses UTF-8. The conversion may not strip off all trailing \0s so remove them here
@@ -86,7 +86,7 @@ namespace Microsoft.Diagnostics.Tools.Collect
                     var candidateName = Path.GetFileNameWithoutExtension(path);
                     return Path.Combine(candidateDir, $"{candidateName}.eventpipeconfig");
                 }
-                catch (Exception)
+                catch (ArgumentException)
                 {
                     return null;  // The pinvoke above may fail - return null in that case to handle error gracefully.
                 }
@@ -136,10 +136,9 @@ namespace Microsoft.Diagnostics.Tools.Collect
                             return Path.Combine(candidateDir, $"{candidateName}.eventpipeconfig");
                         }
                     }
-                    catch (Exception)
-                    {
-                        // Suppress exception and just try the next entry.
-                    }
+                    catch (ArgumentNullException) { return null; }
+                    catch (InvalidDataException) { return null; }
+                    catch (InvalidOperationException) { return null; }
                 }
                 return null;
             }


### PR DESCRIPTION
This adds the ability to collect EventPipe traces via `--process-id` parameter on OSX. 

Addresses #128 