### PR TITLE
 Some UI improvements/refactor to dotnet-counters

### DIFF
--- a/src/Tools/dotnet-counters/CounterMonitor.cs
+++ b/src/Tools/dotnet-counters/CounterMonitor.cs
@@ -198,7 +198,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
             Task monitorTask = new Task(() => {
                 try
                 {
-                    RequestTracingV1(providerString);
+                    RequestTracingV2(providerString);
                 }
                 catch (EventPipeUnknownCommandException)
                 {

--- a/src/Tools/dotnet-counters/CounterPayload.cs
+++ b/src/Tools/dotnet-counters/CounterPayload.cs
@@ -15,16 +15,16 @@ namespace Microsoft.Diagnostics.Tools.Counters
         string GetDisplay();
     }
 
-
     class CounterPayload : ICounterPayload
     {
         public string m_Name;
         public string m_Value;
         public string m_DisplayName;
+
         public CounterPayload(IDictionary<string, object> payloadFields)
         {
             m_Name = payloadFields["Name"].ToString();
-            m_Value = payloadFields["Mean"].ToString();
+            m_Value = Int32.Parse(payloadFields["Mean"].ToString()).ToString("N0");
             m_DisplayName = payloadFields["DisplayName"].ToString();
         }
 
@@ -50,10 +50,11 @@ namespace Microsoft.Diagnostics.Tools.Counters
         public string m_Value;
         public string m_DisplayName;
         public string m_DisplayRateTimeScale;
+
         public IncrementingCounterPayload(IDictionary<string, object> payloadFields)
         {
             m_Name = payloadFields["Name"].ToString();
-            m_Value = payloadFields["Increment"].ToString();
+            m_Value = Int32.Parse(payloadFields["Increment"].ToString()).ToString("N0");
             m_DisplayName = payloadFields["DisplayName"].ToString();
             m_DisplayRateTimeScale = TimeSpan.Parse(payloadFields["DisplayRateTimeScale"].ToString()).ToString("%s' sec'");
         }


### PR DESCRIPTION
This change does the following:
- The display for long numeric values (i.e. Gen 0 Heap Size) is now comma-separated (or whatever numeric format is used in the user's current cultural context).
- Remove the bizarre check (Length == 6) for checking whether a counter payload is an IncrementingCounterPayload or CounterPayload which was an unfortunate remnant from pre-preview6 era.
- In Dynamic_All, if we get some exception, we may throw, but this hangs the process and we can't make the process quit.