### PR TITLE
[test] Profile-Provider Merging Tests

### DIFF
--- a/src/Microsoft.Diagnostics.Tools.RuntimeClient/Eventing/Provider.cs
+++ b/src/Microsoft.Diagnostics.Tools.RuntimeClient/Eventing/Provider.cs
@@ -51,15 +51,8 @@ namespace Microsoft.Diagnostics.Tools.RuntimeClient
             return !(left == right);
         }
 
-        // override object.Equals
         public override bool Equals(object obj)
         {
-            //
-            // See the full list of guidelines at
-            //   http://go.microsoft.com/fwlink/?LinkID=85237
-            // and also the guidance for operator== at
-            //   http://go.microsoft.com/fwlink/?LinkId=85238
-            //
             
             if (obj == null || GetType() != obj.GetType())
             {
@@ -68,11 +61,15 @@ namespace Microsoft.Diagnostics.Tools.RuntimeClient
             
             return this == (Provider)obj;
         }
-        
-        // override object.GetHashCode
+
         public override int GetHashCode()
         {
-            return base.GetHashCode();
+            int hash = 0;
+            hash ^= this.Name.GetHashCode();
+            hash ^= this.Keywords.GetHashCode();
+            hash ^= this.EventLevel.GetHashCode();
+            hash ^= this.FilterData.GetHashCode();
+            return hash;
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Tools.RuntimeClient/Eventing/Provider.cs
+++ b/src/Microsoft.Diagnostics.Tools.RuntimeClient/Eventing/Provider.cs
@@ -37,5 +37,42 @@ namespace Microsoft.Diagnostics.Tools.RuntimeClient
 
         public string ToDisplayString() =>
             String.Format("{0, -40}", Name) + String.Format("0x{0, -18}", $"{Keywords:X16}") + String.Format("{0, -8}", EventLevel.ToString() + $"({(int)EventLevel})");
+        
+        public static bool operator ==(Provider left, Provider right)
+        {
+            return left.Name == right.Name &&
+                left.Keywords == right.Keywords &&
+                left.EventLevel == right.EventLevel &&
+                left.FilterData == right.FilterData;
+        }
+
+        public static bool operator !=(Provider left, Provider right)
+        {
+            return !(left == right);
+        }
+
+        // override object.Equals
+        public override bool Equals(object obj)
+        {
+            //
+            // See the full list of guidelines at
+            //   http://go.microsoft.com/fwlink/?LinkID=85237
+            // and also the guidance for operator== at
+            //   http://go.microsoft.com/fwlink/?LinkId=85238
+            //
+            
+            if (obj == null || GetType() != obj.GetType())
+            {
+                return false;
+            }
+            
+            return this == (Provider)obj;
+        }
+        
+        // override object.GetHashCode
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
     }
 }

--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                         return ErrorCodes.ArgumentError;
                     }
 
-                    Extensions.MergeProfileAndProviders(selectedProfile, providerCollection, enabledBy);
+                    Profile.MergeProfileAndProviders(selectedProfile, providerCollection, enabledBy);
                 }
 
 

--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
@@ -66,7 +66,6 @@ namespace Microsoft.Diagnostics.Tools.Trace
 
                 if (profile.Length != 0)
                 {
-                    var profileProviders = new List<Provider>();
                     var selectedProfile = ListProfilesCommandHandler.DotNETRuntimeProfiles
                         .FirstOrDefault(p => p.Name.Equals(profile, StringComparison.OrdinalIgnoreCase));
                     if (selectedProfile == null)
@@ -75,32 +74,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                         return ErrorCodes.ArgumentError;
                     }
 
