### PR TITLE
Changes for redirected stdin

### DIFF
--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
@@ -185,7 +185,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
 
                     do
                     {
-                        while (!Console.KeyAvailable && !shouldExit.WaitOne(250)) { }
+                        while (Console.In.Peek() == -1 && !shouldExit.WaitOne(250)) { }
                     } while (!shouldExit.WaitOne(0) && Console.ReadKey(true).Key != ConsoleKey.Enter);
 
                     if (!terminated)
@@ -231,6 +231,9 @@ namespace Microsoft.Diagnostics.Tools.Trace
 
         private static void ResetCurrentConsoleLine(bool isVTerm)
         {
+            if (Console.IsOutputRedirected)
+                return;
+
             if (isVTerm)
             {
                 // ANSI escape codes:

--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
@@ -186,7 +186,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                     do
                     {
                         while (Console.In.Peek() == -1 && !shouldExit.WaitOne(250)) { }
-                    } while (!shouldExit.WaitOne(0) && Console.ReadKey(true).Key != ConsoleKey.Enter);
+                    } while (!shouldExit.WaitOne(0) && (char)Console.In.Read() != (char)ConsoleKey.Enter);
 
                     if (!terminated)
                     {
@@ -232,9 +232,10 @@ namespace Microsoft.Diagnostics.Tools.Trace
         private static void ResetCurrentConsoleLine(bool isVTerm)
         {
             if (Console.IsOutputRedirected)
-                return;
-
-            if (isVTerm)
+            {
+                Console.Out.WriteLine();
+            }
+            else if (isVTerm)
             {
                 // ANSI escape codes:
                 //  [2K => clear current line

--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
@@ -156,7 +156,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
 
                                 systemConsole.Out.WriteLine("\n\n");
 
-                                var region = new Region(0, systemConsole.CursorTop - 1, Console.WindowWidth - 2, 1, true);
+                                var region = new Region(0, systemConsole.CursorTop, 55, 1, true);
                                 var renderer = new ConsoleRenderer(systemConsole, resetAfterRender: true);
 
                                 var buffer = new byte[16 * 1024];
@@ -165,6 +165,8 @@ namespace Microsoft.Diagnostics.Tools.Trace
                                 {
                                     while (true)
                                     {
+                                        if (!fs.CanWrite)
+                                            break;
                                         renderer.RenderToRegion($"[{stopwatch.Elapsed.ToString(@"dd\:hh\:mm\:ss")}]\tRecording trace {GetSize(fs.Length)}", region);
                                     }
                                 });


### PR DESCRIPTION
Modifies the exit loop when input is redirected to not use `Console.ReadKey` and `Console.KeyAvailable` which don't work if stdin is redirected.

Also changes the line rewriting logic to use the S.CommandLine.Rendering API.  I'm planning on refactoring some of the printing code to further involve these APIs after we do the initial release.  That should hopefully simplify and clean up our output.

**NOT TO BE MERGED TILL AFTER SNAP**