### PR TITLE
Update System.CommandLine for dotnet-dump

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -25,16 +25,13 @@
     <MicrosoftDiagnosticsRuntimeVersion>1.0.5</MicrosoftDiagnosticsRuntimeVersion>
 
     <MicrosoftDiagnosticsTracingTraceEventVersion>2.0.41</MicrosoftDiagnosticsTracingTraceEventVersion>
-    <SystemCommandLineExperimentalVersion>0.2.0-alpha.19213.1</SystemCommandLineExperimentalVersion>
-    <SystemCommandLineRenderingVersion>0.2.0-alpha.19213.1</SystemCommandLineRenderingVersion>
+    <SystemCommandLineExperimentalVersion>0.2.0-alpha.19254.1</SystemCommandLineExperimentalVersion>
+    <SystemCommandLineRenderingVersion>0.2.0-alpha.19254.1</SystemCommandLineRenderingVersion>
 
     <XUnitVersion>2.4.1</XUnitVersion>
     <XUnitAbstractionsVersion>2.0.3</XUnitAbstractionsVersion>
 
     <cdbsosversion>1.1.0</cdbsosversion>
-
-    <!-- The Repl project depends on types that were removed from  -->
-    <SystemCommandLineExperimentalVersionRepl>0.1.0-alpha-63807-01</SystemCommandLineExperimentalVersionRepl>
 
   </PropertyGroup>
 

--- a/src/Microsoft.Diagnostic.Repl/Command/Attributes.cs
+++ b/src/Microsoft.Diagnostic.Repl/Command/Attributes.cs
@@ -66,4 +66,20 @@ namespace Microsoft.Diagnostic.Repl
     public class ArgumentAttribute : BaseAttribute
     {
     }
+
+    /// <summary>
+    /// Marks the function to invoke to execute the command.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method)]
+    public class CommandInvokeAttribute : Attribute
+    {
+    }
+
+    /// <summary>
+    /// Marks the function to invoke to display alternate help for command.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method)]
+    public class HelpInvokeAttribute : Attribute
+    {
+    }
 }

--- a/src/Microsoft.Diagnostic.Repl/Command/CommandBase.cs
+++ b/src/Microsoft.Diagnostic.Repl/Command/CommandBase.cs
@@ -15,17 +15,16 @@ namespace Microsoft.Diagnostic.Repl
     /// </summary>
     public abstract class CommandBase
     {
-        public const string EntryPointName = nameof(InvokeAsync);
-
         /// <summary>
-        /// Parser invocation context. Contains the ParseResult, CommandResult, etc.
+        /// Parser invocation context. Contains the ParseResult, CommandResult, etc. Is null when 
+        /// InvokeAdditionalHelp is called.
         /// </summary>
         public InvocationContext InvocationContext { get; set; }
 
         /// <summary>
         /// Console instance
         /// </summary>
-        public IConsole Console { get { return InvocationContext.Console; } }
+        public IConsole Console { get; set; }
 
         /// <summary>
         /// The AliasExpansion value from the CommandAttribute or null if none.
@@ -35,7 +34,8 @@ namespace Microsoft.Diagnostic.Repl
         /// <summary>
         /// Execute the command
         /// </summary>
-        public abstract Task InvokeAsync();
+        [CommandInvoke]
+        public abstract void Invoke();
 
         /// <summary>
         /// Display text

--- a/src/Microsoft.Diagnostic.Repl/Command/CommandProcessor.cs
+++ b/src/Microsoft.Diagnostic.Repl/Command/CommandProcessor.cs
@@ -106,9 +106,6 @@ namespace Microsoft.Diagnostic.Repl
                     if (baseAttribute is CommandAttribute commandAttribute)
                     {
                         command = new Command(commandAttribute.Name, commandAttribute.Help);
-                        var builder = new CommandLineBuilder(command);
-                        builder.UseHelp();
-
                         var properties = new List<(PropertyInfo, Option)>();
                         PropertyInfo argument = null;
 
@@ -212,7 +209,7 @@ namespace Microsoft.Diagnostic.Repl
                 _methodInfoHelp = type.GetMethods().Where((methodInfo) => methodInfo.GetCustomAttribute<HelpInvokeAttribute>() != null).SingleOrDefault();
             }
 
-            public Task<int> InvokeAsync(InvocationContext context)
+            Task<int> ICommandHandler.InvokeAsync(InvocationContext context)
             {
                 try
                 {
@@ -312,6 +309,8 @@ namespace Microsoft.Diagnostic.Repl
                 object[] arguments = new object[parameters.Length];
                 for (int i = 0; i < parameters.Length; i++) {
                     Type parameterType = parameters[i].ParameterType;
+                    // Ignoring false: the parameter will passed as null to allow for "optional"
+                    // services. The invoked method needs to check for possible null parameters.
                     TryGetService(parameterType, context, out arguments[i]);
                 }
                 return arguments;

--- a/src/Microsoft.Diagnostic.Repl/Command/CommandProcessor.cs
+++ b/src/Microsoft.Diagnostic.Repl/Command/CommandProcessor.cs
@@ -332,12 +332,10 @@ namespace Microsoft.Diagnostic.Repl
         class LocalHelpBuilder : IHelpBuilder
         {
             private readonly CommandProcessor _commandProcessor;
-            private readonly HelpBuilder _helpBuilder;
 
             public LocalHelpBuilder(CommandProcessor commandProcessor)
             {
                 _commandProcessor = commandProcessor;
-                _helpBuilder = new HelpBuilder(commandProcessor.GetService<IConsole>(), maxWidth: Console.WindowWidth);
             }
 
             void IHelpBuilder.Write(ICommand command)
@@ -348,7 +346,8 @@ namespace Microsoft.Diagnostic.Repl
                         return;
                     }
                 }
-                _helpBuilder.Write(command);
+                var helpBuilder = new HelpBuilder(_commandProcessor.GetService<IConsole>(), maxWidth: Console.WindowWidth);
+                helpBuilder.Write(command);
             }
         }
     }

