### PR TITLE
Fix missing metadata in Linux core dumps.

### DIFF
--- a/src/SOS/SOS.Hosting/LLDBServicesWrapper.cs
+++ b/src/SOS/SOS.Hosting/LLDBServicesWrapper.cs
@@ -77,6 +77,17 @@ namespace SOS
             int localIndex,
             out IntPtr localVarName);
 
+        private delegate int GetMetadataLocatorDelegate(
+            [MarshalAs(UnmanagedType.LPWStr)] string imagePath,
+            uint imageTimestamp,
+            uint imageSize,
+            [MarshalAs(UnmanagedType.LPArray, SizeConst = 16)] byte[] mvid,
+            uint mdRva,
+            uint flags,
+            uint bufferSize,
+            IntPtr buffer,
+            IntPtr dataSize);
+
         #endregion
 
         /// <summary>
@@ -94,6 +105,7 @@ namespace SOS
             public ResolveSequencePointDelegate ResolveSequencePointDelegate;
             public GetLineByILOffsetDelegate GetLineByILOffsetDelegate;
             public GetLocalVariableNameDelegate GetLocalVariableNameDelegate;
+            public GetMetadataLocatorDelegate GetMetadataLocatorDelegate;
         }
 
         static SOSNetCoreCallbacks s_callbacks = new SOSNetCoreCallbacks {
@@ -105,7 +117,8 @@ namespace SOS
             DisposeDelegate  = SymbolReader.Dispose,
             ResolveSequencePointDelegate = SymbolReader.ResolveSequencePoint,
             GetLineByILOffsetDelegate = SymbolReader.GetLineByILOffset,
-            GetLocalVariableNameDelegate  = SymbolReader.GetLocalVariableName,
+            GetLocalVariableNameDelegate = SymbolReader.GetLocalVariableName,
+            GetMetadataLocatorDelegate = MetadataHelper.GetMetadataLocator
         };
 
         static readonly string s_coreclrModuleName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "coreclr" : "libcoreclr.so";

--- a/src/SOS/SOS.NETCore/MetadataHelper.cs
+++ b/src/SOS/SOS.NETCore/MetadataHelper.cs
@@ -1,0 +1,70 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.SymbolStore;
+using Microsoft.SymbolStore.KeyGenerators;
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+using System.Runtime.InteropServices;
+
+namespace SOS
+{
+    public class MetadataHelper
+    {
+        public static int GetMetadataLocator(
+            [MarshalAs(UnmanagedType.LPWStr)] string imagePath,
+            uint imageTimestamp,
+            uint imageSize, 
+            [MarshalAs(UnmanagedType.LPArray, SizeConst = 16)] byte[] mvid, 
+            uint mdRva,
+            uint flags,
+            uint bufferSize,
+            IntPtr pMetadata,
+            IntPtr pMetadataSize)
+        {
+            int hr = unchecked((int)0x80004005);
+            int dataSize = 0;
+
+            Debug.Assert(pMetadata != IntPtr.Zero);
+
+            Stream peStream = null;
+            if (imagePath != null && File.Exists(imagePath))
+            {
+                peStream = SymbolReader.TryOpenFile(imagePath);
+            }
+            else if (SymbolReader.IsSymbolStoreEnable())
+            {
+                SymbolStoreKey key = PEFileKeyGenerator.GetKey(imagePath, imageTimestamp, imageSize);
+                peStream = SymbolReader.GetSymbolStoreFile(key)?.Stream;
+            }
+            if (peStream != null)
+            {
+                using (var peReader = new PEReader(peStream, PEStreamOptions.Default))
+                {
+                    if (peReader.HasMetadata)
+                    {
+                        PEMemoryBlock metadataInfo = peReader.GetMetadata();
+                        unsafe
+                        {
+                            int size = Math.Min((int)bufferSize, metadataInfo.Length);
+                            Marshal.Copy(metadataInfo.GetContent().ToArray(), 0, pMetadata, size);
+                        }
+                        dataSize = metadataInfo.Length;
+                        hr = 0;
+                    }
+                }
+            }
+
+            if (pMetadataSize != IntPtr.Zero)
+            {
+                Marshal.WriteInt32(pMetadataSize, dataSize);
+            }
+            return hr;
+        }
+    }
+}

--- a/src/SOS/SOS.NETCore/MetadataHelper.cs
+++ b/src/SOS/SOS.NETCore/MetadataHelper.cs
@@ -37,7 +37,7 @@ namespace SOS
             {
                 peStream = SymbolReader.TryOpenFile(imagePath);
             }
