### PR TITLE
Display unknown EventSource's provider name properly

### DIFF
--- a/src/Tools/dotnet-counters/ConsoleWriter.cs
+++ b/src/Tools/dotnet-counters/ConsoleWriter.cs
@@ -16,11 +16,13 @@ namespace Microsoft.Diagnostics.Tools.Counters
         private int maxRow;  // Running maximum of row number
         private int maxCol;  // Running maximum of col number
         private Dictionary<string, int> knownProvidersRowNum;
+        private Dictionary<string, int> unknownProvidersRowNum;
 
         public ConsoleWriter()
         {
             displayPosition = new Dictionary<string, (int, int)>();
             knownProvidersRowNum = new Dictionary<string, int>();
+            unknownProvidersRowNum = new Dictionary<string, int>();
 
             foreach(CounterProvider provider in KnownData.GetAllProviders())
             {
@@ -64,7 +66,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
                     {
                         knownProvidersRowNum[providerName] = maxRow + 1;
                         Console.SetCursorPosition(0, maxRow);
-                        Console.WriteLine(providerName);
+                        Console.WriteLine($"[{providerName}]");
                         maxRow += 1;
                     }
 
@@ -84,6 +86,14 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 else
                 {
                     // If it's from an unknown provider, just append it at the end.
+                    if (!unknownProvidersRowNum.ContainsKey(providerName))
+                    {
+                        knownProvidersRowNum[providerName] = maxRow + 1;
+                        Console.SetCursorPosition(0, maxRow);
+                        Console.WriteLine($"[{providerName}]");
+                        maxRow += 1;
+                    }
+
                     string displayName = payload.GetDisplay();
                     if (string.IsNullOrEmpty(displayName))
                     {

--- a/src/Tools/dotnet-counters/CounterMonitor.cs
+++ b/src/Tools/dotnet-counters/CounterMonitor.cs
@@ -101,11 +101,6 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 return 1;
             }
 
-            if (_interval == 0) {
-                _console.Error.WriteLine("refreshInterval is required.");
-                return 1;
-            }
-
             String providerString;
 
             if (_counterList.Count == 0)


### PR DESCRIPTION
This will fix https://github.com/dotnet/diagnostics/issues/297
Also removed some useless code that can't be reached.