### PR TITLE
Various fixes and update cdb

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -32,7 +32,7 @@
     <XUnitVersion>2.4.1</XUnitVersion>
     <XUnitAbstractionsVersion>2.0.3</XUnitAbstractionsVersion>
 
-    <cdbsosversion>1.1.0</cdbsosversion>
+    <cdbsosversion>10.0.18362</cdbsosversion>
 
   </PropertyGroup>
 

--- a/src/SOS/SOS.NETCore/SymbolReader.cs
+++ b/src/SOS/SOS.NETCore/SymbolReader.cs
@@ -332,6 +332,9 @@ namespace SOS
                         {
                             downloadFilePath = file.FileName;
 
+                            // Make sure the stream is at the beginning of the module
+                            file.Stream.Position = 0;
+
                             // If the downloaded doesn't already exists on disk in the cache, then write it to a temporary location.
                             if (!File.Exists(downloadFilePath))
                             {
@@ -931,6 +934,8 @@ namespace SOS
                     {
                         return null;
                     }
+                    // Make sure the stream is at the beginning of the pdb.
+                    pdbStream.Position = 0;
                 }
 
                 provider = MetadataReaderProvider.FromPortablePdbStream(pdbStream);

--- a/src/SOS/SOS.UnitTests/ConfigFiles/Windows/Debugger.Tests.Config.txt
+++ b/src/SOS/SOS.UnitTests/ConfigFiles/Windows/Debugger.Tests.Config.txt
@@ -17,7 +17,7 @@
   <InstallDir>$(RootBinDir)\bin\Windows_NT.$(TargetArchitecture).$(TargetConfiguration)</InstallDir>
   <LogDir>$(RootBinDir)\TestResults\$(TargetConfiguration)\sos.unittests_$(Timestamp)</LogDir>
   <DumpDir>$(RootBinDir)\tmp\$(TargetConfiguration)\dumps</DumpDir>
-  <CDBPath>$(NuGetPackageCacheDir)\cdb-sos\1.1.0\runtimes\win-$(TargetArchitecture)\native\cdb.exe</CDBPath>
+  <CDBPath>$(NuGetPackageCacheDir)\cdb-sos\10.0.18362\runtimes\win-$(TargetArchitecture)\native\cdb.exe</CDBPath>
   <CDBHelperExtension>$(InstallDir)\runcommand.dll</CDBHelperExtension>
 
   <DebuggeeSourceRoot>$(RepoRootDir)\src\SOS\SOS.UnitTests\Debuggees</DebuggeeSourceRoot>

--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -10066,7 +10066,7 @@ DECLARE_API (EEVersion)
 #ifndef FEATURE_PAL
             if (version.dwFileFlags & VS_FF_DEBUG) 
             {                    
-                ExtOut(" Checked or debug build");
+                ExtOut(" checked or debug build");
             }
             else
             { 
@@ -10113,7 +10113,7 @@ DECLARE_API (EEVersion)
 
             if (sosVersion.dwFileFlags & VS_FF_DEBUG) 
             {                    
-                ExtOut(" Checked or debug build");                    
+                ExtOut(" debug build");                    
             }
             else
             { 

--- a/src/pal/prebuilt/inc/fxver.h
+++ b/src/pal/prebuilt/inc/fxver.h
@@ -86,7 +86,7 @@
 #define VER_FILESUBTYPE             VFT2_UNKNOWN
 
 /* default is nodebug */
-#if DBG
+#if _DEBUG
 #define VER_DEBUG                   VS_FF_DEBUG
 #else
 #define VER_DEBUG                   0


### PR DESCRIPTION
Update cdb version to 10.0.18362 and fixes a program in the dotnet-dump analyze register service because the dumps generated by this new cdb have bigger thread context's.

Fix issue in the read virtual memory module mapping for dotnet-dump analyze on Windows.