### PR TITLE
Add duration option to dotnet-trace

### DIFF
--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
@@ -292,7 +292,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
             new Option(
                 alias: "--duration",
                 description: @"When specified, will trace for the given timespan and then automatically stop the trace. Provided in the form of dd:hh:mm:ss.",
-                argument: new Argument<TimeSpan>(defaultValue: null) { Name = "duration-time-in-seconds" },
+                argument: new Argument<TimeSpan>(defaultValue: null) { Name = "duration-timespan" },
                 isHidden: true);
     }
 }

--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
 {
     internal static class CollectCommandHandler
     {
-        delegate Task<int> CollectDelegate(CancellationToken ct, IConsole console, int processId, FileInfo output, uint buffersize, string providers, string profile, TraceFileFormat format, int duration);
+        delegate Task<int> CollectDelegate(CancellationToken ct, IConsole console, int processId, FileInfo output, uint buffersize, string providers, string profile, TraceFileFormat format, TimeSpan duration);
 
         /// <summary>
         /// Collects a diagnostic trace from a currently running process.
@@ -32,7 +32,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
         /// <param name="profile">A named pre-defined set of provider configurations that allows common tracing scenarios to be specified succinctly.</param>
         /// <param name="format">The desired format of the created trace file.</param>
         /// <returns></returns>
-        private static async Task<int> Collect(CancellationToken ct, IConsole console, int processId, FileInfo output, uint buffersize, string providers, string profile, TraceFileFormat format, int duration)
+        private static async Task<int> Collect(CancellationToken ct, IConsole console, int processId, FileInfo output, uint buffersize, string providers, string profile, TraceFileFormat format, TimeSpan duration)
         {
             try
             {
@@ -113,10 +113,10 @@ namespace Microsoft.Diagnostics.Tools.Trace
                         return ErrorCodes.SessionCreationError;
                     }
 
-                    if (duration != -1)
+                    if (duration != null)
                     {
-                        durationTimer = new System.Timers.Timer(duration * 1000);
-                        durationTimer.Elapsed += (s, e) => EventPipeClient.StopTracing(processId, sessionId);
+                        durationTimer = new System.Timers.Timer(duration.TotalMilliseconds);
+                        durationTimer.Elapsed += (s, e) => shouldExit.Set();
                         durationTimer.AutoReset = false;
                     }
 
@@ -133,6 +133,8 @@ namespace Microsoft.Diagnostics.Tools.Trace
                                 Console.Out.WriteLine($"Process     : {process.MainModule.FileName}");
                                 Console.Out.WriteLine($"Output File : {fs.Name}");
                                 Console.Out.WriteLine($"\tSession Id: 0x{sessionId:X16}");
+                                if (duration != null)
+                                    Console.WriteLine($"Tracing for {duration.ToString(@"dd\:hh\:mm\:ss")}");
                                 lineToClear = Console.CursorTop;
                                 var buffer = new byte[16 * 1024];
 
@@ -144,7 +146,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                                     fs.Write(buffer, 0, nBytesRead);
 
                                     ResetCurrentConsoleLine(vTermMode.IsEnabled);
-                                    Console.Out.Write($"[{stopwatch.Elapsed.Seconds,3}s]\tRecording trace {GetSize(fs.Length)}");
+                                    Console.Out.Write($"[{stopwatch.Elapsed.ToString(@"dd\:hh\:mm\:ss")}]\tRecording trace {GetSize(fs.Length)}");
 
                                     Debug.WriteLine($"PACKET: {Convert.ToBase64String(buffer, 0, nBytesRead)} (bytes {nBytesRead})");
                                 }
@@ -283,14 +285,14 @@ namespace Microsoft.Diagnostics.Tools.Trace
             new Option(
                 alias: "--profile",
                 description: @"A named pre-defined set of provider configurations that allows common tracing scenarios to be specified succinctly.",
-                argument: new Argument<string>(defaultValue: "runtime-basic") { Name = "profile_name" },
+                argument: new Argument<string>(defaultValue: "runtime-basic") { Name = "profile-name" },
                 isHidden: false);
 
         private static Option DurationOption() =>
             new Option(
                 alias: "--duration",
-                description: @"When specified, will trace for the given number of seconds and automatically stop the trace.",
-                argument: new Argument<int>(defaultValue: -1) { Name = "duration_time_in_seconds" },
-                isHidden: false);
+                description: @"When specified, will trace for the given timespan and then automatically stop the trace. Provided in the form of dd:hh:mm:ss.",
+                argument: new Argument<TimeSpan>(defaultValue: null) { Name = "duration-time-in-seconds" },
+                isHidden: true);
     }
 }


### PR DESCRIPTION
Adds a new `--duration` option to `dotnet-trace` that allows a user to specify a time in seconds after which the trace will automatically end.  The trace can be prematurely stopped using the same inputs as a regular trace.

This is one step in making automation using `dotnet-trace` easier.

CC - @tommcdon 