--- a/src/Microsoft.Diagnostic.Repl/Microsoft.Diagnostic.Repl.csproj
+++ b/src/Microsoft.Diagnostic.Repl/Microsoft.Diagnostic.Repl.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="System.CommandLine.Experimental" Version="$(SystemCommandLineExperimentalVersionRepl)" />
+    <PackageReference Include="System.CommandLine.Experimental" Version="$(SystemCommandLineExperimentalVersion)" />
   </ItemGroup>
   
 </Project>

--- a/src/Tools/dotnet-dump/Analyzer.cs
+++ b/src/Tools/dotnet-dump/Analyzer.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Diagnostic.Tools.Dump
         public Analyzer()
         {
             _consoleProvider = new ConsoleProvider();
-            _commandProcessor = new CommandProcessor(new Assembly[] { typeof(Analyzer).Assembly });
+            _commandProcessor = new CommandProcessor(_consoleProvider, new Assembly[] { typeof(Analyzer).Assembly });
             _commandProcessor.AddService(_consoleProvider);
         }
 
@@ -71,14 +71,14 @@ namespace Microsoft.Diagnostic.Tools.Dump
                     if (command != null)
                     {
                         foreach (string cmd in command) {
-                            await _commandProcessor.Parse(cmd, _consoleProvider);
+                            await _commandProcessor.Parse(cmd);
                         }
                     }
 
                     // Start interactive command line processing
                     await _consoleProvider.Start(async (string commandLine, CancellationToken cancellation) => {
                         analyzeContext.CancellationToken = cancellation;
-                        await _commandProcessor.Parse(commandLine, _consoleProvider);
+                        await _commandProcessor.Parse(commandLine);
                     });
                 }
             }

--- a/src/Tools/dotnet-dump/Commands/ClrModulesCommand.cs
+++ b/src/Tools/dotnet-dump/Commands/ClrModulesCommand.cs
@@ -11,13 +11,12 @@ namespace Microsoft.Diagnostic.Tools.Dump
     {
         public AnalyzeContext AnalyzeContext { get; set; }
 
-        public override Task InvokeAsync()
+        public override void Invoke()
         {
             foreach (ClrModule module in AnalyzeContext.Runtime.Modules)
             {
                 WriteLine("{0:X16} {1}", module.Address, module.FileName);
             }
-            return Task.CompletedTask;
         }
     }
 }

--- a/src/Tools/dotnet-dump/Commands/ExitCommand.cs
+++ b/src/Tools/dotnet-dump/Commands/ExitCommand.cs
@@ -11,10 +11,9 @@ namespace Microsoft.Diagnostic.Tools.Dump
     {
         public ConsoleProvider ConsoleProvider { get; set; }
 
-        public override Task InvokeAsync()
+        public override void Invoke()
         {
             ConsoleProvider.Stop();
-            return Task.CompletedTask;
         }
     }
 }

--- a/src/Tools/dotnet-dump/Commands/HelpCommand.cs
+++ b/src/Tools/dotnet-dump/Commands/HelpCommand.cs
@@ -12,25 +12,17 @@ namespace Microsoft.Diagnostic.Tools.Dump
 
         public CommandProcessor CommandProcessor { get; set; }
 
-        public override Task InvokeAsync()
-        {
-            return Task.CompletedTask;
-        }
+        public IHelpBuilder HelpBuilder { get; set; }
 
