### PR TITLE
Temporarily disable gc profiles.

### DIFF
--- a/src/Tools/dotnet-trace/CommandLine/Commands/ProfilesCommandHandler.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/ProfilesCommandHandler.cs
@@ -48,6 +48,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                     new Provider("Microsoft-Windows-DotNETRuntime", (ulong)ClrTraceEventParser.Keywords.Default, EventLevel.Informational),
                 },
                 "Useful for tracking CPU usage and general runtime information. This the default option if no profile is specified."),
+#if DEBUG // Coming soon: Preview6
             new Profile(
                 "gc",
                 new Provider[] {
@@ -76,7 +77,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                         eventLevel: EventLevel.Informational),
                 },
                 "Tracks GC collection only at very low overhead."),
-
+#endif // DEBUG
             new Profile(
                 "none",
                 null,


### PR DESCRIPTION
Not ready on Non-Windows platform for **.NET 3.0 Preview5**. This is related to this bug fix: https://github.com/dotnet/coreclr/pull/24198, which will be included in **Preview6**.
The issue manifests when EventPipe is enabled without LTTng. In this case, GC events are disabled after the first GC because LTTng probes are disabled.