### PR TITLE
Standardize on spelling (Diagnostic -> Diagnostics)

### DIFF
--- a/src/Microsoft.Diagnostic.Repl/Command/Attributes.cs
+++ b/src/Microsoft.Diagnostic.Repl/Command/Attributes.cs
@@ -5,7 +5,7 @@
 // --------------------------------------------------------------------
 using System;
 
-namespace Microsoft.Diagnostic.Repl
+namespace Microsoft.Diagnostics.Repl
 {
     /// <summary>
     /// Base command option attribute.

--- a/src/Microsoft.Diagnostic.Repl/Command/CommandBase.cs
+++ b/src/Microsoft.Diagnostic.Repl/Command/CommandBase.cs
@@ -8,7 +8,7 @@ using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.Threading.Tasks;
 
-namespace Microsoft.Diagnostic.Repl
+namespace Microsoft.Diagnostics.Repl
 {
     /// <summary>
     /// The common command context

--- a/src/Microsoft.Diagnostic.Repl/Command/CommandProcessor.cs
+++ b/src/Microsoft.Diagnostic.Repl/Command/CommandProcessor.cs
@@ -15,7 +15,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 
-namespace Microsoft.Diagnostic.Repl
+namespace Microsoft.Diagnostics.Repl
 {
     public class CommandProcessor
     {

--- a/src/Microsoft.Diagnostic.Repl/Console/CharToLineConverter.cs
+++ b/src/Microsoft.Diagnostic.Repl/Console/CharToLineConverter.cs
@@ -7,7 +7,7 @@
 using System;
 using System.Text;
 
-namespace Microsoft.Diagnostic.Repl
+namespace Microsoft.Diagnostics.Repl
 {
     public sealed class CharToLineConverter
     {

--- a/src/Microsoft.Diagnostic.Repl/Console/ConsoleProvider.cs
+++ b/src/Microsoft.Diagnostic.Repl/Console/ConsoleProvider.cs
@@ -11,7 +11,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Microsoft.Diagnostic.Repl
+namespace Microsoft.Diagnostics.Repl
 {
     public sealed class ConsoleProvider : IConsole
     {

--- a/src/Microsoft.Diagnostic.Repl/Console/OutputType.cs
+++ b/src/Microsoft.Diagnostic.Repl/Console/OutputType.cs
@@ -4,7 +4,7 @@
 //
 // --------------------------------------------------------------------
 
-namespace Microsoft.Diagnostic.Repl
+namespace Microsoft.Diagnostics.Repl
 {
     /// <summary>
     /// The type of output. 

--- a/src/Microsoft.Diagnostics.Tools.RuntimeClient/DiagnosticHelpers.cs
+++ b/src/Microsoft.Diagnostics.Tools.RuntimeClient/DiagnosticHelpers.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.Diagnostics.Tools.RuntimeClient
 {
-    public static class DiagnosticHelpers
+    public static class DiagnosticsHelpers
     {
         /// <summary>
         /// Controls the contents of the dump
@@ -30,7 +30,7 @@ namespace Microsoft.Diagnostics.Tools.RuntimeClient
         /// <param name="dumpName">Path and file name of core dump</param>
         /// <param name="dumpType">Type of dump</param>
         /// <param name="diagnostics">If true, log to console the dump generation diagnostics</param>
-        /// <returns>DiagnosticServerErrorCode</returns>
+        /// <returns>DiagnosticsServerErrorCode</returns>
         public static int GenerateCoreDump(int processId, string dumpName, DumpType dumpType, bool diagnostics)
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
@@ -41,15 +41,15 @@ namespace Microsoft.Diagnostics.Tools.RuntimeClient
 
 
             var payload = SerializeCoreDump(dumpName, dumpType, diagnostics);
-            var message = new IpcMessage(DiagnosticServerCommandSet.Dump, (byte)DumpCommandId.GenerateCoreDump, payload);
+            var message = new IpcMessage(DiagnosticsServerCommandSet.Dump, (byte)DumpCommandId.GenerateCoreDump, payload);
 
             var response = IpcClient.SendMessage(processId, message);
 
             var hr = 0;
-            switch ((DiagnosticServerCommandId)response.Header.CommandId)
+            switch ((DiagnosticsServerCommandId)response.Header.CommandId)
             {
-                case DiagnosticServerCommandId.Error:
-                case DiagnosticServerCommandId.OK:
+                case DiagnosticsServerCommandId.Error:
+                case DiagnosticsServerCommandId.OK:
                     hr = BitConverter.ToInt32(response.Payload);
                     break;
                 default:
@@ -81,20 +81,20 @@ namespace Microsoft.Diagnostics.Tools.RuntimeClient
             }
 
             var header = new MessageHeader {
-                RequestType = DiagnosticMessageType.AttachProfiler,
+                RequestType = DiagnosticsMessageType.AttachProfiler,
                 Pid = (uint)Process.GetCurrentProcess().Id,
             };
 
             byte[] serializedConfiguration = SerializeProfilerAttach(attachTimeout, profilerGuid, profilerPath, additionalData);
-            var message = new IpcMessage(DiagnosticServerCommandSet.Profiler, (byte)ProfilerCommandId.AttachProfiler, serializedConfiguration);
+            var message = new IpcMessage(DiagnosticsServerCommandSet.Profiler, (byte)ProfilerCommandId.AttachProfiler, serializedConfiguration);
 
             var response = IpcClient.SendMessage(processId, message);
 
             var hr = 0;
-            switch ((DiagnosticServerCommandId)response.Header.CommandId)
+            switch ((DiagnosticsServerCommandId)response.Header.CommandId)
             {
-                case DiagnosticServerCommandId.Error:
-                case DiagnosticServerCommandId.OK:
+                case DiagnosticsServerCommandId.Error:
+                case DiagnosticsServerCommandId.OK:
                     hr = BitConverter.ToInt32(response.Payload);
                     break;
                 default:

--- a/src/Microsoft.Diagnostics.Tools.RuntimeClient/DiagnosticsIpc/IpcClient.cs
+++ b/src/Microsoft.Diagnostics.Tools.RuntimeClient/DiagnosticsIpc/IpcClient.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Diagnostics.Tools.RuntimeClient.DiagnosticsIpc
 {
     public class IpcClient
     {
-        private static string DiagnosticPortPattern { get; } = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? @"^dotnet-diagnostic-(\d+)$" : @"^dotnet-diagnostic-(\d+)-(\d+)-socket$";
+        private static string DiagnosticsPortPattern { get; } = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? @"^dotnet-diagnostic-(\d+)$" : @"^dotnet-diagnostic-(\d+)-(\d+)-socket$";
 
         private static string IpcRootPath { get; } = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? @"\\.\pipe\" : Path.GetTempPath();
 
@@ -53,7 +53,7 @@ namespace Microsoft.Diagnostics.Tools.RuntimeClient.DiagnosticsIpc
         }
 
         /// <summary>
-        /// Sends a single DiagnosticIpc Message to the dotnet process with PID processId.
+        /// Sends a single DiagnosticsIpc Message to the dotnet process with PID processId.
         /// </summary>
         /// <param name="processId">The PID of the dotnet process</param>
         /// <param name="message">The DiagnosticsIpc Message to be sent</param>
@@ -68,7 +68,7 @@ namespace Microsoft.Diagnostics.Tools.RuntimeClient.DiagnosticsIpc
         }
 
         /// <summary>
-        /// Sends a single DiagnosticIpc Message to the dotnet process with PID processId
+        /// Sends a single DiagnosticsIpc Message to the dotnet process with PID processId
         /// and returns the Stream for reuse in Optional Continuations.
         /// </summary>
         /// <param name="processId">The PID of the dotnet process</param>

--- a/src/Microsoft.Diagnostics.Tools.RuntimeClient/DiagnosticsIpc/IpcCommands.cs
+++ b/src/Microsoft.Diagnostics.Tools.RuntimeClient/DiagnosticsIpc/IpcCommands.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace Microsoft.Diagnostics.Tools.RuntimeClient.DiagnosticsIpc
 {
-    public enum DiagnosticServerCommandSet : byte
+    public enum DiagnosticsServerCommandSet : byte
     {
         Dump           = 0x01,
         EventPipe      = 0x02,
@@ -13,7 +13,7 @@ namespace Microsoft.Diagnostics.Tools.RuntimeClient.DiagnosticsIpc
         Server         = 0xFF,
     }
 
-    public enum DiagnosticServerCommandId : byte
+    public enum DiagnosticsServerCommandId : byte
     {
         OK    = 0x00,
         Error = 0xFF,

--- a/src/Microsoft.Diagnostics.Tools.RuntimeClient/DiagnosticsIpc/IpcHeader.cs
+++ b/src/Microsoft.Diagnostics.Tools.RuntimeClient/DiagnosticsIpc/IpcHeader.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Diagnostics.Tools.RuntimeClient.DiagnosticsIpc
     {
         IpcHeader() { }
 
-        public IpcHeader(DiagnosticServerCommandSet commandSet, byte commandId)
+        public IpcHeader(DiagnosticsServerCommandSet commandSet, byte commandId)
         {
             CommandSet = (byte)commandSet;
             CommandId = commandId;

--- a/src/Microsoft.Diagnostics.Tools.RuntimeClient/DiagnosticsIpc/IpcMessage.cs
+++ b/src/Microsoft.Diagnostics.Tools.RuntimeClient/DiagnosticsIpc/IpcMessage.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Diagnostics.Tools.RuntimeClient.DiagnosticsIpc
             Header = header;
         }
 
-        internal IpcMessage(DiagnosticServerCommandSet commandSet, byte commandId, byte[] payload = null)
+        internal IpcMessage(DiagnosticsServerCommandSet commandSet, byte commandId, byte[] payload = null)
         {
             Header = new IpcHeader(commandSet, commandId);
             Payload = payload;

--- a/src/Microsoft.Diagnostics.Tools.RuntimeClient/Eventing/DiagnosticMessageType.cs
+++ b/src/Microsoft.Diagnostics.Tools.RuntimeClient/Eventing/DiagnosticMessageType.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Diagnostics.Tools.RuntimeClient
     /// <summary>
     /// Different diagnostic message types that are handled by the runtime.
     /// </summary>
-    public enum DiagnosticMessageType : uint
+    public enum DiagnosticsMessageType : uint
     {
         /// <summary>
         /// Initiates core dump generation 

--- a/src/Microsoft.Diagnostics.Tools.RuntimeClient/Eventing/EventPipeClient.cs
+++ b/src/Microsoft.Diagnostics.Tools.RuntimeClient/Eventing/EventPipeClient.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Diagnostics.Tools.RuntimeClient
 {
     public static class EventPipeClient
     {
-        private static string DiagnosticPortPattern { get; } = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? @"^dotnet-diagnostic-(\d+)$" : @"^dotnet-diagnostic-(\d+)-(\d+)-socket$";
+        private static string DiagnosticsPortPattern { get; } = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? @"^dotnet-diagnostic-(\d+)$" : @"^dotnet-diagnostic-(\d+)-(\d+)-socket$";
 
         private static string IpcRootPath { get; } = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? @"\\.\pipe\" : Path.GetTempPath();
 
@@ -34,8 +34,8 @@ namespace Microsoft.Diagnostics.Tools.RuntimeClient
         {
             return Directory.GetFiles(IpcRootPath)
                 .Select(namedPipe => (new FileInfo(namedPipe)).Name)
-                .Where(input => Regex.IsMatch(input, DiagnosticPortPattern))
-                .Select(input => int.Parse(Regex.Match(input, DiagnosticPortPattern).Groups[1].Value, NumberStyles.Integer));
+                .Where(input => Regex.IsMatch(input, DiagnosticsPortPattern))
+                .Select(input => int.Parse(Regex.Match(input, DiagnosticsPortPattern).Groups[1].Value, NumberStyles.Integer));
         }
 
         /// <summary>
@@ -48,15 +48,15 @@ namespace Microsoft.Diagnostics.Tools.RuntimeClient
         public static Stream CollectTracing(int processId, SessionConfiguration configuration, out ulong sessionId)
         {
             sessionId = 0;
-            var message = new IpcMessage(DiagnosticServerCommandSet.EventPipe, (byte)EventPipeCommandId.CollectTracing, configuration.Serialize());
+            var message = new IpcMessage(DiagnosticsServerCommandSet.EventPipe, (byte)EventPipeCommandId.CollectTracing, configuration.Serialize());
             var stream = IpcClient.SendMessage(processId, message, out var response);
 
-            switch ((DiagnosticServerCommandId)response.Header.CommandId)
+            switch ((DiagnosticsServerCommandId)response.Header.CommandId)
             {
-                case DiagnosticServerCommandId.OK:
+                case DiagnosticsServerCommandId.OK:
                     sessionId = BitConverter.ToUInt64(response.Payload);
                     break;
-                case DiagnosticServerCommandId.Error:
+                case DiagnosticsServerCommandId.Error:
                     // bad...
                     var hr = BitConverter.ToInt32(response.Payload);
                     throw new Exception($"Session start FAILED 0x{hr:X8}");
@@ -80,13 +80,13 @@ namespace Microsoft.Diagnostics.Tools.RuntimeClient
 
             byte[] payload = BitConverter.GetBytes(sessionId);
 
-            var response = IpcClient.SendMessage(processId, new IpcMessage(DiagnosticServerCommandSet.EventPipe, (byte)EventPipeCommandId.StopTracing, payload));
+            var response = IpcClient.SendMessage(processId, new IpcMessage(DiagnosticsServerCommandSet.EventPipe, (byte)EventPipeCommandId.StopTracing, payload));
 
-            switch ((DiagnosticServerCommandId)response.Header.CommandId)
+            switch ((DiagnosticsServerCommandId)response.Header.CommandId)
             {
-                case DiagnosticServerCommandId.OK:
+                case DiagnosticsServerCommandId.OK:
                     return BitConverter.ToUInt64(response.Payload);
-                case DiagnosticServerCommandId.Error:
+                case DiagnosticsServerCommandId.Error:
                     return 0;
                 default:
                     return 0;

--- a/src/Microsoft.Diagnostics.Tools.RuntimeClient/Eventing/MessageHeader.cs
+++ b/src/Microsoft.Diagnostics.Tools.RuntimeClient/Eventing/MessageHeader.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Diagnostics.Tools.RuntimeClient
         /// <summary>
         /// Request type.
         /// </summary>
-        public DiagnosticMessageType RequestType;
+        public DiagnosticsMessageType RequestType;
 
         /// <summary>
         /// Remote process Id.

--- a/src/Tools/dotnet-dump/AnalyzeContext.cs
+++ b/src/Tools/dotnet-dump/AnalyzeContext.cs
@@ -16,7 +16,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 
-namespace Microsoft.Diagnostic.Tools.Dump
+namespace Microsoft.Diagnostics.Tools.Dump
 {
     /// <summary>
     /// The the common context for analyze commands

--- a/src/Tools/dotnet-dump/Analyzer.cs
+++ b/src/Tools/dotnet-dump/Analyzer.cs
@@ -1,4 +1,4 @@
-using Microsoft.Diagnostic.Repl;
+using Microsoft.Diagnostics.Repl;
 using Microsoft.Diagnostics.Runtime;
 using SOS;
 using System;
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Microsoft.Diagnostic.Tools.Dump
+namespace Microsoft.Diagnostics.Tools.Dump
 {
     public class Analyzer
     {

--- a/src/Tools/dotnet-dump/Commands/ClrModulesCommand.cs
+++ b/src/Tools/dotnet-dump/Commands/ClrModulesCommand.cs
@@ -1,10 +1,10 @@
 
-using Microsoft.Diagnostic.Repl;
+using Microsoft.Diagnostics.Repl;
 using Microsoft.Diagnostics.Runtime;
 using System.CommandLine;
 using System.Threading.Tasks;
 
-namespace Microsoft.Diagnostic.Tools.Dump
+namespace Microsoft.Diagnostics.Tools.Dump
 {
     [Command(Name = "clrmodules", Help = "Lists the managed modules in the process.")]
     public class ClrModulesCommand : CommandBase

--- a/src/Tools/dotnet-dump/Commands/ExitCommand.cs
+++ b/src/Tools/dotnet-dump/Commands/ExitCommand.cs
@@ -1,9 +1,9 @@
 
-using Microsoft.Diagnostic.Repl;
+using Microsoft.Diagnostics.Repl;
 using System.CommandLine;
 using System.Threading.Tasks;
 
-namespace Microsoft.Diagnostic.Tools.Dump
+namespace Microsoft.Diagnostics.Tools.Dump
 {
     [Command(Name = "exit", Help = "Exit interactive mode.")]
     [CommandAlias(Name = "quit")]

--- a/src/Tools/dotnet-dump/Commands/HelpCommand.cs
+++ b/src/Tools/dotnet-dump/Commands/HelpCommand.cs
@@ -1,7 +1,7 @@
-using Microsoft.Diagnostic.Repl;
+using Microsoft.Diagnostics.Repl;
 using System.CommandLine;
 
-namespace Microsoft.Diagnostic.Tools.Dump
+namespace Microsoft.Diagnostics.Tools.Dump
 {
     [Command(Name = "help", Help = "Display help for a command.")]
     public class HelpCommand : CommandBase

--- a/src/Tools/dotnet-dump/Commands/ModulesCommand.cs
+++ b/src/Tools/dotnet-dump/Commands/ModulesCommand.cs
@@ -1,11 +1,11 @@
 
-using Microsoft.Diagnostic.Repl;
+using Microsoft.Diagnostics.Repl;
 using Microsoft.Diagnostics.Runtime;
 using System.CommandLine;
 using System.Linq;
 using System.Threading.Tasks;
 
-namespace Microsoft.Diagnostic.Tools.Dump
+namespace Microsoft.Diagnostics.Tools.Dump
 {
     [Command(Name = "modules", Help = "Displays the native modules in the process.")]
     [CommandAlias(Name = "lm")]

--- a/src/Tools/dotnet-dump/Commands/SOSCommand.cs
+++ b/src/Tools/dotnet-dump/Commands/SOSCommand.cs
@@ -1,10 +1,10 @@
-using Microsoft.Diagnostic.Repl;
+using Microsoft.Diagnostics.Repl;
 using System;
 using System.CommandLine;
 using System.IO;
 using System.Linq;
 
-namespace Microsoft.Diagnostic.Tools.Dump
+namespace Microsoft.Diagnostics.Tools.Dump
 {
     [Command(Name = "clrstack",         AliasExpansion = "ClrStack",            Help = "Provides a stack trace of managed code only.")]
     [Command(Name = "clrthreads",       AliasExpansion = "Threads",             Help = "List the managed threads running.")]

--- a/src/Tools/dotnet-dump/Commands/SetThreadCommand.cs
+++ b/src/Tools/dotnet-dump/Commands/SetThreadCommand.cs
@@ -1,11 +1,11 @@
 
-using Microsoft.Diagnostic.Repl;
+using Microsoft.Diagnostics.Repl;
 using System;
 using System.Collections.Generic;
 using System.CommandLine;
 using System.Linq;
 
-namespace Microsoft.Diagnostic.Tools.Dump
+namespace Microsoft.Diagnostics.Tools.Dump
 {
     [Command(Name = "setthread", Help = "Sets or displays the current thread for the SOS commands.")]
     [CommandAlias(Name = "threads")]

--- a/src/Tools/dotnet-dump/Dumper.Linux.cs
+++ b/src/Tools/dotnet-dump/Dumper.Linux.cs
@@ -4,7 +4,7 @@ using System.Diagnostics;
 using System.Threading.Tasks;
 using System.IO;
 
-namespace Microsoft.Diagnostic.Tools.Dump
+namespace Microsoft.Diagnostics.Tools.Dump
 {
     public partial class Dumper
     {

--- a/src/Tools/dotnet-dump/Dumper.Windows.cs
+++ b/src/Tools/dotnet-dump/Dumper.Windows.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Microsoft.Win32.SafeHandles;
 
-namespace Microsoft.Diagnostic.Tools.Dump
+namespace Microsoft.Diagnostics.Tools.Dump
 {
     public partial class Dumper
     {

--- a/src/Tools/dotnet-dump/Dumper.cs
+++ b/src/Tools/dotnet-dump/Dumper.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Microsoft.Diagnostic.Tools.Dump
+namespace Microsoft.Diagnostics.Tools.Dump
 {
     public partial class Dumper
     {
@@ -57,10 +57,10 @@ namespace Microsoft.Diagnostic.Tools.Dump
                 }
                 else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 {
-                    DiagnosticHelpers.DumpType dumpType = type == DumpTypeOption.Heap ? DiagnosticHelpers.DumpType.WithHeap : DiagnosticHelpers.DumpType.Normal;
+                    DiagnosticsHelpers.DumpType dumpType = type == DumpTypeOption.Heap ? DiagnosticsHelpers.DumpType.WithHeap : DiagnosticsHelpers.DumpType.Normal;
 
                     // Send the command to the runtime to initiate the core dump
-                    var hr = DiagnosticHelpers.GenerateCoreDump(processId, output, dumpType, diagnostics: false);
+                    var hr = DiagnosticsHelpers.GenerateCoreDump(processId, output, dumpType, diagnostics: false);
                     if (hr != 0)
                     {
                         throw new InvalidOperationException($"Core dump generation FAILED 0x{hr:X8}");

--- a/src/Tools/dotnet-dump/Program.cs
+++ b/src/Tools/dotnet-dump/Program.cs
@@ -4,7 +4,7 @@ using System.CommandLine.Invocation;
 using System.IO;
 using System.Threading.Tasks;
 
-namespace Microsoft.Diagnostic.Tools.Dump
+namespace Microsoft.Diagnostics.Tools.Dump
 {
     class Program
     {

--- a/src/tests/Microsoft.Diagnostics.Tools.RuntimeClient/Program.cs
+++ b/src/tests/Microsoft.Diagnostics.Tools.RuntimeClient/Program.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Diagnostics.Tools.RuntimeClient.Tests
         static int Main(string[] args)
         {
             SendSmallerHeaderCommand();
-            SendInvalidDiagnosticMessageTypeCommand();
+            SendInvalidDiagnosticsMessageTypeCommand();
             SendInvalidInputData();
             TestCollectEventPipeTracing();
             return 100;
@@ -39,7 +39,7 @@ namespace Microsoft.Diagnostics.Tools.RuntimeClient.Tests
                 {
                     using (var bw = new BinaryWriter(stream))
                     {
-                        bw.Write((uint)DiagnosticMessageType.StartEventPipeTracing);
+                        bw.Write((uint)DiagnosticsMessageType.StartEventPipeTracing);
                         bw.Flush();
                         stream.Position = 0;
 
@@ -60,7 +60,7 @@ namespace Microsoft.Diagnostics.Tools.RuntimeClient.Tests
             }
         }
 
-        private static void SendInvalidDiagnosticMessageTypeCommand()
+        private static void SendInvalidDiagnosticsMessageTypeCommand()
         {
             Console.WriteLine("Send a wrong message type as the diagnostic header header.");
             ulong sessionId = 0;
@@ -178,7 +178,7 @@ namespace Microsoft.Diagnostics.Tools.RuntimeClient.Tests
                 try
                 {
                     var header = new MessageHeader {
-                        RequestType = DiagnosticMessageType.CollectEventPipeTracing,
+                        RequestType = DiagnosticsMessageType.CollectEventPipeTracing,
                         Pid = (uint)Process.GetCurrentProcess().Id,
                     };
 


### PR DESCRIPTION
This handles all the occurrences that are capitalized.

All I did is replace "Diagnostics" -> "Diagnostic" and then replace "Diagnostic" -> "Diagnostics" on all C# files, case sensitive.

The test related files are intentionally unchanged.