### PR TITLE
Change the dotnet-dump setthread command to take the thread index

### DIFF
--- a/src/Tools/dotnet-dump/Commands/HelpCommand.cs
+++ b/src/Tools/dotnet-dump/Commands/HelpCommand.cs
@@ -1,6 +1,5 @@
 using Microsoft.Diagnostic.Repl;
 using System.CommandLine;
-using System.Threading.Tasks;
 
 namespace Microsoft.Diagnostic.Tools.Dump
 {

--- a/src/Tools/dotnet-dump/Commands/SOSCommand.cs
+++ b/src/Tools/dotnet-dump/Commands/SOSCommand.cs
@@ -1,12 +1,8 @@
 using Microsoft.Diagnostic.Repl;
-using SOS;
 using System;
 using System.CommandLine;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Microsoft.Diagnostic.Tools.Dump
 {

--- a/src/Tools/dotnet-dump/Commands/SetThreadCommand.cs
+++ b/src/Tools/dotnet-dump/Commands/SetThreadCommand.cs
@@ -1,24 +1,30 @@
 
 using Microsoft.Diagnostic.Repl;
+using System;
+using System.Collections.Generic;
 using System.CommandLine;
-using System.Threading.Tasks;
+using System.Linq;
 
 namespace Microsoft.Diagnostic.Tools.Dump
 {
-    [Command(Name = "setthread", Help = "Sets or displays the current thread id for the SOS commands.")]
+    [Command(Name = "setthread", Help = "Sets or displays the current thread for the SOS commands.")]
     [CommandAlias(Name = "threads")]
     public class SetThreadCommand : CommandBase
     {
-        [Argument(Help = "The thread id to set, otherwise displays the current id.")]
-        public int? ThreadId { get; set; } = null;
+        [Argument(Help = "The thread index to set, otherwise displays the list of threads.")]
+        public int? ThreadIndex { get; set; } = null;
 
         public AnalyzeContext AnalyzeContext { get; set; }
 
         public override void Invoke()
         {
-            if (ThreadId.HasValue)
+            if (ThreadIndex.HasValue)
             {
-                AnalyzeContext.CurrentThreadId = ThreadId.Value;
+                IEnumerable<uint> threads = AnalyzeContext.Target.DataReader.EnumerateAllThreads();
+                if (ThreadIndex.Value >= threads.Count()) {
+                    throw new InvalidOperationException($"Invalid thread index {ThreadIndex.Value}");
+                }
+                AnalyzeContext.CurrentThreadId = unchecked((int)threads.ElementAt(ThreadIndex.Value));
             }
             else
             {


### PR DESCRIPTION
User feedback determined that using the artificial thread index to select the thread in dotnet-dump is less confusing than the OS ID.  Both cdb and lldb select threads this way.