### PR TITLE
Bringing dotnet counters up to spec [part 1]

### DIFF
--- a/src/Tools/dotnet-counters/CounterFilter.cs
+++ b/src/Tools/dotnet-counters/CounterFilter.cs
@@ -8,23 +8,23 @@ using System.Collections.Generic;
 
 namespace Microsoft.Diagnostics.Tools.Counters
 {
-	public class CounterFilter
-	{
-		private Dictionary<string, List<string>> enabledCounters;
+    public class CounterFilter
+    {
+        private Dictionary<string, List<string>> enabledCounters;
 
-		public CounterFilter()
-		{
-			enabledCounters = new Dictionary<string, List<string>>();
-		}
+        public CounterFilter()
+        {
+            enabledCounters = new Dictionary<string, List<string>>();
+        }
 
-		public void AddFilter(string providerName, string[] counters)
-		{
-			enabledCounters[providerName] = new List<string>(counters);
-		}
+        public void AddFilter(string providerName, string[] counters)
+        {
+            enabledCounters[providerName] = new List<string>(counters);
+        }
 
-		public bool Filter(string providerName, string counterName)
-		{
-			return enabledCounters.ContainsKey(providerName) && enabledCounters[providerName].Contains(counterName);
-		}
-	}
+        public bool Filter(string providerName, string counterName)
+        {
+            return enabledCounters.ContainsKey(providerName) && enabledCounters[providerName].Contains(counterName);
+        }
+    }
 }

--- a/src/Tools/dotnet-counters/CounterFilter.cs
+++ b/src/Tools/dotnet-counters/CounterFilter.cs
@@ -10,11 +10,19 @@ namespace Microsoft.Diagnostics.Tools.Counters
 {
     public class CounterFilter
     {
+        private List<string> enabledProviders;
         private Dictionary<string, List<string>> enabledCounters;
 
         public CounterFilter()
         {
+            enabledProviders = new List<string>();
             enabledCounters = new Dictionary<string, List<string>>();
+        }
+
+        // Called when we want to enable all counters under a provider name.
+        public void AddFilter(string providerName)
+        {
+            enabledProviders.Add(providerName);
         }
 
         public void AddFilter(string providerName, string[] counters)
@@ -24,7 +32,8 @@ namespace Microsoft.Diagnostics.Tools.Counters
 
         public bool Filter(string providerName, string counterName)
         {
-            return enabledCounters.ContainsKey(providerName) && enabledCounters[providerName].Contains(counterName);
+            return enabledProviders.Contains(providerName) || 
+                (enabledCounters.ContainsKey(providerName) && enabledCounters[providerName].Contains(counterName));
         }
     }
 }

--- a/src/Tools/dotnet-counters/CounterFilter.cs
+++ b/src/Tools/dotnet-counters/CounterFilter.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+
+namespace Microsoft.Diagnostics.Tools.Counters
+{
+	public class CounterFilter
+	{
+		private Dictionary<string, List<string>> enabledCounters;
+
+		public CounterFilter()
+		{
+			enabledCounters = new Dictionary<string, List<string>>();
+		}
+
+		public void AddFilter(string providerName, string[] counters)
+		{
+			enabledCounters[providerName] = new List<string>(counters);
+		}
+
+		public bool Filter(string providerName, string counterName)
+		{
+			return enabledCounters.ContainsKey(providerName) && enabledCounters[providerName].Contains(counterName);
+		}
+	}
+}

--- a/src/Tools/dotnet-counters/CounterMonitor.cs
+++ b/src/Tools/dotnet-counters/CounterMonitor.cs
@@ -125,11 +125,17 @@ namespace Microsoft.Diagnostics.Tools.Counters
                         sb.Append(",");
                     }
 
-
-                    string counterNames = tokens[1];
-                    string[] enabledCounters = counterNames.Substring(0, counterNames.Length-1).Split(',');
-                    
-                    filter.AddFilter(providerName, enabledCounters);
+                    if (tokens.Length == 1)
+                    {
+                        filter.AddFilter(providerName); // This means no counter filter was specified.
+                    }
+                    else
+                    {
+                        string counterNames = tokens[1];
+                        string[] enabledCounters = counterNames.Substring(0, counterNames.Length-1).Split(',');
+                        
+                        filter.AddFilter(providerName, enabledCounters);
+                    }
                 }
                 providerString = sb.ToString();
             }
@@ -148,7 +154,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
             });
 
             monitorTask.Start();
-
+            
             await monitorTask;
             
             try

