### PR TITLE
Enable disasm mixed gc info

### DIFF
--- a/src/SOS/Strike/disasm.cpp
+++ b/src/SOS/Strike/disasm.cpp
@@ -1174,7 +1174,7 @@ bool GCEncodingInfo::ReallocBuf()
         return false;
     }
 
-    newSize = max(1000, newSize);
+    newSize = _max(1000, newSize);
     char* newbuffer = new char[newSize];
     if (newbuffer == NULL)
     {

--- a/src/SOS/Strike/disasm.cpp
+++ b/src/SOS/Strike/disasm.cpp
@@ -1138,4 +1138,137 @@ LPCSTR ARM64Machine::s_SPName           = "sp";
 
 #endif // SOS_TARGET_ARM64
 
+//
+// GCEncodingInfo class member implementations
+//
 
+bool GCEncodingInfo::Initialize()
+{
+    buf = nullptr;
+    cchBufAllocation = 0;
+    cchBuf = 0;
+    curPtr = nullptr;
+    done = false;
+    hotSizeToAdd = 0;
+
+    return ReallocBuf();
+}
+
+void GCEncodingInfo::Deinitialize()
+{
+    delete[] buf;
+    buf = nullptr;
+    cchBufAllocation = 0;
+    cchBuf = 0;
+    curPtr = nullptr;
+    done = false;
+    hotSizeToAdd = 0;
+}
+
+bool GCEncodingInfo::ReallocBuf()
+{
+    size_t newSize;
+    if (!ClrSafeInt<size_t>::multiply(cchBufAllocation, 2, newSize))
+    {
+        ExtOut("<integer overflow>\n");
+        return false;
+    }
+
+    newSize = max(1000, newSize);
+    char* newbuffer = new char[newSize];
+    if (newbuffer == NULL)
+    {
+        ExtOut("Could not allocate memory for the gc info dump.\n");
+        return false;
+    }
+
+    if (buf != nullptr)
+    {
+        memcpy(newbuffer, buf, cchBufAllocation);
+        delete[] buf;
+    }
+    buf = newbuffer;
+    cchBufAllocation = newSize;
+
+    // Make sure it is null terminated. It should already be, unless this is the first time.
+    buf[cchBuf] = '\0';
+
+    return true;
+}
+
+void GCEncodingInfo::DumpGCInfoThrough(size_t curOffset)
+{
+    if (done)
+    {
+        // We've already output all the GC info
+        return;
+    }
+
+    if (curPtr == nullptr)
+    {
+        // We're just starting iteration.
+        curPtr = buf;
+    }
+
+    for (;;)
+    {
+        char *pNewLine = strchr(curPtr, '\n');
+        if (pNewLine != nullptr)
+            *pNewLine = '\0';
+        SIZE_T cchLine = strlen(curPtr);
+
+        // There are two kinds of lines: those that start with an offset, and
+        // those that don't. It should be the case that all lines without
+        // offset come first, but that's certainly not guaranteed.
+        //
+        // For the lines with offset, it will be a 16-bit (x86) or 32-bit (non-x86) hex
+        // offset.  strtoul returns ULONG_MAX or 0 on failure.  0 is a valid
+        // offset for the first encoding.
+
+        char *pEnd;
+        ULONG ofs = strtoul(curPtr, &pEnd, /* base */ 16);
+
+        if ((pEnd != curPtr) && isspace(*pEnd) && (ULONG_MAX != ofs))
+        {
+            // We got a number. Assume it's an offset.
+            if (ofs <= curOffset)
+            {
+                ExtOut(curPtr);
+                ExtOut("\n");
+                curPtr += cchLine + 1; // +1 to pass the terminating null
+            }
+            else
+            {
+                // We'll come back and output this one later. Restore the newline, if any.
+                // Leave curPtr alone.
+                if (pNewLine != nullptr)
+                    *pNewLine = '\n';
+                break;
+            }
+        }
+        else
+        {
+            // This is something else. Output it.
+            ExtOut(curPtr);
+            ExtOut("\n");
+            curPtr += cchLine + 1; // +1 to pass the terminating null
+        }
+
+        if (pNewLine == nullptr)
+        {
+            // There was no trailing newline, and we output some text; we must be done
+            // (if we didn't output any text, we wouldn't get here).
+            done = true;
+            break;
+        }
+        else if (*curPtr == '\0')
+        {
+            // We must have output a line with a newline, and now we're pointing at the
+            // trailing null.
+            done = true;
+            break;
+        }
+
+        // Otherwise, we have text left to output.
+    }
+}

--- a/src/SOS/Strike/disasm.cpp
+++ b/src/SOS/Strike/disasm.cpp
@@ -1196,7 +1196,18 @@ bool GCEncodingInfo::ReallocBuf()
     return true;
 }
 
