### PR TITLE
Fix config parser and logging path to support

### DIFF
--- a/src/Microsoft.Diagnostics.TestHelpers/TestConfiguration.cs
+++ b/src/Microsoft.Diagnostics.TestHelpers/TestConfiguration.cs
@@ -196,7 +196,7 @@ namespace Microsoft.Diagnostics.TestHelpers
 
             foreach (XAttribute attr in node.Attributes("Condition"))
             {
-                string conditionText = attr.Value;
+                string conditionText = attr.Value.Trim();
                 bool isNegative = conditionText.Length > 0 && conditionText[0] == '!';
 
                 // Check if Exists('<directory or file>')
@@ -264,7 +264,10 @@ namespace Microsoft.Diagnostics.TestHelpers
                 return false;
             }
 
-            if (functionKeyworkIndex != 0 || functionKeyworkIndex >= 1 && expression[0] != '!' || !expression.EndsWith(')'))
+            if ((functionKeyworkIndex != 0 
+                    && functionKeyworkIndex == 1 && expression[0] != '!')
+                || functionKeyworkIndex > 1
+                || !expression.EndsWith(')'))
             {
                 throw new InvalidDataException($"Condition {expression} malformed. Currently only single-function conditions are supported.");
             }

--- a/src/Microsoft.Diagnostics.TestHelpers/TestRunner.cs
+++ b/src/Microsoft.Diagnostics.TestHelpers/TestRunner.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Diagnostics.TestHelpers
             ConsoleTestOutputHelper consoleLogger = null;
             if (!string.IsNullOrEmpty(config.LogDirPath))
             {
-                string logFileName = testName + "." + config.ToString() + ".log";
+                string logFileName = $"{ testName }.{ config.GetLogSuffix() }.log";
                 string logPath = Path.Combine(config.LogDirPath, logFileName);
                 fileLogger = new FileTestOutputHelper(logPath, FileMode.Append);
             }


### PR DESCRIPTION
* The config parser had one remaining bug in the case of negative expressions
* Logging paths can't have wildcards, but runtime specifiers can. In that case I resorted to use `<Major.Minor.Patch>` as the version for the log while preserving old behavior. That way xUnit still displays the full arg list for test disambiguation, but the logs only contain valid file names.