### PR TITLE
Bringing dotnet-counters up to spec [part 2]

### DIFF
--- a/src/Tools/dotnet-counters/ConsoleWriter.cs
+++ b/src/Tools/dotnet-counters/ConsoleWriter.cs
@@ -33,8 +33,9 @@ namespace Microsoft.Diagnostics.Tools.Counters
             Console.Clear();
             origRow = Console.CursorTop;
             origCol = Console.CursorLeft;
+            Console.WriteLine("Press p to pause, r to resume, q to quit.");
 
-            maxRow = origRow;
+            maxRow = origRow+1;
             maxCol = origCol;
         }
 
@@ -47,7 +48,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
             {
                 (int left, int row) = displayPosition[name];
                 Console.SetCursorPosition(left, row);
-                Console.Write(new String(' ', 16));
+                Console.Write(new String(' ', 8));
 
                 Console.SetCursorPosition(left, row);
                 Console.Write(payload.GetValue());  


### PR DESCRIPTION
This adds a command handler to dotnet-counters that supports these commands as documented in the spec:
- `p` for pause
- `r` for resume
- `q` for quit

Please let me know if there is anything that doesn't match the spec as of this PR. 

I will be following up with a PR that modifies the documentation & creates a README for dotnet-counters. 
