### PR TITLE
Standardize license header for all C# files

### DIFF
--- a/src/Microsoft.Diagnostics.Repl/Command/Attributes.cs
+++ b/src/Microsoft.Diagnostics.Repl/Command/Attributes.cs
@@ -1,8 +1,7 @@
-// --------------------------------------------------------------------
-// 
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-// 
-// --------------------------------------------------------------------
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 
 namespace Microsoft.Diagnostics.Repl

--- a/src/Microsoft.Diagnostics.Repl/Command/CommandBase.cs
+++ b/src/Microsoft.Diagnostics.Repl/Command/CommandBase.cs
@@ -1,8 +1,7 @@
-// --------------------------------------------------------------------
-// 
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-// 
-// --------------------------------------------------------------------
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.CommandLine;
 using System.CommandLine.Invocation;

--- a/src/Microsoft.Diagnostics.Repl/Command/CommandProcessor.cs
+++ b/src/Microsoft.Diagnostics.Repl/Command/CommandProcessor.cs
@@ -1,8 +1,6 @@
-﻿// --------------------------------------------------------------------
-//
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//
-// --------------------------------------------------------------------
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections;

--- a/src/Microsoft.Diagnostics.Repl/Console/CharToLineConverter.cs
+++ b/src/Microsoft.Diagnostics.Repl/Console/CharToLineConverter.cs
@@ -1,8 +1,6 @@
-﻿// --------------------------------------------------------------------
-// 
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-// 
-// --------------------------------------------------------------------
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Text;

--- a/src/Microsoft.Diagnostics.Repl/Console/ConsoleProvider.cs
+++ b/src/Microsoft.Diagnostics.Repl/Console/ConsoleProvider.cs
@@ -1,8 +1,7 @@
-// --------------------------------------------------------------------
-// 
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-// 
-// --------------------------------------------------------------------
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.CommandLine;

