### PR TITLE
Make gc/gc-collect profiles available

### DIFF
--- a/src/Tools/dotnet-trace/CommandLine/Commands/ListProfilesCommandHandler.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/ListProfilesCommandHandler.cs
@@ -48,7 +48,6 @@ namespace Microsoft.Diagnostics.Tools.Trace
                     new Provider("Microsoft-Windows-DotNETRuntime", (ulong)ClrTraceEventParser.Keywords.Default, EventLevel.Informational),
                 },
                 "Useful for tracking CPU usage and general runtime information. This the default option if no profile is specified."),
-#if DEBUG // Coming soon: Preview6
             new Profile(
                 "gc",
                 new Provider[] {
@@ -77,7 +76,6 @@ namespace Microsoft.Diagnostics.Tools.Trace
                         eventLevel: EventLevel.Informational),
                 },
                 "Tracks GC collection only at very low overhead."),
-#endif // DEBUG
             new Profile(
                 "none",
                 null,

--- a/src/Tools/dotnet-trace/CommandLine/Commands/ListProfilesCommandHandler.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/ListProfilesCommandHandler.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 },
                 "Useful for tracking CPU usage and general runtime information. This the default option if no profile is specified."),
             new Profile(
-                "gc",
+                "gc-with-heapsurvival",
                 new Provider[] {
                     new Provider("Microsoft-DotNETCore-SampleProfiler"),
                     new Provider(
@@ -64,11 +64,23 @@ namespace Microsoft.Diagnostics.Tools.Trace
                                   (ulong)ClrTraceEventParser.Keywords.Exception,
                         eventLevel: EventLevel.Verbose),
                 },
-                "Tracks allocation and collection performance."),
+                "Tracks allocation and collection performance at the most verbose level."),
+            new Profile(
+                "gc-verbose",
+                new Provider[] {
+                    new Provider("Microsoft-DotNETCore-SampleProfiler"),
+                    new Provider(
+                        name: "Microsoft-Windows-DotNETRuntime",
+                        keywords: (ulong)ClrTraceEventParser.Keywords.GC |
+                                  (ulong)ClrTraceEventParser.Keywords.GCHandle |
+                                  (ulong)ClrTraceEventParser.Keywords.Exception,
+                        eventLevel: EventLevel.Verbose
+                    ),
+                },
+                "Tracks GC and GC handle events at a more verbose level"),
             new Profile(
                 "gc-collect",
                 new Provider[] {
-                    new Provider("Microsoft-DotNETCore-SampleProfiler"),
                     new Provider(
                         name: "Microsoft-Windows-DotNETRuntime",
                         keywords:   (ulong)ClrTraceEventParser.Keywords.GC |

--- a/src/Tools/dotnet-trace/CommandLine/Commands/ListProfilesCommandHandler.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/ListProfilesCommandHandler.cs
@@ -49,23 +49,6 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 },
                 "Useful for tracking CPU usage and general runtime information. This the default option if no profile is specified."),
             new Profile(
-                "gc-with-heapsurvival",
-                new Provider[] {
-                    new Provider("Microsoft-DotNETCore-SampleProfiler"),
-                    new Provider(
-                        name: "Microsoft-Windows-DotNETRuntime",
-                        keywords: (ulong)ClrTraceEventParser.Keywords.GC |
-                                  (ulong)ClrTraceEventParser.Keywords.GCHeapSurvivalAndMovement |
-                                  (ulong)ClrTraceEventParser.Keywords.Stack |
-                                  (ulong)ClrTraceEventParser.Keywords.Jit |
-                                  (ulong)ClrTraceEventParser.Keywords.StopEnumeration |
-                                  (ulong)ClrTraceEventParser.Keywords.SupressNGen |
-                                  (ulong)ClrTraceEventParser.Keywords.Loader |
-                                  (ulong)ClrTraceEventParser.Keywords.Exception,
-                        eventLevel: EventLevel.Verbose),
-                },
-                "Tracks allocation and collection performance at the most verbose level."),
-            new Profile(
                 "gc-verbose",
                 new Provider[] {
                     new Provider(
@@ -76,7 +59,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                         eventLevel: EventLevel.Verbose
                     ),
                 },
-                "Tracks GC and GC handle events at a more verbose level"),
+                "Tracks GC and GC handle events at verbose level, and samples the allocation events as well."),
             new Profile(
                 "gc-collect",
                 new Provider[] {

--- a/src/Tools/dotnet-trace/CommandLine/Commands/ListProfilesCommandHandler.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/ListProfilesCommandHandler.cs
@@ -68,7 +68,6 @@ namespace Microsoft.Diagnostics.Tools.Trace
             new Profile(
                 "gc-verbose",
                 new Provider[] {
-                    new Provider("Microsoft-DotNETCore-SampleProfiler"),
                     new Provider(
                         name: "Microsoft-Windows-DotNETRuntime",
                         keywords: (ulong)ClrTraceEventParser.Keywords.GC |


### PR DESCRIPTION
We originally disabled these profiles in https://github.com/dotnet/diagnostics/pull/178 because of a runtime issue which caused GC events to not show up and was fixed around preview 6 timeframe (https://github.com/dotnet/coreclr/pull/24198). Now that the runtime fix has been out for a while, these profiles should be public again. 