### PR TITLE
Updating gc/gc-collect options to map PerfView flags.

### DIFF
--- a/src/Tools/dotnet-trace/CommandLine/Commands/ProfilesCommandHandler.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/ProfilesCommandHandler.cs
@@ -52,14 +52,28 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 "gc",
                 new Provider[] {
                     new Provider("Microsoft-DotNETCore-SampleProfiler"),
-                    new Provider("Microsoft-Windows-DotNETRuntime", (ulong)ClrTraceEventParser.Keywords.GC, EventLevel.Verbose),
+                    new Provider(
+                        name: "Microsoft-Windows-DotNETRuntime",
+                        keywords: (ulong)ClrTraceEventParser.Keywords.GC |
+                                  (ulong)ClrTraceEventParser.Keywords.GCHeapSurvivalAndMovement |
+                                  (ulong)ClrTraceEventParser.Keywords.Stack |
+                                  (ulong)ClrTraceEventParser.Keywords.Jit |
+                                  (ulong)ClrTraceEventParser.Keywords.StopEnumeration |
+                                  (ulong)ClrTraceEventParser.Keywords.SupressNGen |
+                                  (ulong)ClrTraceEventParser.Keywords.Loader |
+                                  (ulong)ClrTraceEventParser.Keywords.Exception,
+                        eventLevel: EventLevel.Verbose),
                 },
                 "Tracks allocation and collection performance."),
             new Profile(
                 "gc-collect",
                 new Provider[] {
                     new Provider("Microsoft-DotNETCore-SampleProfiler"),
-                    new Provider("Microsoft-Windows-DotNETRuntime", (ulong)ClrTraceEventParser.Keywords.GC, EventLevel.Informational),
+                    new Provider(
+                        name: "Microsoft-Windows-DotNETRuntime",
+                        keywords:   (ulong)ClrTraceEventParser.Keywords.GC |
+                                    (ulong)ClrTraceEventParser.Keywords.Exception,
+                        eventLevel: EventLevel.Informational),
                 },
                 "Tracks GC collection only at very low overhead."),
 


### PR DESCRIPTION
This is the new mapping:
`--profile gc` -> [GCOnly](https://github.com/Microsoft/perfview/blob/28a1477d4d0b0316294b2942f90a787449e08a79/src/PerfView/CommandLineArgs.cs#L441)
`--profile gc-collect` -> [GCCollectOnly](https://github.com/Microsoft/perfview/blob/28a1477d4d0b0316294b2942f90a787449e08a79/src/PerfView/CommandLineArgs.cs#L461)