### PR TITLE
Fix default PID value and add rollforward forgcdump

### DIFF
--- a/src/Tools/dotnet-gcdump/CommandLine/CollectCommandHandler.cs
+++ b/src/Tools/dotnet-gcdump/CommandLine/CollectCommandHandler.cs
@@ -32,6 +32,12 @@ namespace Microsoft.Diagnostics.Tools.GCDump
         {
             try
             {
+                if (processId < 0)
+                {
+                    Console.Out.WriteLine($"The PID cannot be negative: {processId}");
+                    return -1;
+                }
+
                 output = string.IsNullOrEmpty(output) ? 
                     $"{DateTime.Now.ToString(@"yyyyMMdd\_hhmmss")}_{processId}.gcdump" :
                     output;
@@ -102,7 +108,7 @@ namespace Microsoft.Diagnostics.Tools.GCDump
             new Option(
                 aliases: new[] { "-p", "--process-id" },
                 description: "The process to collect the trace from",
-                argument: new Argument<int> { Name = "pid" },
+                argument: new Argument<int>(defaultValue: -1) { Name = "pid" },
                 isHidden: false);
 
         private static Option OutputPathOption() =>

--- a/src/Tools/dotnet-gcdump/CommandLine/CollectCommandHandler.cs
+++ b/src/Tools/dotnet-gcdump/CommandLine/CollectCommandHandler.cs
@@ -38,6 +38,12 @@ namespace Microsoft.Diagnostics.Tools.GCDump
                     return -1;
                 }
 
+                if (processId == 0)
+                {
+                    Console.Out.WriteLine($"Please specify a PID");
+                    return -1;
+                }
+
                 output = string.IsNullOrEmpty(output) ? 
                     $"{DateTime.Now.ToString(@"yyyyMMdd\_hhmmss")}_{processId}.gcdump" :
                     output;
@@ -108,7 +114,7 @@ namespace Microsoft.Diagnostics.Tools.GCDump
             new Option(
                 aliases: new[] { "-p", "--process-id" },
                 description: "The process to collect the trace from",
-                argument: new Argument<int>(defaultValue: -1) { Name = "pid" },
+                argument: new Argument<int>(defaultValue: 0) { Name = "pid" },
                 isHidden: false);
 
         private static Option OutputPathOption() =>

--- a/src/Tools/dotnet-gcdump/CommandLine/CollectCommandHandler.cs
+++ b/src/Tools/dotnet-gcdump/CommandLine/CollectCommandHandler.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Diagnostics.Tools.GCDump
 
                 if (processId == 0)
                 {
-                    Console.Out.WriteLine($"Please specify a PID");
+                    Console.Out.WriteLine($"-p|--process-id is required");
                     return -1;
                 }
 

--- a/src/Tools/dotnet-gcdump/runtimeconfig.template.json
+++ b/src/Tools/dotnet-gcdump/runtimeconfig.template.json
@@ -1,0 +1,3 @@
+{
+  "rollForwardOnNoCandidateFx": 2
+}


### PR DESCRIPTION
Prevent default value for pid
add roll forward runtimeconfig to dotnet-gcdump