--- a/src/Microsoft.Diagnostics.Repl/Console/OutputType.cs
+++ b/src/Microsoft.Diagnostics.Repl/Console/OutputType.cs
@@ -1,8 +1,6 @@
-﻿// --------------------------------------------------------------------
-//
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//
-// --------------------------------------------------------------------
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Repl
 {

--- a/src/Microsoft.Diagnostics.Tools.RuntimeClient/DiagnosticsIpc/IpcClient.cs
+++ b/src/Microsoft.Diagnostics.Tools.RuntimeClient/DiagnosticsIpc/IpcClient.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Pipes;

--- a/src/Microsoft.Diagnostics.Tools.RuntimeClient/DiagnosticsIpc/IpcCommands.cs
+++ b/src/Microsoft.Diagnostics.Tools.RuntimeClient/DiagnosticsIpc/IpcCommands.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 

--- a/src/Microsoft.Diagnostics.Tools.RuntimeClient/DiagnosticsIpc/IpcHeader.cs
+++ b/src/Microsoft.Diagnostics.Tools.RuntimeClient/DiagnosticsIpc/IpcHeader.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;

--- a/src/Microsoft.Diagnostics.Tools.RuntimeClient/DiagnosticsIpc/IpcMessage.cs
+++ b/src/Microsoft.Diagnostics.Tools.RuntimeClient/DiagnosticsIpc/IpcMessage.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;

--- a/src/Tools/Common/CommandLineException.cs
+++ b/src/Tools/Common/CommandLineException.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Runtime.Serialization;
 

--- a/src/Tools/Common/ConsoleCancellation.cs
+++ b/src/Tools/Common/ConsoleCancellation.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Tools/Common/DebugUtil.cs
+++ b/src/Tools/Common/DebugUtil.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/Tools/dotnet-analyze/AnalysisSession.cs
+++ b/src/Tools/dotnet-analyze/AnalysisSession.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Tracing.Etlx;
 

--- a/src/Tools/dotnet-analyze/AsyncHangAnalyzer.cs
+++ b/src/Tools/dotnet-analyze/AsyncHangAnalyzer.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Threading.Tasks;
 using McMaster.Extensions.CommandLineUtils;

--- a/src/Tools/dotnet-analyze/ClrMdExtensions.cs
+++ b/src/Tools/dotnet-analyze/ClrMdExtensions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Runtime;
 

--- a/src/Tools/dotnet-analyze/CommandProcessor.cs
+++ b/src/Tools/dotnet-analyze/CommandProcessor.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Tools/dotnet-analyze/Commands/DumpCommandBase.cs
+++ b/src/Tools/dotnet-analyze/Commands/DumpCommandBase.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using McMaster.Extensions.CommandLineUtils;

--- a/src/Tools/dotnet-analyze/Commands/DumpHeapCommand.cs
+++ b/src/Tools/dotnet-analyze/Commands/DumpHeapCommand.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Tools/dotnet-analyze/Commands/DumpStackCommand.cs
+++ b/src/Tools/dotnet-analyze/Commands/DumpStackCommand.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/src/Tools/dotnet-analyze/Commands/EventStackCommand.cs
+++ b/src/Tools/dotnet-analyze/Commands/EventStackCommand.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;

--- a/src/Tools/dotnet-analyze/Commands/IAnalysisCommand.cs
+++ b/src/Tools/dotnet-analyze/Commands/IAnalysisCommand.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using McMaster.Extensions.CommandLineUtils;

--- a/src/Tools/dotnet-analyze/Commands/InfoCommand.cs
+++ b/src/Tools/dotnet-analyze/Commands/InfoCommand.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using McMaster.Extensions.CommandLineUtils;

--- a/src/Tools/dotnet-analyze/Commands/LogsCommand.cs
+++ b/src/Tools/dotnet-analyze/Commands/LogsCommand.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Tools/dotnet-analyze/Commands/RequestsCommand.cs
+++ b/src/Tools/dotnet-analyze/Commands/RequestsCommand.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Tools/dotnet-analyze/Commands/ThreadsCommand.cs
+++ b/src/Tools/dotnet-analyze/Commands/ThreadsCommand.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using McMaster.Extensions.CommandLineUtils;

--- a/src/Tools/dotnet-analyze/Commands/TraceCommandBase.cs
+++ b/src/Tools/dotnet-analyze/Commands/TraceCommandBase.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using McMaster.Extensions.CommandLineUtils;

--- a/src/Tools/dotnet-analyze/LogMessage.cs
+++ b/src/Tools/dotnet-analyze/LogMessage.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using Microsoft.Diagnostics.Tracing;

--- a/src/Tools/dotnet-analyze/MemoryDump.cs
+++ b/src/Tools/dotnet-analyze/MemoryDump.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Tools/dotnet-analyze/Program.cs
+++ b/src/Tools/dotnet-analyze/Program.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Tools/dotnet-dump/AnalyzeContext.cs
+++ b/src/Tools/dotnet-dump/AnalyzeContext.cs
@@ -1,8 +1,7 @@
-// --------------------------------------------------------------------
-// 
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-// 
-// --------------------------------------------------------------------
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using Microsoft.Diagnostics.Runtime;
 using Microsoft.SymbolStore;
 using Microsoft.SymbolStore.KeyGenerators;

--- a/src/Tools/dotnet-dump/Analyzer.cs
+++ b/src/Tools/dotnet-dump/Analyzer.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using Microsoft.Diagnostics.Repl;
 using Microsoft.Diagnostics.Runtime;
 using SOS;

--- a/src/Tools/dotnet-dump/Commands/ClrModulesCommand.cs
+++ b/src/Tools/dotnet-dump/Commands/ClrModulesCommand.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Repl;
 using Microsoft.Diagnostics.Runtime;

--- a/src/Tools/dotnet-dump/Commands/ExitCommand.cs
+++ b/src/Tools/dotnet-dump/Commands/ExitCommand.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Repl;
 using System.CommandLine;

--- a/src/Tools/dotnet-dump/Commands/HelpCommand.cs
+++ b/src/Tools/dotnet-dump/Commands/HelpCommand.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using Microsoft.Diagnostics.Repl;
 using System.CommandLine;
 

--- a/src/Tools/dotnet-dump/Commands/ModulesCommand.cs
+++ b/src/Tools/dotnet-dump/Commands/ModulesCommand.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Repl;
 using Microsoft.Diagnostics.Runtime;

--- a/src/Tools/dotnet-dump/Commands/SOSCommand.cs
+++ b/src/Tools/dotnet-dump/Commands/SOSCommand.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using Microsoft.Diagnostics.Repl;
 using System;
 using System.CommandLine;

--- a/src/Tools/dotnet-dump/Commands/SOSCommandForWindows.cs
+++ b/src/Tools/dotnet-dump/Commands/SOSCommandForWindows.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using Microsoft.Diagnostics.Repl;
 using System.CommandLine;
 

--- a/src/Tools/dotnet-dump/Commands/SetThreadCommand.cs
+++ b/src/Tools/dotnet-dump/Commands/SetThreadCommand.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Repl;
 using System;

--- a/src/Tools/dotnet-dump/Dumper.Linux.cs
+++ b/src/Tools/dotnet-dump/Dumper.Linux.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Linq;
 using System.Diagnostics;

--- a/src/Tools/dotnet-dump/Dumper.Windows.cs
+++ b/src/Tools/dotnet-dump/Dumper.Windows.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Diagnostics;
 using System.IO;

--- a/src/Tools/dotnet-dump/Dumper.cs
+++ b/src/Tools/dotnet-dump/Dumper.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using Microsoft.Diagnostics.Tools.RuntimeClient;
 using System;
 using System.CommandLine;

--- a/src/Tools/dotnet-dump/Program.cs
+++ b/src/Tools/dotnet-dump/Program.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.CommandLine;
 using System.CommandLine.Builder;
 using System.CommandLine.Invocation;

--- a/src/Tools/dotnet-sos/Program.cs
+++ b/src/Tools/dotnet-sos/Program.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using SOS;
 using System;

--- a/src/Tools/dotnet-trace/CommandLine/Commands/ErrorCode.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/ErrorCode.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 namespace Microsoft.Diagnostics.Tools.Trace
 {
     internal static class ErrorCodes

--- a/src/Tools/dotnet-trace/Profile.cs
+++ b/src/Tools/dotnet-trace/Profile.cs
@@ -1,4 +1,8 @@
-﻿using Microsoft.Diagnostics.Tools.RuntimeClient;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Tools.RuntimeClient;
 using System.Collections.Generic;
 using System.Linq;
 


### PR DESCRIPTION
I left the `Xunit.Extensions` files alone, not sure what license header we should have there, the rest should all be MIT.