-                    // If user defined a different key/level on the same provider via --providers option that was specified via --profile option,
-                    // --providers option takes precedence. Go through the list of providers specified and only add it if it wasn't specified
-                    // via --providers options.
-                    if (selectedProfile.Providers != null)
-                    {
-                        foreach (Provider selectedProfileProvider in selectedProfile.Providers)
-                        {
-                            bool shouldAdd = true;
-
-                            foreach (Provider providerCollectionProvider in providerCollection)
-                            {
-                                if (providerCollectionProvider.Name.Equals(selectedProfileProvider.Name))
-                                {
-                                    shouldAdd = false;
-                                    break;
-                                }
-                            }
-
-                            if (shouldAdd)
-                            {
-                                enabledBy[selectedProfileProvider.Name] = "--profile ";
-                                profileProviders.Add(selectedProfileProvider);
-                            }
-                        }
-                    }
-                    providerCollection.AddRange(profileProviders);
+                    Extensions.MergeProfileAndProviders(selectedProfile, providerCollection, enabledBy);
                 }
 
 

--- a/src/Tools/dotnet-trace/Extensions.cs
+++ b/src/Tools/dotnet-trace/Extensions.cs
@@ -55,36 +55,5 @@ namespace Microsoft.Diagnostics.Tools.Trace
 
             return new Provider(providerName, keywords, eventLevel, filterData);
         }
-
-        public static void MergeProfileAndProviders(Profile selectedProfile, List<Provider> providerCollection, Dictionary<string, string> enabledBy)
-        {
-            var profileProviders = new List<Provider>();
-            // If user defined a different key/level on the same provider via --providers option that was specified via --profile option,
-            // --providers option takes precedence. Go through the list of providers specified and only add it if it wasn't specified
-            // via --providers options.
-            if (selectedProfile.Providers != null)
-            {
-                foreach (Provider selectedProfileProvider in selectedProfile.Providers)
-                {
-                    bool shouldAdd = true;
-
-                    foreach (Provider providerCollectionProvider in providerCollection)
-                    {
-                        if (providerCollectionProvider.Name.Equals(selectedProfileProvider.Name))
-                        {
-                            shouldAdd = false;
-                            break;
-                        }
-                    }
-
-                    if (shouldAdd)
-                    {
-                        enabledBy[selectedProfileProvider.Name] = "--profile ";
-                        profileProviders.Add(selectedProfileProvider);
-                    }
-                }
-            }
-            providerCollection.AddRange(profileProviders);
-        }
     }
 }

--- a/src/Tools/dotnet-trace/Extensions.cs
+++ b/src/Tools/dotnet-trace/Extensions.cs
@@ -55,5 +55,36 @@ namespace Microsoft.Diagnostics.Tools.Trace
 
             return new Provider(providerName, keywords, eventLevel, filterData);
         }
+
+        public static void MergeProfileAndProviders(Profile selectedProfile, List<Provider> providerCollection, Dictionary<string, string> enabledBy)
+        {
+            var profileProviders = new List<Provider>();
+            // If user defined a different key/level on the same provider via --providers option that was specified via --profile option,
+            // --providers option takes precedence. Go through the list of providers specified and only add it if it wasn't specified
+            // via --providers options.
+            if (selectedProfile.Providers != null)
+            {
+                foreach (Provider selectedProfileProvider in selectedProfile.Providers)
+                {
+                    bool shouldAdd = true;
+
+                    foreach (Provider providerCollectionProvider in providerCollection)
+                    {
+                        if (providerCollectionProvider.Name.Equals(selectedProfileProvider.Name))
+                        {
+                            shouldAdd = false;
+                            break;
+                        }
+                    }
+
+                    if (shouldAdd)
+                    {
+                        enabledBy[selectedProfileProvider.Name] = "--profile ";
+                        profileProviders.Add(selectedProfileProvider);
+                    }
+                }
+            }
+            providerCollection.AddRange(profileProviders);
+        }
     }
 }

--- a/src/Tools/dotnet-trace/Profile.cs
+++ b/src/Tools/dotnet-trace/Profile.cs
@@ -22,5 +22,36 @@ namespace Microsoft.Diagnostics.Tools.Trace
         public IEnumerable<Provider> Providers { get; }
 
         public string Description { get; }
