### PR TITLE
Fix incorrect value displayed for rate counters

### DIFF
--- a/src/Tools/dotnet-counters/CounterPayload.cs
+++ b/src/Tools/dotnet-counters/CounterPayload.cs
@@ -52,20 +52,24 @@ namespace Microsoft.Diagnostics.Tools.Counters
 
     class IncrementingCounterPayload : ICounterPayload
     {
+        private int timescaleInSec;
         public string m_Name;
         public double m_Value;
         public string m_DisplayName;
         public string m_DisplayRateTimeScale;
+
         public IncrementingCounterPayload(IDictionary<string, object> payloadFields, int interval)
         {
             m_Name = payloadFields["Name"].ToString();
             m_Value = (double)payloadFields["Increment"];
             m_DisplayName = payloadFields["DisplayName"].ToString();
             m_DisplayRateTimeScale = payloadFields["DisplayRateTimeScale"].ToString();
+            timescaleInSec = m_DisplayRateTimeScale.Length == 0 ? 1 : (int)TimeSpan.Parse(m_DisplayRateTimeScale).TotalSeconds;
+            m_Value *= timescaleInSec;
 
             // In case these properties are not provided, set them to appropriate values.
             m_DisplayName = m_DisplayName.Length == 0 ? m_Name : m_DisplayName;
-            m_DisplayRateTimeScale = m_DisplayRateTimeScale.Length == 0 ? $"{interval} sec" : TimeSpan.Parse(m_DisplayRateTimeScale).ToString("%s' sec'");
+            m_DisplayRateTimeScale = m_DisplayRateTimeScale.Length == 0 ? $"{interval} sec" : $"{timescaleInSec} sec";
         }
 
         public string GetName()

--- a/src/tests/dotnet-counters/CSVExporterTests.cs
+++ b/src/tests/dotnet-counters/CSVExporterTests.cs
@@ -99,7 +99,48 @@ namespace DotnetCounters.UnitTests
             {
                 File.Delete(fileName);
             }
-
         }
+
+        [Fact]
+        public void DifferentDisplayRateTest()
+        {
+            string fileName = "displayRateTest.csv";
+        	CSVExporter exporter = new CSVExporter(fileName);
+            exporter.Initialize();
+            for (int i = 0; i < 100; i++)
+            {
+                exporter.CounterPayloadReceived("myProvider", TestHelpers.GenerateCounterPayload(true, "incrementingCounterOne", i, 60, "Incrementing Counter One: " + i.ToString()), false);
+            }
+            exporter.Stop();
+
+            Assert.True(File.Exists(fileName));
+
+            try
+            {
+                List<string> lines = File.ReadLines(fileName).ToList();
+                Assert.Equal(101, lines.Count); // should be 101 including the headers
+
+                string[] headerTokens = lines[0].Split(',');
+                Assert.Equal("Provider", headerTokens[1]);
+                Assert.Equal("Counter Name", headerTokens[2]);
+                Assert.Equal("Counter Type", headerTokens[3]);
+                Assert.Equal("Mean/Increment", headerTokens[4]);
+
+                for (int i = 1; i < lines.Count; i++)
+                {
+                    string[] tokens = lines[i].Split(',');
+
+                    Assert.Equal("myProvider", tokens[1]);
+                    Assert.Equal($"Incrementing Counter One: {i-1} / 60 sec", tokens[2]);
+                    Assert.Equal("Rate", tokens[3]);
+                    Assert.Equal(((i - 1) * 60).ToString(), tokens[4]);
+                }
+            }
+            finally
+            {
+                File.Delete(fileName);
+            }
+        }
+
     }
 }

--- a/src/tests/dotnet-counters/JSONExporterTests.cs
+++ b/src/tests/dotnet-counters/JSONExporterTests.cs
@@ -75,6 +75,36 @@ namespace DotnetCounters.UnitTests
                 }
             }
         }
+
+        [Fact]
+        public void DifferentDisplayRateTest()
+        {
+            string fileName = "displayRateTest.json";
+            JSONExporter exporter = new JSONExporter(fileName, "myProcess.exe");
+            exporter.Initialize();
+            for (int i = 0; i < 10; i++)
+            {
+                exporter.CounterPayloadReceived("myProvider", TestHelpers.GenerateCounterPayload(true, "incrementingCounterOne", 1.0, 60, "Incrementing Counter One"), false);
+            }
+            exporter.Stop();
+
+            Assert.True(File.Exists(fileName));
+            using (StreamReader r = new StreamReader(fileName))
+            {
+                string json = r.ReadToEnd();
+                JSONCounterTrace counterTrace = JsonConvert.DeserializeObject<JSONCounterTrace>(json);
+
+                Assert.Equal("myProcess.exe", counterTrace.targetProcess);
+                Assert.Equal(10, counterTrace.events.Length);
+                foreach (JSONCounterPayload payload in counterTrace.events)
+                {
+                    Assert.Equal("myProvider", payload.provider);
+                    Assert.Equal("Incrementing Counter One / 60 sec", payload.name);
+                    Assert.Equal("Rate", payload.counterType);
+                    Assert.Equal(60.0, payload.value);
+                }
+            }
+        }
     }
 
     class JSONCounterPayload


### PR DESCRIPTION
An incorrect name/value was being displayed for rate (Incrementing) counters that are user-defined. 

This fixes #563. 