### PR TITLE
Remove double escape in provider filter strings

### DIFF
--- a/documentation/dotnet-trace-instructions.md
+++ b/documentation/dotnet-trace-instructions.md
@@ -173,7 +173,8 @@ Options:
                 4 - Informational
                 5 - Verbose
             KeyValueArgs            - A semicolon separated list of key=value
-        KeyValueArgs format: '[key1=value1][;key2=value2]'
+        KeyValueArgs format: '[key1=value1][;key2=value2]' 
+            note: values that contain ';' or '=' characters should be surrounded by double quotes ("), e.g., 'key="value;with=symbols";key2=value2'
 
   --buffersize <Size>
     Sets the size of the in-memory circular buffer in megabytes. Default 256 MB.

--- a/src/Microsoft.Diagnostics.Tools.RuntimeClient/Eventing/Provider.cs
+++ b/src/Microsoft.Diagnostics.Tools.RuntimeClient/Eventing/Provider.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics.Tracing;
+using System.Text.RegularExpressions;
 
 namespace Microsoft.Diagnostics.Tools.RuntimeClient
 {
@@ -20,7 +21,7 @@ namespace Microsoft.Diagnostics.Tools.RuntimeClient
             Name = name;
             Keywords = keywords;
             EventLevel = eventLevel;
-            FilterData = string.IsNullOrWhiteSpace(filterData) ? null : filterData;
+            FilterData = string.IsNullOrWhiteSpace(filterData) ? null : Regex.Unescape(filterData);
         }
 
         public ulong Keywords { get; }


### PR DESCRIPTION
Something is double escaping escape characters in the input arguments.  If someone specifies a provider of `Microsoft-DotNETCore-Runtime:0:0:filter="reallycool\r\nfilter"`, it will have been converted to `Microsoft-DotNETCore-Runtime:0:0:filter="reallycool\\r\\nfilter"` by the time it reaches `CollectCommand` in the `providers` input argument.  Using the `System.Text.RegularExpressions.Regex.Unescape` method, we can ensure that this double escape is removed and we send the _correct_ bytes across the IPC transport.

DiagnosticSourceEventSource uses new-line delimited strings in its provider filter to specify transforms for diagnostics messages, so this change plus dotnet/coreclr#26159 should unblock anyone using DiagnosticSourceEventSource via dotnet-trace.

CC - @tommcdon 