### PR TITLE
Make dotnet-counters use UseDefaults() with System.CommandLine

### DIFF
--- a/src/Tools/dotnet-counters/Program.cs
+++ b/src/Tools/dotnet-counters/Program.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
             var parser = new CommandLineBuilder()
                 .AddCommand(MonitorCommand())
                 .AddCommand(ListCommand())
-                .CancelOnProcessTermination()
+                .UseDefaults()
                 .Build();
             return parser.InvokeAsync(args);
         }


### PR DESCRIPTION
dotnet-counters was not using `UseDefaults()` that's provided by System.CommandLine. This allows the tool for misc. CLI things like spitting out help messages or erroring out when not all parameters are provided, etc. Mike suggested I change this, so here it is. 