### PR TITLE
Add dotnet-counters 

### DIFF
--- a/src/Tools/dotnet-counters/CollectionConfiguration.cs
+++ b/src/Tools/dotnet-counters/CollectionConfiguration.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using System.Linq;
+using System.Text;
+
+namespace Microsoft.Diagnostics.Tools.Counters
+{
+    public class CollectionConfiguration
+    {
+        public int? ProcessId { get; set; }
+        public string OutputPath { get; set; }
+        public int? CircularMB { get; set; }
+        public int? Interval { get; set; }
+        public IList<CounterProvider> Providers { get; set; } = new List<CounterProvider>();
+
+        internal string ToConfigString()
+        {
+            var builder = new StringBuilder();
+            if (ProcessId != null)
+            {
+                builder.AppendLine($"ProcessId={ProcessId.Value}");
+            }
+            if (!string.IsNullOrEmpty(OutputPath))
+            {
+                builder.AppendLine($"OutputPath={OutputPath}");
+            }
+            if (CircularMB != null)
+            {
+                builder.AppendLine($"CircularMB={CircularMB}");
+            }
+            if (Providers != null && Providers.Count > 0)
+            {
+                builder.AppendLine($"Providers={SerializeProviders(Providers)}");
+            }
+            return builder.ToString();
+        }
+
+        public void AddProvider(CounterProvider provider)
+        {
+            Providers.Add(provider);
+        }
+
+        public string SerializeProvider(CounterProvider provider)
+        {
+            return $"{provider.Name}:{provider.Keywords}:{provider.Level}:EventCounterIntervalSec={Interval}";
+        }
+
+        private string SerializeProviders(IEnumerable<CounterProvider> providers) => string.Join(",", providers.Select(p => SerializeProvider(p)));
+    }
+}

--- a/src/Tools/dotnet-counters/CollectionConfiguration.cs
+++ b/src/Tools/dotnet-counters/CollectionConfiguration.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Tracing;
@@ -41,11 +44,12 @@ namespace Microsoft.Diagnostics.Tools.Counters
             Providers.Add(provider);
         }
 
-        public string SerializeProvider(CounterProvider provider)
+        private string SerializeProviders(IEnumerable<CounterProvider> providers) => string.Join(",", providers.Select(p => SerializeProvider(p)));
+
+        private string SerializeProvider(CounterProvider provider)
         {
             return $"{provider.Name}:{provider.Keywords}:{provider.Level}:EventCounterIntervalSec={Interval}";
         }
 
-        private string SerializeProviders(IEnumerable<CounterProvider> providers) => string.Join(",", providers.Select(p => SerializeProvider(p)));
     }
 }

--- a/src/Tools/dotnet-counters/ConfigPathDetector.cs
+++ b/src/Tools/dotnet-counters/ConfigPathDetector.cs
@@ -1,0 +1,212 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Diagnostics.Tools.Counters
+{
+    internal static class ConfigPathDetector
+    {
+        private static readonly HashSet<string> _managedExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { ".exe", ".dll" };
+
+        // Known .NET Platform Assemblies
+        private static readonly HashSet<string> _platformAssemblies = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "System.Private.CoreLib.dll",
+            "clrjit.dll",
+        };
+
+        internal static string TryDetectConfigPath(int processId)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return Windows.TryDetectConfigPath(processId);
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return Linux.TryDetectConfigPath(processId);
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return OSX.TryDetectConfigPath(processId);
+            }
+            return null;
+        }
+
+        private static class OSX
+        {
+            // This is defined in proc_info.h (https://opensource.apple.com/source/xnu/xnu-1228/bsd/sys/proc_info.h)
+            private const int PROC_PIDPATHINFO_MAXSIZE = 1024 * 4;
+
+            /// <summary>
+            /// Gets the full path to the executable file identified by the specified PID
+            /// </summary>
+            /// <param name="pid">The PID of the running process</param>
+            /// <param name="buffer">A pointer to an allocated block of memory that will be filled with the process path</param>
+            /// <param name="bufferSize">The size of the buffer, should be PROC_PIDPATHINFO_MAXSIZE</param>
+            /// <returns>Returns the length of the path returned on success</returns>
+            [DllImport("libproc.dylib", SetLastError = true)]
+            private static extern unsafe int proc_pidpath(
+                int pid, 
+                byte* buffer, 
+                uint bufferSize);
+
+            /// <summary>
+            /// Gets the full path to the executable file identified by the specified PID
+            /// </summary>
+            /// <param name="pid">The PID of the running process</param>
+            /// <returns>Returns the full path to the process executable</returns>
+            internal static unsafe string proc_pidpath(int pid)
+            {
+                // The path is a fixed buffer size, so use that and trim it after
+                int result = 0;
+                byte* pBuffer = stackalloc byte[PROC_PIDPATHINFO_MAXSIZE];
+
+                // WARNING - Despite its name, don't try to pass in a smaller size than specified by PROC_PIDPATHINFO_MAXSIZE.
+                // For some reason libproc returns -1 if you specify something that's NOT EQUAL to PROC_PIDPATHINFO_MAXSIZE
+                // even if you declare your buffer to be smaller/larger than this size. 
+                result = proc_pidpath(pid, pBuffer, (uint)(PROC_PIDPATHINFO_MAXSIZE * sizeof(byte)));
+                if (result <= 0)
+                {
+                    throw new InvalidOperationException("Could not find procpath using libproc.");
+                }
+
+                // OS X uses UTF-8. The conversion may not strip off all trailing \0s so remove them here
+                return System.Text.Encoding.UTF8.GetString(pBuffer, result);
+            }
+
+            public static string TryDetectConfigPath(int processId)
+            {
+                try
+                {
+                    var path = proc_pidpath(processId);
+                    var candidateDir = Path.GetDirectoryName(path);
+                    var candidateName = Path.GetFileNameWithoutExtension(path);
+                    return Path.Combine(candidateDir, $"{candidateName}.eventpipeconfig");
+                }
+                catch (InvalidOperationException)
+                {
+                    return null;  // The pinvoke above may fail - return null in that case to handle error gracefully.
+                }
+            }
+        }
+
+        private static class Linux
+        {
+            public static string TryDetectConfigPath(int processId)
+            {
+                // Read procfs maps list
+                var lines = File.ReadAllLines($"/proc/{processId}/maps");
+
+                foreach (var line in lines)
+                {
+                    try
+                    {
+                        var parser = new StringParser(line, separator: ' ', skipEmpty: true);
+
+                        // Skip the address range
+                        parser.MoveNext();
+
+                        var permissions = parser.MoveAndExtractNext();
+
+                        // The managed entry point is Read-Only, Non-Execute and Shared.
+                        if (!string.Equals(permissions, "r--s", StringComparison.Ordinal))
+                        {
+                            continue;
+                        }
+
+                        // Skip offset, dev, and inode
+                        parser.MoveNext();
+                        parser.MoveNext();
+                        parser.MoveNext();
+
+                        // Parse the path
+                        if (!parser.MoveNext())
+                        {
+                            continue;
+                        }
+
+                        var path = parser.ExtractCurrentToEnd();
+                        var candidateDir = Path.GetDirectoryName(path);
+                        var candidateName = Path.GetFileNameWithoutExtension(path);
+                        if (File.Exists(Path.Combine(candidateDir, $"{candidateName}.deps.json")))
+                        {
+                            return Path.Combine(candidateDir, $"{candidateName}.eventpipeconfig");
+                        }
+                    }
+                    catch (ArgumentNullException) { return null; }
+                    catch (InvalidDataException) { return null; }
+                    catch (InvalidOperationException) { return null; }
+                }
+                return null;
+            }
+        }
+
+        private static class Windows
+        {
+            private static readonly HashSet<string> _knownNativeLibraries = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                // .NET Core Host
+                "dotnet.exe",
+                "hostfxr.dll",
+                "hostpolicy.dll",
+                "coreclr.dll",
+
+                // Windows Native Libraries
+                "ntdll.dll",
+                "kernel32.dll",
+                "kernelbase.dll",
+                "apphelp.dll",
+                "ucrtbase.dll",
+                "advapi32.dll",
+                "msvcrt.dll",
+                "sechost.dll",
+                "rpcrt4.dll",
+                "ole32.dll",
+                "combase.dll",
+                "bcryptPrimitives.dll",
+                "gdi32.dll",
+                "gdi32full.dll",
+                "msvcp_win.dll",
+                "user32.dll",
+                "win32u.dll",
+                "oleaut32.dll",
+                "shlwapi.dll",
+                "version.dll",
+                "bcrypt.dll",
+                "imm32.dll",
+                "kernel.appcore.dll",
+            };
+
+            public static string TryDetectConfigPath(int processId)
+            {
+                var process = Process.GetProcessById(processId);
+
+                // Iterate over modules
+                foreach (var module in process.Modules.Cast<ProcessModule>())
+                {
+                    // Filter out things that aren't exes and dlls (useful on Unix/macOS to skip native libraries)
+                    var extension = Path.GetExtension(module.FileName);
+                    var name = Path.GetFileName(module.FileName);
+                    if (_managedExtensions.Contains(extension) && !_knownNativeLibraries.Contains(name) && !_platformAssemblies.Contains(name))
+                    {
+                        var candidateDir = Path.GetDirectoryName(module.FileName);
+                        var appName = Path.GetFileNameWithoutExtension(module.FileName);
+
+                        // Check for the deps.json file
+                        // TODO: Self-contained apps?
+                        if (File.Exists(Path.Combine(candidateDir, $"{appName}.deps.json")))
+                        {
+                            // This is an app!
+                            return Path.Combine(candidateDir, $"{appName}.eventpipeconfig");
+                        }
+                    }
+                }
+
+                return null;
+            }
+        }
+    }
+}

