### PR TITLE
Fix issue with dotnet-counters not being able to target user-defined EventSource

### DIFF
--- a/src/Tools/dotnet-counters/ConsoleWriter.cs
+++ b/src/Tools/dotnet-counters/ConsoleWriter.cs
@@ -83,8 +83,12 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 }
                 else
                 {
-                    // If it's from an provider, just append it at the end.
+                    // If it's from an unknown provider, just append it at the end.
                     string displayName = payload.GetDisplay();
+                    if (string.IsNullOrEmpty(displayName))
+                    {
+                        displayName = payload.GetName();
+                    }
                     int left = displayName.Length + 7; // displayName + " : "
                     int row = maxRow;
                     displayPosition[name] = (left, row);

--- a/src/Tools/dotnet-counters/CounterProvider.cs
+++ b/src/Tools/dotnet-counters/CounterProvider.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
 
         public static string SerializeUnknownProviderName(string unknownCounterProviderName, int interval)
         {
-            return $"{unknownCounterProviderName}:0xffffffff:0x4:EventCounterIntervalSec={interval}";
+            return $"{unknownCounterProviderName}:ffffffff:4:EventCounterIntervalSec={interval}";
         }
 
         public IReadOnlyList<CounterProfile> GetAllCounters() => Counters.Values.ToList();


### PR DESCRIPTION
Addresses #221. 

Also, if the user-defined counter didn't specify any `DisplayName` property, just display its `Name`.