-void GCEncodingInfo::DumpGCInfoThrough(size_t curOffset)
+bool GCEncodingInfo::EnsureAdequateBufferSpace(SIZE_T count)
+{
+    while (cchBuf + count + 1 > cchBufAllocation) // +1 for null terminator
+    {
+        if (!ReallocBuf())
+            return false;
+    }
+
+    return true;
+}
+
+void GCEncodingInfo::DumpGCInfoThrough(SIZE_T curOffset)
 {
     if (done)
     {

--- a/src/SOS/Strike/disasm.h
+++ b/src/SOS/Strike/disasm.h
@@ -26,21 +26,161 @@ struct DumpStackFlag
 
 struct GCEncodingInfo
 {
-    LPVOID pvMainFiber;
-    LPVOID pvGCTableFiber;
+    GCEncodingInfo() : buf(nullptr), cchBufAllocation(0), cchBuf(0), curPtr(nullptr), done(false), hotSizeToAdd(0)
+    {
+        // We don't call Initialize() here because we want to call it somewhere
+        // we can handle memory allocation or other failures.
+    }
 
-    BYTE *table;
-    unsigned int methodSize;
+    ~GCEncodingInfo()
+    {
+        Deinitialize();
+    }
 
-    char buf[1000];
-    int cch;
+    bool Initialize()
+    {
+        buf = nullptr;
+        cchBufAllocation = 0;
+        cchBuf = 0;
+        curPtr = nullptr;
+        done = false;
+        hotSizeToAdd = 0;
 
-    SIZE_T ofs;
+        return ReallocBuf();
+    }
+
+    void Deinitialize()
+    {
+        delete[] buf;
+        buf = nullptr;
+        cchBufAllocation = 0;
+        cchBuf = 0;
+        curPtr = nullptr;
+        done = false;
+        hotSizeToAdd = 0;
+    }
+
+    // Reallocate the buffer. Double the size. Returns 'true' on success, 'false' on failure.
+    // This is also called to initialize the buffer the first time.
+    bool ReallocBuf()
+    {
+        size_t newSize;
+        if (!ClrSafeInt<size_t>::multiply(cchBufAllocation, 2, newSize))
+        {
+            ExtOut("<integer overflow>\n");
+            return false;
+        }
+
+        newSize = max(1000, newSize);
+        char* newbuffer = new NOTHROW char[newSize];
+        if (newbuffer == NULL)
+        {
+            ExtOut("Could not allocate memory for the gc info dump.\n");
+            return false;
+        }
+
+        if (buf != nullptr)
+        {
+            memcpy(newbuffer, buf, cchBufAllocation);
+            delete[] buf;
+        }
+        buf = newbuffer;
+        cchBufAllocation = newSize;
+
+        // Make sure it is null terminated. It should already be, unless this is the first time.
+        buf[cchBuf] = '\0';
+
+        return true;
+    }
+
+    // Output all GC info from the current position up to and including 'curOffset'.
+    void DumpGCInfoThrough(size_t curOffset)
+    {
+        if (done)
+        {
+            // We've already output all the GC info
+            return;
+        }
+
+        if (curPtr == nullptr)
+        {
+            // We're just starting iteration.
+            curPtr = buf;
+        }
+
+        for (;;)
+        {
+            char *pNewLine = strchr(curPtr, '\n');
+            if (pNewLine != nullptr)
+                *pNewLine = '\0';
+            SIZE_T cchLine = strlen(curPtr);
+
+            // There are two kinds of lines: those that start with an offset, and
+            // those that don't. It should be the case that all lines without
+            // offset come first, but that's certainly not guaranteed.
+            //
+            // For the lines with offset, it will be a 16-bit (x86) or 32-bit (non-x86) hex
+            // offset.  strtoul returns ULONG_MAX or 0 on failure.  0 is a valid
+            // offset for the first encoding.
+
+            char *pEnd;
+            ULONG ofs = strtoul(curPtr, &pEnd, /* base */ 16);
+
+            if ((pEnd != curPtr) && isspace(*pEnd) && (ULONG_MAX != ofs))
+            {
+                // We got a number. Assume it's an offset.
+                if (ofs <= curOffset)
+                {
+                    ExtOut(curPtr);
+                    ExtOut("\n");
+                    curPtr += cchLine + 1; // +1 to pass the terminating null
+                }
+                else
+                {
+                    // We'll come back and output this one later. Restore the newline, if any.
+                    // Leave curPtr alone.
+                    if (pNewLine != nullptr)
+                        *pNewLine = '\n';
+                    break;
+                }
+            }
+            else
+            {
+                // This is something else. Output it.
+                ExtOut(curPtr);
+                ExtOut("\n");
+                curPtr += cchLine + 1; // +1 to pass the terminating null
+            }
+
+            if (pNewLine == nullptr)
+            {
+                // There was no trailing newline, and we output some text; we must be done
+                // (if we didn't output any text, we wouldn't get here).
+                done = true;
+                break;
+            }
+            else if (*curPtr == '\0')
+            {
+                // We must have output a line with a newline, and now we're pointing at the
+                // trailing null.
+                done = true;
+                break;
+            }
+
+            // Otherwise, we have text left to output.
+        }
+    }
+
+    char* buf;                 // GC info textual output memory.
+    SIZE_T cchBufAllocation;   // Number of characters allocated to buf.
+    SIZE_T cchBuf;             // Number of characters stored in 'buf' (not including terminating null).
+
+    char* curPtr;              // Current pointer in 'buf', when iterating through the GC info.
+    bool done;                 // Have we output all the GC info?
     
     // When decoding a cold region, set this to the size of the hot region to keep offset
     // calculations working.
     SIZE_T hotSizeToAdd;    
-    bool fDoneDecoding;
 };
 
 // Returns:

--- a/src/SOS/Strike/disasm.h
+++ b/src/SOS/Strike/disasm.h
@@ -37,139 +37,15 @@ struct GCEncodingInfo
         Deinitialize();
     }
 
-    bool Initialize()
-    {
-        buf = nullptr;
-        cchBufAllocation = 0;
-        cchBuf = 0;
-        curPtr = nullptr;
-        done = false;
-        hotSizeToAdd = 0;
-
-        return ReallocBuf();
-    }
-
-    void Deinitialize()
-    {
-        delete[] buf;
-        buf = nullptr;
-        cchBufAllocation = 0;
-        cchBuf = 0;
-        curPtr = nullptr;
-        done = false;
-        hotSizeToAdd = 0;
-    }
-
+    bool Initialize();
+    void Deinitialize();
+    
     // Reallocate the buffer. Double the size. Returns 'true' on success, 'false' on failure.
     // This is also called to initialize the buffer the first time.
-    bool ReallocBuf()
-    {
-        size_t newSize;
-        if (!ClrSafeInt<size_t>::multiply(cchBufAllocation, 2, newSize))
-        {
-            ExtOut("<integer overflow>\n");
-            return false;
-        }
-
-        newSize = max(1000, newSize);
-        char* newbuffer = new NOTHROW char[newSize];
-        if (newbuffer == NULL)
-        {
-            ExtOut("Could not allocate memory for the gc info dump.\n");
-            return false;
-        }
-
-        if (buf != nullptr)
-        {
-            memcpy(newbuffer, buf, cchBufAllocation);
-            delete[] buf;
-        }
-        buf = newbuffer;
-        cchBufAllocation = newSize;
-
-        // Make sure it is null terminated. It should already be, unless this is the first time.
-        buf[cchBuf] = '\0';
-
-        return true;
-    }
+    bool ReallocBuf();
 
     // Output all GC info from the current position up to and including 'curOffset'.
-    void DumpGCInfoThrough(size_t curOffset)
-    {
-        if (done)
-        {
-            // We've already output all the GC info
-            return;
-        }
-
-        if (curPtr == nullptr)
-        {
-            // We're just starting iteration.
-            curPtr = buf;
-        }
-
-        for (;;)
-        {
-            char *pNewLine = strchr(curPtr, '\n');
-            if (pNewLine != nullptr)
-                *pNewLine = '\0';
-            SIZE_T cchLine = strlen(curPtr);
-
-            // There are two kinds of lines: those that start with an offset, and
-            // those that don't. It should be the case that all lines without
-            // offset come first, but that's certainly not guaranteed.
-            //
-            // For the lines with offset, it will be a 16-bit (x86) or 32-bit (non-x86) hex
-            // offset.  strtoul returns ULONG_MAX or 0 on failure.  0 is a valid
-            // offset for the first encoding.
-
-            char *pEnd;
-            ULONG ofs = strtoul(curPtr, &pEnd, /* base */ 16);
-
-            if ((pEnd != curPtr) && isspace(*pEnd) && (ULONG_MAX != ofs))
-            {
-                // We got a number. Assume it's an offset.
-                if (ofs <= curOffset)
-                {
-                    ExtOut(curPtr);
-                    ExtOut("\n");
-                    curPtr += cchLine + 1; // +1 to pass the terminating null
-                }
-                else
-                {
-                    // We'll come back and output this one later. Restore the newline, if any.
-                    // Leave curPtr alone.
-                    if (pNewLine != nullptr)
-                        *pNewLine = '\n';
-                    break;
-                }
-            }
-            else
-            {
-                // This is something else. Output it.
-                ExtOut(curPtr);
-                ExtOut("\n");
-                curPtr += cchLine + 1; // +1 to pass the terminating null
-            }
-
-            if (pNewLine == nullptr)
-            {
-                // There was no trailing newline, and we output some text; we must be done
-                // (if we didn't output any text, we wouldn't get here).
-                done = true;
-                break;
-            }
-            else if (*curPtr == '\0')
-            {
-                // We must have output a line with a newline, and now we're pointing at the
-                // trailing null.
-                done = true;
-                break;
-            }
-
-            // Otherwise, we have text left to output.
-        }
-    }
+    void DumpGCInfoThrough(size_t curOffset);
 
     char* buf;                 // GC info textual output memory.
     SIZE_T cchBufAllocation;   // Number of characters allocated to buf.

--- a/src/SOS/Strike/disasm.h
+++ b/src/SOS/Strike/disasm.h
@@ -44,8 +44,12 @@ struct GCEncodingInfo
     // This is also called to initialize the buffer the first time.
     bool ReallocBuf();
 
+    // Ensure there are at least 'count' characters available in the buffer, by reallocating
+    // if necessary. Returns 'true' on success, 'false' on failure (e.g., failure to allocate memory).
+    bool EnsureAdequateBufferSpace(SIZE_T count);
+
     // Output all GC info from the current position up to and including 'curOffset'.
-    void DumpGCInfoThrough(size_t curOffset);
+    void DumpGCInfoThrough(SIZE_T curOffset);
 
     char* buf;                 // GC info textual output memory.
     SIZE_T cchBufAllocation;   // Number of characters allocated to buf.

--- a/src/SOS/Strike/disasmARM64.cpp
+++ b/src/SOS/Strike/disasmARM64.cpp
@@ -41,14 +41,6 @@ namespace ARM64GCDump
 #include "gcdumpnonx86.cpp"
 }
 
