### PR TITLE
Add alpine/MUSL SOS build/packaging

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -43,6 +43,22 @@ phases:
 
 - template: /eng/build.yml
   parameters:
+    name: Alpine3_6
+    agentOs: Linux
+    dockerImage: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.6-WithNode-f4d3fe3-20181220200247
+    queue:
+      name: DotNet-Build
+      demands:
+        - agent.os -equals Linux
+      parallel: 2
+      matrix:
+        Build_Release:
+          _BuildConfig: Release
+          _BuildArch: x64
+          _PublishArtifacts: bin/Linux.x64.Release
+
+- template: /eng/build.yml
+  parameters:
     name: MacOS
     agentOs: Darwin
     queue: 
@@ -207,6 +223,7 @@ phases:
   dependsOn:
   - Windows
   - CentOS_7
+  - Alpine3_6
   - MacOS
   condition: ne(variables['Build.Reason'], 'Schedule')
   queue:
@@ -275,15 +292,6 @@ phases:
       targetFolder: '$(Build.SourcesDirectory)/artifacts/Windows_NT.x64.Release'
     condition: succeeded()
 
-  - task: ArchiveFiles@2
-    displayName: Archive Windows x64 Artifacts
-    inputs:
-      archiveType: zip
-      includeRootFolder: false
-      rootFolderOrFile: '$(Build.SourcesDirectory)/artifacts/Windows_NT.x64.Release'
-      archiveFile: '$(Build.SourcesDirectory)/artifacts/packages/Release/sos-win-x64.zip'
-    condition: succeeded()
-
   # Windows x86 download, copy and archive.
 
   - task: DownloadBuildArtifacts@0
@@ -310,22 +318,13 @@ phases:
       targetFolder: '$(Build.SourcesDirectory)/artifacts/bin/Windows_NT.x86.Release'
     condition: succeeded()
 
-  - task: ArchiveFiles@2
-    displayName: Archive Windows x86 Artifacts
-    inputs:
-      archiveType: zip
-      includeRootFolder: false
-      rootFolderOrFile: '$(Build.SourcesDirectory)/artifacts/bin/Windows_NT.x86.Release'
-      archiveFile: '$(Build.SourcesDirectory)/artifacts/packages/Release/sos-win-x86.zip'
-    condition: succeeded()
-  
   # Copy and archive the files for windbg extension gallery.
 
   - powershell: $(Build.SourcesDirectory)\eng\create-gallery-zip.ps1 $(Build.SourcesDirectory)
     displayName: Create Extension Gallery Zip File
     condition: succeeded()
 
-  # Linux download, copy and archive
+  # Linux x64 download, copy and archive
 
   - task: DownloadBuildArtifacts@0
     displayName: Download Linux Artifacts
@@ -351,13 +350,30 @@ phases:
       targetFolder: '$(Build.SourcesDirectory)/artifacts/bin/Linux.x64.Release'
     condition: succeeded()
 
-  - task: ArchiveFiles@2
-    displayName: Archive Linux Artifacts
+  # Linux MUSL x64 download, copy and archive
+
+  - task: DownloadBuildArtifacts@0
+    displayName: Download Linux Artifacts
     inputs:
-      archiveType: zip
-      includeRootFolder: false
-      rootFolderOrFile: '$(Build.SourcesDirectory)/artifacts/bin/Linux.x64.Release'
-      archiveFile: '$(Build.SourcesDirectory)/artifacts/packages/Release/sos-linux-x64.zip'
+      artifactName: Alpine3_6_x64_Release
+      downloadPath: '$(System.ArtifactsDirectory)'
+    condition: succeeded()
+
+  - task: CopyFiles@2
+    displayName: Copy Linux Artifacts
+    inputs:
+      sourceFolder: '$(System.ArtifactsDirectory)/Alpine3_6_x64_Release'
+      contents: ?(libsos.so|libsosplugin.so|sosdocsunix.txt)
+      targetFolder: '$(Build.SourcesDirectory)/artifacts/bin/Linux-musl.x64.Release'
+    condition: succeeded()
+
+  - task: CopyFiles@2
+    displayName: Copy Linux Artifacts
+    inputs:
+      sourceFolder: '$(_SOSNETCorePath)'
+      contents: '*.dll'
+      overWrite: true
+      targetFolder: '$(Build.SourcesDirectory)/artifacts/bin/Linux-musl.x64.Release'
     condition: succeeded()
 
   # MacOS download, copy and archive