-            else if (SymbolReader.IsSymbolStoreEnable())
+            else if (SymbolReader.IsSymbolStoreEnabled())
             {
                 SymbolStoreKey key = PEFileKeyGenerator.GetKey(imagePath, imageTimestamp, imageSize);
                 peStream = SymbolReader.GetSymbolStoreFile(key)?.Stream;

--- a/src/SOS/SOS.NETCore/SymbolReader.cs
+++ b/src/SOS/SOS.NETCore/SymbolReader.cs
@@ -244,7 +244,7 @@ namespace SOS
         /// <param name="readMemory">read memory callback delegate</param>
         public static void LoadNativeSymbols(SymbolFileCallback callback, IntPtr parameter, string tempDirectory, string moduleFilePath, ulong address, int size, ReadMemoryDelegate readMemory)
         {
-            if (IsSymbolStoreEnable())
+            if (IsSymbolStoreEnabled())
             {
                 Debug.Assert(s_tracer != null);
                 Stream stream = new TargetStream(address, size, readMemory);
@@ -874,7 +874,7 @@ namespace SOS
 
                 if (pdbStream == null)
                 {
-                    if (IsSymbolStoreEnable())
+                    if (IsSymbolStoreEnabled())
                     {
                         Debug.Assert(codeViewEntry.MinorVersion == ImageDebugDirectory.PortablePDBMinorVersion);
                         SymbolStoreKey key = PortablePDBFileKeyGenerator.GetKey(pdbPath, data.Guid);
@@ -940,7 +940,7 @@ namespace SOS
         /// <summary>
         /// Returns true if symbol download has been enabled.
         /// </summary>
-        internal static bool IsSymbolStoreEnable()
+        internal static bool IsSymbolStoreEnabled()
         {
             return s_symbolStore != null;
         }

--- a/src/SOS/Strike/datatarget.cpp
+++ b/src/SOS/Strike/datatarget.cpp
@@ -138,6 +138,10 @@ DataTarget::ReadVirtual(
 #ifdef FEATURE_PAL
     if (g_sos != nullptr)
     {
+        // LLDB synthesizes memory (returns 0's) for missing pages (in this case the missing metadata 
+        // pages) in core dumps. This functions creates a list of the metadata regions and returns true
+        // if the read would be in the metadata of a loaded assembly. This allows an error to be returned 
+        // instead of 0's so the DAC will call the GetMetadataLocator datatarget callback.
         if (IsMetadataMemory(address, request))
         {
             return E_ACCESSDENIED;

--- a/src/SOS/Strike/datatarget.cpp
+++ b/src/SOS/Strike/datatarget.cpp
@@ -37,6 +37,12 @@ DataTarget::QueryInterface(
         AddRef();
         return S_OK;
     }
+    else if (InterfaceId == IID_ICLRMetadataLocator)
+    {
+        *Interface = (ICLRMetadataLocator*)this;
+        AddRef();
+        return S_OK;
+    }
     else
     {
         *Interface = NULL;
@@ -129,6 +135,15 @@ DataTarget::ReadVirtual(
     {
         return E_UNEXPECTED;
     }
+#ifdef FEATURE_PAL
+    if (g_sos != nullptr)
+    {
+        if (IsMetadataMemory(address, request))
+        {
+            return E_ACCESSDENIED;
+        }
+    }
+#endif
     return g_ExtData->ReadVirtual(address, (PVOID)buffer, request, (PULONG)done);
 }
 
@@ -250,6 +265,8 @@ DataTarget::Request(
     return E_NOTIMPL;
 }
 
+// ICorDebugDataTarget4
+
 HRESULT STDMETHODCALLTYPE 
 DataTarget::VirtualUnwind(
     /* [in] */ DWORD threadId,
@@ -266,3 +283,30 @@ DataTarget::VirtualUnwind(
     return E_NOTIMPL;
 #endif
 }
+
+// ICLRMetadataLocator
+
+HRESULT STDMETHODCALLTYPE
+DataTarget::GetMetadata(
+    /* [in] */ LPCWSTR imagePath,
+    /* [in] */ ULONG32 imageTimestamp,
+    /* [in] */ ULONG32 imageSize,
+    /* [in] */ GUID* mvid,
+    /* [in] */ ULONG32 mdRva,
+    /* [in] */ ULONG32 flags,
+    /* [in] */ ULONG32 bufferSize,
+    /* [out, size_is(bufferSize), length_is(*dataSize)] */
+    BYTE* buffer,
+    /* [out] */ ULONG32* dataSize)
+{
+    HRESULT hr = InitializeHosting();
+    if (FAILED(hr))
+    {
+        return hr;
+    }
+    InitializeSymbolStore();
+    _ASSERTE(g_SOSNetCoreCallbacks.GetMetadataLocatorDelegate != nullptr);
+    return g_SOSNetCoreCallbacks.GetMetadataLocatorDelegate(imagePath, imageTimestamp, imageSize, mvid, mdRva, flags, bufferSize, buffer, dataSize);
+}
+
+

--- a/src/SOS/Strike/datatarget.h
+++ b/src/SOS/Strike/datatarget.h
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-class DataTarget : public ICLRDataTarget, ICorDebugDataTarget4
+class DataTarget : public ICLRDataTarget, ICorDebugDataTarget4, ICLRMetadataLocator
 {
 private:
     LONG m_ref;                         // Reference count.
@@ -87,4 +87,18 @@ public:
         /* [in] */ DWORD threadId,
         /* [in] */ ULONG32 contextSize,
         /* [in, out, size_is(contextSize)] */ PBYTE context);
+
+    // ICLRMetadataLocator
+
+    virtual HRESULT STDMETHODCALLTYPE GetMetadata(
+        /* [in] */ LPCWSTR imagePath,
+        /* [in] */ ULONG32 imageTimestamp,
+        /* [in] */ ULONG32 imageSize,
+        /* [in] */ GUID* mvid,
+        /* [in] */ ULONG32 mdRva,
+        /* [in] */ ULONG32 flags,
+        /* [in] */ ULONG32 bufferSize,
+        /* [out, size_is(bufferSize), length_is(*dataSize)] */
+        BYTE* buffer,
+        /* [out] */ ULONG32* dataSize);
 };

--- a/src/SOS/Strike/disasmARM64.cpp
+++ b/src/SOS/Strike/disasmARM64.cpp
@@ -294,7 +294,7 @@ void ARM64Machine::Unassembly (
             // Print out real code address in place of the copy address
             //
 
-			ExtOut("%08x`%08x ", (ULONG)(InstrAddr >> 32), (ULONG)InstrAddr);
+            ExtOut("%08x`%08x ", (ULONG)(InstrAddr >> 32), (ULONG)InstrAddr);
 
             ptr = line;
             NextTerm (ptr);

--- a/src/SOS/Strike/dllsext.cpp
+++ b/src/SOS/Strike/dllsext.cpp
@@ -50,7 +50,7 @@ typedef struct _PRIVATE_LDR_DATA_TABLE_ENTRY {
 static void DllsNameFromPeb(
     ULONG_PTR addrContaining,
     __out_ecount (MAX_LONGPATH) WCHAR *dllName
-	)
+    )
 {
     ULONG64 ProcessPeb;
     g_ExtSystem->GetCurrentProcessPeb (&ProcessPeb);

--- a/src/SOS/Strike/gchist.cpp
+++ b/src/SOS/Strike/gchist.cpp
@@ -56,7 +56,7 @@
 
 #ifndef _ASSERTE
 #ifdef _DEBUG
-#define _ASSERTE(expr) 		\
+#define _ASSERTE(expr) \
         do { if (!(expr) ) { ExtOut(#expr); DebugBreak(); } } while (0)
 #else // _DEBUG
 #define _ASSERTE(expr)

--- a/src/SOS/Strike/hostcoreclr.h
+++ b/src/SOS/Strike/hostcoreclr.h
@@ -12,8 +12,9 @@
 
 #include <soshostservices.h>
 
-static const char *SymbolReaderDllName = "SOS.NETCore";
+static const char *SOSManagedDllName = "SOS.NETCore";
 static const char *SymbolReaderClassName = "SOS.SymbolReader";
+static const char *MetadataHelperClassName = "SOS.MetadataHelper";
 
 extern HMODULE g_hInstance;
 extern LPCSTR g_hostRuntimeDirectory;
@@ -24,6 +25,7 @@ extern LPCSTR GetDbiFilePath();
 extern BOOL IsHostingInitialized();
 extern HRESULT InitializeHosting();
 extern HRESULT InitializeSymbolStore(BOOL logging, BOOL msdl, BOOL symweb, const char* symbolServer, const char* cacheDirectory);
+extern void InitializeSymbolStore();
 extern HRESULT LoadNativeSymbols(bool runtimeOnly = false);
 extern void DisplaySymbolStore();
 extern void DisableSymbolStore();

--- a/src/SOS/Strike/sos.cpp
+++ b/src/SOS/Strike/sos.cpp
@@ -171,7 +171,7 @@ namespace sos
     {
         TADDR mt = GetMT();
         MethodTableInfo* info = g_special_mtCache.Lookup((DWORD_PTR)mt);
-        if (!info->IsInitialized())	
+        if (!info->IsInitialized())
         {
             // this is the first time we see this method table, so we need to get the information
             // from the target

--- a/src/SOS/Strike/soshostservices.h
+++ b/src/SOS/Strike/soshostservices.h
@@ -34,7 +34,19 @@ typedef  BOOL (*ResolveSequencePointDelegate)(PVOID, const char*, unsigned int, 
 typedef  BOOL (*GetLocalVariableNameDelegate)(PVOID, int, int, BSTR*);
 typedef  BOOL (*GetLineByILOffsetDelegate)(PVOID, mdMethodDef, ULONG64, ULONG *, BSTR*);
 
-#define SOSNetCoreCallbacksVersion 1
+typedef  BOOL (*GetMetadataLocatorDelegate)(
+    LPCWSTR imagePath,
+    unsigned int imageTimestamp,
+    unsigned int imageSize,
+    GUID* mvid,
+    unsigned int mdRva,
+    unsigned int flags,
+    unsigned int bufferSize,
+    PVOID pMetadata,
+    unsigned int* pMetadataSize
+);
+
+#define SOSNetCoreCallbacksVersion 2
 
 struct SOSNetCoreCallbacks
 {
@@ -47,6 +59,7 @@ struct SOSNetCoreCallbacks
     ResolveSequencePointDelegate ResolveSequencePointDelegate;
     GetLineByILOffsetDelegate GetLineByILOffsetDelegate;
     GetLocalVariableNameDelegate GetLocalVariableNameDelegate;
+    GetMetadataLocatorDelegate GetMetadataLocatorDelegate;
 };
 
 MIDL_INTERFACE("D13608FB-AD14-4B49-990A-80284F934C41")

--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -13757,6 +13757,9 @@ DECLARE_API( SOSFlush )
     INIT_API();
 
     g_clrData->Flush();
+#ifdef FEATURE_PAL
+    FlushMetadataRegions();
+#endif
     
     return Status;
 }   // DECLARE_API( SOSFlush )

--- a/src/SOS/Strike/util.h
+++ b/src/SOS/Strike/util.h
@@ -1852,6 +1852,11 @@ BOOL IsObjectArray (DacpObjectData *pData);
 BOOL IsDerivedFrom(CLRDATA_ADDRESS mtObj, __in_z LPCWSTR baseString);
 BOOL TryGetMethodDescriptorForDelegate(CLRDATA_ADDRESS delegateAddr, CLRDATA_ADDRESS* pMD);
 
+#ifdef FEATURE_PAL
+void FlushMetadataRegions();
+bool IsMetadataMemory(CLRDATA_ADDRESS address, ULONG32 size);
+#endif
+
 /* Returns a list of all modules in the process.
  * Params:
  *      name - The name of the module you would like.  If mName is NULL the all modules are returned.
@@ -2896,7 +2901,7 @@ private:
                 if (curr_next)
                     curr_next->Prev = Prev;
             }
-        }	
+        }
     };
 
 public:

--- a/src/SOS/lldbplugin/services.cpp
+++ b/src/SOS/lldbplugin/services.cpp
@@ -420,6 +420,17 @@ LLDBServices::GetDebuggeeType(
 {
     *debugClass = DEBUG_CLASS_USER_WINDOWS; 
     *qualifier = 0;
+
+    lldb::SBProcess process = GetCurrentProcess();
+    if (process.IsValid())
+    {
+        const char* pluginName = process.GetPluginName();
+        if ((strcmp(pluginName, "elf-core") == 0) || (strcmp(pluginName, "mach-o-core") == 0))
+        {
+            *qualifier = DEBUG_DUMP_FULL;
+        }
+    }
+
     return S_OK;
 }
 


### PR DESCRIPTION
Issue #https://github.com/dotnet/diagnostics/issues/56

Both Windows and Linux minidumps don't save all the assemblies' metadata which can cause
stack traces to display !Unknown. On Windows most debuggers like Windbg and VS can load
the module from file for this kind of dumps. On Linux lldb/SOS doesn't load the native
modules and really doesn't know anything about the managed assemblies.

Add metadata callback to datatarget and it's implementation in SOS.NETCore.

Add IsMetadataMemory() and the metadata region list. This is because lldb on core dumps
returns 0's on missing metadata memory reads instead of an error.