### PR TITLE
Change ResetCurrentConsoleLine() to use explicit ANSI escape codes 

### DIFF
--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                                 fs.Write(buffer, 0, nBytesRead);
 
                                 ResetCurrentConsoleLine();
-                                Console.Out.Write($"  Recording trace {GetSize(fs.Length)}");
+                                Console.Out.Write($"\tRecording trace {GetSize(fs.Length)}");
 
                                 Debug.WriteLine($"PACKET: {Convert.ToBase64String(buffer, 0, nBytesRead)} (bytes {nBytesRead})");
                             }
@@ -99,10 +99,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
 
         private static void ResetCurrentConsoleLine()
         {
-            int currentCursorTop = Console.CursorTop;
-            Console.SetCursorPosition(0, Console.CursorTop);
-            Console.Out.Write(new string(' ', Console.WindowWidth));
-            Console.SetCursorPosition(0, currentCursorTop);
+            Console.Out.Write("\u001b[2K\u001b[1000D");
         }
 
         private static string GetSize(long length)

--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
@@ -99,15 +99,23 @@ namespace Microsoft.Diagnostics.Tools.Trace
             }
         }
 
+        private static int prevBufferWidth = 0;
+        private static string clearLineString = "";
         private static void ResetCurrentConsoleLine(bool isVTerm)
         {
             if (isVTerm)
             {
-                Console.Out.Write("\u001b[2K\u001b[1000D");
+                Console.Out.Write("\u001b[2K\u001b[1G");
             }
             else
             {
-                Console.Out.Write("\r" + new string(' ', Console.BufferWidth - 1) + "\r");
+                if (prevBufferWidth != Console.BufferWidth)
+                {
+                    clearLineString = new string(' ', Console.BufferWidth - 1);
+                }
+                Console.SetCursorPosition(0,Console.BufferHeight);
+                Console.Out.Write(clearLineString);
+                Console.SetCursorPosition(0,Console.BufferHeight);
             }
         }
 

--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
@@ -54,6 +54,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                         {
                             Console.Out.WriteLine($"Recording tracing session to: {fs.Name}");
                             Console.Out.WriteLine($"\tSession Id: 0x{sessionId:X16}");
+                            lineToClear = Console.CursorTop;
 
                             while (true)
                             {
@@ -101,21 +102,26 @@ namespace Microsoft.Diagnostics.Tools.Trace
 
         private static int prevBufferWidth = 0;
         private static string clearLineString = "";
+        private static int lineToClear = 0;
         private static void ResetCurrentConsoleLine(bool isVTerm)
         {
             if (isVTerm)
             {
-                Console.Out.Write("\u001b[2K\u001b[1G");
+                // ANSI escape codes:
+                //  [2K => clear current line
+                //  [{lineToClear};0H => move cursor to column 0 of row `lineToClear`
+                Console.Out.Write($"\u001b[2K\u001b[{lineToClear};0H");
             }
             else
             {
                 if (prevBufferWidth != Console.BufferWidth)
                 {
+                    prevBufferWidth = Console.BufferWidth;
                     clearLineString = new string(' ', Console.BufferWidth - 1);
                 }
-                Console.SetCursorPosition(0,Console.BufferHeight);
+                Console.SetCursorPosition(0,lineToClear);
                 Console.Out.Write(clearLineString);
-                Console.SetCursorPosition(0,Console.BufferHeight);
+                Console.SetCursorPosition(0,lineToClear);
             }
         }
 

--- a/src/Tools/dotnet-trace/dotnet-trace.csproj
+++ b/src/Tools/dotnet-trace/dotnet-trace.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.CommandLine.Experimental" Version="0.2.0-alpha.19179.1" />
+    <PackageReference Include="System.CommandLine.Rendering" Version="0.2.0-alpha.19179.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Use the `\u001b[` family of ANSI escape codes to reset the console line.  Should work crossplat.