### PR TITLE
[dotnet-trace] Allow user to specify text version of event level

### DIFF
--- a/documentation/design-docs/dotnet-tools.md
+++ b/documentation/design-docs/dotnet-tools.md
@@ -290,7 +290,7 @@ COLLECT
             Provider format: KnownProviderName[:Keywords[:Level][:KeyValueArgs]]
                 KnownProviderName       - The provider's name
                 Keywords                - 8 character hex number bit mask
-                Level                   - A number in the range [0, 5]
+                Level                   - A number in the range [0, 5], or their corresponding text values (refer to https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.tracing.eventlevel?view=netframework-4.8).
                 KeyValueArgs            - A semicolon separated list of key=value
             KeyValueArgs format: '[key1=value1][;key2=value2]'
 

--- a/documentation/design-docs/dotnet-tools.md
+++ b/documentation/design-docs/dotnet-tools.md
@@ -302,11 +302,21 @@ COLLECT
 
 
     Examples:
+      
+      To perform a default `cpu-tracing` profiling:
+
       > dotnet trace collect --process-id 1902
       No profile or providers specified, defaulting to trace profile 'cpu-sampling'
       Recording trace 38MB
 
       's' - stop tracing
+
+
+      To collect just the GC keyword events from the .NET runtime at informational level:
+
+      > dotnet trace collect --process-id 1902 --providers Microsoft-Windows-DotNETRuntime:0x1:Informational
+
+
 
 CONVERT
 

--- a/src/Tools/dotnet-trace/Extensions.cs
+++ b/src/Tools/dotnet-trace/Extensions.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                     case "Warning":
                         return EventLevel.Warning;
                     default:
-                        return defaultEventLevel;
+                        throw new ArgumentException($"Unknown EventLevel: {token}");
                 }
             }
         }

