### PR TITLE
Fix dumpmd/ip2md commands for < 3.x runtimes

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -23,7 +23,7 @@
 
     <!-- Other libs -->
     <MicrosoftSymbolStoreVersion>1.0.41901</MicrosoftSymbolStoreVersion>
-    <MicrosoftDiagnosticsRuntimeVersion>1.1.37504</MicrosoftDiagnosticsRuntimeVersion>
+    <MicrosoftDiagnosticsRuntimeVersion>1.1.46104</MicrosoftDiagnosticsRuntimeVersion>
     <MicrosoftDiaSymReaderNativePackageVersion>1.7.0</MicrosoftDiaSymReaderNativePackageVersion>
     <MicrosoftDiagnosticsTracingTraceEventVersion>2.0.44</MicrosoftDiagnosticsTracingTraceEventVersion>
     <SystemCommandLineExperimentalVersion>0.2.0-alpha.19254.1</SystemCommandLineExperimentalVersion>

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -130,7 +130,7 @@ phases:
       inputs:
         pathtoPublish: '$(Build.SourcesDirectory)/artifacts/$(_PublishArtifacts)'
         artifactName: $(_PhaseName)_$(_BuildArch)_$(_BuildConfig)
-      condition: and(succeeded(), ne(variables['_PublishArtifacts'], ''))
+      condition: ne(variables['_PublishArtifacts'], '')
 
     - task: CopyFiles@2
       displayName: Gather Build Logs

--- a/src/Microsoft.Diagnostics.TestHelpers/TestConfiguration.cs
+++ b/src/Microsoft.Diagnostics.TestHelpers/TestConfiguration.cs
@@ -480,6 +480,7 @@ namespace Microsoft.Diagnostics.TestHelpers
         /// <summary>
         /// The major portion of the runtime framework version
         /// </summary>
