### PR TITLE
Bring dotnet-sos and dotnet-dump collect up to spec

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -214,9 +214,14 @@ phases:
     demands:
       - agent.os -equals Windows_NT
   variables: 
-    _PublishBlobFeedUrl: https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
-    _SOSNETCorePath: $(Build.SourcesDirectory)/artifacts/bin/SOS.NETCore/Release/netstandard2.0/publish
-    _TeamName: DotNetCore
+    - group: DotNet-Blob-Feed
+    - group: DotNet-MyGet-Publish
+    - name: _PublishBlobFeedUrl
+      value: https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
+    - name: _SOSNETCorePath
+      value: $(Build.SourcesDirectory)/artifacts/bin/SOS.NETCore/Release/netstandard2.0/publish
+    - name: _TeamName
+      value: DotNetCore
 
   steps: 
   - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@1
@@ -399,7 +404,7 @@ phases:
       /p:DotNetSignType=$(SignType) 
       /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1) 
       /p:DotNetPublishBlobFeedUrl=$(_PublishBlobFeedUrl)
-      /p:DotNetPublishToBlobFeed=false
+      /p:DotNetPublishToBlobFeed=true
       /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
       /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
       /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
@@ -407,40 +412,41 @@ phases:
     continueOnError: true
     condition: succeeded()
 
-  # Optionally drop the artifacts on a share
-
   - task: PublishBuildArtifacts@1
-    displayName: Drop Binaries
+    displayName: Publish Package Artifacts
     inputs:
-      publishLocation: FilePath
-      pathtoPublish: '$(Build.SourcesDirectory)\artifacts\bin'
-      artifactName: bin
-      targetPath: '$(DropRoot)\DotNetCore\$(Build.DefinitionName)\$(Build.BuildNumber)'
-    condition: and(succeeded(), eq(variables['DropArtifacts'], 'true'))
+      publishLocation: Container
+      pathtoPublish: '$(Build.SourcesDirectory)/artifacts/packages'
+      artifactName: packages
+    condition: succeeded()
+
+  # Optionally drop the artifacts on a share
 
   - task: PublishBuildArtifacts@1
     displayName: Drop Packages
     inputs:
       publishLocation: FilePath
-      pathtoPublish: '$(Build.SourcesDirectory)\artifacts\packages'
-      artifactName: packages
+      pathtoPublish: '$(Build.SourcesDirectory)/artifacts/packages'
+      artifactName: _packages
       targetPath: '$(DropRoot)\DotNetCore\$(Build.DefinitionName)\$(Build.BuildNumber)'
-    condition: and(succeeded(), eq(variables['DropArtifacts'], 'true'))
-
-  # Optionally publish the packages to a blob feed
-
-  - task: NuGetCommand@2
-    displayName: Publish TestHelpers to MyGet dotnet-buildtools feed
-    inputs:
-      command: custom
-      arguments: 'push $(Build.SourcesDirectory)\artifacts\packages\Release\Shipping\Microsoft.Diagnostic.TestHelpers.*.nupkg -ApiKey $(dotnetfeed-storage-access-key-1) -Source $(_PublishBlobFeedUrl)'
-    condition: and(succeeded(), eq(variables['PushPackages'], 'true'))
+    continueOnError: true
+    condition: eq(variables['DropPackages'], 'true')
 
   - task: PublishBuildArtifacts@1
-    displayName: Publish Logs to VSTS
+    displayName: Drop Binaries
     inputs:
-      pathtoPublish: '$(Build.SourcesDirectory)/artifacts/log'
+      publishLocation: FilePath
+      pathtoPublish: '$(Build.SourcesDirectory)/artifacts/bin'
+      artifactName: _bin
+      targetPath: '$(DropRoot)\DotNetCore\$(Build.DefinitionName)\$(Build.BuildNumber)'
+    continueOnError: true
+    condition: eq(variables['DropBinaries'], 'true')
+
+  - task: PublishBuildArtifacts@1
+    displayName: Publish Logs Artifacts
+    inputs:
       publishLocation: Container
