### PR TITLE
Add /ContinueOnError option to speedscope converter

### DIFF
--- a/src/Tools/dotnet-trace/TraceFileFormatConverter.cs
+++ b/src/Tools/dotnet-trace/TraceFileFormatConverter.cs
@@ -35,7 +35,15 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 case TraceFileFormat.NetTrace:
                     break;
                 case TraceFileFormat.Speedscope:
-                    ConvertToSpeedscope(fileToConvert, outputFilename);
+                    try
+                    {
+                        ConvertToSpeedscope(fileToConvert, outputFilename);
+                    }
+                    catch (Exception)
+                    {
+                        Console.WriteLine("Detected a potentially broken trace. Continuing with best-efforts to convert the trace, but resulting speedscope file may contain broken stacks as a result.");
+                        ConvertToSpeedscope(fileToConvert, outputFilename, true);
+                    }
                     break;
                 default:
                     // Validation happened way before this, so we shoud never reach this...
@@ -44,9 +52,9 @@ namespace Microsoft.Diagnostics.Tools.Trace
             Console.Out.WriteLine("Conversion complete");
         }
 
-        private static void ConvertToSpeedscope(string fileToConvert, string outputFilename)
+        private static void ConvertToSpeedscope(string fileToConvert, string outputFilename, bool continueOnError=false)
         {
-            var etlxFilePath = TraceLog.CreateFromEventPipeDataFile(fileToConvert, null, new TraceLogOptions() { ContinueOnError = true } );
+            var etlxFilePath = TraceLog.CreateFromEventPipeDataFile(fileToConvert, null, new TraceLogOptions() { ContinueOnError = continueOnError } );
             using (var symbolReader = new SymbolReader(System.IO.TextWriter.Null) { SymbolPath = SymbolPath.MicrosoftSymbolServerPath })
             using (var eventLog = new TraceLog(etlxFilePath))
             {

--- a/src/Tools/dotnet-trace/TraceFileFormatConverter.cs
+++ b/src/Tools/dotnet-trace/TraceFileFormatConverter.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
 
         private static void ConvertToSpeedscope(string fileToConvert, string outputFilename)
         {
-            var etlxFilePath = TraceLog.CreateFromEventPipeDataFile(fileToConvert);
+            var etlxFilePath = TraceLog.CreateFromEventPipeDataFile(fileToConvert, null, new TraceLogOptions() { ContinueOnError = true } );
             using (var symbolReader = new SymbolReader(System.IO.TextWriter.Null) { SymbolPath = SymbolPath.MicrosoftSymbolServerPath })
             using (var eventLog = new TraceLog(etlxFilePath))
             {

--- a/src/Tools/dotnet-trace/TraceFileFormatConverter.cs
+++ b/src/Tools/dotnet-trace/TraceFileFormatConverter.cs
@@ -39,10 +39,19 @@ namespace Microsoft.Diagnostics.Tools.Trace
                     {
                         ConvertToSpeedscope(fileToConvert, outputFilename);
                     }
-                    catch (Exception)
+                    // TODO: On a broken/truncated trace, the exception we get from TraceEvent is a plain System.Exception type because it gets caught and rethrown inside TraceEvent.
+                    // We should probably modify TraceEvent to throw a better exception.
+                    catch (Exception ex)
                     {
-                        Console.WriteLine("Detected a potentially broken trace. Continuing with best-efforts to convert the trace, but resulting speedscope file may contain broken stacks as a result.");
-                        ConvertToSpeedscope(fileToConvert, outputFilename, true);
+                        if (ex.ToString().Contains("Read past end of stream."))
+                        {
+                            Console.WriteLine("Detected a potentially broken trace. Continuing with best-efforts to convert the trace, but resulting speedscope file may contain broken stacks as a result.");
+                            ConvertToSpeedscope(fileToConvert, outputFilename, true);
+                        }
+                        else
+                        {
+                            Console.WriteLine(ex);
+                        }
                     }
                     break;
                 default:


### PR DESCRIPTION
Related issue: #521 

When the app being traced exists abruptly from unhandled exceptions or signals, they don't flush all the events that are in the runtime's buffer that holds the events, which leads to the last payload to have truncated values in them. This is an expected behavior by design that we don't intend to change. 

When the user views the trace file from such a case, they may run into issues where TraceEvent won't be able to properly parse the event payload due to incomplete tags, so tools like PerfView throws an exception and refuses to continue. However, PerfView has the /ContinueOnError option to continue on such error and make "best effort" to parse the trace file, to show whatever *can* be parsed. 

This changes dotnet-trace's speedscope converter to do the same thing, but instead of providing an optional argument, do it by default, so that the user does not see an exception like one shown in #521 and it always tries its best to move forward in a bad trace. I had initially thought about adding it as an option to `convert` command, but I think it might confuse the users especially because the exception message looks cryptic ("Read past end of the stream") and it is likely they won't have the context to make sense out of that stack. 
