### PR TITLE
Add initial spec for gcheap dump tool

### DIFF
--- a/documentation/design-docs/dotnet-tools.md
+++ b/documentation/design-docs/dotnet-tools.md
@@ -551,6 +551,53 @@ UNINSTALL
       Uninstalling SOS from ~/.dotnet/sos
       Complete
 
+### dotnet-gcheapdump
+
+SYNOPSIS
+
+    dotnet-gcheapdump [--version]
+                      [-h, --help]
+                      <command> [<args>]
+
+OPTIONS
+
+    --version
+        Display the version of the dotnet-dump utility.
+
+    -h, --help
+        Show command line help
+
+COMMANDS
+
+    collect   Capture dumps from a process
+
+COLLECT
+
+    dotnet-gcheapdump collect -p|--process-id <pid> [-h|--help] [-o|--output <output_dump_path>]
+
+    Capture GC Heap dumps from a dotnet core process
+
+    Usage:
+      dotnet-gcheapdump collect [options]
+
+    Options:
+      -p, --process-id
+          The process to collect a memory dump from.
+
+      -h, --help
+          Show command line help
+
+      -o, --output
+          The path where collected dumps should be written. Defaults to '.\YYYYMMDD_HHMMSS.gcheapdump' where YYYYMMDD is Year/Month/Day
+          and HHMMSS is Hour/Minute/Second. Otherwise, it is the full path and file name of the dump.
+
+Examples:
+
+    $ dotnet gcheapdump collect --process-id 1902
+    Writing gcheapdump to file ./20190226_135837.gcheapdump
+    Written 98983936 bytes file
+    Complete
+
 ## Future suggestions
 
 Work described in here captures potential future directions these tools could take given time and customer interest. Some of these might come relatively soon, others feel quite speculative or duplicative with existing technology. Regardless, understanding potential future options helps to ensure that we don't unknowingly paint ourselves into a corner or build an incoherent offering.

--- a/documentation/design-docs/dotnet-tools.md
+++ b/documentation/design-docs/dotnet-tools.md
@@ -562,7 +562,7 @@ SYNOPSIS
 OPTIONS
 
     --version
-        Display the version of the dotnet-dump utility.
+        Display the version of the dotnet-gcdump utility.
 
     -h, --help
         Show command line help

--- a/documentation/design-docs/dotnet-tools.md
+++ b/documentation/design-docs/dotnet-tools.md
@@ -551,11 +551,11 @@ UNINSTALL
       Uninstalling SOS from ~/.dotnet/sos
       Complete
 
-### dotnet-gcheapdump
+### dotnet-gcdump
 
 SYNOPSIS
 
-    dotnet-gcheapdump [--version]
+    dotnet-gcdump [--version]
                       [-h, --help]
                       <command> [<args>]
 
@@ -573,29 +573,29 @@ COMMANDS
 
 COLLECT
 
-    dotnet-gcheapdump collect -p|--process-id <pid> [-h|--help] [-o|--output <output_dump_path>]
+    dotnet-gcdump collect -p|--process-id <pid> [-h|--help] [-o|--output <output_dump_path>]
 
-    Capture GC Heap dumps from a dotnet process
+    Capture GC dumps from a dotnet process
 
     Usage:
-      dotnet-gcheapdump collect [options]
+      dotnet-gcdump collect [options]
 
     Options:
       -p, --process-id
-          The process to collect a gcheap dump from.
+          The process to collect a gc dump from.
 
       -h, --help
           Show command line help
 
       -o, --output
-          The path where collected dumps should be written. Defaults to '.\YYYYMMDD_HHMMSS.gcheapdump' where YYYYMMDD is Year/Month/Day
+          The path where collected dumps should be written. Defaults to '.\YYYYMMDD_HHMMSS_<pid>.gcdump' where YYYYMMDD is Year/Month/Day
           and HHMMSS is Hour/Minute/Second. Otherwise, it is the full path and file name of the dump.
 
 Examples:
 
-    $ dotnet gcheapdump collect --process-id 1902
-    Writing gcheapdump to file ./20190226_135837.gcheapdump
-    Written 98983936 bytes file
+    $ dotnet gcdump collect --process-id 1902
+    Writing gcdump to file ./20190226_135837_1902.gcdump
+    Wrote 12576 bytes to file
     Complete
 
 ## Future suggestions

--- a/documentation/design-docs/dotnet-tools.md
+++ b/documentation/design-docs/dotnet-tools.md
@@ -575,14 +575,14 @@ COLLECT
 
     dotnet-gcheapdump collect -p|--process-id <pid> [-h|--help] [-o|--output <output_dump_path>]
 
-    Capture GC Heap dumps from a dotnet core process
+    Capture GC Heap dumps from a dotnet process
 
     Usage:
       dotnet-gcheapdump collect [options]
 
     Options:
       -p, --process-id
-          The process to collect a memory dump from.
+          The process to collect a gcheap dump from.
 
       -h, --help
           Show command line help

--- a/documentation/design-docs/dotnet-tools.md
+++ b/documentation/design-docs/dotnet-tools.md
@@ -556,8 +556,8 @@ UNINSTALL
 SYNOPSIS
 
     dotnet-gcdump [--version]
-                      [-h, --help]
-                      <command> [<args>]
+                  [-h, --help]
+                  <command> [<args>]
 
 OPTIONS
 
@@ -573,7 +573,7 @@ COMMANDS
 
 COLLECT
 
-    dotnet-gcdump collect -p|--process-id <pid> [-h|--help] [-o|--output <output_dump_path>]
+    dotnet-gcdump collect -p|--process-id <pid> [-h|--help] [-o|--output <output_dump_path>] [-v|--verbose]
 
     Capture GC dumps from a dotnet process
 
@@ -588,8 +588,11 @@ COLLECT
           Show command line help
 
       -o, --output
-          The path where collected dumps should be written. Defaults to '.\YYYYMMDD_HHMMSS_<pid>.gcdump' where YYYYMMDD is Year/Month/Day
+          The path where collected gcdumps should be written. Defaults to '.\YYYYMMDD_HHMMSS_<pid>.gcdump' where YYYYMMDD is Year/Month/Day
           and HHMMSS is Hour/Minute/Second. Otherwise, it is the full path and file name of the dump.
+      
+      -v, --verbose
+          Turns on logging for gcdump
 
 Examples:
 


### PR DESCRIPTION
This is an initial specification for a commandline tool capable of collecting GC Heap Dumps of dotnet processes on Linux, Mac, and Windows.

CC - @caslan