### PR TITLE
Align counter values

### DIFF
--- a/src/Tools/dotnet-counters/ConsoleWriter.cs
+++ b/src/Tools/dotnet-counters/ConsoleWriter.cs
@@ -140,16 +140,9 @@ namespace Microsoft.Diagnostics.Tools.Counters
                     {
                         displayName = payload.GetDisplay();
                     }
-
-                    // If counter name is longer than left-indent of counter values, move values to the right
+                    
                     int left = displayName.Length;
-                    if (left+indentLength+4 > leftAlign) // +4 so that the counter value does not start right where the counter name ends
-                    {
-                        leftAlign = left+indentLength+4;
-                    }
-
                     string spaces = new String(' ', leftAlign-left-indentLength);
-
                     int row = maxRow;
                     string val = payload.GetValue();
                     displayPosition[keyName] = (leftAlign, row); 
@@ -174,16 +167,16 @@ namespace Microsoft.Diagnostics.Tools.Counters
                     {
                         displayName = payload.GetName();
                     }
-
-                    // If counter name is longer than left-indent of counter values, move values to the right
+                    
                     int left = displayName.Length;
+
+                    // If counter name is exceeds position of counter values, move values to the right
                     if (left+indentLength+4 > leftAlign) // +4 so that the counter value does not start right where the counter name ends
                     {
                         leftAlign = left+indentLength+4;
                     }
 
                     string spaces = new String(' ', leftAlign-left-indentLength);
-
                     int row = maxRow;
                     string val = payload.GetValue();
                     displayPosition[keyName] = (leftAlign, row); 

--- a/src/Tools/dotnet-counters/ConsoleWriter.cs
+++ b/src/Tools/dotnet-counters/ConsoleWriter.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
             displayLength = new Dictionary<string, int>();
             knownProvidersRowNum = new Dictionary<string, int>();
             unknownProvidersRowNum = new Dictionary<string, int>();
-            leftAlign = 45;
+            leftAlign = 45; // Width of counter names column
 
             foreach(CounterProvider provider in KnownData.GetAllProviders())
             {
@@ -97,8 +97,8 @@ namespace Microsoft.Diagnostics.Tools.Counters
             }
             string name = payload.GetName();
             string keyName = CounterNameString(providerName, name);
-            string indent = "    ";
-            int indentLength = 4;
+            const string indent = "    ";
+            const int indentLength = 4;
             // We already know what this counter is! Just update the value string on the console.
             if (displayPosition.ContainsKey(keyName))
             {

--- a/src/Tools/dotnet-counters/ConsoleWriter.cs
+++ b/src/Tools/dotnet-counters/ConsoleWriter.cs
@@ -132,8 +132,9 @@ namespace Microsoft.Diagnostics.Tools.Counters
                         displayName = payload.GetDisplay();
                     }
 
+                    // If counter name is longer than left-indent of counter values, increase indent size 
                     int left = displayName.Length;
-                    if (left+3 > leftAlign)
+                    if (left+3 > leftAlign) // +3 so that the counter value does not start right where the counter name ends
                     {
                         leftAlign = left+3;
                     }
@@ -142,7 +143,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
 
                     int row = maxRow;
                     string val = payload.GetValue();
-                    displayPosition[keyName] = (leftAlign+4, row);
+                    displayPosition[keyName] = (leftAlign+4, row); // +4 because counter names are indented by 4 spaces
                     displayLength[keyName] = val.Length;
                     Console.WriteLine("{0}{1}{2}", $"    {displayName}", spaces, val);
                     maxRow += 1;
@@ -165,8 +166,9 @@ namespace Microsoft.Diagnostics.Tools.Counters
                         displayName = payload.GetName();
                     }
 
+                    // If counter name is longer than left-indent of counter values, increase indent size
                     int left = displayName.Length;
-                    if (left+3 > leftAlign)
+                    if (left+3 > leftAlign) // +3 so that the counter value does not start right where the counter name ends
                     {
                         leftAlign = left+3;
                     }
@@ -175,7 +177,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
 
                     int row = maxRow;
                     string val = payload.GetValue();
