### PR TITLE
Improve output formatting and fix bugs in dotnet-counters

### DIFF
--- a/src/Tools/dotnet-counters/ConsoleWriter.cs
+++ b/src/Tools/dotnet-counters/ConsoleWriter.cs
@@ -41,22 +41,22 @@ namespace Microsoft.Diagnostics.Tools.Counters
         private bool paused = false;
         private bool initialized = false;
 
-        private void UpdateStatus(string msg)
+        private void UpdateStatus()
         {
             Console.SetCursorPosition(0, STATUS_ROW);
-            Console.Write(new String(' ', 42)); // Length of the initial string we print on the console..
-            Console.SetCursorPosition(0, STATUS_ROW);
-            Console.Write(msg);
+            Console.Write($"    Status: {GetStatus()}{new string(' ', 40)}"); // Write enough blanks to clear previous status.
         }
+
+        private string GetStatus() => !initialized ? "Waiting for initial payload..." : (paused ? "Paused" : "Running");
 
         /// <summary>Clears display and writes out category and counter name layout.</summary>
         public void AssignRowsAndInitializeDisplay()
         {
             Console.Clear();
             int row = Console.CursorTop;
-            Console.WriteLine("Press p to pause, r to resume, q to quit.");               row++;
-            Console.WriteLine("    Status: Waiting for initial payload..."); STATUS_ROW = row++;
-            Console.WriteLine();                                                          row++; // Blank line.
+            Console.WriteLine("Press p to pause, r to resume, q to quit."); row++;
+            Console.WriteLine($"    Status: {GetStatus()}");                STATUS_ROW = row++;
+            Console.WriteLine();                                            row++; // Blank line.
 
             foreach (ObservedProvider provider in providers.Values.OrderBy(p => p.KnownProvider == null).ThenBy(p => p.Name)) // Known providers first.
             {
@@ -75,24 +75,17 @@ namespace Microsoft.Diagnostics.Tools.Counters
             {
                 return;
             }
-            else if (pauseCmdSet)
-            {
-                UpdateStatus("    Status: Paused");
-            }
-            else
-            {
-                UpdateStatus("    Status: Running");
-            }
+
             paused = pauseCmdSet;
+            UpdateStatus();
         }
 
         public void Update(string providerName, ICounterPayload payload, bool pauseCmdSet)
         {
             if (!initialized)
             {
-                AssignRowsAndInitializeDisplay();
                 initialized = true;
-                UpdateStatus("    Status: Running");
+                AssignRowsAndInitializeDisplay();
             }
 
             if (pauseCmdSet)

--- a/src/Tools/dotnet-counters/ConsoleWriter.cs
+++ b/src/Tools/dotnet-counters/ConsoleWriter.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 
 namespace Microsoft.Diagnostics.Tools.Counters
@@ -120,7 +119,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
 
             const string DecimalPlaces = "###";
             string payloadVal = payload.GetValue().ToString("#,0." + DecimalPlaces);
-            int decimalIndex = payloadVal.IndexOf(NumberFormatInfo.CurrentInfo.NumberDecimalSeparator);
+            int decimalIndex = payloadVal.IndexOf('.');
             if (decimalIndex == -1)
             {
                 decimalIndex = payloadVal.Length;

--- a/src/Tools/dotnet-counters/CounterMonitor.cs
+++ b/src/Tools/dotnet-counters/CounterMonitor.cs
@@ -195,7 +195,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
             _ct.Register(() => shouldExit.Set());
 
             var terminated = false;
-            writer.InitializeDisplay();
+            writer.AssignRowsAndInitializeDisplay();
 
             Task monitorTask = new Task(() => {
                 try

--- a/src/Tools/dotnet-counters/CounterPayload.cs
+++ b/src/Tools/dotnet-counters/CounterPayload.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
     public interface ICounterPayload
     {
         string GetName();
-        string GetValue();
+        double GetValue();
         string GetDisplay();
     }
 
@@ -19,12 +19,12 @@ namespace Microsoft.Diagnostics.Tools.Counters
     class CounterPayload : ICounterPayload
     {
         public string m_Name;
-        public string m_Value;
+        public double m_Value;
         public string m_DisplayName;
         public CounterPayload(IDictionary<string, object> payloadFields)
         {
             m_Name = payloadFields["Name"].ToString();
-            m_Value = payloadFields["Mean"].ToString();
+            m_Value = (double)payloadFields["Mean"];
             m_DisplayName = payloadFields["DisplayName"].ToString();
         }
 
@@ -33,7 +33,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
             return m_Name;
         }
 
-        public string GetValue()
+        public double GetValue()
         {
             return m_Value;
         }
@@ -47,13 +47,13 @@ namespace Microsoft.Diagnostics.Tools.Counters
     class IncrementingCounterPayload : ICounterPayload
     {
         public string m_Name;
-        public string m_Value;
+        public double m_Value;
         public string m_DisplayName;
         public string m_DisplayRateTimeScale;
         public IncrementingCounterPayload(IDictionary<string, object> payloadFields, int interval)
         {
             m_Name = payloadFields["Name"].ToString();
-            m_Value = payloadFields["Increment"].ToString();
+            m_Value = (double)payloadFields["Increment"];
             m_DisplayName = payloadFields["DisplayName"].ToString();
             m_DisplayRateTimeScale = payloadFields["DisplayRateTimeScale"].ToString();
 
@@ -67,7 +67,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
             return m_Name;
         }
 
-        public string GetValue()
+        public double GetValue()
         {
             return m_Value;
         }


### PR DESCRIPTION
**This change improves output formatting in dotnet-counters by:**
1. Right aligning counter values.
2. Decimal numbers are aligned on the decimal separator.
3. Introducing thousand separators.

**It fixes the following bug:**
- If monitoring multiple providers (for example System.Runtime and a user-defined one), the provider and counter names get mixed up in the output.

I simplified the logic in `ConsoleWriter.cs` a great deal with these changes, so it has 63 fewer lines than before now.


**This is how it looked before this change:**
```
Press p to pause, r to resume, q to quit.
    Status: Running
[Driver-Volume-b]
    GetPathStatus /sec                              422.127609176254
[System.Runtime]
    CPU Usage (%)                                   7
[Driver-MmfStore]
    Files downloaded /sec                           0
    GetPathStatus duration                          0.022179111111111094
    Bytes downloaded /sec                           0
    Bytes served /sec                               6097619.430666088
    In-progress IOs                                 0
    Working Set (MB)                                2705
    GC Heap Size (MB)                               2338
    Gen 0 GC / sec                                  1
    Gen 1 GC / sec                                  0
    Gen 2 GC / sec                                  0
    Exceptions / sec                                0
    ThreadPool Threads Count                        9
    Monitor Lock Contention Count / sec             0
    ThreadPool Queue Length                         0
    ThreadPool Completed Work Items / sec           176
    % Time in GC (since last GC)                    0
    Gen 0 Size (B)                                  24
    Gen 1 Size (B)                                  466976
    Gen 2 Size (B)                                  2427119880
    LOH Size (B)                                    18486040
    Allocation Rate (Bytes / sec)                   15091784
    # of Assemblies Loaded                          88
    Number of Active Timers                         13
```

**This is how it looks now:**
```
Press p to pause, r to resume, q to quit.
    Status: Waiting for initial payload...

[System.Runtime]
    # of Assemblies Loaded                              88
    % Time in GC (since last GC)                         0
    Allocation Rate (Bytes / sec)               13,748,496
    CPU Usage (%)                                        4
    Exceptions / sec                                     0
    GC Heap Size (MB)                                2,325
    Gen 0 GC / sec                                       1
    Gen 0 Size (B)                                      24
    Gen 1 GC / sec                                       0
    Gen 1 Size (B)                                 181,928
    Gen 2 GC / sec                                       0
    Gen 2 Size (B)                           2,427,119,880
    LOH Size (B)                                18,486,040
    Monitor Lock Contention Count / sec                  0
    Number of Active Timers                             13
    ThreadPool Completed Work Items / sec              173
    ThreadPool Queue Length                              0
    ThreadPool Threads Count                            10
    Working Set (MB)                                 2,702
[Driver-MmfStore]
    Bytes downloaded /sec                                0
    Files downloaded /sec                                0
[Driver-Volume-b]
    Bytes served /sec                              326,177.083
    GetPathStatus /sec                                 310.711
    GetPathStatus duration                               0.026
    In-progress IOs                                      0
```
