### PR TITLE
Fix the issue that the constructor for UnixDomainSocketEndPoint is unavailable

### DIFF
--- a/src/Microsoft.Diagnostics.Tools.RuntimeClient/DiagnosticsIpc/IpcClient.cs
+++ b/src/Microsoft.Diagnostics.Tools.RuntimeClient/DiagnosticsIpc/IpcClient.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Pipes;
 using System.Linq;
+using System.Net;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using System.Security.Principal;
@@ -48,7 +49,8 @@ namespace Microsoft.Diagnostics.Tools.RuntimeClient.DiagnosticsIpc
                     throw new PlatformNotSupportedException($"Process {processId} not running compatible .NET Core runtime");
                 }
                 string path = Path.Combine(Path.GetTempPath(), ipcPort);
-                var remoteEP = new UnixDomainSocketEndPoint(path);
+                Type unixDomainSocketEndPointType = typeof(Socket).Assembly.GetType("System.Net.Sockets.UnixDomainSocketEndPoint");
+                var remoteEP = (EndPoint)Activator.CreateInstance(unixDomainSocketEndPointType, new object[]{path});
 
                 var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
                 socket.Connect(remoteEP);

--- a/src/Microsoft.Diagnostics.Tools.RuntimeClient/DiagnosticsIpc/IpcClient.cs
+++ b/src/Microsoft.Diagnostics.Tools.RuntimeClient/DiagnosticsIpc/IpcClient.cs
@@ -46,10 +46,14 @@ namespace Microsoft.Diagnostics.Tools.RuntimeClient.DiagnosticsIpc
                     .SingleOrDefault(input => Regex.IsMatch(input, $"^dotnet-diagnostic-{processId}-(\\d+)-socket$"));
                 if (ipcPort == null)
                 {
-                    throw new PlatformNotSupportedException($"Process {processId} not running compatible .NET Core runtime");
+                    throw new PlatformNotSupportedException($"Process {processId} is not running a compatible .NET Core runtime");
                 }
                 string path = Path.Combine(Path.GetTempPath(), ipcPort);
                 Type unixDomainSocketEndPointType = typeof(Socket).Assembly.GetType("System.Net.Sockets.UnixDomainSocketEndPoint");
+                if (unixDomainSocketEndPointType == null)
+                {
+                    throw new PlatformNotSupportedException($"Current process is not running a compatible .NET Core runtime");
+                }
                 var remoteEP = (EndPoint)Activator.CreateInstance(unixDomainSocketEndPointType, new object[]{path});
 
                 var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);

--- a/src/Microsoft.Diagnostics.Tools.RuntimeClient/Microsoft.Diagnostics.Tools.RuntimeClient.csproj
+++ b/src/Microsoft.Diagnostics.Tools.RuntimeClient/Microsoft.Diagnostics.Tools.RuntimeClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Microsoft.Diagnostics.Tools.RuntimeClient</RootNamespace>
     <Description>.NET Core Diagnostics Runtime Client</Description>
     <IsPackable>True</IsPackable>


### PR DESCRIPTION
Fixes #307 

Fundamentally, we can't use [UnixDomainSocketEndPoint](https://docs.microsoft.com/en-us/dotnet/api/system.net.sockets.unixdomainsocketendpoint) if it is not .NET Core 3.0. 

Before this change, leveraging anything in this library is impossible for library targetting .NET standard 2.0.

After this change, it is possible to use anything in this library besides the code path I added. In particular, this should unblock the scenario for the user who filed issue #307

If this library is being referenced by an application, @hoyosjs suggested this could be solved by having a package that contains multiple binaries for different target framework monikers. That allows us to have a nice compilation error when unsupported functionalities are used.

However, if this library is going to be referenced by another library (currently targetting .NET standard 2.0) and is in turn referenced by thousands of others. I don't think there is another way round.

We do have customers who want to build that into their application framework that supports all runtime environments. So the scenario above is not fictitious but a real need.