### PR TITLE
Change SOS and diagnostic tool versioning

### DIFF
--- a/eng/Build-Native.cmd
+++ b/eng/Build-Native.cmd
@@ -197,7 +197,7 @@ if /i %__BuildCrossArch% EQU 1 (
 
     echo Generating Version Header
     set __GenerateVersionLog="%__LogDir%\GenerateVersion.binlog"
-    "%__DotNetCli%" msbuild "%__ProjectDir%\eng\CreateVersionFile.csproj" /v:!__Verbosity! /bl:!__GenerateVersionLog! /t:GenerateVersionFiles /p:VersionPrefixFile=%__RootBinDir%\bin\VersionPrefix.txt /p:GenerateVersionHeader=true /p:NativeVersionHeaderFile=%__CrossCompIntermediatesDir%\_version.h /p:Configuration=%__BuildType% /p:Platform=%__BuildArch% %__UnprocessedBuildArgs%
+    "%__DotNetCli%" msbuild "%__ProjectDir%\eng\CreateVersionFile.csproj" /v:!__Verbosity! /bl:!__GenerateVersionLog! /t:GenerateVersionFiles /p:FileVersionFile=%__RootBinDir%\bin\FileVersion.txt /p:GenerateVersionHeader=true /p:NativeVersionHeaderFile=%__CrossCompIntermediatesDir%\_version.h /p:Configuration=%__BuildType% /p:Platform=%__BuildArch% %__UnprocessedBuildArgs%
     if not !errorlevel! == 0 (
         echo Generate Version Header FAILED
         exit /b 1
@@ -275,7 +275,7 @@ if %__Build% EQU 1 (
 
     echo Generating Version Header
     set __GenerateVersionLog="%__LogDir%\GenerateVersion.binlog"
-    "%__DotNetCli%" msbuild "%__ProjectDir%\eng\CreateVersionFile.csproj" /v:!__Verbosity! /bl:!__GenerateVersionLog! /t:GenerateVersionFiles /p:VersionPrefixFile=%__RootBinDir%\bin\VersionPrefix.txt /p:GenerateVersionHeader=true /p:NativeVersionHeaderFile=%__IntermediatesDir%\_version.h /p:Configuration=%__BuildType% /p:Platform=%__BuildArch% %__UnprocessedBuildArgs%
+    "%__DotNetCli%" msbuild "%__ProjectDir%\eng\CreateVersionFile.csproj" /v:!__Verbosity! /bl:!__GenerateVersionLog! /t:GenerateVersionFiles /p:FileVersionFile=%__RootBinDir%\bin\FileVersion.txt /p:GenerateVersionHeader=true /p:NativeVersionHeaderFile=%__IntermediatesDir%\_version.h /p:Configuration=%__BuildType% /p:Platform=%__BuildArch% %__UnprocessedBuildArgs%
     if not !errorlevel! == 0 (
         echo Generate Version Header FAILED
         exit /b 1

--- a/eng/CreateVersionFile.csproj
+++ b/eng/CreateVersionFile.csproj
@@ -4,13 +4,13 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
-  <Target Name="GenerateVersionFiles" DependsOnTargets="GenerateVersionPrefixFile;GenerateVersionHeader;GenerateVersionSourceFile" />
+  <Target Name="GenerateVersionFiles" DependsOnTargets="GenerateFileVersionFile;GenerateVersionHeader;GenerateVersionSourceFile" />
 
-  <Target Name="GenerateVersionPrefixFile" Condition="'$(VersionPrefixFile)' != ''">
+  <Target Name="GenerateFileVersionFile" DependsOnTargets="GetAssemblyVersion;AddSourceRevisionToInformationalVersion" Condition="'$(FileVersionFile)' != ''">
     <ItemGroup>
-      <VersionPrefixLines Include="$(VersionPrefix).0" />
+      <FileVersionLines Include="$(FileVersion)" />
     </ItemGroup>
-    <WriteLinesToFile File="$(VersionPrefixFile)" Lines="@(VersionPrefixLines)" Overwrite="true" />
+    <WriteLinesToFile File="$(FileVersionFile)" Lines="@(FileVersionLines)" Overwrite="true" />
   </Target>
 
   <Target Name="GenerateVersionHeader" DependsOnTargets="GetAssemblyVersion;AddSourceRevisionToInformationalVersion" Condition="'$(NativeVersionHeaderFile)' != '' and '$(GenerateVersionHeader)' == 'true' and !Exists($(NativeVersionHeaderFile))">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,9 +2,10 @@
 <Project>
   <PropertyGroup>
     <RepositoryUrl>https://github.com/dotnet/diagnostics</RepositoryUrl>
-    <PreReleaseVersionLabel>preview6</PreReleaseVersionLabel>
-    <VersionPrefix>1.0.5</VersionPrefix>
+    <PreReleaseVersionLabel>preview7</PreReleaseVersionLabel>
+    <VersionPrefix>3.0.0</VersionPrefix>
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>
+    <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/eng/create-gallery-zip.ps1
+++ b/eng/create-gallery-zip.ps1
@@ -7,7 +7,7 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference="Stop"
 
 $BinDir = "$SourceDirectory\artifacts\bin"
-$SOSGalleryVersion = cat $BinDir\VersionPrefix.txt
+$SOSGalleryVersion = cat $BinDir\FileVersion.txt
 
 $SOSNETCorePath = "$BinDir\SOS.NETCore\Release\netstandard2.0\publish"
 $GalleryDir = "$BinDir\gallery\$SOSGalleryVersion"


### PR DESCRIPTION
Change the major/minor/patch to 3.0.0 to match our runtime.

Changed the extension gallery zip file and version to the file version
generated by Arcade.