### PR TITLE
Clear out correct length for counter value 

### DIFF
--- a/src/Tools/dotnet-counters/ConsoleWriter.cs
+++ b/src/Tools/dotnet-counters/ConsoleWriter.cs
@@ -94,12 +94,12 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 return;
             }
             string name = payload.GetName();
-
+            string keyName = CounterNameString(providerName, name);
             // We already know what this counter is! Just update the value string on the console.
-            if (displayPosition.ContainsKey(name))
+            if (displayPosition.ContainsKey(keyName))
             {
-                (int left, int row) = displayPosition[CounterNameString(providerName, name)];
-                int clearLength = displayLength[CounterNameString(providerName, name)];
+                (int left, int row) = displayPosition[keyName];
+                int clearLength = displayLength[keyName];
                 Console.SetCursorPosition(left, row);
                 Console.Write(new String(' ', clearLength));
 
@@ -131,8 +131,8 @@ namespace Microsoft.Diagnostics.Tools.Counters
                     int left = displayName.Length + 7; // displayName + " : "
                     int row = maxRow;
                     string val = payload.GetValue();
-                    displayPosition[CounterNameString(providerName, name)] = (left, row);
-                    displayLength[CounterNameString(providerName, name)] = val.Length;
+                    displayPosition[keyName] = (left, row);
+                    displayLength[keyName] = val.Length;
                     Console.WriteLine($"    {displayName} : {val}");
                     maxRow += 1;
                 }
@@ -155,8 +155,8 @@ namespace Microsoft.Diagnostics.Tools.Counters
                     int left = displayName.Length + 7; // displayName + " : "
                     int row = maxRow;
                     string val = payload.GetValue();
-                    displayPosition[CounterNameString(providerName, name)] = (left, row);
-                    displayLength[CounterNameString(providerName, name)] = val.Length;
+                    displayPosition[keyName] = (left, row);
+                    displayLength[keyName] = val.Length;
                     Console.WriteLine($"    {displayName} : {val}");
                     maxRow += 1;
                 }

--- a/src/Tools/dotnet-counters/ConsoleWriter.cs
+++ b/src/Tools/dotnet-counters/ConsoleWriter.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
     public class ConsoleWriter
     {
         private Dictionary<string, (int, int)> displayPosition; // Display position (x-y coordiates) of each counter values.
-        private Dictionary<string, (int, int)> displayLength; // Length of the counter values displayed for each counter.
+        private Dictionary<string, int> displayLength; // Length of the counter values displayed for each counter.
         private int origRow;
         private int origCol;
         private int maxRow;  // Running maximum of row number
@@ -34,6 +34,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
         public ConsoleWriter()
         {
             displayPosition = new Dictionary<string, (int, int)>();
+            displayLength = new Dictionary<string, int>();
             knownProvidersRowNum = new Dictionary<string, int>();
             unknownProvidersRowNum = new Dictionary<string, int>();
 
@@ -129,9 +130,10 @@ namespace Microsoft.Diagnostics.Tools.Counters
                     
                     int left = displayName.Length + 7; // displayName + " : "
                     int row = maxRow;
+                    string val = payload.GetValue();
                     displayPosition[CounterNameString(providerName, name)] = (left, row);
-                    displayLength[CounterNameString(providerName, name)] = val.Length();
-                    Console.WriteLine($"    {displayName} : {payload.GetValue()}");
+                    displayLength[CounterNameString(providerName, name)] = val.Length;
+                    Console.WriteLine($"    {displayName} : {val}");
                     maxRow += 1;
                 }
                 else
@@ -152,9 +154,9 @@ namespace Microsoft.Diagnostics.Tools.Counters
                     }
                     int left = displayName.Length + 7; // displayName + " : "
                     int row = maxRow;
-                    string val = payload.getValue();
+                    string val = payload.GetValue();
                     displayPosition[CounterNameString(providerName, name)] = (left, row);
-                    displayLength[CounterNameString(providerName, name)] = val.Length();
+                    displayLength[CounterNameString(providerName, name)] = val.Length;
                     Console.WriteLine($"    {displayName} : {val}");
                     maxRow += 1;
                 }


### PR DESCRIPTION
Fixes #318. 

Also modified `displayPosition`'s key slightly to be robust to potential key collisions when same counter names are used across different providers.