--- a/src/Tools/dotnet-counters/CounterMonitor.cs
+++ b/src/Tools/dotnet-counters/CounterMonitor.cs
@@ -39,21 +39,22 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 // There really isn't a great way to tell whether an EventCounter payload is an instance of 
                 // IncrementingCounterPayload or CounterPayload, so here we check the number of fields 
                 // to distinguish the two.                
-                ICounterPayload payload = payloadFields["CounterType"] == "Sum" ? (ICounterPayload)new IncrementingCounterPayload(payloadFields) : (ICounterPayload)new CounterPayload(payloadFields);
+                ICounterPayload payload = payloadFields["CounterType"].Equals("Sum") ? (ICounterPayload)new IncrementingCounterPayload(payloadFields) : (ICounterPayload)new CounterPayload(payloadFields);
                 
                 writer.Update(obj.ProviderName, payload);
             }
         }
 
-        public async Task<int> Monitor(CancellationToken ct, string counter_list, IConsole console, int processId, int interval)
+        public async Task<int> Monitor(CancellationToken ct, string counter_list, IConsole console, int processId, int refreshInterval)
         {
             try
             {
+                Console.WriteLine($"interval: {refreshInterval}");
                 _ct = ct;
                 _counterList = counter_list; // NOTE: This variable name has an underscore because that's the "name" that the CLI displays. System.CommandLine doesn't like it if we change the variable to camelcase. 
                 _console = console;
                 _processId = processId;
-                _interval = interval;
+                _interval = refreshInterval;
 
                 return await StartMonitor();
             }
@@ -79,7 +80,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
             }
 
             if (_interval == 0) {
-                _console.Error.WriteLine("interval is required.");
+                _console.Error.WriteLine("refreshInterval is required.");
                 return 1;
             }
 
@@ -135,7 +136,6 @@ namespace Microsoft.Diagnostics.Tools.Counters
             await monitorTask;
             EventPipeClient.StopTracing(_processId, _sessionId);
 
-            Task.FromResult(0);
             return 0;
         }
     }

--- a/src/Tools/dotnet-counters/CounterMonitor.cs
+++ b/src/Tools/dotnet-counters/CounterMonitor.cs
@@ -101,6 +101,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
                     return 1;
                 }
                 providerString = defaultProvider.ToProviderString(_interval);
+                filter.AddFilter("System.Runtime");
             }
             else
             {

--- a/src/Tools/dotnet-counters/CounterProvider.cs
+++ b/src/Tools/dotnet-counters/CounterProvider.cs
@@ -45,6 +45,9 @@ namespace Microsoft.Diagnostics.Tools.Counters
         {
             return $"{unknownCounterProviderName}:0xffffffff:0x4:EventCounterIntervalSec={interval}";
         }
+
+        public IReadOnlyList<CounterProfile> GetAllCounters() => Counters.Values.ToList();
+
     }
 
     public class CounterProfile

--- a/src/Tools/dotnet-counters/CounterProvider.cs
+++ b/src/Tools/dotnet-counters/CounterProvider.cs
@@ -40,6 +40,11 @@ namespace Microsoft.Diagnostics.Tools.Counters
         {
             return $"{Name}:{Keywords}:{Level}:EventCounterIntervalSec={interval}";
         }
+
+        public static string SerializeUnknownProviderName(string unknownCounterProviderName, int interval)
+        {
+            return $"{unknownCounterProviderName}:0xffffffff:0x4:EventCounterIntervalSec={interval}";
+        }
     }
 
     public class CounterProfile

--- a/src/Tools/dotnet-counters/KnownData.cs
+++ b/src/Tools/dotnet-counters/KnownData.cs
@@ -27,10 +27,10 @@ namespace Microsoft.Diagnostics.Tools.Counters
                     new CounterProfile{ Name="cpu-usage", Description="Amount of time the process has utilized the CPU (ms)", DisplayName="CPU Usage (%)" },
                     new CounterProfile{ Name="working-set", Description="Amount of working set used by the process (MB)", DisplayName="Working Set (MB)" },
                     new CounterProfile{ Name="gc-heap-size", Description="Total heap size reported by the GC (MB)", DisplayName="GC Heap Size (MB)" },