-        /// <summary>
-        /// Get help builder interface
-        /// </summary>
-        /// <param name="helpBuilder">help builder</param>
-        public Task InvokeAsync(IHelpBuilder helpBuilder)
+        public override void Invoke()
         {
             Command command = CommandProcessor.GetCommand(Command);
             if (command != null) {
-                helpBuilder.Write(command);
+                HelpBuilder.Write(command);
             }
             else {
                 Console.Error.WriteLine($"Help for {Command} not found.");
             }
-            return Task.CompletedTask;
         }
     }
 }

--- a/src/Tools/dotnet-dump/Commands/ModulesCommand.cs
+++ b/src/Tools/dotnet-dump/Commands/ModulesCommand.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Diagnostic.Tools.Dump
 
         public AnalyzeContext AnalyzeContext { get; set; }
 
-        public override Task InvokeAsync()
+        public override void Invoke()
         {
             foreach (ModuleInfo module in AnalyzeContext.Target.DataReader.EnumerateModules())
             {
@@ -38,7 +38,6 @@ namespace Microsoft.Diagnostic.Tools.Dump
                     WriteLine("{0:X16} {1:X8} {2}", module.ImageBase, module.FileSize, module.FileName);
                 }
             }
-            return Task.CompletedTask;
         }
     }
 }

--- a/src/Tools/dotnet-dump/Commands/SOSCommand.cs
+++ b/src/Tools/dotnet-dump/Commands/SOSCommand.cs
@@ -41,7 +41,6 @@ namespace Microsoft.Diagnostic.Tools.Dump
     [Command(Name = "histobjfind",      AliasExpansion = "HistObjFind",         Help = "Displays all the log entries that reference an object at the specified address.")]
     [Command(Name = "histroot",         AliasExpansion = "HistRoot",            Help = "Displays information related to both promotions and relocations of the specified root.")]
     [Command(Name = "setsymbolserver",  AliasExpansion = "SetSymbolServer",     Help = "Enables the symbol server support ")]
-    [Command(Name = "soshelp",          AliasExpansion = "Help",                Help = "Displays all available commands when no parameter is specified, or displays detailed help information about the specified command. soshelp <command>")]
     public class SOSCommand : CommandBase
     {
         [Argument(Name = "arguments", Help = "Arguments to SOS command.")]
@@ -49,7 +48,7 @@ namespace Microsoft.Diagnostic.Tools.Dump
 
         public AnalyzeContext AnalyzeContext { get; set; }
 
-        public override Task InvokeAsync()
+        public override void Invoke()
         {
             try {
                 string arguments = null;
@@ -61,7 +60,12 @@ namespace Microsoft.Diagnostic.Tools.Dump
             catch (Exception ex) when (ex is FileNotFoundException || ex is EntryPointNotFoundException || ex is InvalidOperationException) {
                 Console.Error.WriteLine(ex.Message);
             }
-            return Task.CompletedTask;
+        }
+
+        [HelpInvoke]
+        public void InvokeHelp()
+        {
+            AnalyzeContext.SOSHost.ExecuteCommand("Help", AliasExpansion);
         }
     }
 }

--- a/src/Tools/dotnet-dump/Commands/SetThreadCommand.cs
+++ b/src/Tools/dotnet-dump/Commands/SetThreadCommand.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Diagnostic.Tools.Dump
 
         public AnalyzeContext AnalyzeContext { get; set; }
 
-        public override Task InvokeAsync()
+        public override void Invoke()
         {
             if (ThreadId.HasValue)
             {
@@ -29,7 +29,6 @@ namespace Microsoft.Diagnostic.Tools.Dump
                     index++;
                 }
             }
-            return Task.CompletedTask;
         }
     }
 }

--- a/src/Tools/dotnet-dump/Program.cs
+++ b/src/Tools/dotnet-dump/Program.cs
@@ -69,6 +69,6 @@ If not specified 'heap' is the default.",
             new Option(
                 new[] { "-c", "--command" },
                 "Run the command on start.",
-                new Argument<string[]>() { Name = "command" });
+                new Argument<string[]>() { Name = "command", Arity = ArgumentArity.ZeroOrMore });
     }
 }


### PR DESCRIPTION
Update System.CommandLine to 0.2.0-alpha.19254.1.

Fixes issues: https://github.com/dotnet/diagnostics/issues/127 https://github.com/dotnet/diagnostics/issues/234

Remove the separate older System.CommandLine version for the Repl. Replaced
the depreciated MethodBinder usage with explicit reflection invoke.

Added the CommandInvoke and HelpInvoke attributes to mark the entry
points into the command class.

Changed the command invoke from async (Task InvokeAsync) to synchronous
(void Invoke) because SOS and CLRMD are basically single threaded.