@@ -384,15 +400,6 @@ phases:
       contents: '*.dll'
       overWrite: true
       targetFolder: '$(Build.SourcesDirectory)/artifacts/bin/OSX.x64.Release'
-    condition: succeeded()
-
-  - task: ArchiveFiles@2
-    displayName: Archive MacOS Artifacts
-    inputs:
-      archiveType: zip
-      includeRootFolder: false
-      rootFolderOrFile: '$(Build.SourcesDirectory)/artifacts/bin/OSX.x64.Release'
-      archiveFile: '$(Build.SourcesDirectory)/artifacts/packages/Release/sos-osx-x64.zip'
     condition: succeeded()
 
   # Create nuget package and sign binaries

--- a/eng/docker-build.sh
+++ b/eng/docker-build.sh
@@ -53,15 +53,15 @@ docker_id="$($docker_bin create -it --rm --privileged --ulimit core=-1 \
 $docker_bin start $docker_id
 
 # Create an user with the same uid in the container
-container_user_name=vsts_$user_name
+container_user_name=vsts_$(echo $user_name | awk '{print tolower($0)}')
 echo "container user name: $container_user_name"
 
 # Add sudo user with same uid that can run any sudo command without password
-$docker_bin exec $docker_id useradd -m -u $user_id $container_user_name
-$docker_bin exec $docker_id groupadd container_SUDO_user
-$docker_bin exec $docker_id usermod -a -G container_SUDO_user $container_user_name
+$docker_bin exec $docker_id useradd -K MAIL_DIR=/dev/null -m -u $user_id $container_user_name
+$docker_bin exec $docker_id groupadd sudouser
+$docker_bin exec $docker_id usermod -a -G sudouser $container_user_name
 $docker_bin exec $docker_id su -c "$source_directory/eng/docker-init.sh"
-$docker_bin exec $docker_id su -c "echo '%container_SUDO_user ALL=(ALL:ALL) NOPASSWD:ALL' >> /etc/sudoers"
+$docker_bin exec $docker_id su -c "echo '%sudouser ALL=(ALL:ALL) NOPASSWD:ALL' >> /etc/sudoers"
 
 echo "Execute $args"
 $docker_bin exec --workdir=$source_directory --user $container_user_name $docker_id $args