+        /// <exception cref="SkipTestException">the RuntimeFrameworkVersion property doesn't exist</exception>
         public int RuntimeFrameworkVersionMajor
         {
             get {

--- a/src/SOS/SOS.Hosting/SOSHost.cs
+++ b/src/SOS/SOS.Hosting/SOSHost.cs
@@ -691,7 +691,7 @@ namespace SOS
             uint i = 0;
             foreach (ModuleInfo module in DataReader.EnumerateModules())
             {
-                if (index != uint.MaxValue && i == index || index == uint.MaxValue && baseAddress == module.ImageBase)
+                if ((index != uint.MaxValue && i == index) || (index == uint.MaxValue && baseAddress == module.ImageBase))
                 {
                     imageNameBuffer?.Append(module.FileName);
                     Write(imageNameSize, (uint)module.FileName.Length + 1);
@@ -760,7 +760,7 @@ namespace SOS
             uint i = 0;
             foreach (ModuleInfo module in DataReader.EnumerateModules())
             {
-                if (index != uint.MaxValue && i == index || index == uint.MaxValue && baseAddress == module.ImageBase)
+                if ((index != uint.MaxValue && i == index) || (index == uint.MaxValue && baseAddress == module.ImageBase))
                 {
                     if (item == "\\")
                     {

--- a/src/SOS/SOS.Hosting/dbgeng/DebugSymbols.cs
+++ b/src/SOS/SOS.Hosting/dbgeng/DebugSymbols.cs
@@ -83,7 +83,7 @@ namespace SOS
         private static void AddDebugSymbols2(VTableBuilder builder, SOSHost soshost)
         {
             AddDebugSymbols(builder, soshost);
-            builder.AddMethod(new GetModuleVersionInformationDelegate((self, index, baseAddress, item, buffer, bufferSize, verInfoSize) => DebugClient.NotImplemented));
+            builder.AddMethod(new GetModuleVersionInformationDelegate(soshost.GetModuleVersionInformation));
             builder.AddMethod(new GetModuleNameStringDelegate((self, which, index, baseAddress, buffer, bufferSize, nameSize) => DebugClient.NotImplemented));
             builder.AddMethod(new GetConstantNameDelegate((self, module, typeId, value, buffer, bufferSize, nameSize) => DebugClient.NotImplemented));
             builder.AddMethod(new GetFieldNameDelegate((self, module, typeId, fieldIndex, buffer, bufferSize, nameSize) => DebugClient.NotImplemented));

--- a/src/SOS/SOS.UnitTests/Debuggees/GCWhere/GCWhere.cs
+++ b/src/SOS/SOS.UnitTests/Debuggees/GCWhere/GCWhere.cs
@@ -49,7 +49,7 @@ class GCWhere
         Debugger.Break();   // GCWhere should temp in Gen2                
         PrintIt(temp);
         GC.KeepAlive(temp);
-        return 100;
+        return 0;
     }
 
     // This is here because without calling something with the object as an argument it'll get optimized away

--- a/src/SOS/SOS.UnitTests/Scripts/StackAndOtherTests.script
+++ b/src/SOS/SOS.UnitTests/Scripts/StackAndOtherTests.script
@@ -23,6 +23,10 @@ VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.Program\.Foo1\(.*\)\s+\[(?i:.*[\\
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.Program\.Main\(.*\)\s+\[(?i:.*[\\|/]SymbolTestApp\.cs) @ 19\]\s*
 SOSCOMMAND:SetSymbolServer -disable
 
+# Test eeversion command
+SOSCOMMAND:EEVersion
+VERIFY:\s+<DECVAL>.<DECVAL>.<DECVAL>.<DECVAL>.*
+
 # Verify that ClrStack with managed/native mixed works
 IFDEF:PROJECTK
 SOSCOMMAND:ClrStack -f

--- a/src/SOS/SOS.UnitTests/Scripts/StackTests.script
+++ b/src/SOS/SOS.UnitTests/Scripts/StackTests.script
@@ -7,6 +7,10 @@ IFDEF:LIVE
 CONTINUE
 ENDIF:LIVE
 
+# Test eeversion command
+SOSCOMMAND:EEVersion
+VERIFY:\s+<DECVAL>.<DECVAL>.<DECVAL>.<DECVAL>.*
+
 # 1) Verifying that ClrStack with no options works
 SOSCOMMAND:ClrStack
 VERIFY:.*OS Thread Id:\s+0x<HEXVAL>\s+.*

--- a/src/SOS/Strike/exts.h
+++ b/src/SOS/Strike/exts.h
@@ -133,6 +133,7 @@ private:
 extern PDEBUG_CONTROL2       g_ExtControl;
 extern PDEBUG_DATA_SPACES    g_ExtData;
 extern PDEBUG_SYMBOLS        g_ExtSymbols;
+extern PDEBUG_SYMBOLS2       g_ExtSymbols2;
 extern PDEBUG_SYSTEM_OBJECTS g_ExtSystem;
 extern PDEBUG_REGISTERS      g_ExtRegisters;
 
@@ -141,7 +142,6 @@ extern PDEBUG_REGISTERS      g_ExtRegisters;
 // Global variables initialized by query.
 extern PDEBUG_CLIENT         g_ExtClient;
 extern PDEBUG_DATA_SPACES2   g_ExtData2;
-extern PDEBUG_SYMBOLS2       g_ExtSymbols2;
 extern PDEBUG_ADVANCED       g_ExtAdvanced;
 
 bool
@@ -150,6 +150,7 @@ IsInitializedByDbgEng();
 #else // FEATURE_PAL
 
 extern ILLDBServices*        g_ExtServices;    
+extern ILLDBServices2*       g_ExtServices2;    
 
 #define IsInitializedByDbgEng() false
 

--- a/src/SOS/Strike/sos_unixexports.src
+++ b/src/SOS/Strike/sos_unixexports.src
@@ -25,6 +25,7 @@ DumpStack
 DumpStackObjects
 DumpVC
 EEHeap
+EEVersion
 GCWhere
 EEStack
 EHInfo

--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -440,6 +440,7 @@ void DumpStackInternal(DumpStackFlag *pDSFlag)
     DumpStackWorker(*pDSFlag);
 }
 
+ 
 DECLARE_API(DumpStack)
 {
     INIT_API_NO_RET_ON_FAILURE();
@@ -1276,6 +1277,14 @@ DECLARE_API(DumpClass)
             ExtOut("NumThreadStaticFields: %x\n", vMethodTableFields.wNumThreadStaticFields);
         }
 
+
+        if (vMethodTableFields.wContextStaticsSize)
+        {
+            ExtOut("ContextStaticOffset: %x\n", vMethodTableFields.wContextStaticOffset);
+            ExtOut("ContextStaticsSize:  %x\n", vMethodTableFields.wContextStaticsSize);
+        }
+
+    
         if (vMethodTableFields.wNumInstanceFields + vMethodTableFields.wNumStaticFields > 0)
         {
             DisplayFields(methodTable, &mtdata, &vMethodTableFields, NULL, TRUE, FALSE);
@@ -7996,11 +8005,7 @@ DECLARE_API(bpmd)
         // did we get dll and type name or file:line#? Search for a colon in the first arg
         // to see if it is in fact a file:line#
         CHAR* pColon = strchr(DllName.data, ':');
-#ifndef FEATURE_PAL 
-        if (FAILED(g_ExtSymbols->GetModuleByModuleName(MAIN_CLR_MODULE_NAME_A, 0, NULL, NULL))) {
-#else
-        if (FAILED(g_ExtSymbols->GetModuleByModuleName(MAIN_CLR_DLL_NAME_A, 0, NULL, NULL))) {
-#endif
+        if (FAILED(GetRuntimeModuleInfo(NULL, NULL))) {
            ExtOut("%s not loaded yet\n", MAIN_CLR_DLL_NAME_A);
            return Status;
         }
@@ -10028,7 +10033,6 @@ DECLARE_API(DumpGCData)
 #endif //GC_CONFIG_DRIVEN
 }
 
-#ifndef FEATURE_PAL
 /**********************************************************************\
 * Routine Description:                                                 *
 *                                                                      *
@@ -10045,39 +10049,42 @@ DECLARE_API (EEVersion)
         ExtOut("CLR not loaded\n");
         return Status;
     }
-    
-    if (g_ExtSymbols2) {
-        VS_FIXEDFILEINFO version;
-        
-        BOOL ret = GetEEVersion(&version);
-            
-        if (ret) 
+    static const int fileVersionBufferSize = 1024;
+    ArrayHolder<char> fileVersionBuffer = new char[fileVersionBufferSize];
+    VS_FIXEDFILEINFO version;
+
+    BOOL ret = GetEEVersion(&version, fileVersionBuffer.GetPtr(), fileVersionBufferSize);
+    if (ret) 
+    {
+        if (version.dwFileVersionMS != (DWORD)-1)
         {
-            if (version.dwFileVersionMS != (DWORD)-1)
-            {
-                ExtOut("%u.%u.%u.%u",
-                       HIWORD(version.dwFileVersionMS),
-                       LOWORD(version.dwFileVersionMS),
-                       HIWORD(version.dwFileVersionLS),
-                       LOWORD(version.dwFileVersionLS));
-                if (version.dwFileFlags & VS_FF_DEBUG) 
-                {                    
-                    ExtOut(" Checked or debug build");
-                }
+            ExtOut("%u.%u.%u.%u",
+                   HIWORD(version.dwFileVersionMS),
+                   LOWORD(version.dwFileVersionMS),
+                   HIWORD(version.dwFileVersionLS),
+                   LOWORD(version.dwFileVersionLS));
+#ifndef FEATURE_PAL
+            if (version.dwFileFlags & VS_FF_DEBUG) 
+            {                    
+                ExtOut(" Checked or debug build");
+            }
+            else
+            { 
+                BOOL fRet = IsRetailBuild ((size_t)g_moduleInfo[eef].baseAddr);
+                if (fRet)
+                    ExtOut(" retail");
                 else
-                { 
-                    BOOL fRet = IsRetailBuild ((size_t)g_moduleInfo[eef].baseAddr);
+                    ExtOut(" free");
+            }
+#endif
+            ExtOut("\n");
 
-                    if (fRet)
-                        ExtOut(" retail");
-                    else
-                        ExtOut(" free");
-                }
-
-                ExtOut("\n");
+            if (fileVersionBuffer[0] != '\0')
+            {
+                ExtOut("%s\n", fileVersionBuffer.GetPtr());
             }
         }
-    }    
+    }
     
     if (!InitializeHeapData ())
         ExtOut("GC Heap not initialized, so GC mode is not determined yet.\n");
@@ -10091,6 +10098,7 @@ DECLARE_API (EEVersion)
         ExtOut("In plan phase of garbage collection\n");
     }
 
+#ifndef FEATURE_PAL
     // Print SOS version
     VS_FIXEDFILEINFO sosVersion;
     if (GetSOSVersion(&sosVersion))
@@ -10102,6 +10110,7 @@ DECLARE_API (EEVersion)
                    LOWORD(sosVersion.dwFileVersionMS),
                    HIWORD(sosVersion.dwFileVersionLS),
                    LOWORD(sosVersion.dwFileVersionLS));
+
             if (sosVersion.dwFileFlags & VS_FF_DEBUG) 
             {                    
                 ExtOut(" Checked or debug build");                    
@@ -10110,13 +10119,12 @@ DECLARE_API (EEVersion)
             { 
                 ExtOut(" retail build");                    
             }
-
             ExtOut("\n");
         }
     }
+#endif // FEATURE_PAL
     return Status;
 }
-#endif // FEATURE_PAL
 
 #ifndef FEATURE_PAL
 /**********************************************************************\
@@ -11386,8 +11394,7 @@ DECLARE_API(TraceToCode)
         {
             if(g_clrBaseAddr == 0)
             {
-                g_ExtSymbols->GetModuleByModuleName (MAIN_CLR_MODULE_NAME_A,0,NULL,
-                    &g_clrBaseAddr);
+                GetRuntimeModuleInfo(NULL, &g_clrBaseAddr);
             }
             if(g_clrBaseAddr == base)
             {
@@ -11522,7 +11529,7 @@ DECLARE_API(GetCodeTypeFlags)
     else if(g_ExtSymbols->GetModuleByOffset (ip, 0, NULL, &base) == S_OK)
     {
         ULONG64 clrBaseAddr = 0;
-        if(SUCCEEDED(g_ExtSymbols->GetModuleByModuleName (MAIN_CLR_MODULE_NAME_A,0,NULL, &clrBaseAddr)) && base==clrBaseAddr)
+        if(SUCCEEDED(GetRuntimeModuleInfo(NULL, &clrBaseAddr)) && base==clrBaseAddr)
         {
             ExtOut("Compiled code in CLR");
             codeType = 4;

--- a/src/SOS/Strike/util.cpp
+++ b/src/SOS/Strike/util.cpp
@@ -150,45 +150,63 @@ DWORD_PTR GetValueFromExpression(___in __in_z const char *const instr)
 
 #endif // FEATURE_PAL
 
-ModuleInfo g_moduleInfo[MSCOREND] = {{0, FALSE, 0}, {0, FALSE, 0}, {0, FALSE, 0}};
+ModuleInfo g_moduleInfo[MSCOREND] = {{0, 0, DEBUG_ANY_ID, FALSE}, {0, 0, DEBUG_ANY_ID, FALSE}, {0, 0, DEBUG_ANY_ID, FALSE}};
 
 void ReportOOM()
 {
     ExtOut("SOS Error: Out of memory\n");
 }
 
+HRESULT GetRuntimeModuleInfo(PULONG moduleIndex, PULONG64 moduleBase)
+{
+#ifdef FEATURE_PAL
+    return g_ExtSymbols->GetModuleByModuleName(MAIN_CLR_DLL_NAME_A, 0, moduleIndex, moduleBase);
+#else
+    return g_ExtSymbols->GetModuleByModuleName(MAIN_CLR_MODULE_NAME_A, 0, moduleIndex, moduleBase);
+#endif
+}
+
 HRESULT CheckEEDll()
 {
-#ifndef FEATURE_PAL
-    // Do we have coreclr.dll
+    HRESULT hr = S_OK;
+
+    // Do we have runtime module info?
     if (g_moduleInfo[MSCORWKS].baseAddr == 0)
     {
-        DEBUG_MODULE_PARAMETERS Params;
-
-        g_ExtSymbols->GetModuleByModuleName(MAIN_CLR_MODULE_NAME_A, 0, NULL, &g_moduleInfo[MSCORWKS].baseAddr);
+        hr = GetRuntimeModuleInfo(&g_moduleInfo[MSCORWKS].index, &g_moduleInfo[MSCORWKS].baseAddr);
+#ifdef FEATURE_PAL
+        if (SUCCEEDED(hr))
+        {
+            if (g_ExtServices2 != nullptr)
+            {
+                g_ExtServices2->GetModuleInfo(g_moduleInfo[MSCORWKS].index, nullptr, &g_moduleInfo[MSCORWKS].size);
+            }
+        }
+#else
         if (g_moduleInfo[MSCORWKS].baseAddr != 0 && g_moduleInfo[MSCORWKS].hasPdb == FALSE)
         {
-            g_ExtSymbols->GetModuleParameters(1, &g_moduleInfo[MSCORWKS].baseAddr, 0, &Params);
-            if (Params.SymbolType == SymDeferred)
+            DEBUG_MODULE_PARAMETERS params;
+            if (SUCCEEDED(g_ExtSymbols->GetModuleParameters(1, &g_moduleInfo[MSCORWKS].baseAddr, 0, &params)))
             {
-                g_ExtSymbols->Reload("/f " MAIN_CLR_DLL_NAME_A);
-                g_ExtSymbols->GetModuleParameters(1, &g_moduleInfo[MSCORWKS].baseAddr, 0, &Params);
+                if (params.SymbolType == SymDeferred)
+                {
+                    g_ExtSymbols->Reload("/f " MAIN_CLR_DLL_NAME_A);
+                    g_ExtSymbols->GetModuleParameters(1, &g_moduleInfo[MSCORWKS].baseAddr, 0, &params);
+                }
+                if (params.SymbolType == SymPdb || params.SymbolType == SymDia)
+                {
+                    g_moduleInfo[MSCORWKS].hasPdb = TRUE;
+                }
+                g_moduleInfo[MSCORWKS].size = params.Size;
             }
-            if (Params.SymbolType == SymPdb || Params.SymbolType == SymDia)
-            {
-                g_moduleInfo[MSCORWKS].hasPdb = TRUE;
-            }
-            g_moduleInfo[MSCORWKS].size = Params.Size;
         }
         if (g_moduleInfo[MSCORWKS].baseAddr != 0 && g_moduleInfo[MSCORWKS].hasPdb == FALSE) 
         {
             ExtOut("PDB symbol for coreclr.dll not loaded\n");
         }
-    }
-    return (g_moduleInfo[MSCORWKS].baseAddr != 0) ? S_OK : E_FAIL;
-#else
-    return S_OK;
 #endif // FEATURE_PAL
+    }
+    return hr;
 }
 
 EEFLAVOR GetEEFlavor()
@@ -197,8 +215,7 @@ EEFLAVOR GetEEFlavor()
     return MSCORWKS;
 #else // FEATUER_PAL
     EEFLAVOR flavor = UNKNOWNEE;    
-    
-    if (SUCCEEDED(g_ExtSymbols->GetModuleByModuleName(MAIN_CLR_MODULE_NAME_A,0,NULL,NULL))) {
+    if (SUCCEEDED(GetRuntimeModuleInfo(NULL, NULL))) {
         flavor = MSCORWKS;
     }
     return flavor;
@@ -2796,42 +2813,77 @@ const char *EHTypeName(EHClauseType et)
         return "UNKNOWN";
 }
 
-void DumpTieredNativeCodeAddressInfo(struct DacpTieredVersionData * pTieredVersionData,
-    const UINT cTieredVersionData, ULONG rejitID, CLRDATA_ADDRESS ilAddr, CLRDATA_ADDRESS ilNodeAddr)
+// 2.x version
+void DumpTieredNativeCodeAddressInfo_2x(struct DacpTieredVersionData_2x * pTieredVersionData, const UINT cTieredVersionData)
 {
+    ExtOut("Code Version History:\n");
+
     for(int i = cTieredVersionData - 1; i >= 0; --i)
     {
-        ExtOut("  NativeCodeVersion:  %p\n", SOS_PTR(pTieredVersionData[i].NativeCodeVersionNodePtr));
-
         const char *descriptor = NULL;
-        switch(pTieredVersionData[i].OptimizationTier)
+        switch(pTieredVersionData[i].TieredInfo)
         {
-        case DacpTieredVersionData::OptimizationTier_Unknown:
+        case DacpTieredVersionData_2x::TIERED_UNKNOWN:
         default:
             descriptor = "Unknown Tier";
             break;
-        case DacpTieredVersionData::OptimizationTier_MinOptJitted:
-            descriptor = "MinOptJitted";
+        case DacpTieredVersionData_2x::NON_TIERED:
+            descriptor = "Non-Tiered";
             break;
-        case DacpTieredVersionData::OptimizationTier_Optimized:
-            descriptor = "Optimized";
+        case DacpTieredVersionData_2x::TIERED_0:
+            descriptor = "Tier 0";
             break;
-        case DacpTieredVersionData::OptimizationTier_QuickJitted:
-            descriptor = "QuickJitted";
-            break;
-        case DacpTieredVersionData::OptimizationTier_OptimizedTier1:
-            descriptor = "OptimizedTier1";
-            break;
-        case DacpTieredVersionData::OptimizationTier_ReadyToRun:
-            descriptor = "ReadyToRun";
+        case DacpTieredVersionData_2x::TIERED_1:
+            descriptor = "Tier 1";
             break;
         }
 
-        ExtOut("    ReJIT ID:           %d\n", rejitID);
-        DMLOut("    CodeAddr:           %s  (%s)\n", DMLIP(pTieredVersionData[i].NativeCodeAddr), descriptor);
-        DMLOut("    IL Addr:            %s\n", DMLIL(ilAddr));
-        ExtOut("    ILCodeVersion:      %p\n", SOS_PTR(ilNodeAddr));
+        DMLOut("  CodeAddr:           %s  (%s)\n", DMLIP(pTieredVersionData[i].NativeCodeAddr), descriptor);
+        ExtOut("  NativeCodeVersion:  %p\n", SOS_PTR(pTieredVersionData[i].NativeCodeVersionNodePtr));
+    }
+}
 
+void DumpTieredNativeCodeAddressInfo(struct DacpTieredVersionData * pTieredVersionData,
+    const UINT cTieredVersionData, ULONG rejitID, CLRDATA_ADDRESS ilAddr, CLRDATA_ADDRESS ilNodeAddr)
+{
+    if (IsRuntimeVersion(3)) {
+        for(int i = cTieredVersionData - 1; i >= 0; --i)
+        {
+            ExtOut("  NativeCodeVersion:  %p\n", SOS_PTR(pTieredVersionData[i].NativeCodeVersionNodePtr));
+
+            const char *descriptor = NULL;
+            switch(pTieredVersionData[i].OptimizationTier)
+            {
+            case DacpTieredVersionData::OptimizationTier_Unknown:
+            default:
+                descriptor = "Unknown Tier";
+                break;
+            case DacpTieredVersionData::OptimizationTier_MinOptJitted:
+                descriptor = "MinOptJitted";
+                break;
+            case DacpTieredVersionData::OptimizationTier_Optimized:
+                descriptor = "Optimized";
+                break;
+            case DacpTieredVersionData::OptimizationTier_QuickJitted:
+                descriptor = "QuickJitted";
+                break;
+            case DacpTieredVersionData::OptimizationTier_OptimizedTier1:
+                descriptor = "OptimizedTier1";
+                break;
+            case DacpTieredVersionData::OptimizationTier_ReadyToRun:
+                descriptor = "ReadyToRun";
+                break;
+            }
+
+            ExtOut("    ReJIT ID:           %d\n", rejitID);
+            DMLOut("    CodeAddr:           %s  (%s)\n", DMLIP(pTieredVersionData[i].NativeCodeAddr), descriptor);
+            DMLOut("    IL Addr:            %s\n", DMLIL(ilAddr));
+            ExtOut("    ILCodeVersion:      %p\n", SOS_PTR(ilNodeAddr));
+
+        }
+    }
+    else {
+        DumpTieredNativeCodeAddressInfo_2x((DacpTieredVersionData_2x*)pTieredVersionData, cTieredVersionData);
     }
 }
 
@@ -3225,20 +3277,63 @@ size_t FunctionType (size_t EIP)
     return (size_t) pMD;
 }
 
-#ifndef FEATURE_PAL
-
 //
 // Gets version info for the CLR in the debuggee process.
 //
-BOOL GetEEVersion(VS_FIXEDFILEINFO *pFileInfo)
+BOOL GetEEVersion(VS_FIXEDFILEINFO* pFileInfo, char* fileVersionBuffer, int fileVersionBufferSize)
 {
-    _ASSERTE(g_ExtSymbols2);
     _ASSERTE(pFileInfo);
+    if (g_ExtSymbols2 == nullptr) {
+        return FALSE;
+    }
+    ModuleInfo moduleInfo = g_moduleInfo[GetEEFlavor()];
+    _ASSERTE(moduleInfo.index != DEBUG_ANY_ID);
 
-    // Grab the version info directly from the module.
-    return g_ExtSymbols2->GetModuleVersionInformation(
-        DEBUG_ANY_ID, g_moduleInfo[GetEEFlavor()].baseAddr, "\\", pFileInfo, sizeof(VS_FIXEDFILEINFO), NULL) == S_OK;
+#ifdef FEATURE_PAL
+    // Load the symbols for runtime. On Linux we are looking for the "sccsid" 
+    // global so "libcoreclr.so/.dylib" symbols need to be loaded.
+    LoadNativeSymbols(true);
+#endif
+
+    HRESULT hr = g_ExtSymbols2->GetModuleVersionInformation(moduleInfo.index, 0, "\\", pFileInfo, sizeof(VS_FIXEDFILEINFO), NULL);
+
+    // Attempt to get the the FileVersion string that contains version and the "built by" and commit id info
+    if (fileVersionBuffer != nullptr)
+    {
+        if (fileVersionBufferSize > 0) {
+            fileVersionBuffer[0] = '\0';
+        }
+        // We can assume the English/CP_UNICODE lang/code page for the runtime modules
+        g_ExtSymbols2->GetModuleVersionInformation(
+            moduleInfo.index, 0, "\\StringFileInfo\\040904B0\\FileVersion", fileVersionBuffer, fileVersionBufferSize, NULL);
+    }
+
+    return SUCCEEDED(hr);
 }
+
+//
+// Return true if major runtime version
+//
+bool IsRuntimeVersion(DWORD major)
+{
+    VS_FIXEDFILEINFO fileInfo;
+    if (GetEEVersion(&fileInfo, nullptr, 0))
+    {
+        switch (major)
+        {
+            case 5:
+                return HIWORD(fileInfo.dwFileVersionMS) == 5;
+            case 3:
+                return HIWORD(fileInfo.dwFileVersionMS) == 4 && LOWORD(fileInfo.dwFileVersionMS) == 700;
+            default:
+                _ASSERTE(FALSE);
+                break;
+        }
+    }
+    return false;
+}
+
+#ifndef FEATURE_PAL
 
 BOOL GetSOSVersion(VS_FIXEDFILEINFO *pFileInfo)
 {
@@ -4450,7 +4545,7 @@ HRESULT InitCorDebugInterface()
     return E_FAIL;
 #else
     ULONG64 ulBase;
-    hr = g_ExtSymbols->GetModuleByModuleName(MAIN_CLR_DLL_NAME_A, 0, NULL, &ulBase);
+    hr = GetRuntimeModuleInfo(NULL, &ulBase);
     if (SUCCEEDED(hr))
     {
         hr = InitCorDebugInterfaceFromModule(ulBase, pClrDebugging);

--- a/src/SOS/Strike/util.h
+++ b/src/SOS/Strike/util.h
@@ -1556,7 +1556,7 @@ HRESULT GetRuntimeModuleInfo(PULONG moduleIndex, PULONG64 moduleBase);
 EEFLAVOR GetEEFlavor ();
 HRESULT InitCorDebugInterface();
 VOID UninitCorDebugInterface();
-BOOL GetEEVersion(VS_FIXEDFILEINFO* pFileInfo, char* fileVersionBuffer, int fileVersionBufferSize);
+BOOL GetEEVersion(VS_FIXEDFILEINFO* pFileInfo, char* fileVersionBuffer, int fileVersionBufferSizeInBytes);
 bool IsRuntimeVersion(DWORD major);
 #ifndef FEATURE_PAL
 BOOL IsRetailBuild (size_t base);

--- a/src/SOS/Strike/util.h
+++ b/src/SOS/Strike/util.h
@@ -1536,6 +1536,7 @@ struct ModuleInfo
 {
     ULONG64 baseAddr;
     ULONG64 size;
+    ULONG index;
     BOOL hasPdb;
 };
 extern ModuleInfo g_moduleInfo[];
@@ -1551,12 +1552,14 @@ HRESULT DecodeILFromAddress(IMetaDataImport *pImport, TADDR ilAddr);
 void DecodeIL(IMetaDataImport *pImport, BYTE *buffer, ULONG bufSize);
 void DecodeDynamicIL(BYTE *data, ULONG Size, DacpObjectData& tokenArray);
 
-BOOL IsRetailBuild (size_t base);
+HRESULT GetRuntimeModuleInfo(PULONG moduleIndex, PULONG64 moduleBase);
 EEFLAVOR GetEEFlavor ();
 HRESULT InitCorDebugInterface();
 VOID UninitCorDebugInterface();
+BOOL GetEEVersion(VS_FIXEDFILEINFO* pFileInfo, char* fileVersionBuffer, int fileVersionBufferSize);
+bool IsRuntimeVersion(DWORD major);
 #ifndef FEATURE_PAL
-BOOL GetEEVersion(VS_FIXEDFILEINFO *pFileInfo);
+BOOL IsRetailBuild (size_t base);
 BOOL GetSOSVersion(VS_FIXEDFILEINFO *pFileInfo);
 #endif
 

--- a/src/SOS/Strike/xplat/dbgeng.h
+++ b/src/SOS/Strike/xplat/dbgeng.h
@@ -24,14 +24,19 @@ class DebugClient
 {
 private:
     LONG m_ref;
-    ILLDBServices *m_lldbservices;
+    ILLDBServices* m_lldbservices;
+    ILLDBServices2* m_lldbservices2;
 
 public:
-    DebugClient(ILLDBServices *lldbservices) : 
+    DebugClient(ILLDBServices* lldbservices, ILLDBServices2* lldbservices2) : 
         m_ref(1),
-        m_lldbservices(lldbservices)
+        m_lldbservices(lldbservices),
+        m_lldbservices2(lldbservices2)
     {
         m_lldbservices->AddRef();
+        if (m_lldbservices2 != nullptr) {
+            m_lldbservices2->AddRef();
+        }
     }
 
     //----------------------------------------------------------------------------
@@ -268,6 +273,21 @@ public:
     }
 
     HRESULT 
+    GetModuleVersionInformation(
+        ULONG index,
+        ULONG64 base,
+        PCSTR item,
+        PVOID buffer,
+        ULONG bufferSize,
+        PULONG versionInfoSize)
+    {
+        if (m_lldbservices2 == nullptr) {
+            return E_NOINTERFACE;
+        }
+        return m_lldbservices2->GetModuleVersionInformation(index, base, item, buffer, bufferSize, versionInfoSize);
+    }
+
+    HRESULT 
     GetLineByOffset(
         ULONG64 offset,
         PULONG line,
@@ -407,6 +427,11 @@ IDebugSymbols : DebugClient
 {
 };
 
+MIDL_INTERFACE("3a707211-afdd-4495-ad4f-56fecdf8163f")
+IDebugSymbols2 : DebugClient
+{
+};
+
 MIDL_INTERFACE("6b86fe2c-2c4f-4f0c-9da2-174311acc327")
 IDebugSystemObjects : DebugClient
 {
@@ -422,6 +447,7 @@ typedef interface IDebugControl2* PDEBUG_CONTROL2;
 typedef interface IDebugControl4* PDEBUG_CONTROL4;
 typedef interface IDebugDataSpaces* PDEBUG_DATA_SPACES;
 typedef interface IDebugSymbols* PDEBUG_SYMBOLS;
+typedef interface IDebugSymbols2* PDEBUG_SYMBOLS2;
 typedef interface IDebugSystemObjects* PDEBUG_SYSTEM_OBJECTS;
 typedef interface IDebugRegisters* PDEBUG_REGISTERS;
 

--- a/src/SOS/lldbplugin/inc/lldbservices.h
+++ b/src/SOS/lldbplugin/inc/lldbservices.h
@@ -562,6 +562,19 @@ public:
     virtual HRESULT AddModuleSymbol(
         void* param, 
         const char* symbolFilePath) = 0;
+
+    virtual HRESULT GetModuleInfo(
+        ULONG index,
+        PULONG64 base,
+        PULONG64 size) = 0;
+
+    virtual HRESULT GetModuleVersionInformation(
+        ULONG index,
+        ULONG64 base,
+        PCSTR item,
+        PVOID buffer,
+        ULONG bufferSize,
+        PULONG versionInfoSize) = 0;
 };
 
 #ifdef __cplusplus

--- a/src/SOS/lldbplugin/soscommand.cpp
+++ b/src/SOS/lldbplugin/soscommand.cpp
@@ -134,6 +134,7 @@ sosCommandInitialize(lldb::SBDebugger debugger)
     interpreter.AddCommand("clrstack", new sosCommand("ClrStack"), "Provides a stack trace of managed code only.");
     interpreter.AddCommand("clrthreads", new sosCommand("Threads"), "List the managed threads running.");
     interpreter.AddCommand("clru", new sosCommand("u"), "Displays an annotated disassembly of a managed method.");
+    interpreter.AddCommand("dumparray", new sosCommand("DumpArray"), "Displays details about a managed array.");
     interpreter.AddCommand("dumpasync", new sosCommand("DumpAsync"), "Displays info about async state machines on the garbage-collected heap.");
     interpreter.AddCommand("dumpassembly", new sosCommand("DumpAssembly"), "Displays details about an assembly.");
     interpreter.AddCommand("dumpclass", new sosCommand("DumpClass"), "Displays information about a EE class structure at the specified address.");
@@ -150,6 +151,7 @@ sosCommandInitialize(lldb::SBDebugger debugger)
     interpreter.AddCommand("dso", new sosCommand("DumpStackObjects"), "Displays all managed objects found within the bounds of the current stack.");
     interpreter.AddCommand("eeheap", new sosCommand("EEHeap"), "Displays info about process memory consumed by internal runtime data structures.");
     interpreter.AddCommand("eestack", new sosCommand("EEStack"), "Runs dumpstack on all threads in the process.");
+    interpreter.AddCommand("eeversion", new sosCommand("EEVersion"), "Displays information about the runtime version.");
     interpreter.AddCommand("finalizequeue", new sosCommand("FinalizeQueue"), "Displays all objects registered for finalization.");
     interpreter.AddCommand("gcroot", new sosCommand("GCRoot"), "Displays info about references (or roots) to an object at the specified address.");
     interpreter.AddCommand("gcwhere", new sosCommand("GCWhere"), "Displays the location in the GC heap of the argument passed in.");

--- a/src/Tools/dotnet-dump/Commands/SOSCommand.cs
+++ b/src/Tools/dotnet-dump/Commands/SOSCommand.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Diagnostics.Tools.Dump
     [Command(Name = "dumpstackobjects", AliasExpansion = "DumpStackObjects",    Help = "Displays all managed objects found within the bounds of the current stack.")]
     [CommandAlias(Name = "dso")]
     [Command(Name = "eeheap",           AliasExpansion = "EEHeap",              Help = "Displays info about process memory consumed by internal runtime data structures.")]
+    [Command(Name = "eeversion",        AliasExpansion = "EEVersion",           Help = "Displays information about the runtime version.")]
     [Command(Name = "finalizequeue",    AliasExpansion = "FinalizeQueue",       Help = "Displays all objects registered for finalization.")]
     [Command(Name = "gcroot",           AliasExpansion = "GCRoot",              Help = "Displays info about references (or roots) to an object at the specified address.")]
     [Command(Name = "gcwhere",          AliasExpansion = "GCWhere",             Help = "Displays the location in the GC heap of the argument passed in.")]

--- a/src/Tools/dotnet-dump/Commands/SOSCommandForWindows.cs
+++ b/src/Tools/dotnet-dump/Commands/SOSCommandForWindows.cs
@@ -18,7 +18,6 @@ namespace Microsoft.Diagnostics.Tools.Dump
     [Command(Name = "watsonbuckets",        AliasExpansion = "WatsonBuckets",       Help = "Displays the Watson buckets.")]
     [Command(Name = "threadpool",           AliasExpansion = "ThreadPool",          Help = "Lists basic information about the thread pool.")]
     [Command(Name = "comstate",             AliasExpansion = "COMState",            Help = "Lists the COM apartment model for each thread.")]
-    [Command(Name = "eeversion",            AliasExpansion = "EEVersion",           Help = "This prints the runtiem and SOS versions.")]
     [Command(Name = "gchandles",            AliasExpansion = "GCHandles",           Help = "Provides statistics about GCHandles in the process.")]
     [Command(Name = "objsize",              AliasExpansion = "ObjSize",             Help = "Lists the sizes of the all the objects found on managed threads.")]
     [Command(Name = "gchandleleaks",        AliasExpansion = "GCHandleLeaks",       Help = "Helps in tracking down GCHandle leaks")]

--- a/src/inc/dacprivate.h
+++ b/src/inc/dacprivate.h
@@ -631,8 +631,8 @@ struct MSLAYOUT DacpTieredVersionData
     CLRDATA_ADDRESS NativeCodeVersionNodePtr;
 };
 
-// 2.1 version
-struct MSLAYOUT DacpTieredVersionData_21
+// 2.x version
+struct MSLAYOUT DacpTieredVersionData_2x
 {
     enum TieredState 
     {


### PR DESCRIPTION
Implement GetEEVersion for xplat using the embedded "@(#)Version" string.

Enabled/add the "eeversion" command for xplat.

Added LLDBService2::GetModuleVersion to get the version string via the "sccid" symbol. Fallback
to using search the data sections to the version string.

Added same to SOSHost so eeversion works in dotnet-dump.

Fixed initializing g_moduleInfo for Linux. It is used by dumpmt. Added new LLDBService2::GetModuleInfo api to do this.

Added "dumparray" alias to lldb command aliases.

Add testing for the eeversion command.