+
+        public static void MergeProfileAndProviders(Profile selectedProfile, List<Provider> providerCollection, Dictionary<string, string> enabledBy)
+        {
+            var profileProviders = new List<Provider>();
+            // If user defined a different key/level on the same provider via --providers option that was specified via --profile option,
+            // --providers option takes precedence. Go through the list of providers specified and only add it if it wasn't specified
+            // via --providers options.
+            if (selectedProfile.Providers != null)
+            {
+                foreach (Provider selectedProfileProvider in selectedProfile.Providers)
+                {
+                    bool shouldAdd = true;
+
+                    foreach (Provider providerCollectionProvider in providerCollection)
+                    {
+                        if (providerCollectionProvider.Name.Equals(selectedProfileProvider.Name))
+                        {
+                            shouldAdd = false;
+                            break;
+                        }
+                    }
+
+                    if (shouldAdd)
+                    {
+                        enabledBy[selectedProfileProvider.Name] = "--profile ";
+                        profileProviders.Add(selectedProfileProvider);
+                    }
+                }
+            }
+            providerCollection.AddRange(profileProviders);
+        }
     }
 }

--- a/src/tests/dotnet-trace/ProfileProviderMerging.cs
+++ b/src/tests/dotnet-trace/ProfileProviderMerging.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 .FirstOrDefault(p => p.Name.Equals(profileName, StringComparison.OrdinalIgnoreCase));
             Assert.NotNull(selectedProfile);
 
-            Extensions.MergeProfileAndProviders(selectedProfile, parsedProviders, enabledBy);
+            Profile.MergeProfileAndProviders(selectedProfile, parsedProviders, enabledBy);
 
             var enabledProvider = parsedProviders.SingleOrDefault(p => p.Name == "Microsoft-Windows-DotNETRuntime");
             Assert.True(enabledProvider != default(Provider));

--- a/src/tests/dotnet-trace/ProfileProviderMerging.cs
+++ b/src/tests/dotnet-trace/ProfileProviderMerging.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+using Microsoft.Diagnostics.Tools.RuntimeClient;
+using System.Collections.Generic;
+using System.Linq;
+using System.Diagnostics.Tracing;
+
+namespace Microsoft.Diagnostics.Tools.Trace
+{
+    public class ProfileProviderMergeTests
+    {
+        [Theory]
+        [InlineData("cpu-sampling", "Microsoft-Windows-DotNETRuntime")]
+        [InlineData("gc-verbose", "Microsoft-Windows-DotNETRuntime")]
+        [InlineData("gc-collect", "Microsoft-Windows-DotNETRuntime")]
+        public void DuplicateProvider_CorrectlyOverrides(string profileName, string providerToParse)
+        {
+            Dictionary<string, string> enabledBy = new Dictionary<string, string>();
+
+            List<Provider> parsedProviders = Extensions.ToProviders(providerToParse);
+
+            foreach (var provider in parsedProviders)
+            {
+                enabledBy[provider.Name] = "--providers";
+            }
+
+            var selectedProfile = ListProfilesCommandHandler.DotNETRuntimeProfiles
+                .FirstOrDefault(p => p.Name.Equals(profileName, StringComparison.OrdinalIgnoreCase));
+            Assert.NotNull(selectedProfile);
+
+            Extensions.MergeProfileAndProviders(selectedProfile, parsedProviders, enabledBy);
+
+            var enabledProvider = parsedProviders.SingleOrDefault(p => p.Name == "Microsoft-Windows-DotNETRuntime");
+            Assert.True(enabledProvider != default(Provider));
+
+            // Assert that our specified provider overrides the version in the profile
+            Assert.True(enabledProvider.Keywords == UInt64.MaxValue);
+            Assert.True(enabledProvider.EventLevel == EventLevel.Verbose);
+            Assert.True(enabledBy[enabledProvider.Name] == "--providers");
+        }
+    }
+}


### PR DESCRIPTION
Some minor refactoring to accommodate testing the logic for merging providers specified by `--providers` and those specified with `--profile`.  We only have 3 profiles right now and they all essentially use the same provider, so the tests are minimal for now, but the refactors make it trivial to add more of these tests as we add providers.

CC - @tommcdon 