--- a/eng/init-distro-rid.sh
+++ b/eng/init-distro-rid.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+
+# initNonPortableDistroRid
+#
+# Input:
+#   buildOs: (str)
+#   buildArch: (str)
+#   isPortable: (int)
+#   rootfsDir: (str)
+#
+# Return:
+#   None
+#
+# Notes:
+#
+# initNonPortableDistroRid will attempt to initialize a non portable rid. These
+# rids are specific to distros need to build the product/package and consume
+# them on the same platform.
+#
+# If -portablebuild=false is passed a non-portable rid will be created for any
+# distro.
+#
+# Below is the list of current non-portable platforms.
+#
+# Builds from the following *must* be non-portable:
+#
+#   |    OS     |           Expected RID            |
+#   -------------------------------------------------
+#   |   rhel6   |           rhel.6-x64              |
+#   |  alpine*  |        linux-musl-(arch)          |
+#   |  freeBSD  |        freebsd.(version)-x64      |
+#
+# It is important to note that the function does not return anything, but it 
+# will set __DistroRid if there is a non-portable distro rid to be used.
+#
+initNonPortableDistroRid()
+{
+    # Make sure out parameter is cleared.
+    __DistroRid=
+
+    local buildOs=$1
+    local buildArch=$2
+    local isPortable=$3
+    local rootfsDir=$4
+
+    if [ "$buildOs" = "Linux" ]; then
+        # RHEL 6 is the only distro we will check redHat release for.
+        if [ -e "${rootfsDir}/etc/os-release" ]; then
+            source "${rootfsDir}/etc/os-release"
+
+            # We have forced __PortableBuild=0. This is because -portablebuld
+            # has been passed as false.
+            if (( ${isPortable} == 0 )); then
+                if [ "${ID}" == "rhel" ]; then
+                    # remove the last version digit	
+                    VERSION_ID=${VERSION_ID%.*}
+                fi
+
+                nonPortableBuildID="${ID}.${VERSION_ID}-${buildArch}"
+            fi
+
+            if [ "${ID}" == "alpine" ]; then
+                export __Alpine=true
+            fi
+            
+        elif [ -e "${rootfsDir}/etc/redhat-release" ]; then
+            local redhatRelease=$(<${rootfsDir}/etc/redhat-release)
+
+            if [[ "${redhatRelease}" == "CentOS release 6."* || "$redhatRelease" == "Red Hat Enterprise Linux Server release 6."* ]]; then
+                nonPortableBuildID="rhel.6-${buildArch}"
+            fi
+        elif [ -e "${rootfsDir}/android_platform" ]; then
+            source $rootfsDir/android_platform
+            nonPortableBuildID="$RID"
+        fi
+    fi
+
+    if [ "$buildOs" = "FreeBSD" ]; then
+        __freebsd_version=`sysctl -n kern.osrelease | cut -f1 -d'.'`
+        nonPortableBuildID="freebsd.$__freebsd_version-${buildArch}"
+    fi
+
+    if [ "${nonPortableBuildID}" != "" ]; then
+        export __DistroRid=${nonPortableBuildID}
+
+        # We are using a non-portable build rid. Force __PortableBuild to false.
+        export __PortableBuild=0
+    fi
+}
+
+
+# initDistroRidGlobal
+#
+# Input:
+#   os: (str)
+#   arch: (str)
+#   isPortable: (int)
+#   rootfsDir?: (nullable:string)
+#
+# Return:
+#   None
+#
+# Notes:
+#
+# The following out parameters are returned
+#
+#   __DistroRid
+#   __PortableBuild
+#
+initDistroRidGlobal()
+{
+    # __DistroRid must be set at the end of the function.
+    # Previously we would create a variable __HostDistroRid and/or __DistroRid.
+    #
+    # __HostDistroRid was used in the case of a non-portable build, it has been
+    # deprecated. Now only __DistroRid is supported. It will be used for both
+    # portable and non-portable rids and will be used in build-packages.sh
+
+    local buildOs=$1
+    local buildArch=$2
+    local isPortable=$3
+    local rootfsDir=$4
+
+    # Setup whether this is a crossbuild. We can find this out if rootfsDir
+    # is set. 
+    local isCrossBuild=0
+
+    if [ -z "${rootfsDir}" ]; then
+        isCrossBuild=0
+    else
+        # We may have a cross build. Check for the existance of the rootfsDir
+        if [ -e ${rootfsDir} ]; then
+            isCrossBuild=1
+        else
+            echo "Error rootfsDir has been passed, but the location is not valid."
+            exit 1
+        fi
+    fi
+
+    initNonPortableDistroRid ${buildOs} ${buildArch} ${isPortable} ${rootfsDir}
+
+    if [ -z "${__DistroRid}" ]; then
+        # The non-portable build rid was not set. Set the portable rid.
+
+        export __PortableBuild=1
+        local distroRid=""
+
+        # Check for alpine. It is the only portable build that will will have
+        # its name in the portable build rid.
+        if [ -e "${rootfsDir}/etc/os-release" ]; then
+            source "${rootfsDir}/etc/os-release"
+            if [ "${ID}" = "alpine" ]; then
+                distroRid="linux-musl-${buildArch}"
+            fi
+        fi
+
+        if [ "${distroRid}" == "" ]; then
+            if [ "$buildOs" = "Linux" ]; then
+                distroRid="linux-$buildArch"
+            elif [ "$buildOs" = "OSX" ]; then
+                distroRid="osx-$buildArch"
+            elif [ "$buildOs" = "FreeBSD" ]; then
+                distroRid="freebsd-$buildArch"
+            fi
+        fi
+
+        export __DistroRid=${distroRid}
+    fi
+
+    if [ -z "$__DistroRid" ]; then
+        echo "DistroRid is not set. This is almost certainly an error"
+
+        exit 1
+    else
+        echo "__DistroRid: ${__DistroRid}"
+        echo "__RuntimeId: ${__DistroRid}"
+        
+        export __RuntimeId=${__DistroRid}
+    fi
+}

--- a/src/SOS/SOS.Hosting/SOS.Hosting.csproj
+++ b/src/SOS/SOS.Hosting/SOS.Hosting.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Microsoft.Diagnostic.Repl\Microsoft.Diagnostic.Repl.csproj" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\SOS.NETCore\SOS.NETCore.csproj" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\SOS.InstallHelper\SOS.InstallHelper.csproj" />
   </ItemGroup>
 </Project>

