### PR TITLE
Improve perf of `!dumpasync -tasks`

### DIFF
--- a/src/SOS/Strike/util.cpp
+++ b/src/SOS/Strike/util.cpp
@@ -2152,6 +2152,23 @@ BOOL IsDerivedFrom(CLRDATA_ADDRESS mtObj, __in_z LPCWSTR baseString)
     return FALSE;
 }
 
+BOOL IsDerivedFrom(CLRDATA_ADDRESS mtObj, DWORD_PTR modulePtr, mdTypeDef typeDef)
+{
+    DacpMethodTableData dmtd;
+    
+    for (CLRDATA_ADDRESS walkMT = mtObj;
+         walkMT != NULL && dmtd.Request(g_sos, walkMT) == S_OK;
+         walkMT = dmtd.ParentMethodTable)
+    {
+        if (dmtd.Module == modulePtr && dmtd.cl == typeDef)
+        {
+            return TRUE;
+        }
+    }
+
+    return FALSE;
+}
+
 BOOL TryGetMethodDescriptorForDelegate(CLRDATA_ADDRESS delegateAddr, CLRDATA_ADDRESS* pMD)
 {
     if (!sos::IsObject(delegateAddr, false))

--- a/src/SOS/Strike/util.h
+++ b/src/SOS/Strike/util.h
@@ -1850,6 +1850,7 @@ BOOL IsStringObject (size_t obj);
 BOOL IsObjectArray (DWORD_PTR objPointer);
 BOOL IsObjectArray (DacpObjectData *pData);
 BOOL IsDerivedFrom(CLRDATA_ADDRESS mtObj, __in_z LPCWSTR baseString);
+BOOL IsDerivedFrom(CLRDATA_ADDRESS mtObj, DWORD_PTR modulePtr, mdTypeDef typeDef);
 BOOL TryGetMethodDescriptorForDelegate(CLRDATA_ADDRESS delegateAddr, CLRDATA_ADDRESS* pMD);
 
 #ifdef FEATURE_PAL


### PR DESCRIPTION
When the `-tasks` flag is set, we look at every object on the heap and walk its hierarchy to decide if it's a task or a task-derived type.  But we currently do that by comparing the name of every object against "System.Threading.Tasks.Task", which is very expensive.  This switches to comparing by module and type def.  On my machine, a `!dumpasync -tasks` command that previously took ~1 minute now takes ~30 seconds.

cc: @PatrickCarnahan, @mikem8361, @noahfalk 