--- a/src/Tools/dotnet-counters/ConfigPathDetector.cs
+++ b/src/Tools/dotnet-counters/ConfigPathDetector.cs
@@ -1,5 +1,4 @@
 // Copyright (c) .NET Foundation. All rights reserved.
-// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/Tools/dotnet-counters/ConfigPathDetector.cs
+++ b/src/Tools/dotnet-counters/ConfigPathDetector.cs
@@ -1,3 +1,7 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -7,6 +11,8 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.Diagnostics.Tools.Counters
 {
+    // NOTE: This is copied over from dotnet-collect.
+    // This will eventually go away once we get the runtime ready to stream events via IPC.
     internal static class ConfigPathDetector
     {
         private static readonly HashSet<string> _managedExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { ".exe", ".dll" };

--- a/src/Tools/dotnet-counters/CounterMonitor.cs
+++ b/src/Tools/dotnet-counters/CounterMonitor.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
 {
     public class CounterMonitor
     {
-        private string configPath;  // Path to the eventpipe config file that needs to be generated
+        private string configPath;
         private EventPipeCollector collector;
         private CollectionConfiguration config;
 

--- a/src/Tools/dotnet-counters/CounterMonitor.cs
+++ b/src/Tools/dotnet-counters/CounterMonitor.cs
@@ -59,8 +59,6 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 return 1;
             }
 
-            _console.Out.WriteLine($"processId: {_processId}, interval: {_interval}, counterList: {_counterList}");
-
             configPath = ConfigPathDetector.TryDetectConfigPath(_processId);
 
             if(string.IsNullOrEmpty(configPath))

--- a/src/Tools/dotnet-counters/CounterMonitor.cs
+++ b/src/Tools/dotnet-counters/CounterMonitor.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.CommandLine;
 using System.Diagnostics;

--- a/src/Tools/dotnet-counters/CounterMonitor.cs
+++ b/src/Tools/dotnet-counters/CounterMonitor.cs
@@ -1,0 +1,87 @@
+using System;
+using System.CommandLine;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.Tools.Counters
+{
+    public class CounterMonitor
+    {
+        string configPath;  // Path to the eventpipe config file that needs to be generated
+
+        public CounterMonitor()
+        {
+        }
+
+        public async Task<int> Monitor(string counterList, IConsole console, int ProcessId, int interval)
+        {
+            if (ProcessId == 0) {
+                console.Error.WriteLine("ProcessId is required.");
+                return 1;
+            }
+
+            if (interval == 0) {
+                console.Error.WriteLine("interval is required.");
+                return 1;
+            }
+
+            console.Out.WriteLine($"processId: {ProcessId}, interval: {interval}, counterList: {counterList}");
+
+            configPath = ConfigPathDetector.TryDetectConfigPath(ProcessId);
+
+            if(string.IsNullOrEmpty(configPath))
+            {
+                console.Error.WriteLine("Couldn't determine the path for the eventpipeconfig file from the process ID. Specify the '--config-path' option to provide it manually.");
+                return 1;
+            }
+
+            console.Out.WriteLine($"Detected config file path: {configPath}");
+
+            var config = new CollectionConfiguration()
+            {
+                ProcessId = ProcessId,
+                CircularMB = 1000,  // TODO: Make this configurable?
+                OutputPath = Directory.GetCurrentDirectory(),
+                Interval = interval
+            };
+
+            if (string.IsNullOrEmpty(counterList))
+            {
+                console.Out.WriteLine($"counter_list is unspecified. Monitoring all counters by default.");
+
+                // Enable the default profile if nothing is specified
+                if (!KnownData.TryGetProvider("System.Runtime", out var defaultProvider))
+                {
+                    console.Error.WriteLine("No providers or profiles were specified and there is no default profile available.");
+                    return 1;
+                }
+                config.AddProvider(defaultProvider);
+            }
+
+            if (File.Exists(configPath))
+            {
+                console.Error.WriteLine("Config file already exists, tracing is already underway by a different consumer.");
+                return 1;
+            }
+
+            EventPipeCollector collector = new EventPipeCollector(config, configPath);
+
+            // Write the config file contents
+            await collector.StartCollectingAsync();
+            console.Out.WriteLine("Tracing has started. Press Ctrl-C to stop.");
+
+            // await WaitForCtrlCAsync(console);
+            Thread.Sleep(20000);
+
+            await collector.StopCollectingAsync();
+            console.Out.WriteLine($"Tracing stopped. Trace files written to {config.OutputPath}");
+
+            console.Out.WriteLine($"Complete");
+            return 0;
+        }
+
+    }
+}

--- a/src/Tools/dotnet-counters/CounterMonitor.cs
+++ b/src/Tools/dotnet-counters/CounterMonitor.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
 
             if(string.IsNullOrEmpty(configPath))
             {
-                _console.Error.WriteLine("Couldn't determine the path for the eventpipeconfig file from the process ID. Specify the '--config-path' option to provide it manually.");
+                _console.Error.WriteLine("Couldn't determine the path for the eventpipeconfig file from the process ID.");
                 return 1;
             }
 

--- a/src/Tools/dotnet-counters/CounterProvider.cs
+++ b/src/Tools/dotnet-counters/CounterProvider.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.Diagnostics.Tools.Counters
+{
+    public class CounterProvider
+    {
+        public static readonly string DefaultProviderName = "System.Runtime";
+
+        public string Name { get; }
+        public string Description { get; }
+        public string Keywords { get; }
+        public string Level { get; }
+        public IReadOnlyList<CounterProfile> Counters { get; }
+
+        public CounterProvider(string name, string description, string keywords, string level, IEnumerable<CounterProfile> counters)
+        {
+            Name = name;
+            Description = description;
+            Keywords = keywords;
+            Level = level;
+            Counters = counters.ToList();
+        }
+    }
+
+    public class CounterProfile
+    {
+        public string Name { get; set; }
+        public string Description { get; set; }
+    }
+}

--- a/src/Tools/dotnet-counters/CounterProvider.cs
+++ b/src/Tools/dotnet-counters/CounterProvider.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Collections.Generic;
 using System.Linq;
 

--- a/src/Tools/dotnet-counters/EventCollector.cs
+++ b/src/Tools/dotnet-counters/EventCollector.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Threading.Tasks;
 
 namespace Microsoft.Diagnostics.Tools.Counters

--- a/src/Tools/dotnet-counters/EventCollector.cs
+++ b/src/Tools/dotnet-counters/EventCollector.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.Tools.Counters
+{
+    public abstract class EventCollector
+    {
+        public abstract Task StartCollectingAsync();
+        public abstract Task StopCollectingAsync();
+    }
+}

--- a/src/Tools/dotnet-counters/EventPipeCollector.cs
+++ b/src/Tools/dotnet-counters/EventPipeCollector.cs
@@ -1,0 +1,29 @@
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.Tools.Counters
+{
+    public class EventPipeCollector : EventCollector
+    {
+        private readonly CollectionConfiguration _config;
+        private readonly string _configPath;
+
+        public EventPipeCollector(CollectionConfiguration config, string configPath)
+        {
+            _config = config;
+            _configPath = configPath;
+        }
+
+        public override Task StartCollectingAsync()
+        {
+            var configContent = _config.ToConfigString();
+            return File.WriteAllTextAsync(_configPath, configContent);
+        }
+
+        public override Task StopCollectingAsync()
+        {
+            File.Delete(_configPath);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Tools/dotnet-counters/KnownData.cs
+++ b/src/Tools/dotnet-counters/KnownData.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Tracing;
@@ -20,6 +23,10 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 "0xffffffff", // Keywords
                 "0x5", // Level 
                 new[] { // Counters
+                    // NOTE: For now, the set of counters below doesn't really matter because 
+                    // we don't really display any counters in real time. (We just collect .netperf files) 
+                    // In the future (with IPC), we should filter counter payloads by name provided below to display.  
+                    // These are mainly here as placeholders. 
                     new CounterProfile{ Name="total-processor-time", Description="Amount of time the process has utilized the CPU (ms)" },
                     new CounterProfile{ Name="private-memory", Description="Amount of private virtual memory used by the process (KB)" },
                     new CounterProfile{ Name="working-set", Description="Amount of working set used by the process (KB)" },

--- a/src/Tools/dotnet-counters/KnownData.cs
+++ b/src/Tools/dotnet-counters/KnownData.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using System.Linq;
+using Microsoft.Diagnostics.Tracing.Parsers;
+
+namespace Microsoft.Diagnostics.Tools.Counters
+{
+    internal static class KnownData
+    {
+        private static readonly IReadOnlyDictionary<string, CounterProvider> _knownProviders =
+            CreateKnownProviders().ToDictionary(p => p.Name, StringComparer.OrdinalIgnoreCase);
+
+
+        private static IEnumerable<CounterProvider> CreateKnownProviders()
+        {
+            yield return new CounterProvider(
+                "System.Runtime", // Name
+                "A default set of performance counters provided by the .NET runtime.", // Description
+                "0xffffffff", // Keywords
+                "0x5", // Level 
+                new[] { // Counters
+                    new CounterProfile{ Name="total-processor-time", Description="Amount of time the process has utilized the CPU (ms)" },
+                    new CounterProfile{ Name="private-memory", Description="Amount of private virtual memory used by the process (KB)" },
+                    new CounterProfile{ Name="working-set", Description="Amount of working set used by the process (KB)" },
+                    new CounterProfile{ Name="virtual-memory", Description="Amount of virtual memory used by the process (KB)" },
+                    new CounterProfile{ Name="gc-total-memory", Description="Amount of commited virtual memory used by the GC (KB)" },
+                    new CounterProfile{ Name="exceptions-thrown-rate", Description="Number of exceptions thrown in a recent 1 minute window (exceptions/min)" },
+                });
+
+            // TODO: Add more providers (ex. ASP.NET ones)
+        }
+
+        public static IReadOnlyList<CounterProvider> GetAllProviders() => _knownProviders.Values.ToList();
+
+        public static bool TryGetProvider(string providerName, out CounterProvider provider) => _knownProviders.TryGetValue(providerName, out provider);
+    }
+}

--- a/src/Tools/dotnet-counters/Program.cs
+++ b/src/Tools/dotnet-counters/Program.cs
@@ -1,0 +1,259 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using McMaster.Extensions.CommandLineUtils;
+using Microsoft.Internal.Utilities;
+
+namespace Microsoft.Diagnostics.Tools.Counters
+{
+    [Command(Name = "dotnet-counters", Description = "Shows real-time performance counters from .NET processes")]
+    internal class Program
+    {
+        [Required]
+        [Option("-p|--process-id <PROCESS_ID>", Description = "Filter to only the process with the specified process ID.")]
+        public int ProcessId { get; set; }
+
+        [Option("-v|--version", Description = "Display the version of the dotnet-counters utility.")]
+        public bool NoDefault { get; set; }
+
+        [Option("-h|--help", Description = "Show command line help.")]
+        public bool NoDefault { get; set; }
+
+        [Option("--list-profiles", Description = "Gets a list of predefined collection profiles.")]
+        public bool ListProfiles { get; set; }
+
+        [Option("--no-default", Description = "Don't enable the default profile.")]
+        public bool NoDefault { get; set; }
+
+        public async Task<int> OnExecuteAsync(IConsole console, CommandLineApplication app)
+        {
+            if (ListProfiles)
+            {
+                WriteProfileList(console.Out);
+                return 0;
+            }
+
+            if (!string.IsNullOrEmpty(KeywordsForProvider))
+            {
+                return ExecuteKeywordsForAsync(console);
+            }
+
+            if(string.IsNullOrEmpty(ConfigPath))
+            {
+                ConfigPath = ConfigPathDetector.TryDetectConfigPath(ProcessId);
+                if(string.IsNullOrEmpty(ConfigPath))
+                {
+                    console.Error.WriteLine("Couldn't determine the path for the eventpipeconfig file from the process ID. Specify the '--config-path' option to provide it manually.");
+                    return 1;
+                }
+                console.WriteLine($"Detected config file path: {ConfigPath}");
+            }
+
+            var config = new CollectionConfiguration()
+            {
+                ProcessId = ProcessId,
+                CircularMB = CircularMB,
+                OutputPath = string.IsNullOrEmpty(OutputDir) ? Directory.GetCurrentDirectory() : OutputDir
+            };
+
+            if (Profiles != null && Profiles.Count > 0)
+            {
+                foreach (var profile in Profiles)
+                {
+                    if (!KnownData.TryGetProfile(profile, out var collectionProfile))
+                    {
+                        console.Error.WriteLine($"Unknown profile name: '{profile}'. See 'dotnet-collect --list-profiles' to get a list of profiles.");
+                        return 1;
+                    }
+                    config.AddProfile(collectionProfile);
+                }
+            }
+
+            if (Providers != null && Providers.Count > 0)
+            {
+                foreach (var provider in Providers)
+                {
+                    if (!EventSpec.TryParse(provider, out var providerSpec))
+                    {
+                        console.Error.WriteLine($"Invalid provider specification: '{provider}'. See 'dotnet-collect --help' for more information.");
+                        return 1;
+                    }
+                    config.Providers.Add(providerSpec);
+                }
+            }
+
+            if (Loggers != null && Loggers.Count > 0)
+            {
+                foreach (var logger in Loggers)
+                {
+                    if (!LoggerSpec.TryParse(logger, out var loggerSpec))
+                    {
+                        console.Error.WriteLine($"Invalid logger specification: '{logger}'. See 'dotnet-collect --help' for more information.");
+                        return 1;
+                    }
+                    config.Loggers.Add(loggerSpec);
+                }
+            }
+
+            if (!NoDefault)
+            {
+                // Enable the default profile if nothing is specified
+                if (!KnownData.TryGetProfile(CollectionProfile.DefaultProfileName, out var defaultProfile))
+                {
+                    console.Error.WriteLine("No providers or profiles were specified and there is no default profile available.");
+                    return 1;
+                }
+                config.AddProfile(defaultProfile);
+            }
+
+            if (!TryCreateCollector(console, config, out var collector))
+            {
+                return 1;
+            }
+
+            // Write the config file contents
+            await collector.StartCollectingAsync();
+            console.WriteLine("Tracing has started. Press Ctrl-C to stop.");
+
+            await console.WaitForCtrlCAsync();
+
+            await collector.StopCollectingAsync();
+            console.WriteLine($"Tracing stopped. Trace files written to {config.OutputPath}");
+
+            return 0;
+        }
+
+        private static void WriteProfileList(TextWriter console)
+        {
+            var profiles = KnownData.GetAllProfiles();
+            var maxNameLength = profiles.Max(p => p.Name.Length);
+            console.WriteLine("Available profiles:");
+            foreach (var profile in profiles)
+            {
+                console.WriteLine($"* {profile.Name.PadRight(maxNameLength)}  {profile.Description}");
+            }
+        }
+
+        private int ExecuteKeywordsForAsync(IConsole console)
+        {
+            if (KnownData.TryGetProvider(KeywordsForProvider, out var provider))
+            {
+                console.WriteLine($"Known keywords for {provider.Name} ({provider.Guid}):");
+                foreach (var keyword in provider.Keywords.Values)
+                {
+                    console.WriteLine($"* 0x{keyword.Value:x16} {keyword.Name}");
+                }
+                return 0;
+            }
+            else
+            {
+                console.WriteLine($"There are no known keywords for {KeywordsForProvider}.");
+                return 1;
+            }
+        }
+
+        private bool TryCreateCollector(IConsole console, CollectionConfiguration config, out EventCollector collector)
+        {
+            collector = null;
+
+            if (Etw)
+            {
+                if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    console.Error.WriteLine("Error: ETW-based collection is only supported on Windows.");
+                    return false;
+                }
+
+                if (!string.IsNullOrEmpty(ConfigPath))
+                {
+                    console.Error.WriteLine("WARNING: The '-c' option is ignored when using ETW-based collection.");
+                }
+                collector = new EtwCollector(config);
+                return true;
+            }
+            else
+            {
+                if (File.Exists(ConfigPath))
+                {
+                    console.Error.WriteLine("Config file already exists, tracing is already underway by a different consumer.");
+                    return false;
+                }
+
+                collector = new EventPipeCollector(config, ConfigPath);
+                return true;
+            }
+        }
+
+        private static int Main(string[] args)
+        {
+            DebugUtil.WaitForDebuggerIfRequested(ref args);
+
+            try
+            {
+                var app = new CommandLineApplication<Program>();
+                app.Conventions.UseDefaultConventions();
+                app.ExtendedHelpText = GetExtendedHelp();
+                return app.Execute(args);
+            }
+            catch (PlatformNotSupportedException ex)
+            {
+                Console.Error.WriteLine(ex.Message);
+                return 1;
+            }
+            catch (CommandLineException clex)
+            {
+                Console.Error.WriteLine(clex.Message);
+                return 1;
+            }
+            catch (OperationCanceledException)
+            {
+                return 0;
+            }
+        }
+
+        private static string GetExtendedHelp()
+        {
+            using (var writer = new StringWriter())
+            {
+                writer.WriteLine();
+                writer.WriteLine("Profiles");
+                writer.WriteLine("  Profiles are sets of well-defined provider configurations that provide useful information.");
+                writer.WriteLine();
+                WriteProfileList(writer);
+                writer.WriteLine();
+                writer.WriteLine("Specifying Loggers:");
+                writer.WriteLine("  Use one of the following formats to specify a logger in '--logger'");
+                writer.WriteLine("    *                                                 - Enable all messages at all levels from all loggers.");
+                writer.WriteLine("    *:<level>                                         - Enable messages at the specified '<level>' or higher from all loggers.");
+                writer.WriteLine("    <loggerPrefix>                                    - Enable all messages at all levels from all loggers starting with '<loggerPrefix>'.");
+                writer.WriteLine("    <loggerPrefix>:<level>                            - Enable messages at the specified '<level>' or higher from all loggers starting with '<loggerPrefix>'.");
+                writer.WriteLine();
+                writer.WriteLine("  '<loggerPrefix>' is the prefix for a logger to enable. For example 'Microsoft.AspNetCore' to enable all ASP.NET Core loggers.");
+                writer.WriteLine("  '<level>' can be one of: Critical, Error, Warning, Informational, Debug, or Trace.");
+                writer.WriteLine();
+                writer.WriteLine("Specifying Providers:");
+                writer.WriteLine("  Use one of the following formats to specify a provider in '--provider'");
+                writer.WriteLine("    <providerName>                                    - Enable all events at all levels for the provider.");
+                writer.WriteLine("    <providerName>:<keywords>                         - Enable events matching the specified keywords for the specified provider.");
+                writer.WriteLine("    <providerName>:<keywords>:<level>                 - Enable events matching the specified keywords, at the specified level for the specified provider.");
+                writer.WriteLine("    <providerName>:<keywords>:<level>:<parameters>    - Enable events matching the specified keywords, at the specified level for the specified provider and provide key-value parameters.");
+                writer.WriteLine();
+                writer.WriteLine("  '<provider>' must be the name of the EventSource.");
+                writer.WriteLine("  '<level>' can be one of: Critical (1), Error (2), Warning (3), Informational (4), Verbose (5). Either the name or number can be specified.");
+                writer.WriteLine("  '<keywords>' is one of the following:");
+                writer.WriteLine("    A '*' character, indicating ALL keywords should be enabled (this can be very costly for some providers!)");
+                writer.WriteLine("    A comma-separated list of known keywords for a provider (use 'dotnet collect --keywords-for [providerName]' to get a list of known keywords for a provider)");
+                writer.WriteLine("    A 64-bit hexadecimal number, starting with '0x' indicating the keywords to enable");
+                writer.WriteLine("  '<parameters>' is an optional list of key-value parameters to provide to the EventPipe provider. The expected values depend on the provider you are enabling.");
+                writer.WriteLine("    This should be a list of key-value pairs, in the form: '<key1>=<value1>;<key2>=<value2>;...'. Note that some shells, such as PowerShell, require that you");
+                writer.WriteLine("    quote or escape the ';' character.");
+                return writer.GetStringBuilder().ToString();
+            }
+        }
+    }
+}

--- a/src/Tools/dotnet-counters/Program.cs
+++ b/src/Tools/dotnet-counters/Program.cs
@@ -6,254 +6,76 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
-using McMaster.Extensions.CommandLineUtils;
+using System.CommandLine;
 using Microsoft.Internal.Utilities;
+using System.CommandLine.Builder;
+using System.CommandLine.Invocation;
 
 namespace Microsoft.Diagnostics.Tools.Counters
 {
-    [Command(Name = "dotnet-counters", Description = "Shows real-time performance counters from .NET processes")]
     internal class Program
     {
-        [Required]
-        [Option("-p|--process-id <PROCESS_ID>", Description = "Filter to only the process with the specified process ID.")]
-        public int ProcessId { get; set; }
+        private static Command MonitorCommand() =>
+            new Command(
+                "monitor", 
+                "Start monitoring a .NET application", 
+                new Option[] { ProcessIdOption(), RefreshIntervalOption() },
+                argument: CounterList(),
+                handler: CommandHandler.Create<string, IConsole, int, int>(new CounterMonitor().Monitor));
 
-        [Option("-v|--version", Description = "Display the version of the dotnet-counters utility.")]
-        public bool NoDefault { get; set; }
+        private static Option ProcessIdOption() =>
+            new Option(
+                new[] { "-p", "--process-id" }, 
+                "The ID of the process that will be monitored.",
+                new Argument<int> { Name = "pid" });
 
-        [Option("-h|--help", Description = "Show command line help.")]
-        public bool NoDefault { get; set; }
+        private static Option RefreshIntervalOption() =>
+            new Option(
+                new[] { "-r", "--interval" }, 
+                "The number of seconds to delay between updating the displayed counters.",
+                new Argument<int> { Name = "interval" });
 
-        [Option("--list-profiles", Description = "Gets a list of predefined collection profiles.")]
-        public bool ListProfiles { get; set; }
-
-        [Option("--no-default", Description = "Don't enable the default profile.")]
-        public bool NoDefault { get; set; }
-
-        public async Task<int> OnExecuteAsync(IConsole console, CommandLineApplication app)
-        {
-            if (ListProfiles)
-            {
-                WriteProfileList(console.Out);
-                return 0;
-            }
-
-            if (!string.IsNullOrEmpty(KeywordsForProvider))
-            {
-                return ExecuteKeywordsForAsync(console);
-            }
-
-            if(string.IsNullOrEmpty(ConfigPath))
-            {
-                ConfigPath = ConfigPathDetector.TryDetectConfigPath(ProcessId);
-                if(string.IsNullOrEmpty(ConfigPath))
-                {
-                    console.Error.WriteLine("Couldn't determine the path for the eventpipeconfig file from the process ID. Specify the '--config-path' option to provide it manually.");
-                    return 1;
-                }
-                console.WriteLine($"Detected config file path: {ConfigPath}");
-            }
-
-            var config = new CollectionConfiguration()
-            {
-                ProcessId = ProcessId,
-                CircularMB = CircularMB,
-                OutputPath = string.IsNullOrEmpty(OutputDir) ? Directory.GetCurrentDirectory() : OutputDir
+        private static Argument CounterList() =>
+            new Argument<string> {
+                Name = "counter_list",
+                Description = @"A space separated list of counters. Counters can be specified provider_name[:counter_name].
+                If the provider_name is used without a qualifying counter_name then all counters will be shown. To discover 
+                provider and counter names, use the list command.
+                ."
             };
 
-            if (Profiles != null && Profiles.Count > 0)
-            {
-                foreach (var profile in Profiles)
-                {
-                    if (!KnownData.TryGetProfile(profile, out var collectionProfile))
-                    {
-                        console.Error.WriteLine($"Unknown profile name: '{profile}'. See 'dotnet-collect --list-profiles' to get a list of profiles.");
-                        return 1;
-                    }
-                    config.AddProfile(collectionProfile);
-                }
-            }
+        private static Command ListCommand() =>
+            new Command(
+                "list", 
+                "Display a list of counter names and descriptions, grouped by provider.", 
+                new Option[] { },
+                handler: CommandHandler.Create<IConsole>(List));
 
-            if (Providers != null && Providers.Count > 0)
-            {
-                foreach (var provider in Providers)
-                {
-                    if (!EventSpec.TryParse(provider, out var providerSpec))
-                    {
-                        console.Error.WriteLine($"Invalid provider specification: '{provider}'. See 'dotnet-collect --help' for more information.");
-                        return 1;
-                    }
-                    config.Providers.Add(providerSpec);
-                }
-            }
-
-            if (Loggers != null && Loggers.Count > 0)
-            {
-                foreach (var logger in Loggers)
-                {
-                    if (!LoggerSpec.TryParse(logger, out var loggerSpec))
-                    {
-                        console.Error.WriteLine($"Invalid logger specification: '{logger}'. See 'dotnet-collect --help' for more information.");
-                        return 1;
-                    }
-                    config.Loggers.Add(loggerSpec);
-                }
-            }
-
-            if (!NoDefault)
-            {
-                // Enable the default profile if nothing is specified
-                if (!KnownData.TryGetProfile(CollectionProfile.DefaultProfileName, out var defaultProfile))
-                {
-                    console.Error.WriteLine("No providers or profiles were specified and there is no default profile available.");
-                    return 1;
-                }
-                config.AddProfile(defaultProfile);
-            }
-
-            if (!TryCreateCollector(console, config, out var collector))
-            {
-                return 1;
-            }
-
-            // Write the config file contents
-            await collector.StartCollectingAsync();
-            console.WriteLine("Tracing has started. Press Ctrl-C to stop.");
-
-            await console.WaitForCtrlCAsync();
-
-            await collector.StopCollectingAsync();
-            console.WriteLine($"Tracing stopped. Trace files written to {config.OutputPath}");
-
-            return 0;
-        }
-
-        private static void WriteProfileList(TextWriter console)
+        public static async Task<int> List(IConsole console)
         {
-            var profiles = KnownData.GetAllProfiles();
+            var profiles = KnownData.GetAllProviders();
             var maxNameLength = profiles.Max(p => p.Name.Length);
-            console.WriteLine("Available profiles:");
+            Console.WriteLine("Showing well-known counters only. Specific processes may support additional counters.\n");
             foreach (var profile in profiles)
             {
-                console.WriteLine($"* {profile.Name.PadRight(maxNameLength)}  {profile.Description}");
+                Console.WriteLine($"* {profile.Name.PadRight(maxNameLength)}");
+                foreach (var counter in profile.Counters)
+                {
+                    Console.WriteLine($"    {counter.Name} \t\t {counter.Description}");
+                }
+                Console.WriteLine("");
             }
+            return 1;
         }
 
-        private int ExecuteKeywordsForAsync(IConsole console)
+        private static Task<int> Main(string[] args)
         {
-            if (KnownData.TryGetProvider(KeywordsForProvider, out var provider))
-            {
-                console.WriteLine($"Known keywords for {provider.Name} ({provider.Guid}):");
-                foreach (var keyword in provider.Keywords.Values)
-                {
-                    console.WriteLine($"* 0x{keyword.Value:x16} {keyword.Name}");
-                }
-                return 0;
-            }
-            else
-            {
-                console.WriteLine($"There are no known keywords for {KeywordsForProvider}.");
-                return 1;
-            }
-        }
-
-        private bool TryCreateCollector(IConsole console, CollectionConfiguration config, out EventCollector collector)
-        {
-            collector = null;
-
-            if (Etw)
-            {
-                if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                {
-                    console.Error.WriteLine("Error: ETW-based collection is only supported on Windows.");
-                    return false;
-                }
-
-                if (!string.IsNullOrEmpty(ConfigPath))
-                {
-                    console.Error.WriteLine("WARNING: The '-c' option is ignored when using ETW-based collection.");
-                }
-                collector = new EtwCollector(config);
-                return true;
-            }
-            else
-            {
-                if (File.Exists(ConfigPath))
-                {
-                    console.Error.WriteLine("Config file already exists, tracing is already underway by a different consumer.");
-                    return false;
-                }
-
-                collector = new EventPipeCollector(config, ConfigPath);
-                return true;
-            }
-        }
-
-        private static int Main(string[] args)
-        {
-            DebugUtil.WaitForDebuggerIfRequested(ref args);
-
-            try
-            {
-                var app = new CommandLineApplication<Program>();
-                app.Conventions.UseDefaultConventions();
-                app.ExtendedHelpText = GetExtendedHelp();
-                return app.Execute(args);
-            }
-            catch (PlatformNotSupportedException ex)
-            {
-                Console.Error.WriteLine(ex.Message);
-                return 1;
-            }
-            catch (CommandLineException clex)
-            {
-                Console.Error.WriteLine(clex.Message);
-                return 1;
-            }
-            catch (OperationCanceledException)
-            {
-                return 0;
-            }
-        }
-
-        private static string GetExtendedHelp()
-        {
-            using (var writer = new StringWriter())
-            {
-                writer.WriteLine();
-                writer.WriteLine("Profiles");
-                writer.WriteLine("  Profiles are sets of well-defined provider configurations that provide useful information.");
-                writer.WriteLine();
-                WriteProfileList(writer);
-                writer.WriteLine();
-                writer.WriteLine("Specifying Loggers:");
-                writer.WriteLine("  Use one of the following formats to specify a logger in '--logger'");
-                writer.WriteLine("    *                                                 - Enable all messages at all levels from all loggers.");
-                writer.WriteLine("    *:<level>                                         - Enable messages at the specified '<level>' or higher from all loggers.");
-                writer.WriteLine("    <loggerPrefix>                                    - Enable all messages at all levels from all loggers starting with '<loggerPrefix>'.");
-                writer.WriteLine("    <loggerPrefix>:<level>                            - Enable messages at the specified '<level>' or higher from all loggers starting with '<loggerPrefix>'.");
-                writer.WriteLine();
-                writer.WriteLine("  '<loggerPrefix>' is the prefix for a logger to enable. For example 'Microsoft.AspNetCore' to enable all ASP.NET Core loggers.");
-                writer.WriteLine("  '<level>' can be one of: Critical, Error, Warning, Informational, Debug, or Trace.");
-                writer.WriteLine();
-                writer.WriteLine("Specifying Providers:");
-                writer.WriteLine("  Use one of the following formats to specify a provider in '--provider'");
-                writer.WriteLine("    <providerName>                                    - Enable all events at all levels for the provider.");
-                writer.WriteLine("    <providerName>:<keywords>                         - Enable events matching the specified keywords for the specified provider.");
-                writer.WriteLine("    <providerName>:<keywords>:<level>                 - Enable events matching the specified keywords, at the specified level for the specified provider.");
-                writer.WriteLine("    <providerName>:<keywords>:<level>:<parameters>    - Enable events matching the specified keywords, at the specified level for the specified provider and provide key-value parameters.");
-                writer.WriteLine();
-                writer.WriteLine("  '<provider>' must be the name of the EventSource.");
-                writer.WriteLine("  '<level>' can be one of: Critical (1), Error (2), Warning (3), Informational (4), Verbose (5). Either the name or number can be specified.");
-                writer.WriteLine("  '<keywords>' is one of the following:");
-                writer.WriteLine("    A '*' character, indicating ALL keywords should be enabled (this can be very costly for some providers!)");
-                writer.WriteLine("    A comma-separated list of known keywords for a provider (use 'dotnet collect --keywords-for [providerName]' to get a list of known keywords for a provider)");
-                writer.WriteLine("    A 64-bit hexadecimal number, starting with '0x' indicating the keywords to enable");
-                writer.WriteLine("  '<parameters>' is an optional list of key-value parameters to provide to the EventPipe provider. The expected values depend on the provider you are enabling.");
-                writer.WriteLine("    This should be a list of key-value pairs, in the form: '<key1>=<value1>;<key2>=<value2>;...'. Note that some shells, such as PowerShell, require that you");
-                writer.WriteLine("    quote or escape the ';' character.");
-                return writer.GetStringBuilder().ToString();
-            }
+            var parser = new CommandLineBuilder()
+                .AddCommand(MonitorCommand())
+                .AddCommand(ListCommand())
+                .UseDefaults()
+                .Build();
+            return parser.InvokeAsync(args);
         }
     }
 }

--- a/src/Tools/dotnet-counters/Program.cs
+++ b/src/Tools/dotnet-counters/Program.cs
@@ -1,15 +1,12 @@
 using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices;
-using System.Threading.Tasks;
 using System.CommandLine;
-using Microsoft.Internal.Utilities;
 using System.CommandLine.Builder;
 using System.CommandLine.Invocation;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
 
 namespace Microsoft.Diagnostics.Tools.Counters
 {
@@ -21,7 +18,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 "Start monitoring a .NET application", 
                 new Option[] { ProcessIdOption(), RefreshIntervalOption() },
                 argument: CounterList(),
-                handler: CommandHandler.Create<string, IConsole, int, int>(new CounterMonitor().Monitor));
+                handler: CommandHandler.Create<CancellationToken, string, IConsole, int, int>(new CounterMonitor().Monitor));
 
         private static Option ProcessIdOption() =>
             new Option(
@@ -51,7 +48,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 new Option[] { },
                 handler: CommandHandler.Create<IConsole>(List));
 
-        public static async Task<int> List(IConsole console)
+        public static int List(IConsole console)
         {
             var profiles = KnownData.GetAllProviders();
             var maxNameLength = profiles.Max(p => p.Name.Length);
@@ -73,7 +70,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
             var parser = new CommandLineBuilder()
                 .AddCommand(MonitorCommand())
                 .AddCommand(ListCommand())
-                .UseDefaults()
+                .CancelOnProcessTermination()
                 .Build();
             return parser.InvokeAsync(args);
         }

--- a/src/Tools/dotnet-counters/Program.cs
+++ b/src/Tools/dotnet-counters/Program.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.CommandLine;
 using System.CommandLine.Builder;

--- a/src/Tools/dotnet-counters/StringParser.cs
+++ b/src/Tools/dotnet-counters/StringParser.cs
@@ -1,0 +1,334 @@
+// Borrowed from https://github.com/dotnet/corefx/blob/b2f960abe1d8690be9d68dd9b56ea7636fb4a38b/src/Common/src/System/IO/StringParser.cs
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+
+namespace System.IO
+{
+    /// <summary>
+    /// Provides a string parser that may be used instead of String.Split 
+    /// to avoid unnecessary string and array allocations.
+    /// </summary>
+    internal struct StringParser
+    {
+        /// <summary>The string being parsed.</summary>
+        private readonly string _buffer;
+
+        /// <summary>The separator character used to separate subcomponents of the larger string.</summary>
+        private readonly char _separator;
+
+        /// <summary>true if empty subcomponents should be skipped; false to treat them as valid entries.</summary>
+        private readonly bool _skipEmpty;
+
+        /// <summary>The starting index from which to parse the current entry.</summary>
+        private int _startIndex;
+
+        /// <summary>The ending index that represents the next index after the last character that's part of the current entry.</summary>
+        private int _endIndex;
+
+        /// <summary>Initialize the StringParser.</summary>
+        /// <param name="buffer">The string to parse.</param>
+        /// <param name="separator">The separator character used to separate subcomponents of <paramref name="buffer"/>.</param>
+        /// <param name="skipEmpty">true if empty subcomponents should be skipped; false to treat them as valid entries.  Defaults to false.</param>
+        public StringParser(string buffer, char separator, bool skipEmpty = false)
+        {
+            if (buffer == null)
+            {
+                throw new ArgumentNullException(nameof(buffer));
+            }
+            _buffer = buffer;
+            _separator = separator;
+            _skipEmpty = skipEmpty;
+            _startIndex = -1;
+            _endIndex = -1;
+        }
+
+        /// <summary>Moves to the next component of the string.</summary>
+        /// <returns>true if there is a next component to be parsed; otherwise, false.</returns>
+        public bool MoveNext()
+        {
+            if (_buffer == null)
+            {
+                throw new InvalidOperationException();
+            }
+
+            while (true)
+            {
+                if (_endIndex >= _buffer.Length)
+                {
+                    _startIndex = _endIndex;
+                    return false;
+                }
+
+                int nextSeparator = _buffer.IndexOf(_separator, _endIndex + 1);
+                _startIndex = _endIndex + 1;
+                _endIndex = nextSeparator >= 0 ? nextSeparator : _buffer.Length;
+
+                if (!_skipEmpty || _endIndex >= _startIndex + 1)
+                {
+                    return true;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Moves to the next component of the string.  If there isn't one, it throws an exception.
+        /// </summary>
+        public void MoveNextOrFail()
+        {
+            if (!MoveNext())
+            {
+                ThrowForInvalidData();
+            }
+        }
+
+        /// <summary>
+        /// Moves to the next component of the string and returns it as a string.
+        /// </summary>
+        /// <returns></returns>
+        public string MoveAndExtractNext()
+        {
+            MoveNextOrFail();
+            return _buffer.Substring(_startIndex, _endIndex - _startIndex);
+        }
+
+        /// <summary>
+        /// Moves to the next component of the string, which must be enclosed in the only set of top-level parentheses
+        /// in the string.  The extracted value will be everything between (not including) those parentheses.
+        /// </summary>
+        /// <returns></returns>
+        public string MoveAndExtractNextInOuterParens()
+        {
+            // Move to the next position
+            MoveNextOrFail();
+
+            // After doing so, we should be sitting at a the opening paren.
+            if (_buffer[_startIndex] != '(')
+            {
+                ThrowForInvalidData();
+            }
+
+            // Since we only allow for one top-level set of parentheses, find the last
+            // parenthesis in the string; it's paired with the opening one we just found.
+            int lastParen = _buffer.LastIndexOf(')');
+            if (lastParen == -1 || lastParen < _startIndex)
+            {
+                ThrowForInvalidData();
+            }
+
+            // Extract the contents of the parens, then move our ending position to be after the paren
+            string result = _buffer.Substring(_startIndex + 1, lastParen - _startIndex - 1);
+            _endIndex = lastParen + 1;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Gets the current subcomponent of the string as a string.
+        /// </summary>
+        public string ExtractCurrent()
+        {
+            if (_buffer == null || _startIndex == -1)
+            {
+                throw new InvalidOperationException();
+            }
+            return _buffer.Substring(_startIndex, _endIndex - _startIndex);
+        }
+
+        /// <summary>Moves to the next component and parses it as an Int32.</summary>
+        public unsafe int ParseNextInt32()
+        {
+            MoveNextOrFail();
+
+            bool negative = false;
+            int result = 0;
+
+            fixed (char* bufferPtr = _buffer)
+            {
+                char* p = bufferPtr + _startIndex;
+                char* end = bufferPtr + _endIndex;
+
+                if (p == end)
+                {
+                    ThrowForInvalidData();
+                }
+
+                if (*p == '-')
+                {
+                    negative = true;
+                    p++;
+                    if (p == end)
+                    {
+                        ThrowForInvalidData();
+                    }
+                }
+
+                while (p != end)
+                {
+                    int d = *p - '0';
+                    if (d < 0 || d > 9)
+                    {
+                        ThrowForInvalidData();
+                    }
+                    result = negative ? checked((result * 10) - d) : checked((result * 10) + d);
+
+                    p++;
+                }
+            }
+
+            Debug.Assert(result == int.Parse(ExtractCurrent()), "Expected manually parsed result to match Parse result");
+            return result;
+        }
+
+        /// <summary>Moves to the next component and parses it as an Int64.</summary>
+        public unsafe long ParseNextInt64()
+        {
+            MoveNextOrFail();
+
+            bool negative = false;
+            long result = 0;
+
+            fixed (char* bufferPtr = _buffer)
+            {
+                char* p = bufferPtr + _startIndex;
+                char* end = bufferPtr + _endIndex;
+
+                if (p == end)
+                {
+                    ThrowForInvalidData();
+                }
+
+                if (*p == '-')
+                {
+                    negative = true;
+                    p++;
+                    if (p == end)
+                    {
+                        ThrowForInvalidData();
+                    }
+                }
+
+                while (p != end)
+                {
+                    int d = *p - '0';
+                    if (d < 0 || d > 9)
+                    {
+                        ThrowForInvalidData();
+                    }
+                    result = negative ? checked((result * 10) - d) : checked((result * 10) + d);
+
+                    p++;
+                }
+            }
+
+            Debug.Assert(result == long.Parse(ExtractCurrent()), "Expected manually parsed result to match Parse result");
+            return result;
+        }
+
+        /// <summary>Moves to the next component and parses it as a UInt32.</summary>
+        public unsafe uint ParseNextUInt32()
+        {
+            MoveNextOrFail();
+            if (_startIndex == _endIndex)
+            {
+                ThrowForInvalidData();
+            }
+
+            uint result = 0;
+            fixed (char* bufferPtr = _buffer)
+            {
+                char* p = bufferPtr + _startIndex;
+                char* end = bufferPtr + _endIndex;
+                while (p != end)
+                {
+                    int d = *p - '0';
+                    if (d < 0 || d > 9)
+                    {
+                        ThrowForInvalidData();
+                    }
+                    result = (uint)checked((result * 10) + d);
+
+                    p++;
+                }
+            }
+
+            Debug.Assert(result == uint.Parse(ExtractCurrent()), "Expected manually parsed result to match Parse result");
+            return result;
+        }
+
+        /// <summary>Moves to the next component and parses it as a UInt64.</summary>
+        public unsafe ulong ParseNextUInt64()
+        {
+            MoveNextOrFail();
+
+            ulong result = 0;
+            fixed (char* bufferPtr = _buffer)
+            {
+                char* p = bufferPtr + _startIndex;
+                char* end = bufferPtr + _endIndex;
+                while (p != end)
+                {
+                    int d = *p - '0';
+                    if (d < 0 || d > 9)
+                    {
+                        ThrowForInvalidData();
+                    }
+                    result = checked((result * 10ul) + (ulong)d);
+
+                    p++;
+                }
+            }
+
+            Debug.Assert(result == ulong.Parse(ExtractCurrent()), "Expected manually parsed result to match Parse result");
+            return result;
+        }
+
+        /// <summary>Moves to the next component and parses it as a Char.</summary>
+        public char ParseNextChar()
+        {
+            MoveNextOrFail();
+
+            if (_endIndex - _startIndex != 1)
+            {
+                ThrowForInvalidData();
+            }
+            char result = _buffer[_startIndex];
+
+            Debug.Assert(result == char.Parse(ExtractCurrent()), "Expected manually parsed result to match Parse result");
+            return result;
+        }
+
+        internal delegate T ParseRawFunc<T>(string buffer, ref int startIndex, ref int endIndex);
+
+        /// <summary>
+        /// Moves to the next component and hands the raw buffer and indexing data to a selector function
+        /// that can validate and return the appropriate data from the component.
+        /// </summary>
+        internal T ParseRaw<T>(ParseRawFunc<T> selector)
+        {
+            MoveNextOrFail();
+            return selector(_buffer, ref _startIndex, ref _endIndex);
+        }
+
+        /// <summary>
+        /// Gets the current subcomponent and all remaining components of the string as a string.
+        /// </summary>
+        public string ExtractCurrentToEnd()
+        {
+            if (_buffer == null || _startIndex == -1)
+            {
+                throw new InvalidOperationException();
+            }
+            return _buffer.Substring(_startIndex);
+        }
+
+        /// <summary>Throws unconditionally for invalid data.</summary>
+        private static void ThrowForInvalidData()
+        {
+            throw new InvalidDataException();
+        }
+    }
+}

--- a/src/Tools/dotnet-counters/dotnet-counters.csproj
+++ b/src/Tools/dotnet-counters/dotnet-counters.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+
+    <!-- Target .NET Core 2.1 so it will run on LTS -->
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+
+    <RootNamespace>Microsoft.Diagnostics.Tools.Counters</RootNamespace>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+
+    <IsPackable>true</IsPackable>
+    <PackAsTool>true</PackAsTool>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Common\CommandLineException.cs" Link="CommandLineException.cs" />
+    <Compile Include="..\Common\ConsoleCancellation.cs" Link="ConsoleCancellation.cs" />
+    <Compile Include="..\Common\DebugUtil.cs" Link="DebugUtil.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.2.5" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.30" />
+  </ItemGroup>
+
+</Project>

--- a/src/Tools/dotnet-counters/dotnet-counters.csproj
+++ b/src/Tools/dotnet-counters/dotnet-counters.csproj
@@ -22,8 +22,10 @@
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.2.5" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.30" />
-    <PackageReference Include="System.CommandLine.Experimental" Version="0.2.0-alpha.19156.3" />
+  </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\Microsoft.Diagnostic.Repl\Microsoft.Diagnostic.Repl.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Tools/dotnet-counters/dotnet-counters.csproj
+++ b/src/Tools/dotnet-counters/dotnet-counters.csproj
@@ -22,6 +22,8 @@
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.2.5" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.30" />
+    <PackageReference Include="System.CommandLine.Experimental" Version="0.2.0-alpha.19156.3" />
+
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Adding dotnet-counters CLI tool. As of this PR, this implements
- CLI commands as documented here: https://github.com/dotnet/diagnostics/blob/master/documentation/design-docs/dotnet-tools.md
- Collecting a .netperf file that contains counters events

Once runtime can stream events through IPC, part of this needs to be rewritten to start monitoring. Also, the UI part that displays the counters need to be written as this isn't something that's supported now. 

Filed https://github.com/dotnet/diagnostics/issues/138 to track what needs to be done in the future.