-                    new CounterProfile{ Name="gen-0-gc-count", Description="Number of Gen 0 GCs", DisplayName="Gen 0 GC / sec" },
-                    new CounterProfile{ Name="gen-1-gc-count", Description="Number of Gen 1 GCs", DisplayName="Gen 1 GC / sec" },
-                    new CounterProfile{ Name="gen-2-gc-count", Description="Number of Gen 2 GCs", DisplayName="Gen 2 GC / sec" },
-                    new CounterProfile{ Name="exception-count", Description="Number of Exceptions / Sec", DisplayName="Exceptions / sec" },
+                    new CounterProfile{ Name="gen-0-gc-count", Description="Number of Gen 0 GCs / sec", DisplayName="Gen 0 GC / sec" },
+                    new CounterProfile{ Name="gen-1-gc-count", Description="Number of Gen 1 GCs / sec", DisplayName="Gen 1 GC / sec" },
+                    new CounterProfile{ Name="gen-2-gc-count", Description="Number of Gen 2 GCs / sec", DisplayName="Gen 2 GC / sec" },
+                    new CounterProfile{ Name="exception-count", Description="Number of Exceptions / sec", DisplayName="Exceptions / sec" },
                 });
             // TODO: Add more providers (ex. ASP.NET ones)
         }

--- a/src/Tools/dotnet-counters/Program.cs
+++ b/src/Tools/dotnet-counters/Program.cs
@@ -32,9 +32,9 @@ namespace Microsoft.Diagnostics.Tools.Counters
 
         private static Option RefreshIntervalOption() =>
             new Option(
-                new[] { "-r", "--interval" }, 
+                new[] { "-r", "--refresh-interval" }, 
                 "The number of seconds to delay between updating the displayed counters.",
-                new Argument<int> { Name = "interval" });
+                new Argument<int> { Name = "refresh-interval" });
 
         private static Argument CounterList() =>
             new Argument<string> {

--- a/src/Tools/dotnet-counters/Program.cs
+++ b/src/Tools/dotnet-counters/Program.cs
@@ -10,6 +10,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Collections.Generic;
 
 
 namespace Microsoft.Diagnostics.Tools.Counters
@@ -22,7 +23,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 "Start monitoring a .NET application", 
                 new Option[] { ProcessIdOption(), RefreshIntervalOption() },
                 argument: CounterList(),
-                handler: CommandHandler.Create<CancellationToken, string, IConsole, int, int>(new CounterMonitor().Monitor));
+                handler: CommandHandler.Create<CancellationToken, List<string>, IConsole, int, int>(new CounterMonitor().Monitor));
 
         private static Option ProcessIdOption() =>
             new Option(
@@ -37,12 +38,13 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 new Argument<int> { Name = "refresh-interval" });
 
         private static Argument CounterList() =>
-            new Argument<string> {
+            new Argument<List<string>> {
                 Name = "counter_list",
                 Description = @"A space separated list of counters. Counters can be specified provider_name[:counter_name].
                 If the provider_name is used without a qualifying counter_name then all counters will be shown. To discover 
                 provider and counter names, use the list command.
                 .",
+                Arity = ArgumentArity.ZeroOrMore
             };
 
         private static Command ListCommand() =>

--- a/src/Tools/dotnet-counters/Program.cs
+++ b/src/Tools/dotnet-counters/Program.cs
@@ -58,13 +58,15 @@ namespace Microsoft.Diagnostics.Tools.Counters
         {
             var profiles = KnownData.GetAllProviders();
             var maxNameLength = profiles.Max(p => p.Name.Length);
+            Console.WriteLine(maxNameLength);
             Console.WriteLine("Showing well-known counters only. Specific processes may support additional counters.\n");
             foreach (var profile in profiles)
             {
-                Console.WriteLine($"* {profile.Name.PadRight(maxNameLength)}");
+                var counters = profile.GetAllCounters();
+                var maxCounterNameLength = counters.Max(c => c.Name.Length);
                 foreach (var counter in profile.Counters.Values)
                 {
-                    Console.WriteLine($"    {counter.Name} \t\t {counter.Description}");
+                    Console.WriteLine($"    {counter.Name.PadRight(maxCounterNameLength)} \t\t {counter.Description}");
                 }
                 Console.WriteLine("");
             }

--- a/src/Tools/dotnet-counters/Program.cs
+++ b/src/Tools/dotnet-counters/Program.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
 
         private static Option RefreshIntervalOption() =>
             new Option(
-                new[] { "-r", "--refresh-interval" }, 
+                new[] { "--refresh-interval" }, 
                 "The number of seconds to delay between updating the displayed counters.",
                 new Argument<int> { Name = "refresh-interval" });
 


### PR DESCRIPTION
This adds the following:

- Filtering counters via specifying them on the command line like: `System.Runtime[cpu-usage,exception-count]`
- Changing some hard-coded descriptions of Runtime event counters
- Fixing broken alignment on list command.

I also found out that for some reason, EventCounter payloads don't have the fields that they should have, namely the `Series` and `CounterType` fields. It's unclear why those fields are missing, but that would require runtime investigation/change, so for the time being I'm reverting back some of the tool change that was trying to read those fields .

After this there will be another PR that specifically handles the 'p', 'r', 'q' commands on the spec. 