### PR TITLE
Missing profile argument

### DIFF
--- a/documentation/dotnet-trace-instructions.md
+++ b/documentation/dotnet-trace-instructions.md
@@ -113,6 +113,15 @@ Options:
   -o, --output <trace-file-path>
     The output path for the collected trace data. If not specified it defaults to 'trace.netperf'
 
+  --profile
+      A named pre-defined set of provider configurations that allows common tracing scenarios to be specified
+      succinctly. The options are:
+      runtime-basic   Useful for tracking CPU usage and general runtime information. This the default option
+                      if no profile is specified.
+      gc              Tracks allocation and collection performance
+      gc-collect      Tracks GC collection only at very low overhead
+      none            Tracks nothing. Only providers specified by the --providers option will be available.
+
   --providers <list-of-comma-separated-providers>
     A list of comma separated EventPipe providers to be enabled.
     This option adds to the configuration already provided via the --profile argument. If the same provider is configured in both places, this option takes precedence.


### PR DESCRIPTION
The providers help mention profile, but it is not in the docs.

I took the profile description from https://github.com/dotnet/diagnostics/blob/master/documentation/design-docs/dotnet-tools.md

But I'm not sure if we should keep the information in both places

It also refers to some profiles not available in the current release 1.0.3-preview5.19251.2. The only profile in this version is runtime-basic