### PR TITLE
Wait for process exit independently of waiting for stream flushing

### DIFF
--- a/src/Microsoft.Diagnostics.TestHelpers/ProcessRunner.cs
+++ b/src/Microsoft.Diagnostics.TestHelpers/ProcessRunner.cs
@@ -405,7 +405,7 @@ namespace Microsoft.Diagnostics.TestHelpers
 
             DebugTrace("awaiting process {0} exit", p.Id);
             await processExit;
-            DebugTrace("await process {0} exit, stdOut, and stdErr complete", p.Id);
+            DebugTrace("process {0} completed with exit code {1}", p.Id, p.ExitCode);
 
             DebugTrace("awaiting to flush stdOut and stdErr for process {0} for up to 15 seconds", p.Id);
             var streamsTask = Task.WhenAll(stdOutTask, stdErrTask);


### PR DESCRIPTION
Before, the ProcessRunner waited for the process completion as well as stream
buffer flushing for stdout and stderr. This is problematic if the process
it ran dies, but its spawned child processes keep the defunct's standard
streams alive by redirecting to them. We have had no way of harvesting
the children, so this process hung the runner.

After this change, we wait for the spawned process to die. As soon as that happens,
we give the pipes a grace period of 15 seconds to flush, after which we assume
the process is dead. This has the shortcoming of two potentially problematic
situations:
- We've potentially left an unobserved aggregate exception unobserved that will throw
on the finalizer thread once the tasks get collected in exceptional cases.
- This might leak threadpool threads.