### PR TITLE
Remove call to Bind() from EventPipeClient

### DIFF
--- a/src/Microsoft.Diagnostics.Tools.RuntimeClient/Eventing/EventPipeClient.cs
+++ b/src/Microsoft.Diagnostics.Tools.RuntimeClient/Eventing/EventPipeClient.cs
@@ -46,12 +46,10 @@ namespace Microsoft.Diagnostics.Tools.RuntimeClient
                     .Select(namedPipe => (new FileInfo(namedPipe)).Name)
                     .Single(input => Regex.IsMatch(input, $"^dotnetcore-diagnostic-{processId}-(\\d+)-socket$"));
                 var path = Path.Combine(Path.GetTempPath(), ipcPort);
-                Console.WriteLine($"Trying to connect to : {path}");
                 var remoteEP = new UnixDomainSocketEndPoint(path);
 
                 using (var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified))
                 {
-                    //socket.Bind(remoteEP);
                     socket.Connect(remoteEP);
                     socket.Send(buffer);
 

--- a/src/Microsoft.Diagnostics.Tools.RuntimeClient/Eventing/EventPipeClient.cs
+++ b/src/Microsoft.Diagnostics.Tools.RuntimeClient/Eventing/EventPipeClient.cs
@@ -46,11 +46,12 @@ namespace Microsoft.Diagnostics.Tools.RuntimeClient
                     .Select(namedPipe => (new FileInfo(namedPipe)).Name)
                     .Single(input => Regex.IsMatch(input, $"^dotnetcore-diagnostic-{processId}-(\\d+)-socket$"));
                 var path = Path.Combine(Path.GetTempPath(), ipcPort);
+                Console.WriteLine($"Trying to connect to : {path}");
                 var remoteEP = new UnixDomainSocketEndPoint(path);
 
                 using (var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified))
                 {
-                    socket.Bind(remoteEP);
+                    //socket.Bind(remoteEP);
                     socket.Connect(remoteEP);
                     socket.Send(buffer);
 


### PR DESCRIPTION
We shouldn't be calling `Bind()`, otherwise we get an exception for address already in use. 