### PR TITLE
Add Windows PE reading to dotnet-dump

### DIFF
--- a/src/SOS/SOS.Hosting/SOSHost.cs
+++ b/src/SOS/SOS.Hosting/SOSHost.cs
@@ -6,12 +6,17 @@ using Microsoft.Diagnostics.DebugServices;
 using Microsoft.Diagnostics.Runtime;
 using Microsoft.Diagnostics.Runtime.Interop;
 using Microsoft.Diagnostics.Runtime.Utilities;
+using Microsoft.SymbolStore;
+using Microsoft.SymbolStore.KeyGenerators;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -54,6 +59,7 @@ namespace SOS
             bool logging,
             bool msdl,
             bool symweb,
+            string tempDirectory,
             string symbolServerPath,
             string symbolCachePath,
             string windowsSymbolPath);
@@ -65,7 +71,6 @@ namespace SOS
         private delegate void LoadNativeSymbolsDelegate(
             SymbolReader.SymbolFileCallback callback,
             IntPtr parameter,
-            string tempDirectory,
             string moduleFilePath,
             ulong address,
             int size,
@@ -158,6 +163,7 @@ namespace SOS
         private readonly COMCallableIUnknown _ccw;  
         private readonly IntPtr _interface;
         private IntPtr _sosLibrary = IntPtr.Zero;
+        private Dictionary<string, PEReader> _pathToPeReader = new Dictionary<string, PEReader>();
 
         /// <summary>
         /// Enable the assembly resolver to get the right SOS.NETCore version (the one
@@ -186,6 +192,7 @@ namespace SOS
         /// <summary>
         /// Create an instance of the hosting class
         /// </summary>
+        /// <param name="serviceProvider">Service provider</param>
         public SOSHost(IServiceProvider serviceProvider)
         {
             DataTarget dataTarget = serviceProvider.GetService<DataTarget>();
@@ -251,7 +258,7 @@ namespace SOS
                 // SOS depends on that the temp directory ends with "/".
                 if (!string.IsNullOrEmpty(tempDirectory) && tempDirectory[tempDirectory.Length - 1] != Path.DirectorySeparatorChar)
                 {
-                    tempDirectory = tempDirectory + Path.DirectorySeparatorChar;
+                    tempDirectory += Path.DirectorySeparatorChar;
                 }
 
                 int result = initializeFunc(
@@ -453,6 +460,93 @@ namespace SOS
                 return S_OK;
             }
             return E_FAIL;
+        }
+
+        internal unsafe int ReadVirtualForWindows(
+            IntPtr self,
+            ulong address,
+            IntPtr buffer,
+            uint bytesRequested,
+            uint* pbytesRead)
+        {
+            if (DataReader.ReadMemory(address, buffer, unchecked((int)bytesRequested), out int bytesRead))
+            {
+                Write(pbytesRead, (uint)bytesRead);
+                return S_OK;
+            }
+
+            foreach (ModuleInfo module in DataReader.EnumerateModules())
+            {
+                ulong start = module.ImageBase;
+                ulong end = start + module.FileSize;
+                if (start <= address && end > address)
+                {
+                    PEReader reader = GetPEReader(module);
+                    if (reader != null)
+                    {
+                        int rva = (int)(address - start);
+                        try
+                        {
+                            PEMemoryBlock block = reader.GetSectionData(rva);
+                            if (block.Pointer == null)
+                            {
+                                block = reader.GetEntireImage();
+                            }
+                            BlobReader blob = block.GetReader();
+                            byte[] data = blob.ReadBytes((int)bytesRequested);
+
+                            Marshal.Copy(data, 0, buffer, data.Length);
+                            Write(pbytesRead, (uint)data.Length);
+                            return S_OK;
+                        }
+                        catch (Exception e) when (e is BadImageFormatException || e is InvalidOperationException || e is IOException)
+                        {
+                        }
+                    }
+                    break;
+                }
+            }
+
+            return E_FAIL;
+        }
+
+        private PEReader GetPEReader(ModuleInfo module)
+        {
+            if (!_pathToPeReader.TryGetValue(module.FileName, out PEReader reader))
+            {
+                Stream stream = null;
+
+                string downloadFilePath = module.FileName;
+                if (!File.Exists(downloadFilePath)) 
+                {
+                    if (SymbolReader.IsSymbolStoreEnabled())
+                    {
+                        SymbolStoreKey key = PEFileKeyGenerator.GetKey(Path.GetFileName(downloadFilePath), module.TimeStamp, module.FileSize);
+                        if (key != null)
+                        {
+                            // Now download the module from the symbol server
+                            downloadFilePath = SymbolReader.GetSymbolFile(key);
+                        }
+                    }
+                }
+
+                if (!string.IsNullOrEmpty(downloadFilePath))
+                {
+                    try
+                    {
+                        stream = File.OpenRead(downloadFilePath);
+                    }
+                    catch (Exception e) when (e is DirectoryNotFoundException || e is FileNotFoundException || e is UnauthorizedAccessException || e is IOException)
+                    {
+                    }
+                    if (stream != null)
+                    {
+                        reader = new PEReader(stream);
+                        _pathToPeReader.Add(module.FileName, reader);
+                    }
+                }
+            }
+            return reader;
         }
 
         internal unsafe int WriteVirtual(

--- a/src/SOS/SOS.Hosting/dbgeng/DebugDataSpaces.cs
+++ b/src/SOS/SOS.Hosting/dbgeng/DebugDataSpaces.cs
@@ -24,7 +24,7 @@ namespace SOS
 
         private static void AddDebugDataSpaces(VTableBuilder builder, SOSHost soshost)
         {
-            builder.AddMethod(new ReadVirtualDelegate(soshost.ReadVirtual));
+            builder.AddMethod(new ReadVirtualDelegate(soshost.ReadVirtualForWindows));
             builder.AddMethod(new WriteVirtualDelegate(soshost.WriteVirtual));
             builder.AddMethod(new SearchVirtualDelegate((self, offset, length, pattern, patternSize, patternGranularity, matchOffset) => DebugClient.NotImplemented));
             builder.AddMethod(new ReadVirtualUncachedDelegate((self, offset, buffer, bufferSize, bytesRead) => DebugClient.NotImplemented));

--- a/src/SOS/SOS.NETCore/Tracer.cs
+++ b/src/SOS/SOS.NETCore/Tracer.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics;
 
 namespace SOS
 {
@@ -11,22 +12,14 @@ namespace SOS
     /// </summary>
     internal sealed class Tracer : Microsoft.SymbolStore.ITracer
     {
-        readonly bool m_enabled;
-        readonly bool m_enabledVerbose;
-        readonly SymbolReader.WriteLine m_output;
-
-        public Tracer(bool enabled, bool enabledVerbose, SymbolReader.WriteLine output)
+        public Tracer()
         {
-            m_enabled = enabled;
-            m_enabledVerbose = enabledVerbose;
-            m_output = output;
         }
 
         public void WriteLine(string message)
         {
-            lock (this) {
-                m_output?.Invoke(message);
-            }
+            Trace.WriteLine(message);
+            Trace.Flush();
         }
 
         public void WriteLine(string format, params object[] arguments)
@@ -36,66 +29,48 @@ namespace SOS
 
         public void Information(string message)
         {
-            if (m_enabled)
-            {
-                WriteLine(message);
-            }
+            Trace.TraceInformation(message);
+            Trace.Flush();
         }
 
         public void Information(string format, params object[] arguments)
         {
-            if (m_enabled)
-            {
-                WriteLine(format, arguments);
-            }
+            Trace.TraceInformation(format, arguments);
+            Trace.Flush();
         }
 
         public void Warning(string message)
         {
-            if (m_enabled)
-            {
-                WriteLine("WARNING: " + message); 
-            }
+            Trace.TraceWarning(message);
+            Trace.Flush();
         }
             
         public void Warning(string format, params object[] arguments)
         {
-            if (m_enabled)
-            {
-                WriteLine("WARNING: " + format, arguments);
-            }
+            Trace.TraceWarning(format, arguments);
+            Trace.Flush();
         }
 
         public void Error(string message)
         {
-            if (m_enabled) 
-            {
-                WriteLine("ERROR: " + message);
-            }
+            Trace.TraceError(message);
+            Trace.Flush();
         }
 
         public void Error(string format, params object[] arguments)
         {
-            if (m_enabled)
-            {
-                WriteLine("ERROR: " + format, arguments);
-            }
+            Trace.TraceError(format, arguments);
+            Trace.Flush();
         }
 
         public void Verbose(string message)
         {
-            if (m_enabledVerbose)
-            {
-                WriteLine(message);
-            }
+            Information(message);
         }
 
         public void Verbose(string format, params object[] arguments)
         {
-            if (m_enabledVerbose)
-            {
-                WriteLine(format, arguments);
-            }
+            Information(format, arguments);
         }
     }
 }

--- a/src/SOS/Strike/hostcoreclr.cpp
+++ b/src/SOS/Strike/hostcoreclr.cpp
@@ -783,7 +783,7 @@ HRESULT InitializeSymbolStore(BOOL logging, BOOL msdl, BOOL symweb, const char* 
     IfFailRet(InitializeHosting());
     _ASSERTE(g_SOSNetCoreCallbacks.InitializeSymbolStoreDelegate != nullptr);
 
-    if (!g_SOSNetCoreCallbacks.InitializeSymbolStoreDelegate(logging, msdl, symweb, symbolServer, cacheDirectory, nullptr))
+    if (!g_SOSNetCoreCallbacks.InitializeSymbolStoreDelegate(logging, msdl, symweb, GetTempDirectory(), symbolServer, cacheDirectory, nullptr))
     {
         ExtErr("Error initializing symbol server support\n");
         return E_FAIL;
@@ -809,7 +809,7 @@ void InitializeSymbolStore()
         {
             if (strlen(symbolPath) > 0)
             {
-                if (!g_SOSNetCoreCallbacks.InitializeSymbolStoreDelegate(false, false, false, nullptr, nullptr, symbolPath))
+                if (!g_SOSNetCoreCallbacks.InitializeSymbolStoreDelegate(false, false, false, GetTempDirectory(), nullptr, nullptr, symbolPath))
                 {
                     ExtErr("Windows symbol path parsing FAILED\n");
                 }
@@ -856,7 +856,7 @@ static void LoadNativeSymbolsCallback(void* param, const char* moduleFilePath, U
 {
     _ASSERTE(g_hostingInitialized);
     _ASSERTE(g_SOSNetCoreCallbacks.LoadNativeSymbolsDelegate != nullptr);
-    g_SOSNetCoreCallbacks.LoadNativeSymbolsDelegate(SymbolFileCallback, param, GetTempDirectory(), moduleFilePath, moduleAddress, moduleSize, ReadMemoryForSymbols);
+    g_SOSNetCoreCallbacks.LoadNativeSymbolsDelegate(SymbolFileCallback, param, moduleFilePath, moduleAddress, moduleSize, ReadMemoryForSymbols);
 }
 
 /**********************************************************************\

--- a/src/SOS/Strike/hostcoreclr.cpp
+++ b/src/SOS/Strike/hostcoreclr.cpp
@@ -902,6 +902,7 @@ HRESULT LoadNativeSymbols(bool runtimeOnly)
     return hr;
 }
 
+
 /**********************************************************************\
  * Displays the symbol server and cache status.
 \**********************************************************************/
@@ -910,7 +911,10 @@ void DisplaySymbolStore()
     if (g_symbolStoreInitialized)
     {
         _ASSERTE(g_SOSNetCoreCallbacks.DisplaySymbolStoreDelegate != nullptr);
-        g_SOSNetCoreCallbacks.DisplaySymbolStoreDelegate();
+        g_SOSNetCoreCallbacks.DisplaySymbolStoreDelegate([] (const char* message) {
+            ExtOut(message);
+            ExtOut("\n");
+        });
     }
 }
 

--- a/src/SOS/Strike/hostcoreclr.h
+++ b/src/SOS/Strike/hostcoreclr.h
@@ -16,10 +16,10 @@ typedef void (*OutputDelegate)(const char*);
 typedef  int (*ReadMemoryDelegate)(ULONG64, uint8_t*, int);
 typedef void (*SymbolFileCallbackDelegate)(void*, const char* moduleFileName, const char* symbolFilePath);
 
-typedef  BOOL (*InitializeSymbolStoreDelegate)(BOOL, BOOL, BOOL, const char*, const char*, const char*);
+typedef  BOOL (*InitializeSymbolStoreDelegate)(BOOL, BOOL, BOOL, const char*, const char*, const char*, const char*);
 typedef  void (*DisplaySymbolStoreDelegate)();
 typedef  void (*DisableSymbolStoreDelegate)();
-typedef  void (*LoadNativeSymbolsDelegate)(SymbolFileCallbackDelegate, void*, const char*, const char*, ULONG64, int, ReadMemoryDelegate);
+typedef  void (*LoadNativeSymbolsDelegate)(SymbolFileCallbackDelegate, void*, const char*, ULONG64, int, ReadMemoryDelegate);
 typedef  PVOID (*LoadSymbolsForModuleDelegate)(const char*, BOOL, ULONG64, int, ULONG64, int, ReadMemoryDelegate);
 typedef  void (*DisposeDelegate)(PVOID);
 typedef  BOOL (*ResolveSequencePointDelegate)(PVOID, const char*, unsigned int, unsigned int*, unsigned int*);

--- a/src/SOS/Strike/hostcoreclr.h
+++ b/src/SOS/Strike/hostcoreclr.h
@@ -12,12 +12,12 @@
 
 struct SymbolModuleInfo;
 
-typedef void (*OutputDelegate)(const char*);
+typedef void (*WriteLineDelegate)(const char*);
 typedef  int (*ReadMemoryDelegate)(ULONG64, uint8_t*, int);
 typedef void (*SymbolFileCallbackDelegate)(void*, const char* moduleFileName, const char* symbolFilePath);
 
 typedef  BOOL (*InitializeSymbolStoreDelegate)(BOOL, BOOL, BOOL, const char*, const char*, const char*, const char*);
-typedef  void (*DisplaySymbolStoreDelegate)();
+typedef  void (*DisplaySymbolStoreDelegate)(WriteLineDelegate);
 typedef  void (*DisableSymbolStoreDelegate)();
 typedef  void (*LoadNativeSymbolsDelegate)(SymbolFileCallbackDelegate, void*, const char*, ULONG64, int, ReadMemoryDelegate);
 typedef  PVOID (*LoadSymbolsForModuleDelegate)(const char*, BOOL, ULONG64, int, ULONG64, int, ReadMemoryDelegate);

--- a/src/Tools/dotnet-dump/Analyzer.cs
+++ b/src/Tools/dotnet-dump/Analyzer.cs
@@ -28,8 +28,6 @@ namespace Microsoft.Diagnostics.Tools.Dump
         private readonly CommandProcessor _commandProcessor;
         private string _dacFilePath;
 
-        private static string s_tempDirectory;
-
         /// <summary>
         /// Enable the assembly resolver to get the right SOS.NETCore version (the one
         /// in the same directory as this assembly).
@@ -73,7 +71,7 @@ namespace Microsoft.Diagnostics.Tools.Dump
                     AddServices(target);
 
                     // Automatically enable symbol server support
-                    SymbolReader.InitializeSymbolStore(logging: false, msdl: true, symweb: false, symbolServerPath: null, symbolCachePath: null, windowsSymbolPath: null);
+                    SymbolReader.InitializeSymbolStore(logging: false, msdl: true, symweb: false, tempDirectory: null, symbolServerPath: null, symbolCachePath: null, windowsSymbolPath: null);
 
                     // Run the commands from the dotnet-dump command line
                     if (command != null)
@@ -132,7 +130,7 @@ namespace Microsoft.Diagnostics.Tools.Dump
 
             _serviceProvider.AddServiceFactory(typeof(SOSHost), () => {
                 var sosHost = new SOSHost(_serviceProvider);
-                sosHost.InitializeSOSHost(s_tempDirectory, _dacFilePath, dbiFilePath: null);
+                sosHost.InitializeSOSHost(SymbolReader.TempDirectory, _dacFilePath, dbiFilePath: null);
                 return sosHost;
             });
         }
@@ -199,13 +197,8 @@ namespace Microsoft.Diagnostics.Tools.Dump
 
                         if (key != null)
                         {
-                            if (s_tempDirectory == null)
-                            {
-                                int processId = Process.GetCurrentProcess().Id;
-                                s_tempDirectory = Path.Combine(Path.GetTempPath(), "analyze" + processId.ToString());
-                            }
                             // Now download the DAC module from the symbol server
-                            _dacFilePath = SymbolReader.GetSymbolFile(key, s_tempDirectory);
+                            _dacFilePath = SymbolReader.GetSymbolFile(key);
                         }
                     }
                 }

--- a/src/Tools/dotnet-dump/Commands/LoggingCommand.cs
+++ b/src/Tools/dotnet-dump/Commands/LoggingCommand.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.DebugServices;
+using Microsoft.Diagnostics.Repl;
+using System;
+using System.CommandLine;
+using System.Diagnostics;
+
+namespace Microsoft.Diagnostics.Tools.Dump
+{
+    [Command(Name = "logging", Help = "Enable/disable internal logging")]
+    public class LoggingCommand : CommandBase
+    {
+        [Option(Name = "enable", Help = "Enable internal loggging.")]
+        public bool Enable { get; set; }
+
+        [Option(Name = "disable", Help = "Disable internal loggging.")]
+        public bool Disable { get; set; }
+
+        private const string ListenerName = "Analyze.LoggingListener";
+
+        public override void Invoke()
+        {
+            if (Enable) {
+                if (Trace.Listeners[ListenerName] == null) {
+                    Trace.Listeners.Add(new LoggingListener(Console));
+                }
+            }
+            else if (Disable) {
+                Trace.Listeners.Remove(ListenerName);
+            }
+            WriteLine("Logging is {0}", Trace.Listeners[ListenerName] != null ? "enabled" : "disabled");
+        }
+
+        class LoggingListener : TraceListener
+        {
+            private readonly IConsoleService _console;
+
+            internal LoggingListener(IConsoleService console)
+                : base(ListenerName)
+            {
+                _console = console;
+            }
+
+            public override void Write(string message)
+            {
+                _console.Write(message);
+            }
+
+            public override void WriteLine(string message)
+            {
+                _console.Write(message + Environment.NewLine);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Finds or downloads the native modules like coreclr.dll or managed
assemblies into the virtual address space of the core dump. Emulates
what the Windows debugger do for minidumps.