--- a/src/SOS/SOS.Hosting/SOSHost.cs
+++ b/src/SOS/SOS.Hosting/SOSHost.cs
@@ -152,20 +152,8 @@ namespace SOS
         /// </summary>
         public SOSHost(IDataReader dataReader, ISOSHostContext context)
         {
-            string os = null;
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
-                os = "win";
-            }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) {
-                os = "linux";
-            }
-            if (os == null) {
-                throw new PlatformNotSupportedException($"Unsupported operating system: {RuntimeInformation.OSDescription}");
-            }
-            string architecture = RuntimeInformation.OSArchitecture.ToString().ToLowerInvariant();
-            string rid = os + "-" + architecture;
+            string rid = InstallHelper.GetRid();
             SOSPath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), rid);
-
             _wrapper = new LLDBServicesWrapper(this, dataReader, context);
         }
 

--- a/src/SOS/SOS.UnitTests/SOSRunner.cs
+++ b/src/SOS/SOS.UnitTests/SOSRunner.cs
@@ -709,6 +709,22 @@ public class SOSRunner : IDisposable
         _outputHelper.Dispose();
     }
 
+    public static bool IsAlpine()
+    {
+        if (OS.Kind == OSKind.Linux)
+        {
+            try
+            {
+                string ostype = File.ReadAllText("/etc/os-release");
+                return ostype.Contains("ID=alpine");
+            }
+            catch (Exception ex) when (ex is FileNotFoundException || ex is DirectoryNotFoundException || ex is IOException)
+            {
+            }
+        }
+        return false;
+    }
+
     private static NativeDebugger GetNativeDebuggerToUse(TestConfiguration config, Options options)
     {
         switch (OS.Kind)
@@ -862,6 +878,10 @@ public class SOSRunner : IDisposable
         else
         {
             throw new NotSupportedException("TargetArchitecture " + _config.TargetArchitecture + " not supported");
+        }
+        if (IsAlpine())
+        {
+            defines.Add("ALPINE");
         }
         return defines;
     }