-#ifdef FEATURE_PAL
-void SwitchToFiber(void*)
-{
-    // TODO: Fix for linux
-    assert(false);
-}
-#endif
-
 #if !defined(_TARGET_WIN64_)
 #error This file only supports SOS targeting ARM64 from a 64-bit debugger
 #endif
@@ -224,13 +216,7 @@ void ARM64Machine::Unassembly (
         if (pGCEncodingInfo)
         {
             SIZE_T curOffset = (currentPC - PCBegin) + pGCEncodingInfo->hotSizeToAdd;
-            while (   !pGCEncodingInfo->fDoneDecoding
-                   && pGCEncodingInfo->ofs <= curOffset)
-            {
-                ExtOut(pGCEncodingInfo->buf);
-                ExtOut("\n");
-                SwitchToFiber(pGCEncodingInfo->pvGCTableFiber);
-            }
+            pGCEncodingInfo->DumpGCInfoThrough(curOffset);
         }
 
         //
@@ -363,6 +349,22 @@ void ARM64Machine::Unassembly (
                 
     }
     ExtOut ("\n");
+
+    //
+    // Print out any "end" GC info
+    //
+    if (pGCEncodingInfo)
+    {
+        pGCEncodingInfo->DumpGCInfoThrough(PC - PCBegin);
+    }
+
+    //
+    // Print out any "end" EH info (where the end address is the byte immediately following the last instruction)
+    //
+    if (pEHInfo)
+    {
+        pEHInfo->FormatForDisassembly(PC - PCBegin);
+    }
 }
 
 

