### PR TITLE
Fix missing metadata problems

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -460,7 +460,7 @@ phases:
         /p:DotNetSignType=$(SignType) 
         /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1) 
         /p:DotNetPublishBlobFeedUrl=$(_PublishBlobFeedUrl)
-        /p:DotNetPublishToBlobFeed=true
+        /p:DotNetPublishToBlobFeed=$(PublishPackages)
         /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
         /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
         /p:OfficialBuildId=$(BUILD.BUILDNUMBER)

--- a/src/SOS/SOS.UnitTests/Scripts/StackAndOtherTests.script
+++ b/src/SOS/SOS.UnitTests/Scripts/StackAndOtherTests.script
@@ -64,9 +64,6 @@ VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.Program\.Foo1\(.*\)\s+\[(?i:.*[
 VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.Program\.Main\(.*\)\s+\[(?i:.*[\\|/]SymbolTestApp\.cs) @ 19\]\s*
 ENDIF:PROJECTK
 
-# Issue #https://github.com/dotnet/diagnostics/issues/266
-IFDEF:NEVER
-
 # Verify that ClrStack with the ICorDebug options works
 IFDEF:PROJECTK
 SOSCOMMAND:ClrStack -i
@@ -96,8 +93,6 @@ VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+\[DEFAULT\] I4 SymbolTestApp\.Program\.Foo1\(.
 VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+\[DEFAULT\] Void SymbolTestApp\.Program\.Main\(.*\)\s+\(.*\)\s+
 VERIFY:.*\s+Stack walk complete.\s+
 ENDIF:PROJECTK
-
-ENDIF:NEVER
 
 !IFDEF:ALPINE
 

--- a/src/SOS/SOS.UnitTests/Scripts/StackAndOtherTests.script
+++ b/src/SOS/SOS.UnitTests/Scripts/StackAndOtherTests.script
@@ -77,6 +77,8 @@ VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+\[DEFAULT\] Void SymbolTestApp\.Program\.Main\
 VERIFY:.*\s+Stack walk complete.\s+
 ENDIF:PROJECTK
 
+!IFDEF:ALPINE
+
 # Verify that ClrStack with the ICorDebug options and all option (locals/params) works
 IFDEF:PROJECTK
 SOSCOMMAND:ClrStack -i -a
@@ -93,8 +95,6 @@ VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+\[DEFAULT\] I4 SymbolTestApp\.Program\.Foo1\(.
 VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+\[DEFAULT\] Void SymbolTestApp\.Program\.Main\(.*\)\s+\(.*\)\s+
 VERIFY:.*\s+Stack walk complete.\s+
 ENDIF:PROJECTK
-
-!IFDEF:ALPINE
 
 # Verify DumpStackObjects works
 IFDEF:PROJECTK

--- a/src/SOS/SOS.UnitTests/Scripts/StackTests.script
+++ b/src/SOS/SOS.UnitTests/Scripts/StackTests.script
@@ -66,9 +66,6 @@ VERIFY:\s+[r|e]ax=<HEXVAL>\s+[r|e]bx=<HEXVAL>\s+[r|e]cx=<HEXVAL>\s+
 ENDIF:64BIT
 ENDIF:PROJECTK
 
-# Issue #https://github.com/dotnet/diagnostics/issues/266
-IFDEF:NEVER
-
 # 5) Verifying that ClrStack with the ICorDebug options works
 SOSCOMMAND:ClrStack -i
 VERIFY:.*\s+Dumping managed stack and managed variables using ICorDebug.\s+
@@ -92,8 +89,6 @@ VERIFY:\s+\+ System.FormatException ex @ 0x<HEXVAL>\s+
 VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+\[DEFAULT\] Void NestedExceptionTest\.Program\.Main\(.*\)\s+\(.*\)\s+
 VERIFY:.*\s+Stack walk complete.\s+
 ENDIF:PROJECTK
-
-ENDIF:NEVER
 
 # 7) Verify DumpStackObjects works
 IFDEF:PROJECTK

--- a/src/SOS/SOS.UnitTests/Scripts/StackTests.script
+++ b/src/SOS/SOS.UnitTests/Scripts/StackTests.script
@@ -76,6 +76,7 @@ VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+\[DEFAULT\] Void NestedExceptionTest\.Program\
 VERIFY:.*\s+Stack walk complete.\s+
 
 # 6) Verifying that ClrStack with the ICorDebug options and all option (locals/params) works
+!IFDEF:ALPINE
 IFDEF:PROJECTK
 SOSCOMMAND:ClrStack -i -a
 VERIFY:.*\s+Dumping managed stack and managed variables using ICorDebug.\s+
@@ -89,6 +90,7 @@ VERIFY:\s+\+ System.FormatException ex @ 0x<HEXVAL>\s+
 VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+\[DEFAULT\] Void NestedExceptionTest\.Program\.Main\(.*\)\s+\(.*\)\s+
 VERIFY:.*\s+Stack walk complete.\s+
 ENDIF:PROJECTK
+ENDIF:ALPINE
 
 # 7) Verify DumpStackObjects works
 IFDEF:PROJECTK

--- a/src/SOS/Strike/datatarget.cpp
+++ b/src/SOS/Strike/datatarget.cpp
@@ -138,13 +138,16 @@ DataTarget::ReadVirtual(
 #ifdef FEATURE_PAL
     if (g_sos != nullptr)
     {
-        // LLDB synthesizes memory (returns 0's) for missing pages (in this case the missing metadata 
-        // pages) in core dumps. This functions creates a list of the metadata regions and returns true
-        // if the read would be in the metadata of a loaded assembly. This allows an error to be returned 
-        // instead of 0's so the DAC will call the GetMetadataLocator datatarget callback.
-        if (IsMetadataMemory(address, request))
-        {
-            return E_ACCESSDENIED;
+        // LLDB synthesizes memory (returns 0's) for missing pages (in this case the missing metadata  pages) 
+        // in core dumps. This functions creates a list of the metadata regions and caches the metadata if 
+        // available from the local or downloaded assembly. If the read would be in the metadata of a loaded 
+        // assembly, the metadata from the this cache will be returned.
+        HRESULT hr = GetMetadataMemory(address, request, buffer);
+        if (SUCCEEDED(hr)) {
+            if (done != nullptr) {
+                *done = request;
+            }
+            return hr;
         }
     }
 #endif
@@ -303,14 +306,7 @@ DataTarget::GetMetadata(
     BYTE* buffer,
     /* [out] */ ULONG32* dataSize)
 {
-    HRESULT hr = InitializeHosting();
-    if (FAILED(hr))
-    {
-        return hr;
-    }
-    InitializeSymbolStore();
-    _ASSERTE(g_SOSNetCoreCallbacks.GetMetadataLocatorDelegate != nullptr);
-    return g_SOSNetCoreCallbacks.GetMetadataLocatorDelegate(imagePath, imageTimestamp, imageSize, mvid, mdRva, flags, bufferSize, buffer, dataSize);
+    return ::GetMetadataLocator(imagePath, imageTimestamp, imageSize, mvid, mdRva, flags, bufferSize, buffer, dataSize);
 }
 
 

--- a/src/SOS/Strike/disasm.cpp
+++ b/src/SOS/Strike/disasm.cpp
@@ -26,6 +26,7 @@ namespace X86GCDump
 #define DAC_ARG(x)
 #define CONTRACTL_END
 #define LIMITED_METHOD_CONTRACT
+#undef NOTHROW
 #define NOTHROW
 #define GC_NOTRIGGER
 #define SUPPORTS_DAC

--- a/src/SOS/Strike/hostcoreclr.cpp
+++ b/src/SOS/Strike/hostcoreclr.cpp
@@ -925,6 +925,29 @@ void DisableSymbolStore()
 }
 
 /**********************************************************************\
+ * Returns the metadata from a local or downloaded assembly
+\**********************************************************************/
+HRESULT GetMetadataLocator(
+    LPCWSTR imagePath,
+    ULONG32 imageTimestamp,
+    ULONG32 imageSize,
+    GUID* mvid,
+    ULONG32 mdRva,
+    ULONG32 flags,
+    ULONG32 bufferSize,
+    BYTE* buffer,
+    ULONG32* dataSize)
+{
+    HRESULT hr = InitializeHosting();
+    if (FAILED(hr)) {
+        return hr;
+    }
+    InitializeSymbolStore();
+    _ASSERTE(g_SOSNetCoreCallbacks.GetMetadataLocatorDelegate != nullptr);
+    return g_SOSNetCoreCallbacks.GetMetadataLocatorDelegate(imagePath, imageTimestamp, imageSize, mvid, mdRva, flags, bufferSize, buffer, dataSize);
+}
+
+/**********************************************************************\
  * Load symbols for an ICorDebugModule. Used by "clrstack -i".
 \**********************************************************************/
 HRESULT SymbolReader::LoadSymbols(___in IMetaDataImport* pMD, ___in ICorDebugModule* pModule)
@@ -1193,6 +1216,9 @@ HRESULT SymbolReader::GetLineByILOffset(___in mdMethodDef methodToken, ___in ULO
     return E_FAIL;
 }
 
+/**********************************************************************\
+ * Returns the name of the local variable from a PDB. 
+\**********************************************************************/
 HRESULT SymbolReader::GetNamedLocalVariable(___in ISymUnmanagedScope * pScope, ___in ICorDebugILFrame * pILFrame, ___in mdMethodDef methodToken, 
     ___in ULONG localIndex, __out_ecount(paramNameLen) WCHAR* paramName, ___in ULONG paramNameLen, ICorDebugValue** ppValue)
 {

--- a/src/SOS/Strike/hostcoreclr.h
+++ b/src/SOS/Strike/hostcoreclr.h
@@ -73,6 +73,17 @@ extern HRESULT LoadNativeSymbols(bool runtimeOnly = false);
 extern void DisplaySymbolStore();
 extern void DisableSymbolStore();
 
+extern HRESULT GetMetadataLocator(
+    LPCWSTR imagePath,
+    ULONG32 imageTimestamp,
+    ULONG32 imageSize,
+    GUID* mvid,
+    ULONG32 mdRva,
+    ULONG32 flags,
+    ULONG32 bufferSize,
+    BYTE* buffer,
+    ULONG32* dataSize);
+
 class SymbolReader
 {
 private:

--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -197,7 +197,6 @@ HMODULE g_hInstance = NULL;
 
 #ifdef FEATURE_PAL
 
-#define NOTHROW
 #define MINIDUMP_NOT_SUPPORTED()
 
 #else // !FEATURE_PAL
@@ -209,8 +208,6 @@ HMODULE g_hInstance = NULL;
         ExtOut("To try the command anyway, run !MinidumpMode 0\n"); \
         return Status;         \
     }
-
-#define NOTHROW (std::nothrow)
 
 #include "safemath.h"
 

--- a/src/SOS/Strike/util.h
+++ b/src/SOS/Strike/util.h
@@ -41,6 +41,12 @@ inline void RestoreSOToleranceState() {}
 typedef LPCSTR  LPCUTF8;
 typedef LPSTR   LPUTF8;
 
+#ifdef FEATURE_PAL
+#define NOTHROW
+#else
+#define NOTHROW (std::nothrow)
+#endif 
+
 DECLARE_HANDLE(OBJECTHANDLE);
 
 #if defined(_TARGET_WIN64_)
@@ -1853,7 +1859,7 @@ BOOL TryGetMethodDescriptorForDelegate(CLRDATA_ADDRESS delegateAddr, CLRDATA_ADD
 
 #ifdef FEATURE_PAL
 void FlushMetadataRegions();
-bool IsMetadataMemory(CLRDATA_ADDRESS address, ULONG32 size);
+HRESULT GetMetadataMemory(CLRDATA_ADDRESS address, ULONG32 bufferSize, BYTE* buffer);
 #endif
 
 /* Returns a list of all modules in the process.


### PR DESCRIPTION
The previous fix forced the metadata to always go through
the metadata locator callback interface. This fix the problem
when the metadata in the core dump isn't complete, but broke
getting metadata for user/app assemblies that only exist in
the core dump.

Needed to "fallback" to reading the core dump memory for the
metadata when the assembly can't be found or downloaded.

Cleaned up building the module list.