### PR TITLE
Fix Windows X86 SOS test failures

### DIFF
--- a/src/SOS/SOS.UnitTests/Scripts/TaskNestedException.script
+++ b/src/SOS/SOS.UnitTests/Scripts/TaskNestedException.script
@@ -29,9 +29,11 @@ VERIFY:StackTrace \(generated\):\s+
 VERIFY:\s+SP\s+IP\s+Function\s+
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>.+RandomTest(::|\.)RandomUserTask\.<\.ctor>.+\+0x<HEXVAL>\s*
 # Desktop sos has a bug that prevents the line number/source file info from being printed. Fixed in ProjectK.
-IFDEF:PROJECTK
+!IFDEF:DESKTOP
+!IFDEF:TRIAGE_DUMP
 VERIFY:[.+[\\|/]Debuggees[\\|/](dotnet.+[\\|/])?[Tt]ask[Nn]ested[Ee]xception[\\|/][Rr]andom[Uu]ser[Ll]ibrary[\\|/][Rr]andom[Uu]ser[Tt]ask\.cs @ (16|23)\]
-ENDIF:PROJECTK
+ENDIF:TRIAGE_DUMP
+ENDIF:DESKTOP
 
 SOSCOMMAND:PrintException -lines <POUT>InnerException:\s+System\.InvalidOperationException, Use !PrintException (<HEXVAL>) to see more<POUT>
 VERIFY:Exception object:\s+<HEXVAL>\s+


### PR DESCRIPTION
Don't check for source/line number on triage dumps.