### PR TITLE
Fix BitConverter calls

### DIFF
--- a/src/Microsoft.Diagnostics.Tools.RuntimeClient/DiagnosticsHelpers.cs
+++ b/src/Microsoft.Diagnostics.Tools.RuntimeClient/DiagnosticsHelpers.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Diagnostics.Tools.RuntimeClient
             {
                 case DiagnosticsServerCommandId.Error:
                 case DiagnosticsServerCommandId.OK:
-                    hr = BitConverter.ToInt32(response.Payload);
+                    hr = BitConverter.ToInt32(response.Payload, 0);
                     break;
                 default:
                     return -1;
@@ -95,7 +95,7 @@ namespace Microsoft.Diagnostics.Tools.RuntimeClient
             {
                 case DiagnosticsServerCommandId.Error:
                 case DiagnosticsServerCommandId.OK:
-                    hr = BitConverter.ToInt32(response.Payload);
+                    hr = BitConverter.ToInt32(response.Payload, 0);
                     break;
                 default:
                     hr = -1;

--- a/src/Microsoft.Diagnostics.Tools.RuntimeClient/Eventing/EventPipeClient.cs
+++ b/src/Microsoft.Diagnostics.Tools.RuntimeClient/Eventing/EventPipeClient.cs
@@ -81,11 +81,11 @@ namespace Microsoft.Diagnostics.Tools.RuntimeClient
             switch ((DiagnosticsServerCommandId)response.Header.CommandId)
             {
                 case DiagnosticsServerCommandId.OK:
-                    sessionId = BitConverter.ToUInt64(response.Payload);
+                    sessionId = BitConverter.ToUInt64(response.Payload, 0);
                     break;
                 case DiagnosticsServerCommandId.Error:
                     // bad...
-                    var hr = BitConverter.ToInt32(response.Payload);
+                    var hr = BitConverter.ToInt32(response.Payload, 0);
                     throw new Exception($"Session start FAILED 0x{hr:X8}");
                 default:
                     break;
@@ -103,11 +103,11 @@ namespace Microsoft.Diagnostics.Tools.RuntimeClient
             switch ((DiagnosticsServerCommandId)response.Header.CommandId)
             {
                 case DiagnosticsServerCommandId.OK:
-                    sessionId = BitConverter.ToUInt64(response.Payload);
+                    sessionId = BitConverter.ToUInt64(response.Payload, 0);
                     break;
                 case DiagnosticsServerCommandId.Error:
                     // bad...
-                    uint hr = BitConverter.ToUInt32(response.Payload);
+                    uint hr = BitConverter.ToUInt32(response.Payload, 0);
                     Exception ex = ConvertHRToException(hr, $"Session start FAILED 0x{hr:X8}");
                     throw ex;
                 default:
@@ -135,7 +135,7 @@ namespace Microsoft.Diagnostics.Tools.RuntimeClient
             switch ((DiagnosticsServerCommandId)response.Header.CommandId)
             {
                 case DiagnosticsServerCommandId.OK:
-                    return BitConverter.ToUInt64(response.Payload);
+                    return BitConverter.ToUInt64(response.Payload, 0);
                 case DiagnosticsServerCommandId.Error:
                     return 0;
                 default:


### PR DESCRIPTION
The `BitConverter.ToXXX(ReadOnlySpan<Byte>)` methods are not available when targetting .NET standard 2.0 (it is only available when targetting .NET standard 2.1 preview). The methods can simply be replaced by the `BitConverter.ToXXX(Byte[], Int32)` methods instead.