### PR TITLE
[WIP] dotnet-trace CLI changes

### DIFF
--- a/src/Microsoft.Diagnostics.Tools.RuntimeClient/Eventing/Provider.cs
+++ b/src/Microsoft.Diagnostics.Tools.RuntimeClient/Eventing/Provider.cs
@@ -34,5 +34,8 @@ namespace Microsoft.Diagnostics.Tools.RuntimeClient
 
         public override string ToString() =>
             $"{Name}:0x{Keywords:X16}:{(uint)EventLevel}{(FilterData == null ? "" : $":{FilterData}")}";
+
+        public string ToDisplayString() =>
+            String.Format("{0, -40}", Name) + String.Format("0x{0, -18}", $"{Keywords:X16}") + String.Format("{0, -8}", EventLevel.ToString() + $"({(int)EventLevel})");
     }
 }

--- a/src/Tools/dotnet-trace/CommandLine/Commands/ListProfilesCommandHandler.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/ListProfilesCommandHandler.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
         // FIXME: Read from a config file!
         internal static IEnumerable<Profile> DotNETRuntimeProfiles { get; } = new[] {
             new Profile(
-                "runtime-basic",
+                "cpu-sampling",
                 new Provider[] {
                     new Provider("Microsoft-DotNETCore-SampleProfiler"),
                     new Provider("Microsoft-Windows-DotNETRuntime", (ulong)ClrTraceEventParser.Keywords.Default, EventLevel.Informational),
@@ -70,10 +70,6 @@ namespace Microsoft.Diagnostics.Tools.Trace
                         eventLevel: EventLevel.Informational),
                 },
                 "Tracks GC collection only at very low overhead."),
-            new Profile(
-                "none",
-                null,
-                "Tracks nothing. Only providers specified by the --providers option will be available."),
         };
     }
 }

--- a/src/Tools/dotnet-trace/CommandLine/Commands/ListProfilesCommandHandler.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/ListProfilesCommandHandler.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                     new Provider("Microsoft-DotNETCore-SampleProfiler"),
                     new Provider("Microsoft-Windows-DotNETRuntime", (ulong)ClrTraceEventParser.Keywords.Default, EventLevel.Informational),
                 },
-                "Useful for tracking CPU usage and general runtime information. This the default option if no profile is specified."),
+                "Useful for tracking CPU usage and general .NET runtime information. This the default option if no profile or providers are specified."),
             new Profile(
                 "gc-verbose",
                 new Provider[] {
@@ -59,7 +59,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                         eventLevel: EventLevel.Verbose
                     ),
                 },
-                "Tracks GC and GC handle events at verbose level, and samples the allocation events as well."),
+                "Tracks GC collection and sampled object allocations."),
             new Profile(
                 "gc-collect",
                 new Provider[] {


### PR DESCRIPTION
This is for https://github.com/dotnet/diagnostics/issues/472. 

Example output:
```
E:\diagnostics\src\Tools\dotnet-trace>dotnet run collect --process-id 11952
No profile or providers specified, defaulting to trace profile 'cpu-sampling'
Configuration:
  Provider Name                           Keywords            Level             Enabled By
  Microsoft-DotNETCore-SampleProfiler     0xFFFFFFFFFFFFFFFF  Verbose(5)        --profile cpu-sampling
  Microsoft-Windows-DotNETRuntime         0x00000004C14FCCBD  Informational(4)  --profile cpu-sampling
Press <Enter> or <Ctrl+C> to exit...
Process        : E:\event-counters-tests\gcperfsim\bin\Debug\netcoreapp3.0\win-x64\publish\gcperfsim.exe
Output File    : E:\diagnostics\src\Tools\dotnet-trace\trace.nettrace
        Session Id: 0x000002979A7357C0

[00:00:00:05]   Recording trace 615.649  (KB)                                              
```