### PR TITLE
Publish symbols part 2

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -300,6 +300,7 @@ jobs:
     - script: $(Build.SourcesDirectory)\eng\cipack.cmd
         -configuration Release
         -prepareMachine 
+        -verbosity normal
         /p:TeamName=$(_TeamName)
         /p:DotNetSignType=$(SignType) 
         /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1) 
@@ -319,10 +320,10 @@ jobs:
         arguments: -task PublishToSymbolServers -restore -msbuildEngine dotnet -configuration Release -verbosity normal
           /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
           /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
-          /p:BlobBasePath='$(Build.SourcesDirectory)/artifacts/packages/Release/NonShipping'
+          /p:PDBArtifactsDirectory='$(Build.SourcesDirectory)/artifacts/SymStore/**'
+          /p:BlobBasePath='$(Build.SourcesDirectory)/artifacts/packages/Release/**'
       continueOnError: true
       condition: and(succeeded(), eq(variables['PublishSymbols'], 'true'))
-
     # Publish package and log build artifacts
 
     - task: PublishBuildArtifacts@1

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -12,6 +12,7 @@
     <!-- Opt-out repo features -->
     <UsingToolXliff>false</UsingToolXliff>
     <UsingToolNetFrameworkReferenceAssemblies>true</UsingToolNetFrameworkReferenceAssemblies>
+    <UsingToolSymbolUploader>true</UsingToolSymbolUploader>
 
     <!-- Build tools -->
     <MicrosoftNetCompilersVersion>3.0.0</MicrosoftNetCompilersVersion>
@@ -22,7 +23,7 @@
     <MicrosoftWin32PrimitivesVersion>4.3.0</MicrosoftWin32PrimitivesVersion>
 
     <!-- Other libs -->
-    <MicrosoftSymbolStoreVersion>1.0.41901</MicrosoftSymbolStoreVersion>
+    <MicrosoftSymbolStoreVersion>1.0.50103</MicrosoftSymbolStoreVersion>
     <MicrosoftDiagnosticsRuntimeVersion>1.1.46104</MicrosoftDiagnosticsRuntimeVersion>
     <MicrosoftDiaSymReaderNativePackageVersion>1.7.0</MicrosoftDiaSymReaderNativePackageVersion>
     <MicrosoftDiagnosticsTracingTraceEventVersion>2.0.44</MicrosoftDiagnosticsTracingTraceEventVersion>

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -122,18 +122,11 @@ jobs:
 
     - ${{ if eq(parameters.osGroup, 'Linux') }}:
       - ${{ if eq(parameters.testOnly, 'true') }}:
-        - task: DownloadBuildArtifacts@0
-          displayName: Download Linux-x64 Artifacts
+        - task: DownloadPipelineArtifact@2
+          displayName: Download Linux Artifacts
           inputs:
             artifactName: $(_PortableLinuxBuild)
-            downloadPath: '$(System.ArtifactsDirectory)'
-          condition: succeeded()
-
-        - task: CopyFiles@2
-          displayName: Place Linux-x64 Artifacts
-          inputs:
-            sourceFolder: '$(System.ArtifactsDirectory)/$(_PortableLinuxBuild)'
-            targetFolder: '$(Build.SourcesDirectory)/artifacts/bin/Linux.x64.$(_BuildConfig)'
+            targetPath: '$(Build.SourcesDirectory)/artifacts/bin/Linux.$(_BuildArch).$(_BuildConfig)'
           condition: succeeded()
 
       - script: $(Build.SourcesDirectory)/eng/docker-build.sh 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,6 +5,8 @@
   
   <PropertyGroup>
     <IsShipping>true</IsShipping>
+    <IsShippingAssembly>false</IsShippingAssembly>
+    <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>

--- a/src/Microsoft.Diagnostics.DebugServices/Microsoft.Diagnostics.DebugServices.csproj
+++ b/src/Microsoft.Diagnostics.DebugServices/Microsoft.Diagnostics.DebugServices.csproj
@@ -5,8 +5,12 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>;1591;1701</NoWarn>
     <Description>Diagnostics debug services</Description>