-                    displayPosition[keyName] = (leftAlign+4, row);
+                    displayPosition[keyName] = (leftAlign+4, row); // +4 because counter names are indented by 4 spaces
                     displayLength[keyName] = val.Length;
                     Console.WriteLine("{0}{1}{2}", $"    {displayName}", spaces, val);
                     maxRow += 1;

--- a/src/Tools/dotnet-counters/ConsoleWriter.cs
+++ b/src/Tools/dotnet-counters/ConsoleWriter.cs
@@ -17,12 +17,11 @@ namespace Microsoft.Diagnostics.Tools.Counters
         private int maxRow;  // Running maximum of row number
         private int maxCol;  // Running maximum of col number
         private int STATUS_ROW; // Row # of where we print the status of dotnet-counters
+        private int leftAlign;
         private bool paused = false;
         private bool initialized = false;
         private Dictionary<string, int> knownProvidersRowNum;
         private Dictionary<string, int> unknownProvidersRowNum;
-
-        private int leftAlign;
 
         private void UpdateStatus(string msg)
         {
@@ -39,7 +38,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
             displayLength = new Dictionary<string, int>();
             knownProvidersRowNum = new Dictionary<string, int>();
             unknownProvidersRowNum = new Dictionary<string, int>();
-            leftAlign = 42;
+            leftAlign = 45;
 
             foreach(CounterProvider provider in KnownData.GetAllProviders())
             {
@@ -98,15 +97,25 @@ namespace Microsoft.Diagnostics.Tools.Counters
             }
             string name = payload.GetName();
             string keyName = CounterNameString(providerName, name);
+            string indent = "    ";
+            int indentLength = 4;
             // We already know what this counter is! Just update the value string on the console.
             if (displayPosition.ContainsKey(keyName))
             {
                 (int left, int row) = displayPosition[keyName];
                 int clearLength = displayLength[keyName];
-                Console.SetCursorPosition(left, row);
+                Console.SetCursorPosition(left, row); 
                 Console.Write(new String(' ', clearLength));
 
-                Console.SetCursorPosition(left, row);
+                if (left < leftAlign)
+                {
+                    displayPosition[keyName] = (leftAlign, row);
+                    Console.SetCursorPosition(leftAlign, row);
+                }
+                else
+                {
+                    Console.SetCursorPosition(left, row);
+                }
                 Console.Write(payload.GetValue());  
             }
             // Got a payload from a new counter that hasn't been written to the console yet.
@@ -132,20 +141,20 @@ namespace Microsoft.Diagnostics.Tools.Counters
                         displayName = payload.GetDisplay();
                     }
 
-                    // If counter name is longer than left-indent of counter values, increase indent size 
+                    // If counter name is longer than left-indent of counter values, move values to the right
                     int left = displayName.Length;
-                    if (left+3 > leftAlign) // +3 so that the counter value does not start right where the counter name ends
+                    if (left+indentLength+4 > leftAlign) // +4 so that the counter value does not start right where the counter name ends
                     {
-                        leftAlign = left+3;
+                        leftAlign = left+indentLength+4;
                     }
 
-                    string spaces = new String(' ', leftAlign-left);
+                    string spaces = new String(' ', leftAlign-left-indentLength);
 
                     int row = maxRow;
                     string val = payload.GetValue();
-                    displayPosition[keyName] = (leftAlign+4, row); // +4 because counter names are indented by 4 spaces
+                    displayPosition[keyName] = (leftAlign, row); 
                     displayLength[keyName] = val.Length;
-                    Console.WriteLine("{0}{1}{2}", $"    {displayName}", spaces, val);
+                    Console.WriteLine($"{indent}{displayName}{spaces}{val}");
                     maxRow += 1;
                 }
                 else
@@ -166,20 +175,20 @@ namespace Microsoft.Diagnostics.Tools.Counters
                         displayName = payload.GetName();
                     }
 
-                    // If counter name is longer than left-indent of counter values, increase indent size
+                    // If counter name is longer than left-indent of counter values, move values to the right
                     int left = displayName.Length;
