### PR TITLE
Force lldb plugin/SOS to build with macOS 10.12 SDK

### DIFF
--- a/eng/build-native.sh
+++ b/eng/build-native.sh
@@ -420,6 +420,8 @@ if [ "$__HostOS" == "OSX" ]; then
     export LLDB_LIB=/Applications/Xcode.app/Contents/SharedFrameworks/LLDB.framework/LLDB
     export LLDB_PATH=/Applications/Xcode.app/Contents/Developer/usr/bin/lldb
 
+    export MACOSX_DEPLOYMENT_TARGET=10.12
+
     # If Xcode 9.2 exists (like on the CI/build machines), use that. Xcode 9.3 or 
     # greater (swift 4.1 lldb) doesn't work that well (seg faults on exit).
     if [ -f "/Applications/Xcode_9.2.app/Contents/Developer/usr/bin/lldb" ]; then


### PR DESCRIPTION
So they work on the supported versions of macOS.