### PR TITLE
Update benchmarkdotnet version to 0.12.0

### DIFF
--- a/src/tests/benchmarks/benchmarks.csproj
+++ b/src/tests/benchmarks/benchmarks.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.11.5" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This adds support for benchmarks in 3.1 and 5.0 runtimes/SDK. 