-                    if (left+3 > leftAlign) // +3 so that the counter value does not start right where the counter name ends
+                    if (left+indentLength+4 > leftAlign) // +4 so that the counter value does not start right where the counter name ends
                     {
-                        leftAlign = left+3;
+                        leftAlign = left+indentLength+4;
                     }
 
-                    string spaces = new String(' ', leftAlign-left);
+                    string spaces = new String(' ', leftAlign-left-indentLength);
 
                     int row = maxRow;
                     string val = payload.GetValue();
-                    displayPosition[keyName] = (leftAlign+4, row); // +4 because counter names are indented by 4 spaces
+                    displayPosition[keyName] = (leftAlign, row); 
                     displayLength[keyName] = val.Length;
-                    Console.WriteLine("{0}{1}{2}", $"    {displayName}", spaces, val);
+                    Console.WriteLine($"{indent}{displayName}{spaces}{val}");
                     maxRow += 1;
                 }
             }

--- a/src/Tools/dotnet-counters/ConsoleWriter.cs
+++ b/src/Tools/dotnet-counters/ConsoleWriter.cs
@@ -22,6 +22,8 @@ namespace Microsoft.Diagnostics.Tools.Counters
         private Dictionary<string, int> knownProvidersRowNum;
         private Dictionary<string, int> unknownProvidersRowNum;
 
+        private int leftAlign;
+
         private void UpdateStatus(string msg)
         {
             Console.SetCursorPosition(0, STATUS_ROW);
@@ -37,6 +39,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
             displayLength = new Dictionary<string, int>();
             knownProvidersRowNum = new Dictionary<string, int>();
             unknownProvidersRowNum = new Dictionary<string, int>();
+            leftAlign = 42;
 
             foreach(CounterProvider provider in KnownData.GetAllProviders())
             {
@@ -123,17 +126,25 @@ namespace Microsoft.Diagnostics.Tools.Counters
 
                     KnownData.TryGetProvider(providerName, out CounterProvider counterProvider);
                     string displayName = counterProvider.TryGetDisplayName(name);
+                    
                     if (displayName == null)
                     {
                         displayName = payload.GetDisplay();
                     }
-                    
-                    int left = displayName.Length + 7; // displayName + " : "
+
+                    int left = displayName.Length;
+                    if (left+3 > leftAlign)
+                    {
+                        leftAlign = left+3;
+                    }
+
+                    string spaces = new String(' ', leftAlign-left);
+
                     int row = maxRow;
                     string val = payload.GetValue();
-                    displayPosition[keyName] = (left, row);
+                    displayPosition[keyName] = (leftAlign+4, row);
                     displayLength[keyName] = val.Length;
-                    Console.WriteLine($"    {displayName} : {val}");
+                    Console.WriteLine("{0}{1}{2}", $"    {displayName}", spaces, val);
                     maxRow += 1;
                 }
                 else
@@ -148,16 +159,25 @@ namespace Microsoft.Diagnostics.Tools.Counters
                     }
 
                     string displayName = payload.GetDisplay();
+                    
                     if (string.IsNullOrEmpty(displayName))
                     {
                         displayName = payload.GetName();
                     }
-                    int left = displayName.Length + 7; // displayName + " : "
+
+                    int left = displayName.Length;
+                    if (left+3 > leftAlign)
+                    {
+                        leftAlign = left+3;
+                    }
+
+                    string spaces = new String(' ', leftAlign-left);
+
                     int row = maxRow;
                     string val = payload.GetValue();
-                    displayPosition[keyName] = (left, row);
+                    displayPosition[keyName] = (leftAlign+4, row);
                     displayLength[keyName] = val.Length;
-                    Console.WriteLine($"    {displayName} : {val}");
+                    Console.WriteLine("{0}{1}{2}", $"    {displayName}", spaces, val);
                     maxRow += 1;
                 }
             }


### PR DESCRIPTION
Fixes #317

Displays counter names and counter values in separate columns. Also accommodates for user adding counter names that are longer than the width of the counter names column.