### PR TITLE
Do not display exception on graceful exit case

### DIFF
--- a/src/Tools/dotnet-counters/CounterMonitor.cs
+++ b/src/Tools/dotnet-counters/CounterMonitor.cs
@@ -177,8 +177,9 @@ namespace Microsoft.Diagnostics.Tools.Counters
                     source.Dynamic.All += Dynamic_All;
                     source.Process();
                 }
-                catch
+                catch (Exception ex)
                 {
+                    Debug.WriteLine($"[ERROR] {ex.ToString()}");
                 }
                 finally
                 {

--- a/src/Tools/dotnet-counters/CounterMonitor.cs
+++ b/src/Tools/dotnet-counters/CounterMonitor.cs
@@ -177,9 +177,8 @@ namespace Microsoft.Diagnostics.Tools.Counters
                     source.Dynamic.All += Dynamic_All;
                     source.Process();
                 }
-                catch (Exception ex)
+                catch
                 {
-                    Console.Error.WriteLine($"[ERROR] {ex.ToString()}");
                 }
                 finally
                 {


### PR DESCRIPTION
Fix issue #298. 

This was added mainly for debugging purposes during development but an end user might think of it as a crash rather than a graceful exit even though it's supposed to be a graceful exit case. 