### PR TITLE
Revert "Update the docker images used to have a newer version of CMak…

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -24,7 +24,7 @@ jobs:
   parameters:
     name: CentOS_7
     osGroup: Linux
-    dockerImage: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-f39df28-20191023143754
+    dockerImage: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-3e800f1-20190501005343
     strategy:
       matrix:
         Build_Debug:

--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -33,7 +33,7 @@ jobs:
   parameters:
     name: CentOS_7
     osGroup: Linux
-    dockerImage: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-f39df28-20191023143754
+    dockerImage: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-3e800f1-20190501005343
     strategy:
       matrix:
         Build_Debug:
@@ -49,7 +49,7 @@ jobs:
   parameters:
     name: Linux_cross
     osGroup: Linux
-    dockerImage: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-14.04-23cacb0-20191023143847
+    dockerImage: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-14.04-cross-1735d26-20190521133857
     crossrootfsDir: '/crossrootfs/arm'
     strategy:
       matrix:
@@ -62,7 +62,7 @@ jobs:
   parameters:
     name: Linux_cross64
     osGroup: Linux
-    dockerImage: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-arm64-cfdd435-20191023143847
+    dockerImage: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-arm64-a3ae44b-20180315221921
     crossrootfsDir: '/crossrootfs/arm64'
     strategy:
       matrix:
@@ -73,9 +73,9 @@ jobs:
 
 - template: /eng/build.yml
   parameters:
-    name: Alpine3_9
+    name: Alpine3_6
     osGroup: Linux
-    dockerImage: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.9-WithNode-0fc54a3-20190918214015
+    dockerImage: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.6-WithNode-f4d3fe3-20181220200247
     strategy:
       matrix:
         Build_Release:
@@ -208,7 +208,7 @@ jobs:
     dependsOn:
     - Windows
     - CentOS_7
-    - Alpine3_9
+    - Alpine3_6
     - MacOS
     - Linux_cross
     - Linux_cross64
@@ -264,7 +264,7 @@ jobs:
     - task: DownloadPipelineArtifact@2
       displayName: Download Linux Musl Artifacts
       inputs:
-        artifactName: Alpine3_9_x64_Release
+        artifactName: Alpine3_6_x64_Release
         targetPath: '$(Build.SourcesDirectory)/artifacts/bin/Linux-musl.x64.Release'
       condition: succeeded()
 


### PR DESCRIPTION
…e. (#597)"

This reverts commit 0efe77744d981e3ecf0adaa9128b9880982f571e.

Not ready for the new CentOS 7 image with lldb 9.0 and the cross build images fail because build-native.sh needs to use clang 9.0 and the alpine image fails just building managed code with:

##[error].packages/microsoft.build.tasks.git/1.0.0-beta2-19270-01/build/Microsoft.Build.Tasks.Git.targets(16,5): error : The type initializer for 'LibGit2Sharp.Core.NativeMethods' threw an exception.
   at LibGit2Sharp.Core.NativeMethods.git_buf_free(GitBuf buf)
   at LibGit2Sharp.Core.Proxy.git_buf_free(GitBuf buf)
   at LibGit2Sharp.Core.Handles.GitBuf.Dispose()
   at LibGit2Sharp.Core.Proxy.ConvertPath(Func`2 pathRetriever)
   at LibGit2Sharp.Core.Proxy.git_repository_discover(FilePath start_path)
   at LibGit2Sharp.Repository.Discover(String startingPath)
   at Microsoft.Build.Tasks.Git.GitOperations.LocateRepository(String directory) in /_/src/Microsoft.Build.Tasks.Git.Operations/GitOperations.cs:line 26
   at Microsoft.Build.Tasks.Git.RepositoryTasks.LocateRepository(LocateRepository task) in /_/src/Microsoft.Build.Tasks.Git.Operations/RepositoryTasks.cs:line 58
/datadisks/disk1/workspace/_work/1/s/.dotnet/sdk/3.0.100/Roslyn/Microsoft.Managed.Core.targets(102,5): error : SourceRoot items must include at least one top-level (not nested) item when DeterministicSourcePaths is true [/datadisks/disk1/workspace/_work/1/s/src/SOS/lldbplugin.tests/TestDebuggee/TestDebuggee.csproj]