--- a/src/SOS/SOS.UnitTests/Scripts/StackAndOtherTests.script
+++ b/src/SOS/SOS.UnitTests/Scripts/StackAndOtherTests.script
@@ -64,9 +64,12 @@ VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.Program\.Foo1\(.*\)\s+\[(?i:.*[
 VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.Program\.Main\(.*\)\s+\[(?i:.*[\\|/]SymbolTestApp\.cs) @ 19\]\s*
 ENDIF:PROJECTK
 
+# Issue #https://github.com/dotnet/diagnostics/issues/266
+IFDEF:NEVER
+
 # Verify that ClrStack with the ICorDebug options works
-SOSCOMMAND:ClrStack -i
 IFDEF:PROJECTK
+SOSCOMMAND:ClrStack -i
 VERIFY:.*\s+Dumping managed stack and managed variables using ICorDebug.\s+
 VERIFY:.*\s+Child\s+SP\s+IP\s+Call Site\s+
 VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+\[NativeStackFrame\]\s+
@@ -94,6 +97,10 @@ VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+\[DEFAULT\] Void SymbolTestApp\.Program\.Main\
 VERIFY:.*\s+Stack walk complete.\s+
 ENDIF:PROJECTK
 
+ENDIF:NEVER
+
+!IFDEF:ALPINE
+
 # Verify DumpStackObjects works
 IFDEF:PROJECTK
 SOSCOMMAND:DumpStackObjects
@@ -111,6 +118,8 @@ VERIFY:\s+[R|E]SP/REG\s+Object\s+Name\s+
 VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+System\.String.*
 VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+System\.String\[\].*
 ENDIF:PROJECTK
+
+ENDIF:ALPINE
 
 !IFDEF:DOTNETDUMP
 IFDEF:PROJECTK

--- a/src/SOS/SOS.UnitTests/Scripts/StackTests.script
+++ b/src/SOS/SOS.UnitTests/Scripts/StackTests.script
@@ -66,6 +66,9 @@ VERIFY:\s+[r|e]ax=<HEXVAL>\s+[r|e]bx=<HEXVAL>\s+[r|e]cx=<HEXVAL>\s+
 ENDIF:64BIT
 ENDIF:PROJECTK
 
+# Issue #https://github.com/dotnet/diagnostics/issues/266
+IFDEF:NEVER
+
 # 5) Verifying that ClrStack with the ICorDebug options works
 SOSCOMMAND:ClrStack -i
 VERIFY:.*\s+Dumping managed stack and managed variables using ICorDebug.\s+
@@ -89,6 +92,8 @@ VERIFY:\s+\+ System.FormatException ex @ 0x<HEXVAL>\s+
 VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+\[DEFAULT\] Void NestedExceptionTest\.Program\.Main\(.*\)\s+\(.*\)\s+
 VERIFY:.*\s+Stack walk complete.\s+
 ENDIF:PROJECTK
+
+ENDIF:NEVER
 
 # 7) Verify DumpStackObjects works
 IFDEF:PROJECTK

--- a/src/Tools/dotnet-dump/dotnet-dump.csproj
+++ b/src/Tools/dotnet-dump/dotnet-dump.csproj
@@ -49,6 +49,18 @@
       <PackagePath>tools/$(TargetFramework)/any/linux-x64</PackagePath>
     </None>
     <None Include="$(SOSNETCoreBinaries)" Pack="true" Visible="false">
+      <PackagePath>tools/$(TargetFramework)/any/linux-musl-x64</PackagePath>
+    </None>
+    <None Include="$(ArtifactsBinDir)\Linux-musl.x64.$(Configuration)\libsosplugin.so" Pack="true" Visible="false">
+      <PackagePath>tools/$(TargetFramework)/any/linux-musl-x64</PackagePath>
+    </None>
+    <None Include="$(ArtifactsBinDir)\Linux-musl.x64.$(Configuration)\libsos.so" Pack="true" Visible="false">
+      <PackagePath>tools/$(TargetFramework)/any/linux-musl-x64</PackagePath>
+    </None>
+    <None Include="$(ArtifactsBinDir)\Linux-musl.x64.$(Configuration)\sosdocsunix.txt" Pack="true" Visible="false">
+      <PackagePath>tools/$(TargetFramework)/any/linux-musl-x64</PackagePath>
+    </None>
+    <None Include="$(SOSNETCoreBinaries)" Pack="true" Visible="false">
       <PackagePath>tools/$(TargetFramework)/any/osx-x64</PackagePath>
     </None>
     <None Include="$(ArtifactsBinDir)\OSX.x64.$(Configuration)\libsosplugin.dylib" Pack="true" Visible="false">

--- a/src/Tools/dotnet-sos/dotnet-sos.csproj
+++ b/src/Tools/dotnet-sos/dotnet-sos.csproj
@@ -44,6 +44,18 @@
       <PackagePath>tools/$(TargetFramework)/any/linux-x64</PackagePath>
     </None>
     <None Include="$(SOSNETCoreBinaries)" Pack="true" Visible="false">
+      <PackagePath>tools/$(TargetFramework)/any/linux-musl-x64</PackagePath>
+    </None>
+    <None Include="$(ArtifactsBinDir)\Linux-musl.x64.$(Configuration)\libsosplugin.so" Pack="true" Visible="false">
+      <PackagePath>tools/$(TargetFramework)/any/linux-musl-x64</PackagePath>
+    </None>
+    <None Include="$(ArtifactsBinDir)\Linux-musl.x64.$(Configuration)\libsos.so" Pack="true" Visible="false">
+      <PackagePath>tools/$(TargetFramework)/any/linux-musl-x64</PackagePath>
+    </None>
+    <None Include="$(ArtifactsBinDir)\Linux-musl.x64.$(Configuration)\sosdocsunix.txt" Pack="true" Visible="false">
+      <PackagePath>tools/$(TargetFramework)/any/linux-musl-x64</PackagePath>
+    </None>
+    <None Include="$(SOSNETCoreBinaries)" Pack="true" Visible="false">
       <PackagePath>tools/$(TargetFramework)/any/osx-x64</PackagePath>
     </None>
     <None Include="$(ArtifactsBinDir)\OSX.x64.$(Configuration)\libsosplugin.dylib" Pack="true" Visible="false">


### PR DESCRIPTION
Build on alpine docker container.

Add new MUSL SOS binaries to dotnet-dump/dotnet-sos.

Add new "linux-musl-x64" rid to SOS installer and
dotnet-dump.

Skip the "clrstack -i" tests that fail on alpine and 3.0.x.