+      pathtoPublish: '$(Build.SourcesDirectory)/artifacts/log'
       artifactName: Logs_Packaging_Signing
     continueOnError: true
     condition: always()

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
 
-    <VersionPrefix>1.0.1</VersionPrefix>
-    <PreReleaseVersionLabel>dev</PreReleaseVersionLabel>
+    <VersionPrefix>1.0.2</VersionPrefix>
+    <PreReleaseVersionLabel>preview3</PreReleaseVersionLabel>
 
     <!-- Opt-out repo features -->
     <UsingToolXliff>false</UsingToolXliff>

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -126,14 +126,12 @@ phases:
         displayName: Build / Test
         condition: succeeded()
  
-    # Internal only build steps (until publishing artifacts in public CI is supported)
-    - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-      - task: PublishBuildArtifacts@1
-        displayName: Upload Artifacts
-        inputs:
-          pathtoPublish: '$(Build.SourcesDirectory)/artifacts/$(_PublishArtifacts)'
-          artifactName: $(_PhaseName)_$(Agent.JobName)
-        condition: and(succeeded(), ne(variables['_PublishArtifacts'], ''))
+    - task: PublishBuildArtifacts@1
+      displayName: Upload Artifacts
+      inputs:
+        pathtoPublish: '$(Build.SourcesDirectory)/artifacts/$(_PublishArtifacts)'
+        artifactName: $(_PhaseName)_$(Agent.JobName)
+      condition: and(succeeded(), ne(variables['_PublishArtifacts'], ''))
 
     - task: CopyFiles@2
       displayName: Gather Build Logs

--- a/src/SOS/SOS.Hosting/SOSHost.cs
+++ b/src/SOS/SOS.Hosting/SOSHost.cs
@@ -48,7 +48,7 @@ namespace SOS
                 os = "linux";
             }
             if (os == null) {
-                throw new PlatformNotSupportedException($"{RuntimeInformation.OSDescription} not supported");
+                throw new PlatformNotSupportedException($"Unsupported operating system: {RuntimeInformation.OSDescription}");
             }
             string architecture = RuntimeInformation.OSArchitecture.ToString().ToLowerInvariant();
             string rid = os + "-" + architecture;

--- a/src/Tools/dotnet-dump/Analyzer.cs
+++ b/src/Tools/dotnet-dump/Analyzer.cs
@@ -1,5 +1,6 @@
 using Microsoft.Diagnostic.Repl;
 using Microsoft.Diagnostics.Runtime;
+using System;
 using System.CommandLine;
 using System.IO;
 using System.Linq;
@@ -25,45 +26,60 @@ namespace Microsoft.Diagnostic.Tools.Dump
         {
             _consoleProvider.Out.WriteLine($"Loading core dump: {dump_path} ...");
 
-            DataTarget target = null;
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) {
-                target = DataTarget.LoadCoreDump(dump_path.FullName);
-            }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
-                target = DataTarget.LoadCrashDump(dump_path.FullName, CrashDumpReader.ClrMD);
-            }
-            else {
-                _consoleProvider.Error.WriteLine($"{RuntimeInformation.OSDescription} not supported");
-                return 1;
-            }
-
-            using (target)
-            {
-                // Create common analyze context for commands
-                var analyzeContext = new AnalyzeContext(_consoleProvider, target, _consoleProvider.Stop) {
-                    CurrentThreadId = unchecked((int)target.DataReader.EnumerateAllThreads().FirstOrDefault())
-                };
-                _commandProcessor.CommandContext = analyzeContext;
-
-                // Automatically enable symbol server support on Linux and MacOS
-                if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
-                    await _commandProcessor.Parse("setsymbolserver -ms", _consoleProvider);
+            try
+            { 
+                DataTarget target = null;
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) {
+                    target = DataTarget.LoadCoreDump(dump_path.FullName);
+                }
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+                    target = DataTarget.LoadCrashDump(dump_path.FullName, CrashDumpReader.ClrMD);
+                }
+                else {
+                    throw new PlatformNotSupportedException($"Unsupported operating system: {RuntimeInformation.OSDescription}");
                 }
 