+    <IsPackable>true</IsPackable>
+    <PackageTags>Diagnostic</PackageTags>
     <PackageReleaseNotes>$(Description)</PackageReleaseNotes>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <IncludeSymbols>true</IncludeSymbols>
+    <IsShippingAssembly>true</IsShippingAssembly>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Microsoft.Diagnostics.Repl/Microsoft.Diagnostics.Repl.csproj
+++ b/src/Microsoft.Diagnostics.Repl/Microsoft.Diagnostics.Repl.csproj
@@ -5,8 +5,12 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>;1591;1701</NoWarn>
     <Description>Diagnostic utility functions and helpers</Description>
+    <IsPackable>true</IsPackable>
+    <PackageTags>Diagnostic</PackageTags>
     <PackageReleaseNotes>$(Description)</PackageReleaseNotes>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <IncludeSymbols>true</IncludeSymbols>
+    <IsShippingAssembly>true</IsShippingAssembly>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Microsoft.Diagnostics.TestHelpers/Microsoft.Diagnostics.TestHelpers.csproj
+++ b/src/Microsoft.Diagnostics.TestHelpers/Microsoft.Diagnostics.TestHelpers.csproj
@@ -8,7 +8,8 @@
     <Description>Diagnostic test support</Description>
     <PackageReleaseNotes>$(Description)</PackageReleaseNotes>
     <PackageTags>tests</PackageTags>
-    <DebugType>embedded</DebugType>
+    <IncludeSymbols>true</IncludeSymbols>
+    <IsShippingAssembly>true</IsShippingAssembly>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Microsoft.Diagnostics.Tools.RuntimeClient/Microsoft.Diagnostics.Tools.RuntimeClient.csproj
+++ b/src/Microsoft.Diagnostics.Tools.RuntimeClient/Microsoft.Diagnostics.Tools.RuntimeClient.csproj
@@ -4,9 +4,11 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <RootNamespace>Microsoft.Diagnostics.Tools.RuntimeClient</RootNamespace>
     <Description>.NET Core Diagnostics Runtime Client</Description>
-    <IsPackable>True</IsPackable>
+    <IsPackable>true</IsPackable>
     <PackageTags>Diagnostic</PackageTags>
     <PackageReleaseNotes>$(Description)</PackageReleaseNotes>
-    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <IncludeSymbols>true</IncludeSymbols>
+    <IsShippingAssembly>true</IsShippingAssembly>
   </PropertyGroup>
 </Project>

--- a/src/SOS/SOS.NETCore/SOS.NETCore.csproj
+++ b/src/SOS/SOS.NETCore/SOS.NETCore.csproj
@@ -6,6 +6,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>;1591;1701</NoWarn>
     <Description>.NET Core SOS</Description>
+    <IsShippingAssembly>true</IsShippingAssembly>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/SOS/SOS.Package/SOS.Package.csproj
+++ b/src/SOS/SOS.Package/SOS.Package.csproj
@@ -120,11 +120,10 @@
   <Target Name="GenerateSymbolsZip">
     <PropertyGroup>
       <SymbolsDir>$(ArtifactsBinDir)\symbols</SymbolsDir>
-      <SOSNETCorePath>$(ArtifactsBinDir)\SOS.NETCore\$(Configuration)\netstandard2.0\publish</SOSNETCorePath>
     </PropertyGroup>
 
     <ItemGroup>
-      <ZipSymbolFiles Include="$(SOSNETCorePath)\*.pdb">
+      <ZipSymbolFiles Include="$(ArtifactsSymStoreDirectory)\SOS.NETCore\netstandard2.0\*.pdb">
          <TargetPath>$(SymbolsDir)</TargetPath>
       </ZipSymbolFiles>
 

--- a/src/SOS/SOS.UnitTests/Debuggees/Directory.Build.props
+++ b/src/SOS/SOS.UnitTests/Debuggees/Directory.Build.props
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <DebugType Condition="'$(TargetFramework)' == 'net462'">full</DebugType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IsShippingAssembly>false</IsShippingAssembly>
     <Optimize>false</Optimize>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Both Windows and Portable PDBs are published.

Change to Windows PDB for SOS.NETCore.dll in sos symbol zip file

Publish Microsoft.Diagnostics.TestHelpers, DebugServices, Repl and RuntimeClient symbols