--- a/src/Tools/dotnet-trace/Extensions.cs
+++ b/src/Tools/dotnet-trace/Extensions.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
     internal static class Extensions
     {
         private static EventLevel defaultEventLevel = EventLevel.Verbose;
+
         public static List<Provider> ToProviders(string providers)
         {
             if (providers == null)
@@ -30,19 +31,19 @@ namespace Microsoft.Diagnostics.Tools.Trace
 
             else
             {
-                switch (token)
+                switch (token.ToLower())
                 {
-                    case "Critical":
+                    case "critical":
                         return EventLevel.Critical;
-                    case "Error":
+                    case "error":
                         return EventLevel.Error;
-                    case "Informational":
+                    case "informational":
                         return EventLevel.Informational;
-                    case "LogAlways":
+                    case "logalways":
                         return EventLevel.LogAlways;
-                    case "Verbose":
+                    case "verbose":
                         return EventLevel.Verbose;
-                    case "Warning":
+                    case "warning":
                         return EventLevel.Warning;
                     default:
                         throw new ArgumentException($"Unknown EventLevel: {token}");

--- a/src/tests/dotnet-trace/ProviderParsing.cs
+++ b/src/tests/dotnet-trace/ProviderParsing.cs
@@ -181,6 +181,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
 
         [Theory]
         [InlineData("ProviderOne:0x1:Verbose")]
+        [InlineData("ProviderOne:0x1:verbose")]
         public void TextLevelProviderSpecVerbose_CorrectlyParse(string providerToParse)
         {
             List<Provider> parsedProviders = Extensions.ToProviders(providerToParse);
@@ -192,6 +193,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
 
         [Theory]
         [InlineData("ProviderOne:0x1:Informational")]
+        [InlineData("ProviderOne:0x1:INFORMATIONAL")]
         public void TextLevelProviderSpecInformational_CorrectlyParse(string providerToParse)
         {
             List<Provider> parsedProviders = Extensions.ToProviders(providerToParse);
@@ -203,6 +205,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
 
         [Theory]
         [InlineData("ProviderOne:0x1:LogAlways")]
+        [InlineData("ProviderOne:0x1:LogAlwayS")]        
         public void TextLevelProviderSpecLogAlways_CorrectlyParse(string providerToParse)
         {
             List<Provider> parsedProviders = Extensions.ToProviders(providerToParse);
@@ -214,6 +217,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
 
         [Theory]
         [InlineData("ProviderOne:0x1:Error")]
+        [InlineData("ProviderOne:0x1:ERRor")]
         public void TextLevelProviderSpecError_CorrectlyParse(string providerToParse)
         {
             List<Provider> parsedProviders = Extensions.ToProviders(providerToParse);
@@ -225,6 +229,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
 
         [Theory]
         [InlineData("ProviderOne:0x1:Critical")]
+        [InlineData("ProviderOne:0x1:CRITICAL")]
         public void TextLevelProviderSpecCritical_CorrectlyParse(string providerToParse)
         {
             List<Provider> parsedProviders = Extensions.ToProviders(providerToParse);
@@ -236,6 +241,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
 
         [Theory]
         [InlineData("ProviderOne:0x1:Warning")]
+        [InlineData("ProviderOne:0x1:warning")]
         public void TextLevelProviderSpecWarning_CorrectlyParse(string providerToParse)
         {
             List<Provider> parsedProviders = Extensions.ToProviders(providerToParse);

--- a/src/tests/dotnet-trace/ProviderParsing.cs
+++ b/src/tests/dotnet-trace/ProviderParsing.cs
@@ -178,5 +178,78 @@ namespace Microsoft.Diagnostics.Tools.Trace
             Assert.True(providerThree.EventLevel == System.Diagnostics.Tracing.EventLevel.Warning);
             Assert.True(providerThree.FilterData == "FilterAndPayloadSpecs=\"QuotedValue:-\r\nQuoted/Value:-A=B;C=D;\"");
         }
+
+        [Theory]
+        [InlineData("ProviderOne:0x1:Verbose")]
+        public void TextLevelProviderSpecVerbose_CorrectlyParse(string providerToParse)
+        {
+            List<Provider> parsedProviders = Extensions.ToProviders(providerToParse);
+            Assert.True(parsedProviders.Count == 1);
+            Assert.True(parsedProviders[0].Name == "ProviderOne");
+            Assert.True(parsedProviders[0].Keywords == 1);
+            Assert.True(parsedProviders[0].EventLevel == System.Diagnostics.Tracing.EventLevel.Verbose);
+        }
+
+        [Theory]
+        [InlineData("ProviderOne:0x1:Informational")]
+        public void TextLevelProviderSpecInformational_CorrectlyParse(string providerToParse)
+        {
+            List<Provider> parsedProviders = Extensions.ToProviders(providerToParse);
+            Assert.True(parsedProviders.Count == 1);
+            Assert.True(parsedProviders[0].Name == "ProviderOne");
+            Assert.True(parsedProviders[0].Keywords == 1);
+            Assert.True(parsedProviders[0].EventLevel == System.Diagnostics.Tracing.EventLevel.Informational);
+        }
+
+        [Theory]
+        [InlineData("ProviderOne:0x1:LogAlways")]
+        public void TextLevelProviderSpecLogAlways_CorrectlyParse(string providerToParse)
+        {
+            List<Provider> parsedProviders = Extensions.ToProviders(providerToParse);
+            Assert.True(parsedProviders.Count == 1);
+            Assert.True(parsedProviders[0].Name == "ProviderOne");
+            Assert.True(parsedProviders[0].Keywords == 1);
+            Assert.True(parsedProviders[0].EventLevel == System.Diagnostics.Tracing.EventLevel.LogAlways);
+        }
+
+        [Theory]
+        [InlineData("ProviderOne:0x1:Error")]
+        public void TextLevelProviderSpecError_CorrectlyParse(string providerToParse)
+        {
+            List<Provider> parsedProviders = Extensions.ToProviders(providerToParse);
+            Assert.True(parsedProviders.Count == 1);
+            Assert.True(parsedProviders[0].Name == "ProviderOne");
+            Assert.True(parsedProviders[0].Keywords == 1);
+            Assert.True(parsedProviders[0].EventLevel == System.Diagnostics.Tracing.EventLevel.Error);
+        }
+
+        [Theory]
+        [InlineData("ProviderOne:0x1:Critical")]
+        public void TextLevelProviderSpecCritical_CorrectlyParse(string providerToParse)
+        {
+            List<Provider> parsedProviders = Extensions.ToProviders(providerToParse);
+            Assert.True(parsedProviders.Count == 1);
+            Assert.True(parsedProviders[0].Name == "ProviderOne");
+            Assert.True(parsedProviders[0].Keywords == 1);
+            Assert.True(parsedProviders[0].EventLevel == System.Diagnostics.Tracing.EventLevel.Critical);
+        }
+
+        [Theory]
+        [InlineData("ProviderOne:0x1:Warning")]
+        public void TextLevelProviderSpecWarning_CorrectlyParse(string providerToParse)
+        {
+            List<Provider> parsedProviders = Extensions.ToProviders(providerToParse);
+            Assert.True(parsedProviders.Count == 1);
+            Assert.True(parsedProviders[0].Name == "ProviderOne");
+            Assert.True(parsedProviders[0].Keywords == 1);
+            Assert.True(parsedProviders[0].EventLevel == System.Diagnostics.Tracing.EventLevel.Warning);
+        }
+
+        [Theory]
+        [InlineData("ProviderOne:0x1:UnknownLevel")]
+        public void TextLevelProviderSpec_CorrectlyThrows(string providerToParse)
+        {
+            Assert.Throws<ArgumentException>(() => Extensions.ToProviders(providerToParse));
+        }
     }
 }


### PR DESCRIPTION
Related issue: #537. 

