### PR TITLE
Make a different option to change the default format for convert command

### DIFF
--- a/src/Tools/dotnet-trace/CommandLine/Commands/ConvertCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/ConvertCommand.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                     Description = $"Input trace file to be converted.  Defaults to '{CollectCommandHandler.DefaultTraceName}'."
                 }).ExistingOnly(),
                 symbols: new Option[] {
-                    CommonOptions.FormatOption(),
+                    CommonOptions.ConvertFormatOption(),
                     OutputOption()
                 },
                 handler: System.CommandLine.Invocation.CommandHandler.Create<IConsole, FileInfo, TraceFileFormat, FileInfo>(ConvertFile),

--- a/src/Tools/dotnet-trace/CommandLine/Commands/ConvertCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/ConvertCommand.cs
@@ -17,18 +17,29 @@ namespace Microsoft.Diagnostics.Tools.Trace
     {
         public static int ConvertFile(IConsole console, FileInfo inputFilename, TraceFileFormat format, FileInfo output)
         {
-                if (format == TraceFileFormat.NetTrace)
-                    throw new ArgumentException("Cannot convert to nettrace format.");
-                
-                if (!inputFilename.Exists)
-                    throw new FileNotFoundException($"File '{inputFilename}' does not exist.");
-                
-                if (output == null)
-                    output = inputFilename;
+            if ((int)format <= 0)
+            {
+                Console.Error.WriteLine("--format is required.");
+                return ErrorCodes.ArgumentError;
+            }
 
-                TraceFileFormatConverter.ConvertToFormat(format, inputFilename.FullName, output.FullName);
+            if (format == TraceFileFormat.NetTrace)
+            {
+                Console.Error.WriteLine("Cannot convert a nettrace file to nettrace format.");
+                return ErrorCodes.ArgumentError;
+            }
 
-                return 0;
+            if (!inputFilename.Exists)
+            {
+                Console.Error.WriteLine($"File '{inputFilename}' does not exist.");
+                return ErrorCodes.ArgumentError;
+            }
+
+            if (output == null)
+                output = inputFilename;
+
+            TraceFileFormatConverter.ConvertToFormat(format, inputFilename.FullName, output.FullName);
+            return 0;
         }
 
         public static Command ConvertCommand() =>

--- a/src/Tools/dotnet-trace/CommandLine/Options/CommonOptions.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Options/CommonOptions.cs
@@ -29,8 +29,8 @@ namespace Microsoft.Diagnostics.Tools.Trace
         public static Option ConvertFormatOption() =>
             new Option(
                 aliases: new[] { "--format" },
-                description: $"Sets the output format for the trace file.  Default is {TraceFileFormat.Speedscope}",
-                argument: new Argument<TraceFileFormat>(defaultValue: TraceFileFormat.Speedscope ) { Name = "trace-file-format" },
+                description: $"Sets the output format for the trace file conversion.",
+                argument: new Argument<TraceFileFormat> { Name = "trace-file-format" },
                 isHidden: false);
     }
 }

--- a/src/Tools/dotnet-trace/CommandLine/Options/CommonOptions.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Options/CommonOptions.cs
@@ -25,5 +25,12 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 description: $"Sets the output format for the trace file.  Default is {DefaultTraceFileFormat}",
                 argument: new Argument<TraceFileFormat>(defaultValue: DefaultTraceFileFormat) { Name = "trace-file-format" },
                 isHidden: false);
+
+        public static Option ConvertFormatOption() =>
+            new Option(
+                aliases: new[] { "--format" },
+                description: $"Sets the output format for the trace file.  Default is {TraceFileFormat.Speedscope}",
+                argument: new Argument<TraceFileFormat>(defaultValue: TraceFileFormat.Speedscope ) { Name = "trace-file-format" },
+                isHidden: false);
     }
 }


### PR DESCRIPTION
If you run `dotnet-trace convert` without any --format argument, it defaults to nettrace format, which causes an exception like the one reported in https://github.com/dotnet/diagnostics/issues/454. 

Changing the default behavior of the convert command to convert to speedscope format instead of the nettrace format. 