### PR TITLE
Fix dotnet-dump when running on preview 6

### DIFF
--- a/eng/install-test-runtimes.ps1
+++ b/eng/install-test-runtimes.ps1
@@ -16,13 +16,15 @@ $RuntimeVersion21="2.1.11"
 $RuntimeVersion22="2.2.5"
 $DailyTestText="true"
 
+# Always install 2.1 for the daily test (scheduled builds) scenario because xunit needs it
+. $DotNetDir\dotnet-install.ps1 -Version $RuntimeVersion21 -Architecture $BuildArch -SkipNonVersionedFiles -Runtime dotnet -InstallDir $DotNetDir
+
 # Install the other versions of .NET Core runtime we are going to test. 1.1.x, 2.1.x, 2.2.x
 # and latest. Only install the latest master for daily jobs and leave the RuntimeVersion* 
 # config properties blank.
 if (!$DailyTest) {
     $DailyTestText="false"
     . $DotNetDir\dotnet-install.ps1 -Version $RuntimeVersion11 -Architecture $BuildArch -SkipNonVersionedFiles -Runtime dotnet -InstallDir $DotNetDir
-    . $DotNetDir\dotnet-install.ps1 -Version $RuntimeVersion21 -Architecture $BuildArch -SkipNonVersionedFiles -Runtime dotnet -InstallDir $DotNetDir
     . $DotNetDir\dotnet-install.ps1 -Version $RuntimeVersion22 -Architecture $BuildArch -SkipNonVersionedFiles -Runtime dotnet -InstallDir $DotNetDir
 }
 

--- a/eng/install-test-runtimes.sh
+++ b/eng/install-test-runtimes.sh
@@ -48,13 +48,15 @@ done
 
 daily_test_text="true"
 
+# Always install 2.1 for the daily test (scheduled builds) scenario because xunit needs it
+bash "$dotnet_dir/dotnet-install.sh" --version "$runtime_version_21" --architecture "$build_arch" --skip-non-versioned-files --runtime dotnet --install-dir "$dotnet_dir"
+
 # Install the other versions of .NET Core runtime we are going to test. 1.1.x, 2.1.x, 2.2.x
 # and latest. Only install the latest master for daily jobs and leave the RuntimeVersion* 
 # config properties blank.
 if [ $daily_test == 0 ]; then
     daily_test_text="false"
     bash "$dotnet_dir/dotnet-install.sh" --version "$runtime_version_11" --architecture "$build_arch" --skip-non-versioned-files --runtime dotnet --install-dir "$dotnet_dir"
-    bash "$dotnet_dir/dotnet-install.sh" --version "$runtime_version_21" --architecture "$build_arch" --skip-non-versioned-files --runtime dotnet --install-dir "$dotnet_dir"
     bash "$dotnet_dir/dotnet-install.sh" --version "$runtime_version_22" --architecture "$build_arch" --skip-non-versioned-files --runtime dotnet --install-dir "$dotnet_dir"
 fi
 

--- a/src/SOS/SOS.NETCore/SOS.NETCore.csproj
+++ b/src/SOS/SOS.NETCore/SOS.NETCore.csproj
@@ -6,6 +6,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>;1591;1701</NoWarn>
     <Description>.NET Core SOS</Description>
+    <VersionPrefix>4.8.0</VersionPrefix>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
When the 3.0 preview 6 runtime is the only one available, it causes
dotnet-dump to throw a missing method exception. This is because it
tries to load the wrong SOS.NETCore.dll assembly from the runtime
directory instead of the one that comes with dotnet-dump/SOS.

The workaround is to change the SOS.NETCore assembly version
to 4.8.0.x which is greater than the 4.7.x version of the
preview 6 runtime.