### PR TITLE
Fix output of console writer of dotnet-counters when displayname is not set

### DIFF
--- a/src/Tools/dotnet-counters/ConsoleWriter.cs
+++ b/src/Tools/dotnet-counters/ConsoleWriter.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
 
             if (!provider.Counters.TryGetValue(name, out ObservedCounter counter))
             {
-                string displayName = provider.KnownProvider?.TryGetDisplayName(name) ?? payload.GetDisplay() ?? name;
+                string displayName = provider.KnownProvider?.TryGetDisplayName(name) ?? (string.IsNullOrWhiteSpace(payload.GetDisplay()) ? name : payload.GetDisplay());
                 provider.Counters[name] = counter = new ObservedCounter(displayName);
                 maxNameLength = Math.Max(maxNameLength, displayName.Length);
                 redraw = true;


### PR DESCRIPTION
This change is a fix for #500. 

When the `DisplayName` of the `DiagnosticCounter` is empty or null the fallback is to use the name of the Counter.