--- a/src/SOS/Strike/disasmX86.cpp
+++ b/src/SOS/Strike/disasmX86.cpp
@@ -545,21 +545,11 @@ void
         // Print out any GC information corresponding to the current instruction offset.
         //
 
-#ifndef FEATURE_PAL
         if (pGCEncodingInfo)
         {
             SIZE_T curOffset = (IP - IPBegin) + pGCEncodingInfo->hotSizeToAdd;
-            while (   !pGCEncodingInfo->fDoneDecoding
-                   && pGCEncodingInfo->ofs <= curOffset)
-            {
-                ExtOut(pGCEncodingInfo->buf);
-                ExtOut("\n");
-                SwitchToFiber(pGCEncodingInfo->pvGCTableFiber);
-            }
+            pGCEncodingInfo->DumpGCInfoThrough(curOffset);
         }
-#endif // FEATURE_PAL        
-
-        ULONG_PTR InstrAddr = IP;
 
         //
         // Print out any EH info corresponding to the current offset
@@ -581,6 +571,8 @@ void
         {
             ExtOut("%04x ", IP - IPBegin);
         }
+
+        ULONG_PTR InstrAddr = IP;
 
         DisasmAndClean (IP, line, _countof(line));
 
@@ -739,6 +731,14 @@ void
                 reg[dest].bValid = FALSE;
         }
         ExtOut ("\n");
+    }
+
+    //
+    // Print out any "end" GC info
+    //
+    if (pGCEncodingInfo)
+    {
+        pGCEncodingInfo->DumpGCInfoThrough(IP - IPBegin);
     }
 
     //


### PR DESCRIPTION
Rewrite the "u -gcinfo" code to not require Windows fibers,
and enable it for non-Windows platforms.

Also,
1. Enable "u -gcinfo" for ARM.
2. Fix minor issues with EHinfo/GCinfo to ensure end-of-function info is displayed