-                // Run the commands from the dotnet-dump command line
-                if (command != null)
+                using (target)
                 {
-                    foreach (string cmd in command)
-                    {
-                        await _commandProcessor.Parse(cmd, _consoleProvider);
-                    }
-                }
+                    // Create common analyze context for commands
+                    var analyzeContext = new AnalyzeContext(_consoleProvider, target, _consoleProvider.Stop) {
+                        CurrentThreadId = unchecked((int)target.DataReader.EnumerateAllThreads().FirstOrDefault())
+                    };
+                    _commandProcessor.CommandContext = analyzeContext;
 
-                // Start interactive command line processing
-                await _consoleProvider.Start(async (string commandLine, CancellationToken cancellation) => {
-                    analyzeContext.CancellationToken = cancellation;
-                    await _commandProcessor.Parse(commandLine, _consoleProvider);
-                });
+                    // Automatically enable symbol server support on Linux and MacOS
+                    if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+                        await _commandProcessor.Parse("setsymbolserver -ms", _consoleProvider);
+                    }
+
+                    // Run the commands from the dotnet-dump command line
+                    if (command != null)
+                    {
+                        foreach (string cmd in command)
+                        {
+                            await _commandProcessor.Parse(cmd, _consoleProvider);
+                        }
+                    }
+
+                    // Start interactive command line processing
+                    await _consoleProvider.Start(async (string commandLine, CancellationToken cancellation) => {
+                        analyzeContext.CancellationToken = cancellation;
+                        await _commandProcessor.Parse(commandLine, _consoleProvider);
+                    });
+                }
+            }
+            catch (Exception ex) when 
+                (ex is ClrDiagnosticsException ||
+                 ex is IOException || 
+                 ex is UnauthorizedAccessException || 
+                 ex is ArgumentException || 
+                 ex is PlatformNotSupportedException || 
+                 ex is InvalidDataException ||
+                 ex is InvalidOperationException ||
+                 ex is NotSupportedException)
+            {
+                _consoleProvider.Error.WriteLine($"{ex.Message}");
+                return 1;
             }
 
             return 0;

--- a/src/Tools/dotnet-dump/Dumper.Linux.cs
+++ b/src/Tools/dotnet-dump/Dumper.Linux.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Diagnostic.Tools.Dump
     {
         private static class Linux
         {
-            internal static async Task CollectDumpAsync(Process process, string fileName)
+            internal static async Task CollectDumpAsync(Process process, string fileName, bool triage)
             {
                 // We don't work on WSL :(
                 string ostype = await File.ReadAllTextAsync("/proc/sys/kernel/osrelease");
@@ -35,25 +35,23 @@ namespace Microsoft.Diagnostic.Tools.Dump
                 }
 
                 // Create the dump
-                int exitCode = await CreateDumpAsync(createDumpPath, fileName, process.Id);
+                int exitCode = await CreateDumpAsync(createDumpPath, fileName, process.Id, triage);
                 if (exitCode != 0)
                 {
-                    throw new Exception($"createdump exited with non-zero exit code: {exitCode}");
+                    throw new InvalidOperationException($"createdump exited with non-zero exit code: {exitCode}");
                 }
             }
 
-            private static Task<int> CreateDumpAsync(string exePath, string fileName, int processId)
+            private static Task<int> CreateDumpAsync(string exePath, string fileName, int processId, bool triage)
             {
+                string dumpType = triage ? "--triage" : "--withheap";
                 var tcs = new TaskCompletionSource<int>();
                 var createdump = new Process()
                 {
                     StartInfo = new ProcessStartInfo()
                     {
                         FileName = exePath,
-                        Arguments = $"--diag -f {fileName} {processId}",
-                        //RedirectStandardError = true,
-                        //RedirectStandardOutput = true,
-                        //RedirectStandardInput = true,
+                        Arguments = $"--name {fileName} {dumpType} {processId}",
                     },
                     EnableRaisingEvents = true,
                 };

--- a/src/Tools/dotnet-dump/Dumper.Windows.cs
+++ b/src/Tools/dotnet-dump/Dumper.Windows.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Diagnostic.Tools.Dump
     {
         private static class Windows
         {
-            internal static Task CollectDumpAsync(Process process, string outputFile)
+            internal static Task CollectDumpAsync(Process process, string outputFile, bool triage)
             {
                 // We can't do this "asynchronously" so just Task.Run it. It shouldn't be "long-running" so this is fairly safe.
                 return Task.Run(() =>
@@ -21,9 +21,10 @@ namespace Microsoft.Diagnostic.Tools.Dump
                     {
                         // Dump the process!
                         var exceptionInfo = new NativeMethods.MINIDUMP_EXCEPTION_INFORMATION();
-                        if (!NativeMethods.MiniDumpWriteDump(process.Handle, (uint)process.Id, stream.SafeFileHandle, NativeMethods.MINIDUMP_TYPE.MiniDumpWithFullMemory, ref exceptionInfo, IntPtr.Zero, IntPtr.Zero))
+                        var dumpType = triage ? NativeMethods.MINIDUMP_TYPE.MiniDumpFilterTriage : NativeMethods.MINIDUMP_TYPE.MiniDumpWithPrivateReadWriteMemory;
+                        if (!NativeMethods.MiniDumpWriteDump(process.Handle, (uint)process.Id, stream.SafeFileHandle, dumpType, ref exceptionInfo, IntPtr.Zero, IntPtr.Zero))
                         {
-                            var err = Marshal.GetHRForLastWin32Error();
+                            int err = Marshal.GetHRForLastWin32Error();
                             Marshal.ThrowExceptionForHR(err);
                         }
                     }

--- a/src/Tools/dotnet-dump/Program.cs
+++ b/src/Tools/dotnet-dump/Program.cs
@@ -22,26 +22,53 @@ namespace Microsoft.Diagnostic.Tools.Dump
         private static Command CollectCommand() =>
             new Command(
                 "collect", 
-                "Captures memory dumps of .NET processes.", 
-                new Option[] { ProcessIdOption(), OutputOption() },
-                handler: CommandHandler.Create<IConsole, int, string>(new Dumper().Collect));
+                "Capture one or more dumps (core files on Mac/Linux) from a process.", 
+                new Option[] { ProcessIdOption(), IntervalOption(), NumberOption(), OutputOption(), TypeOption() },
+                handler: CommandHandler.Create<IConsole, int, int, int, string, string>(new Dumper().Collect));
 
         private static Option ProcessIdOption() =>
             new Option(
                 new[] { "-p", "--process-id" }, 
-                "The ID of the process to collect a memory dump.",
-                new Argument<int> { Name = "processId" });
+                "The the process to collect a memory dump.",
+                new Argument<int> { Name = "pid" });
+
+        private static Option IntervalOption() =>
+            new Option(
+                "--interval-sec",
+                "The number of seconds to wait between collecting each dump. Defaults to 10 seconds if not specified.",
+                new Argument<int>() { Name = "seconds" });
+
+        private static Option NumberOption() =>
+            new Option(
+                "--number", 
+                "The number of dumps to collect from the target process. Defaults to 1 if not specified.",
+                new Argument<int>() { Name = "number_of_dumps" });
 
         private static Option OutputOption() =>
             new Option(
-                new[] { "-o", "--output" }, 
-                "The directory to write the dump. Defaults to the current working directory.",
-                new Argument<string>(Directory.GetCurrentDirectory()) { Name = "directory" });
+                new[] { "-o", "--output" },
+                @"The path where collected dumps should be written. Defaults to '.\dump_YYYYMMDD_HHMMSS.dmp' on Windows and 
+'.\core_YYYYMMDD_HHMMSS' on Linux where YYYYMMDD is Year/Month/Day and HHMMSS is Hour/Minute/Second. This 
+option is a directory if an existing directory, ends with '\' or '/', or if the --number or --interval-sec
+options are specified, otherwise it is an exact file name.",
+                new Argument<string>(Directory.GetCurrentDirectory()) { Name = "output_dump_path" });
+
+        private static Option TypeOption() =>
+            new Option(
+                "--type",
+                @"The dump type determines the kinds of information that are collected from the process. There are two types:
+
+heap - A large and relatively comprehensive dump containing module lists, thread lists, all stacks,
+       exception information, handle information, and all memory except for mapped images.
+triage - A small dump containing module lists, thread lists, exception information and all stacks.
+
+If not specified 'heap' is the default.",
+                new Argument<string>("heap") { Name = "dump_type" });
 
         private static Command AnalyzeCommand() =>
             new Command(
                 "analyze",
-                "Start interactive dump analyze.",
+                "Starts an interactive shell with debugging commands to explore a dump.",
                 new Option[] { RunCommand() }, argument: DumpPath(),
                 handler: CommandHandler.Create<FileInfo, string[]>(new Analyzer().Analyze));
 

--- a/src/Tools/dotnet-dump/dotnet-dump.csproj
+++ b/src/Tools/dotnet-dump/dotnet-dump.csproj
@@ -4,14 +4,15 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <RuntimeFrameworkVersion>2.1.0</RuntimeFrameworkVersion>
-    <!-- Don't pack until ship engineering is done. Currently causing the official job to fail.
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
-    -->
     <PackAsToolShimRuntimeIdentifiers>win-x64;win-x86;osx-x64</PackAsToolShimRuntimeIdentifiers>
-    <!-- The package version needs to be hard coded as a stable version so "dotnet tool install -g dotnet-dump" works -->
+
+    <!-- The package version needs to be hard coded as a stable version so "dotnet tool install -g dotnet-dump" works
     <Version>$(VersionPrefix)</Version>
     <PackageVersion>$(VersionPrefix)</PackageVersion>
+     -->
+
     <ToolCommandName>dotnet-dump</ToolCommandName>
     <RootNamespace>Microsoft.Diagnostic.Tools.Dump</RootNamespace>
     <Description>Diagnostic dump collect and analyze tool</Description>

--- a/src/Tools/dotnet-sos/dotnet-sos.csproj
+++ b/src/Tools/dotnet-sos/dotnet-sos.csproj
@@ -6,9 +6,12 @@
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <PackAsToolShimRuntimeIdentifiers>win-x64;win-x86;osx-x64</PackAsToolShimRuntimeIdentifiers>
-    <!-- The package version needs to be hard coded as a stable version so "dotnet tool install -g dotnet-sos" works -->
+
+    <!-- The package version needs to be hard coded as a stable version so "dotnet tool install -g dotnet-sos" works
     <Version>$(VersionPrefix)</Version>
     <PackageVersion>$(VersionPrefix)</PackageVersion>
+     -->
+
     <ToolCommandName>dotnet-sos</ToolCommandName>
     <RootNamespace>Microsoft.Diagnostics.Tools.SOS</RootNamespace>
     <Description>Diagnostic SOS installer</Description>

--- a/src/Tools/dotnet-sos/dotnet-sos.csproj
+++ b/src/Tools/dotnet-sos/dotnet-sos.csproj
@@ -23,13 +23,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.2.5" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\SOS\SOS.InstallHelper\SOS.InstallHelper.csproj" />
   </ItemGroup>
-
+  
+  <ItemGroup>
+    <PackageReference Include="System.CommandLine.Experimental" Version="0.1.0-alpha-63807-01" />
+  </ItemGroup>
+  
   <ItemGroup>
     <_PackageFiles Include="$(SOSNETCoreBinaries)">
       <BuildAction>None</BuildAction>


### PR DESCRIPTION
Bring dotnet-dump collect up to spec

Issue #125

Spec changes:
   Change the dotnet-dump collect file naming to timestamp based.
   Change the collect spew to match createdump's.
   Lowercase all the dotnet-dump analyze commands to match sos on Linux/lldb.
   Changed "mini" dump type to "triage".

Bring up dotnet-sos syntax up to spec.

Restrict the assembly resolver to just SOS.NETCore.

Fix some official build artifacts:
   Break up "DropArtifacts" build variable into "DropPackages" and "DropBinaries".
   Pushes all packages to dotnet-core blob feed.