### PR TITLE
Prepare SOS for single file support and add desktop CLR support

### DIFF
--- a/src/SOS/SOS.Hosting/SOSHost.cs
+++ b/src/SOS/SOS.Hosting/SOSHost.cs
@@ -157,6 +157,8 @@ namespace SOS
 
         internal readonly IDataReader DataReader;
 
+        const string DesktopRuntimeModuleName = "clr";
+
         private static readonly string s_coreclrModuleName;
 
         private readonly AnalyzeContext _analyzeContext;
@@ -1109,6 +1111,9 @@ namespace SOS
 
         internal static bool IsRuntimeModule(ModuleInfo module)
         {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && IsModuleEqual(module, DesktopRuntimeModuleName)) {
+                return true;
+            }
             return IsModuleEqual(module, s_coreclrModuleName);
         }
 

--- a/src/SOS/SOS.UnitTests/ConfigFiles/Unix/Debugger.Tests.Config.txt
+++ b/src/SOS/SOS.UnitTests/ConfigFiles/Unix/Debugger.Tests.Config.txt
@@ -117,6 +117,7 @@
   <Options>
     <Option Condition="$(OS) == Linux">
       <SOSPath>$(InstallDir)/libsosplugin.so</SOSPath>
+      <DotNetDumpHost>$(RepoRootDir)/.dotnet/dotnet</DotNetDumpHost>
       <DotNetDumpPath>$(RootBinDir)/bin/dotnet-dump/$(TargetConfiguration)/netcoreapp2.1/publish/dotnet-dump.dll</DotNetDumpPath>
       <DebuggeeDumpOutputRootDir>$(DumpDir)/$(TestProduct)/$(RuntimeFrameworkVersion)/$(BuildProjectFramework)</DebuggeeDumpOutputRootDir>
       <DebuggeeDumpInputRootDir>$(DebuggeeDumpOutputRootDir)</DebuggeeDumpInputRootDir>

--- a/src/SOS/SOS.UnitTests/ConfigFiles/Windows/Debugger.Tests.Config.txt
+++ b/src/SOS/SOS.UnitTests/ConfigFiles/Windows/Debugger.Tests.Config.txt
@@ -154,7 +154,7 @@
 
   <SOSPath>$(InstallDir)\sos.dll</SOSPath>
   <DotNetDumpHost>$(RepoRootDir)\.dotnet\dotnet.exe</DotNetDumpHost>
-  <DotNetDumpPath>$(RootBinDir)/bin/dotnet-dump/$(TargetConfiguration)/netcoreapp2.1/publish/dotnet-dump.dll</DotNetDumpPath>
+  <DotNetDumpPath>$(RootBinDir)\bin\dotnet-dump\$(TargetConfiguration)\netcoreapp2.1\publish\dotnet-dump.dll</DotNetDumpPath>
   <DebuggeeDumpOutputRootDir>$(DumpDir)\$(TestProduct)\$(RuntimeFrameworkVersion)\$(BuildProjectFramework)</DebuggeeDumpOutputRootDir>
   <DebuggeeDumpInputRootDir>$(DebuggeeDumpOutputRootDir)</DebuggeeDumpInputRootDir>
 </Configuration>

--- a/src/SOS/SOS.UnitTests/ConfigFiles/Windows/Debugger.Tests.Config.txt
+++ b/src/SOS/SOS.UnitTests/ConfigFiles/Windows/Debugger.Tests.Config.txt
@@ -128,8 +128,6 @@
       <HostExe>$(RepoRootDir)\.dotnet\dotnet.exe</HostExe>
       <HostArgs>--fx-version $(RuntimeFrameworkVersion)</HostArgs>
       <RuntimeSymbolsPath>$(RepoRootDir)\.dotnet\shared\Microsoft.NETCore.App\$(RuntimeFrameworkVersion)</RuntimeSymbolsPath>
-      <SOSPath>$(InstallDir)\sos.dll</SOSPath>
-      <DotNetDumpPath>$(RootBinDir)/bin/dotnet-dump/$(TargetConfiguration)/netcoreapp2.1/publish/dotnet-dump.dll</DotNetDumpPath>
     </Option>
     <!--
         Desktop Runtime (debuggees cli built)
@@ -151,10 +149,12 @@
       <FrameworkDirPath Condition="$(TargetArchitecture) == x64">$(WinDir)\Microsoft.Net\Framework64\v4.0.30319\</FrameworkDirPath>
       <FrameworkDirPath Condition="$(TargetArchitecture) != x64">$(WinDir)\Microsoft.Net\Framework\v4.0.30319\</FrameworkDirPath>
       <RuntimeSymbolsPath>$(FrameworkDirPath)</RuntimeSymbolsPath>
-      <SOSPath>$(FrameworkDirPath)\sos.dll</SOSPath>
     </Option>
   </Options>
 
+  <SOSPath>$(InstallDir)\sos.dll</SOSPath>
+  <DotNetDumpHost>$(RepoRootDir)\.dotnet\dotnet.exe</DotNetDumpHost>
+  <DotNetDumpPath>$(RootBinDir)/bin/dotnet-dump/$(TargetConfiguration)/netcoreapp2.1/publish/dotnet-dump.dll</DotNetDumpPath>
   <DebuggeeDumpOutputRootDir>$(DumpDir)\$(TestProduct)\$(RuntimeFrameworkVersion)\$(BuildProjectFramework)</DebuggeeDumpOutputRootDir>
   <DebuggeeDumpInputRootDir>$(DebuggeeDumpOutputRootDir)</DebuggeeDumpInputRootDir>
 </Configuration>

--- a/src/SOS/SOS.UnitTests/Debuggees/DivZero/DivZero.csproj
+++ b/src/SOS/SOS.UnitTests/Debuggees/DivZero/DivZero.csproj
@@ -2,6 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework Condition="'$(BuildProjectFramework)' != ''">$(BuildProjectFramework)</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildProjectFramework)' == ''">netcoreapp1.1;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildProjectFramework)' == ''">netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/src/SOS/SOS.UnitTests/Debuggees/GCWhere/GCWhere.csproj
+++ b/src/SOS/SOS.UnitTests/Debuggees/GCWhere/GCWhere.csproj
@@ -2,6 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework Condition="'$(BuildProjectFramework)' != ''">$(BuildProjectFramework)</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildProjectFramework)' == ''">netcoreapp1.1;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildProjectFramework)' == ''">netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/src/SOS/SOS.UnitTests/Debuggees/NestedExceptionTest/NestedExceptionTest.csproj
+++ b/src/SOS/SOS.UnitTests/Debuggees/NestedExceptionTest/NestedExceptionTest.csproj
@@ -2,6 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework Condition="'$(BuildProjectFramework)' != ''">$(BuildProjectFramework)</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildProjectFramework)' == ''">netcoreapp1.1;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildProjectFramework)' == ''">netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/src/SOS/SOS.UnitTests/Debuggees/Overflow/Overflow.csproj
+++ b/src/SOS/SOS.UnitTests/Debuggees/Overflow/Overflow.csproj
@@ -2,6 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework Condition="'$(BuildProjectFramework)' != ''">$(BuildProjectFramework)</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildProjectFramework)' == ''">netcoreapp1.1;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildProjectFramework)' == ''">netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/src/SOS/SOS.UnitTests/Debuggees/ReflectionTest/ReflectionTest.csproj
+++ b/src/SOS/SOS.UnitTests/Debuggees/ReflectionTest/ReflectionTest.csproj
@@ -2,6 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework Condition="'$(BuildProjectFramework)' != ''">$(BuildProjectFramework)</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildProjectFramework)' == ''">netcoreapp1.1;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildProjectFramework)' == ''">netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/src/SOS/SOS.UnitTests/Debuggees/SimpleThrow/SimpleThrow.csproj
+++ b/src/SOS/SOS.UnitTests/Debuggees/SimpleThrow/SimpleThrow.csproj
@@ -2,6 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework Condition="'$(BuildProjectFramework)' != ''">$(BuildProjectFramework)</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildProjectFramework)' == ''">netcoreapp1.1;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildProjectFramework)' == ''">netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/src/SOS/SOS.UnitTests/Debuggees/SymbolTestApp/SymbolTestApp/SymbolTestApp.csproj
+++ b/src/SOS/SOS.UnitTests/Debuggees/SymbolTestApp/SymbolTestApp/SymbolTestApp.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework Condition="'$(BuildProjectFramework)' != ''">$(BuildProjectFramework)</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildProjectFramework)' == ''">netcoreapp1.1;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildProjectFramework)' == ''">netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
     <DefineConstants Condition="'$(TargetFramework)' == 'net462'">$(DefineConstants);FULL_CLR</DefineConstants>
   </PropertyGroup>
 

--- a/src/SOS/SOS.UnitTests/Debuggees/SymbolTestApp/SymbolTestDll/SymbolTestDll.csproj
+++ b/src/SOS/SOS.UnitTests/Debuggees/SymbolTestApp/SymbolTestDll/SymbolTestDll.csproj
@@ -2,6 +2,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework Condition="'$(BuildProjectFramework)' != ''">$(BuildProjectFramework)</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildProjectFramework)' == ''">netcoreapp1.1;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildProjectFramework)' == ''">netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/src/SOS/SOS.UnitTests/Debuggees/TaskNestedException/RandomUserLibrary/RandomUserLibrary.csproj
+++ b/src/SOS/SOS.UnitTests/Debuggees/TaskNestedException/RandomUserLibrary/RandomUserLibrary.csproj
@@ -2,6 +2,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework Condition="'$(BuildProjectFramework)' != ''">$(BuildProjectFramework)</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildProjectFramework)' == ''">netcoreapp1.1;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildProjectFramework)' == ''">netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/src/SOS/SOS.UnitTests/Debuggees/TaskNestedException/TaskNestedException/TaskNestedException.csproj
+++ b/src/SOS/SOS.UnitTests/Debuggees/TaskNestedException/TaskNestedException/TaskNestedException.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework Condition="'$(BuildProjectFramework)' != ''">$(BuildProjectFramework)</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildProjectFramework)' == ''">netcoreapp1.1;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildProjectFramework)' == ''">netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SOS/SOS.UnitTests/SOS.cs
+++ b/src/SOS/SOS.UnitTests/SOS.cs
@@ -74,7 +74,7 @@ public class SOS
                     }
                 }
 
-                // With the dotnet-dump analyze tool
+                // Using the dotnet-dump analyze tool if the path exists in the config file. Don't test dotnet-dump on triage dumps when running on desktop CLR.
                 if (information.TestConfiguration.DotNetDumpPath() != null && (information.TestConfiguration.IsNETCore || information.DumpType != SOSRunner.DumpType.Triage))
                 {
                     using (SOSRunner runner = await SOSRunner.StartDebugger(information, SOSRunner.DebuggerAction.LoadDumpWithDotNetDump))

--- a/src/SOS/SOS.UnitTests/SOS.cs
+++ b/src/SOS/SOS.UnitTests/SOS.cs
@@ -75,7 +75,7 @@ public class SOS
                 }
 
                 // With the dotnet-dump analyze tool
-                if (information.TestConfiguration.DotNetDumpPath() != null)
+                if (information.TestConfiguration.DotNetDumpPath() != null && (information.TestConfiguration.IsNETCore || information.DumpType != SOSRunner.DumpType.Triage))
                 {
                     using (SOSRunner runner = await SOSRunner.StartDebugger(information, SOSRunner.DebuggerAction.LoadDumpWithDotNetDump))
                     {

--- a/src/SOS/SOS.UnitTests/Scripts/DivZero.script
+++ b/src/SOS/SOS.UnitTests/Scripts/DivZero.script
@@ -1,5 +1,5 @@
 # Divide By Zero debugging scenario
-# 1) load the executable
+# 1) Load the executable
 # 2) Run the executable and wait for it to crash
 # 3) Take a dump of the executable.
 # 4) Open the dump and compare the output

--- a/src/SOS/SOS.UnitTests/Scripts/GCTests.script
+++ b/src/SOS/SOS.UnitTests/Scripts/GCTests.script
@@ -3,25 +3,25 @@
 #
 # Commands Verified: GCWhere, GCRoot, DumpObj, DumpHeap, DumpStackObjects
 #
-# 1) load sos
-# 2) run to the first debug break
-# 3) dump stack objects to get the address of GCWhere!temp
+# 1) Run to the first debug break
+# 2) Load sos
+# 3) Dump stack objects to get the address of GCWhere!temp
 # 4) Run various commands on the address, verify Gen0
-# 5) run to the second debug break
+# 5) Run to the second debug break
 # 6) Run various commands on the address, verify Gen1
-# 7) run to the third debug break
+# 7) Run to the third debug break
 # 8) Run various commands on the address, verify Gen2
-# 9) run to the fourth debug break
+# 9) Run to the fourth debug break
 #10) Run various commands on the address, verify it is still Gen2
-#11) let the program run to completion
-
-LOADSOS
+#11) Let the program run to completion
 
 # Continue to the DebugBreak
 CONTINUE
 IFDEF:CDB
 VERIFY:Break instruction exception - code 80000003
 ENDIF:CDB
+
+LOADSOS
 
 SOSCOMMAND:DumpStackObjects
 VERIFY:<HEXVAL>\s+<HEXVAL>\s+System.IO.StringWriter\s+

--- a/src/SOS/SOS.UnitTests/Scripts/NestedExceptionTest.script
+++ b/src/SOS/SOS.UnitTests/Scripts/NestedExceptionTest.script
@@ -7,19 +7,28 @@
 LOADSOS
 
 # Verify that bpmd works
-IFDEF:PROJECTK
 IFDEF:LIVE
 !IFDEF:MAJOR_RUNTIME_VERSION_1
 
+IFDEF:DESKTOP
+SOSCOMMAND:bpmd NestedExceptionTest.exe NestedExceptionTest.Program.Main
+ENDIF:DESKTOP
+!IFDEF:DESKTOP
 SOSCOMMAND:bpmd NestedExceptionTest.dll NestedExceptionTest.Program.Main
+ENDIF:DESKTOP
 CONTINUE
+
+# Unloads desktop sos and reloads new SOS
+IFDEF:DESKTOP
+LOADSOS
+ENDIF:DESKTOP
+
 SOSCOMMAND:ClrStack
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+NestedExceptionTest\.Program\.Main(\(.*\))?\s*
 VERIFY:\[.*[\\|/]Debuggees[\\|/](dotnet.+[\\|/])?[Nn]ested[Ee]xception[Tt]est[\\|/][Nn]ested[Ee]xception[Tt]est\.cs @ 8\s*\]\s*
 
 ENDIF:MAJOR_RUNTIME_VERSION_1
 ENDIF:LIVE
-ENDIF:PROJECTK
 
 CONTINUE
 
@@ -80,10 +89,7 @@ VERIFY:InnerException:\s+System\.FormatException, Use !PrintException <HEXVAL> t
 VERIFY:StackTrace \(generated\):
 VERIFY:\s+SP\s+IP\s+Function\s+
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+[Nn]ested[Ee]xception[Tt]est.*!NestedExceptionTest\.Program\.Main(\(.*\))?\+0x<HEXVAL>\s*
-# Desktop sos has a bug that prevents the line number/source file info from being printed.
-IFDEF:PROJECTK
 VERIFY:\[.*[\\|/]Debuggees[\\|/](dotnet.+[\\|/])?[Nn]ested[Ee]xception[Tt]est[\\|/][Nn]ested[Ee]xception[Tt]est\.cs @ 8\s*\]\s*
-ENDIF:PROJECTK
 VERIFY:(StackTraceString: <none>\s+)?
 VERIFY:HResult:\s+80131509\s+
 VERIFY:There are nested exceptions on this thread. Run with -nested for details
@@ -109,7 +115,4 @@ SOSCOMMAND:ClrStack
 VERIFY:.*OS Thread Id:\s+0x<HEXVAL>\s+.*
 VERIFY:\s+Child\s+SP\s+IP\s+Call Site\s+
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+NestedExceptionTest\.Program\.Main(\(.*\))?\s*
-# Desktop sos has a bug that prevents the line number/source file info from being printed.
-IFDEF:PROJECTK
 VERIFY:\[.*[\\|/]Debuggees[\\|/](dotnet.+[\\|/])?[Nn]ested[Ee]xception[Tt]est[\\|/][Nn]ested[Ee]xception[Tt]est\.cs @ 8\s*\]\s*
-ENDIF:PROJECTK

--- a/src/SOS/SOS.UnitTests/Scripts/OtherCommands.script
+++ b/src/SOS/SOS.UnitTests/Scripts/OtherCommands.script
@@ -5,25 +5,48 @@
 LOADSOS
 
 # Verify that bpmd works
-IFDEF:PROJECTK
 IFDEF:LIVE
 !IFDEF:MAJOR_RUNTIME_VERSION_1
 
+IFDEF:DESKTOP
+SOSCOMMAND:bpmd SymbolTestApp.exe SymbolTestApp.Program.Main
+ENDIF:DESKTOP
+!IFDEF:DESKTOP
 SOSCOMMAND:bpmd SymbolTestApp.dll SymbolTestApp.Program.Main
+ENDIF:DESKTOP
+
 CONTINUE
+
+# Unloads desktop sos and reloads new SOS
+IFDEF:DESKTOP
+LOADSOS
+ENDIF:DESKTOP
+
 SOSCOMMAND:ClrStack
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.Program\.Main\(.*\)\s+\[(?i:.*[\\|/]SymbolTestApp\.cs) @ 16\]\s*
 
 SOSCOMMAND:bpmd SymbolTestApp.cs:29
+IFDEF:DESKTOP
+SOSCOMMAND:bpmd SymbolTestApp.exe SymbolTestApp.Program.Foo4
+ENDIF:DESKTOP
+!IFDEF:DESKTOP
 SOSCOMMAND:bpmd SymbolTestApp.dll SymbolTestApp.Program.Foo4
+ENDIF:DESKTOP
 
+IFDEF:PROJECTK
 CONTINUE
 SOSCOMMAND:ClrStack
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.Program\.Main\(.*\)\s+\[(?i:.*[\\|/]SymbolTestApp\.cs) @ 16\]\s*
+ENDIF:PROJECTK
 
 CONTINUE
 SOSCOMMAND:ClrStack
+IFDEF:DESKTOP
+VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.Program\.Foo2\(.*\)\s+\[(?i:.*[\\|/]SymbolTestApp\.cs) @ 29\]\s*
+ENDIF:DESKTOP
+!IFDEF:DESKTOP
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.Program\.Foo2\(.*\)\s+\[(?i:.*[\\|/]SymbolTestApp\.cs) @ 28\]\s*
+ENDIF:DESKTOP
 
 CONTINUE
 SOSCOMMAND:ClrStack
@@ -31,16 +54,13 @@ VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.Program\.Foo4\(.*\)\s+\[(?i:.*[\\
 
 ENDIF:MAJOR_RUNTIME_VERSION_1
 ENDIF:LIVE
-ENDIF:PROJECTK
 
 CONTINUE
 
-IFDEF:PROJECTK
 SOSCOMMAND:SetSymbolServer -ms
 !IFDEF:DOTNETDUMP
 SOSCOMMAND:SetHostRuntime
 ENDIF:DOTNETDUMP
-ENDIF:PROJECTK
 
 IFDEF:DOTNETDUMP
 COMMAND:clrmodules
@@ -76,10 +96,8 @@ VERIFY:\s*Parent Domain:\s+<HEXVAL>\s+
 VERIFY:\s*Name:\s+.*(System\.Private\.CoreLib(\.ni)?\.dll|mscorlib.dll)\s+
 
 SOSCOMMAND:DumpModule <POUT>\s+Module Name\s+(<HEXVAL>)\s+.*<POUT>
-!IFDEF:DESKTOP
 VERIFY:\s*PEFile:\s+<HEXVAL>\s+
 VERIFY:\s*ModuleId:\s+<HEXVAL>\s+
-ENDIF:DESKTOP
 VERIFY:\s*LoaderHeap:\s+<HEXVAL>\s+
 VERIFY:\s*TypeDefToMethodTableMap:\s+<HEXVAL>\s+
 

--- a/src/SOS/SOS.UnitTests/Scripts/Reflection.script
+++ b/src/SOS/SOS.UnitTests/Scripts/Reflection.script
@@ -1,5 +1,5 @@
 # Reflection debugging scenario
-# 1) load the executable
+# 1) Load the executable
 # 2) Run the executable and wait for it to crash
 # 3) Take a dump of the executable.
 # 4) Open the dump and compare the output
@@ -38,10 +38,7 @@ VERIFY:Message:\s+(<Invalid Object>|Exception has been thrown by the target of a
 VERIFY:InnerException:\s+System\.Exception, Use !PrintException <HEXVAL> to see more\.\s+
 VERIFY:StackTrace \(generated\):\s+
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+[Rr]eflection[Tt]est.*!(\$0_)?RefLoader\.Loader\.Main(\(\))?\+0x<HEXVAL>\s*
-# Desktop sos has a bug that prevents the line number/source file info from being printed.
-IFDEF:PROJECTK
 VERIFY:[.*[\\|/]Debuggees[\\|/](dotnet.+[\\|/])?[Rr]eflection[Tt]est[\\|/][Rr]eflection[Tt]est\.cs @ 32\s*\]
-ENDIF:PROJECTK
 VERIFY:(StackTraceString: <none>\s+)?
 VERIFY:HResult:\s+80131604
 
@@ -66,7 +63,4 @@ SOSCOMMAND:ClrStack
 VERIFY:.*OS Thread Id:\s+0x<HEXVAL>\s+.*
 VERIFY:\s+Child\s+SP\s+IP\s+Call Site\s+
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+(\*\*\* WARNING: Unable to verify checksum for ReflectionTest.exe\s*)?RefLoader\.Loader\.Main(\(\))?\s*
-# Desktop sos has a bug that prevents the line number/source file info from being printed.
-IFDEF:PROJECTK
 VERIFY:[.*[\\|/]Debuggees[\\|/](dotnet.+[\\|/])?[Rr]eflection[Tt]est[\\|/][Rr]eflection[Tt]est\.cs @ 32\s*\]
-ENDIF:PROJECTK

--- a/src/SOS/SOS.UnitTests/Scripts/SimpleThrow.script
+++ b/src/SOS/SOS.UnitTests/Scripts/SimpleThrow.script
@@ -54,11 +54,6 @@ SOSCOMMAND:ClrStack
 VERIFY:.*OS Thread Id:\s+0x<HEXVAL>\s+.*
 VERIFY:\s+Child\s+SP\s+IP\s+Call Site\s+
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+(\*\*\* WARNING: Unable to verify checksum for SimpleThrow.exe\s*)?UserObject\.UseObject.*\s+
-# Desktop sos has a bug that prevents the line number/source file info from being printed.
-IFDEF:PROJECTK
 VERIFY:[.*[\\|/]Debuggees[\\|/](dotnet.+[\\|/])?SimpleThrow[\\|/]UserObject\.cs @ 18\s*\]
-ENDIF:PROJECTK
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+Simple\.Main\(\)\s+
-IFDEF:PROJECTK
 VERIFY:[.*[\\|/]Debuggees[\\|/](dotnet.+[\\|/])?SimpleThrow[\\|/]SimpleThrow\.cs @ 9\s*\]
-ENDIF:PROJECTK

--- a/src/SOS/SOS.UnitTests/Scripts/StackAndOtherTests.script
+++ b/src/SOS/SOS.UnitTests/Scripts/StackAndOtherTests.script
@@ -7,25 +7,42 @@
 LOADSOS
 
 # Verify that bpmd works
-IFDEF:PROJECTK
 IFDEF:LIVE
 !IFDEF:MAJOR_RUNTIME_VERSION_1
 
+IFDEF:DESKTOP
+SOSCOMMAND:bpmd SymbolTestApp.exe SymbolTestApp.Program.Main
+ENDIF:DESKTOP
+!IFDEF:DESKTOP
 SOSCOMMAND:bpmd SymbolTestApp.dll SymbolTestApp.Program.Main
+ENDIF:DESKTOP
 CONTINUE
+
+# Unloads desktop sos and reloads new SOS
+IFDEF:DESKTOP
+LOADSOS
+ENDIF:DESKTOP
+
 SOSCOMMAND:ClrStack
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.Program\.Main\(.*\)\s+\[(?i:.*[\\|/]SymbolTestApp\.cs) @ 16\]\s*
 
 SOSCOMMAND:bpmd SymbolTestApp.cs:29
+IFDEF:DESKTOP
+SOSCOMMAND:bpmd SymbolTestApp.exe SymbolTestApp.Program.Foo4
+ENDIF:DESKTOP
+!IFDEF:DESKTOP
 SOSCOMMAND:bpmd SymbolTestApp.dll SymbolTestApp.Program.Foo4
+ENDIF:DESKTOP
 
+!IFDEF:DESKTOP
 CONTINUE
 SOSCOMMAND:ClrStack
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.Program\.Main\(.*\)\s+\[(?i:.*[\\|/]SymbolTestApp\.cs) @ 16\]\s*
+ENDIF:DESKTOP
 
 CONTINUE
 SOSCOMMAND:ClrStack
-VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.Program\.Foo2\(.*\)\s+\[(?i:.*[\\|/]SymbolTestApp\.cs) @ 28\]\s*
+VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.Program\.Foo2\(.*\)\s+\[(?i:.*[\\|/]SymbolTestApp\.cs) @ (28|29)\]\s*
 
 CONTINUE
 SOSCOMMAND:ClrStack
@@ -33,16 +50,13 @@ VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.Program\.Foo4\(.*\)\s+\[(?i:.*[\\
 
 ENDIF:MAJOR_RUNTIME_VERSION_1
 ENDIF:LIVE
-ENDIF:PROJECTK
 
 CONTINUE
 
-IFDEF:PROJECTK
 SOSCOMMAND:SetSymbolServer -ms
 !IFDEF:DOTNETDUMP
 SOSCOMMAND:SetHostRuntime
 ENDIF:DOTNETDUMP
-ENDIF:PROJECTK
 
 # Verify that ClrStack with no options works
 SOSCOMMAND:SetSymbolServer -ms
@@ -63,7 +77,6 @@ SOSCOMMAND:EEVersion
 VERIFY:\s+<DECVAL>.<DECVAL>.<DECVAL>.<DECVAL>.*
 
 # Verify that ClrStack with managed/native mixed works
-IFDEF:PROJECTK
 SOSCOMMAND:ClrStack -f
 VERIFY:.*OS Thread Id:\s+0x<HEXVAL>\s+.*
 VERIFY:\s+Child\s+SP\s+IP\s+Call Site\s+
@@ -71,10 +84,8 @@ VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.(dll|exe)!SymbolTestApp\.Program\
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.(dll|exe)!SymbolTestApp\.Program\.Foo2\(.*\)\s+\+\s+<DECVAL>\s+\[(?i:.*[\\|/]SymbolTestApp\.cs) @ 29\]\s*
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.(dll|exe)!SymbolTestApp\.Program\.Foo1\(.*\)\s+\+\s+<DECVAL>\s+\[(?i:.*[\\|/]SymbolTestApp\.cs) @ 24\]\s*
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.(dll|exe)!SymbolTestApp\.Program\.Main\(.*\)\s+\+\s+<DECVAL>\s+\[(?i:.*[\\|/]SymbolTestApp\.cs) @ 19\]\s*
-ENDIF:PROJECTK
 
 # Verify that ClrStack all option works (locals/params)
-IFDEF:PROJECTK
 SOSCOMMAND:ClrStack -a
 VERIFY:.*OS Thread Id:\s+0x<HEXVAL>\s+.*
 VERIFY:\s+Child\s+SP\s+IP\s+Call Site\s+
@@ -86,10 +97,8 @@ VERIFY:\s+0x<HEXVAL> = 0x<HEXVAL>\s+
 VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.Program\.Foo2\(.*\)\s+\[(?i:.*[\\|/]SymbolTestApp\.cs) @ 29\]\s*
 VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.Program\.Foo1\(.*\)\s+\[(?i:.*[\\|/]SymbolTestApp\.cs) @ 24\]\s*
 VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.Program\.Main\(.*\)\s+\[(?i:.*[\\|/]SymbolTestApp\.cs) @ 19\]\s*
-ENDIF:PROJECTK
 
 # Verify that ClrStack displays registers
-IFDEF:PROJECTK
 SOSCOMMAND:ClrStack -r
 VERIFY:.*OS Thread Id:\s+0x<HEXVAL>\s+.*
 VERIFY:\s+Child\s+SP\s+IP\s+Call Site\s+
@@ -126,10 +135,11 @@ ENDIF:X86
 
 VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.Program\.Foo1\(.*\)\s+\[(?i:.*[\\|/]SymbolTestApp\.cs) @ 24\]\s*
 VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.Program\.Main\(.*\)\s+\[(?i:.*[\\|/]SymbolTestApp\.cs) @ 19\]\s*
-ENDIF:PROJECTK
+
+# There seems no way to get -i to work on desktop under cdb. It does work under dotnet-dump because of the module mapping.
+IFDEF:NETCORE_OR_DOTNETDUMP
 
 # Verify that ClrStack with the ICorDebug options works
-IFDEF:PROJECTK
 SOSCOMMAND:ClrStack -i
 VERIFY:.*\s+Dumping managed stack and managed variables using ICorDebug.\s+
 VERIFY:.*\s+Child\s+SP\s+IP\s+Call Site\s+
@@ -139,13 +149,16 @@ VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+\[DEFAULT\] I4 SymbolTestApp\.Program\.Foo2\(.
 VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+\[DEFAULT\] I4 SymbolTestApp\.Program\.Foo1\(.*\)\s+\(.*\)\s+
 VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+\[DEFAULT\] Void SymbolTestApp\.Program\.Main\(.*\)\s+\(.*\)\s+
 VERIFY:.*\s+Stack walk complete.\s+
-ENDIF:PROJECTK
+
+ENDIF:NETCORE_OR_DOTNETDUMP
 
 # Issue: https://github.com/dotnet/diagnostics/issues/504
 !IFDEF:ALPINE
 
+# There seems no way to get -i to work on desktop under cdb. It does work under dotnet-dump because of the module mapping.
+IFDEF:NETCORE_OR_DOTNETDUMP
+
 # Verify that ClrStack with the ICorDebug options and all option (locals/params) works
-IFDEF:PROJECTK
 SOSCOMMAND:ClrStack -i -a
 VERIFY:.*\s+Dumping managed stack and managed variables using ICorDebug.\s+
 VERIFY:.*\s+Child\s+SP\s+IP\s+Call Site\s+
@@ -161,31 +174,27 @@ VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+\[DEFAULT\] I4 SymbolTestApp\.Program\.Foo2\(.
 VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+\[DEFAULT\] I4 SymbolTestApp\.Program\.Foo1\(.*\)\s+\(.*\)\s+
 VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+\[DEFAULT\] Void SymbolTestApp\.Program\.Main\(.*\)\s+\(.*\)\s+
 VERIFY:.*\s+Stack walk complete.\s+
-ENDIF:PROJECTK
+
+ENDIF:NETCORE_OR_DOTNETDUMP
 
 # Verify DumpStackObjects works
-IFDEF:PROJECTK
 SOSCOMMAND:DumpStackObjects
 VERIFY:.*OS Thread Id:\s+0x<HEXVAL>\s+.*
 VERIFY:\s+([R|E])*SP/REG\s+Object\s+Name\s+
 VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+System\.String.*
 VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+System\.String\[\].*
-ENDIF:PROJECTK
 
 # Verify DumpStackObjects -verify works
-IFDEF:PROJECTK
 SOSCOMMAND:DumpStackObjects -verify
 VERIFY:.*OS Thread Id:\s+0x<HEXVAL>\s+.*
 VERIFY:\s+([R|E])*SP/REG\s+Object\s+Name\s+
 VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+System\.String.*
 VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+System\.String\[\].*
-ENDIF:PROJECTK
 
 ENDIF:ALPINE
 
 !IFDEF:DOTNETDUMP
 !IFDEF:ARM
-IFDEF:PROJECTK
 
 # Verify DumpStack works
 SOSCOMMAND:DumpStack
@@ -204,7 +213,6 @@ SOSCOMMAND:EEStack
 VERIFY:.*Child(-SP|EBP|FP)\s+RetAddr\s+Caller, Callee\s+
 VERIFY:(.*\s+<HEXVAL>\s+<HEXVAL>\s+\(MethodDesc\s+<HEXVAL>\s+(\+\s*0x<HEXVAL>\s+)?SymbolTestApp\.Program\.Foo4\(System\.String\)\),\s+calling.*\s+)|(.*\s+<HEXVAL>\s+<HEXVAL>\s+\(MethodDesc\s+<HEXVAL>\s+(\+\s*0x<HEXVAL>\s+)?SymbolTestApp\.Program\.Foo2\(Int32, System\.String\)\),\s+calling.*\s+)
 
-ENDIF:PROJECTK
 ENDIF:ARM
 ENDIF:DOTNETDUMP
 
@@ -216,16 +224,14 @@ VERIFY:.*\s+Source file:\s+(?i:.*[\\|/]SymbolTestApp\.cs) @ (50|54)\s+
 
 # Verify that DumpIL works (depends on the IP2MD right above)
 SOSCOMMAND:DumpIL <POUT>\s*MethodDesc:\s+(<HEXVAL>)\s*<POUT>
+IFDEF:DESKTOP
+VERIFY:.*IL_<HEXVAL>: call class \[mscorlib\]System\.Reflection\.Assembly System\.Reflection\.Assembly::Load\(uint8\[\],uint8\[\]\)
+ENDIF:DESKTOP
 !IFDEF:DESKTOP
 VERIFY:.*IL_<HEXVAL>: callvirt class \[System\.(Runtime|Reflection)\]System\.Reflection\.Assembly System\.Runtime\.Loader\.AssemblyLoadContext::LoadFromStream\(class \[System\.(Runtime|IO)\]System\.IO\.Stream,class \[System\.(Runtime|IO)\]System\.IO\.Stream\)
 ENDIF:DESKTOP
-IFDEF:DESKTOP
-# Disable until the new SOS supports desktop clr
-# VERIFY:.*IL_<HEXVAL>: call class \[System.Runtime\]System\.Reflection\.Assembly System\.Reflection\.Assembly::Load\(uint8\[\],uint8\[\]\)
-ENDIF:DESKTOP
 
 !IFDEF:DOTNETDUMP
-IFDEF:PROJECTK
 
 # Verify that "u" works (depends on the IP2MD here)
 SOSCOMMAND:ClrStack
@@ -249,17 +255,14 @@ VERIFY:\s+SymbolTestApp\.Program\.Foo4\(System\.String\)\s+
 VERIFY:\s+Begin\s+<HEXVAL>,\s+size\s+<HEXVAL>\s+
 VERIFY:\s+(?i:.*[\\|/]SymbolTestApp\.cs) @ (50|54):\s+
 
-ENDIF:PROJECTK
 ENDIF:DOTNETDUMP
 
 # Verify that Name2EE works
-IFDEF:PROJECTK
 SOSCOMMAND:Name2EE *!SymbolTestApp.Program.Foo4
 VERIFY:\s*Module:\s+\s+<HEXVAL>\s+
 VERIFY:\s+Assembly:\s+(?i:SymbolTestApp).*\s+
 VERIFY:\s+Name:\s+SymbolTestApp\.Program\.Foo4\(System\.String\)\s+
 VERIFY:\s+JITTED Code Address:\s+<HEXVAL>\s+
-ENDIF:PROJECTK
 
 # Verify that Threads (clrthreads) works
 IFDEF:DOTNETDUMP

--- a/src/SOS/SOS.UnitTests/Scripts/StackTests.script
+++ b/src/SOS/SOS.UnitTests/Scripts/StackTests.script
@@ -20,7 +20,6 @@ VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+NestedExceptionTest\.Program\.Main\(.*\)\s+\[(
 ENDIF:64BIT
 
 # 2) Verifying that ClrStack with managed/native mixed works
-IFDEF:PROJECTK
 SOSCOMMAND:SetSymbolServer -ms -loadsymbols
 !IFDEF:DOTNETDUMP
 SOSCOMMAND:SetHostRuntime
@@ -33,10 +32,8 @@ IFDEF:64BIT
 VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+(?i:NestedExceptionTest.*)!NestedExceptionTest\.Program\.Main\(.*\)\s+\+\s+<DECVAL>\s+\[(?i:.*[\\|/]NestedExceptionTest\.cs) @ 13\s*\]\s+
 ENDIF:64BIT
 SOSCOMMAND:SetSymbolServer -disable
-ENDIF:PROJECTK
 
 # 3) Verifying that ClrStack all option works (locals/params)
-IFDEF:PROJECTK
 SOSCOMMAND:ClrStack -a
 VERIFY:.*OS Thread Id:\s+0x<HEXVAL>\s+.*
 VERIFY:\s+Child\s+SP\s+IP\s+Call Site\s+
@@ -52,10 +49,8 @@ VERIFY:\s+args \(0x<HEXVAL>\) = 0x<HEXVAL>\s+
 VERIFY:\s+LOCALS:\s+
 VERIFY:\s+0x<HEXVAL> = 0x<HEXVAL>\s+
 ENDIF:64BIT
-ENDIF:PROJECTK
 
 # 4) Verifying that ClrStack displays registers
-IFDEF:PROJECTK
 SOSCOMMAND:ClrStack -r
 VERIFY:.*OS Thread Id:\s+0x<HEXVAL>\s+.*
 VERIFY:\s+Child\s+SP\s+IP\s+Call Site\s+
@@ -91,13 +86,14 @@ IFDEF:X86
 VERIFY:\s+eax=<HEXVAL>\s+ebx=<HEXVAL>\s+ecx=<HEXVAL>\s+
 ENDIF:X86
 ENDIF:64BIT
-ENDIF:PROJECTK
+
+# There seems no way to get -i to work on desktop under cdb. It does work under dotnet-dump because of the module mapping.
+IFDEF:NETCORE_OR_DOTNETDUMP
 
 # Issue: https://github.com/dotnet/diagnostics/issues/504
 !IFDEF:ALPINE
 
 # 5) Verifying that ClrStack with the ICorDebug options works
-IFDEF:PROJECTK
 SOSCOMMAND:ClrStack -i
 VERIFY:.*\s+Dumping managed stack and managed variables using ICorDebug.\s+
 VERIFY:.*\s+Child\s+SP\s+IP\s+Call Site\s+
@@ -105,10 +101,8 @@ VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+\[NativeStackFrame\]\s+
 VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+\[DEFAULT\] Void NestedExceptionTest\.Program\.Main\(.*\)\s+\(.*\)\s+
 VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+\[DEFAULT\] Void NestedExceptionTest\.Program\.Main\(.*\)\s+\(.*\)\s+
 VERIFY:.*\s+Stack walk complete.\s+
-ENDIF:PROJECTK
 
 # 6) Verifying that ClrStack with the ICorDebug options and all option (locals/params) works
-IFDEF:PROJECTK
 SOSCOMMAND:ClrStack -i -a
 VERIFY:.*\s+Dumping managed stack and managed variables using ICorDebug.\s+
 VERIFY:.*\s+Child\s+SP\s+IP\s+Call Site\s+
@@ -120,29 +114,25 @@ VERIFY:\s+LOCALS:\s+
 VERIFY:\s+\+ System.FormatException ex @ 0x<HEXVAL>\s+
 VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+\[DEFAULT\] Void NestedExceptionTest\.Program\.Main\(.*\)\s+\(.*\)\s+
 VERIFY:.*\s+Stack walk complete.\s+
-ENDIF:PROJECTK
 
 ENDIF:ALPINE
+ENDIF:NETCORE_OR_DOTNETDUMP
 
 # 7) Verify DumpStackObjects works
-IFDEF:PROJECTK
 SOSCOMMAND:DumpStackObjects
 VERIFY:.*OS Thread Id:\s+0x<HEXVAL>\s+.*
 VERIFY:\s+([R|E])*SP/REG\s+Object\s+Name\s+
 VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+System\.FormatException\s+
 VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+System\.InvalidOperationException\s+
 VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+System\.String.*
-ENDIF:PROJECTK
 
 # 8) Verify DumpStackObjects -verify works
-IFDEF:PROJECTK
 SOSCOMMAND:DumpStackObjects -verify
 VERIFY:.*OS Thread Id:\s+0x<HEXVAL>\s+.*
 VERIFY:\s+([R|E])*SP/REG\s+Object\s+Name\s+
 VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+System\.FormatException\s+
 VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+System\.InvalidOperationException\s+
 VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+System\.String.*
-ENDIF:PROJECTK
 
 !IFDEF:DOTNETDUMP
 !IFDEF:ARM

--- a/src/SOS/SOS.UnitTests/Scripts/TaskNestedException.script
+++ b/src/SOS/SOS.UnitTests/Scripts/TaskNestedException.script
@@ -28,7 +28,6 @@ VERIFY:InnerException:\s+System\.InvalidOperationException, Use !PrintException 
 VERIFY:StackTrace \(generated\):\s+
 VERIFY:\s+SP\s+IP\s+Function\s+
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>.+RandomTest(::|\.)RandomUserTask\.<\.ctor>.+\+0x<HEXVAL>\s*
-# Desktop sos has a bug that prevents the line number/source file info from being printed. Fixed in ProjectK.
 !IFDEF:DESKTOP
 !IFDEF:TRIAGE_DUMP
 VERIFY:[.+[\\|/]Debuggees[\\|/](dotnet.+[\\|/])?[Tt]ask[Nn]ested[Ee]xception[\\|/][Rr]andom[Uu]ser[Ll]ibrary[\\|/][Rr]andom[Uu]ser[Tt]ask\.cs @ (16|23)\]
@@ -43,7 +42,6 @@ VERIFY:InnerException:\s+<none>\s+
 VERIFY:StackTrace \(generated\):\s+
 VERIFY:\s+SP\s+IP\s+Function\s+
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>.+RandomTest(::|\.)RandomUserTask\.InnerException(\(\))?\+0x<HEXVAL>\s*
-# Desktop sos has a bug that prevents the line number/source file info from being printed. Fixed in ProjectK.
 !IFDEF:DESKTOP
 !IFDEF:TRIAGE_DUMP
 VERIFY:[.+[\\|/]Debuggees[\\|/](dotnet.+[\\|/])?[Tt]ask[Nn]ested[Ee]xception[\\|/][Rr]andom[Uu]ser[Ll]ibrary[\\|/][Rr]andom[Uu]ser[Tt]ask\.cs @ 34\]

--- a/src/SOS/Strike/exts.h
+++ b/src/SOS/Strike/exts.h
@@ -196,7 +196,7 @@ public:
 
 inline void EENotLoadedMessage(HRESULT Status)
 {
-    ExtOut("Failed to find runtime module (%s), 0x%08x\n", MAKEDLLNAME_A("coreclr"), Status);
+    ExtOut("Failed to find runtime module (%s), 0x%08x\n", GetRuntimeDllName(), Status);
     ExtOut("Extension commands need it in order to have something to do.\n");
 }
 
@@ -205,30 +205,30 @@ inline void DACMessage(HRESULT Status)
     ExtOut("Failed to load data access module, 0x%08x\n", Status);
 #ifndef FEATURE_PAL
     ExtOut("Verify that 1) you have a recent build of the debugger (6.2.14 or newer)\n");
-    ExtOut("            2) the file mscordaccore.dll that matches your version of coreclr.dll is\n");
+    ExtOut("            2) the file %s that matches your version of %s is\n", GetDacDllName(), GetRuntimeDllName());
     ExtOut("                in the version directory or on the symbol path\n");
     ExtOut("            3) or, if you are debugging a dump file, verify that the file \n");
-    ExtOut("                mscordaccore_<arch>_<arch>_<version>.dll is on your symbol path.\n");
+    ExtOut("                %s_<arch>_<arch>_<version>.dll is on your symbol path.\n", GetDacModuleName());
     ExtOut("            4) you are debugging on supported cross platform architecture as \n");
     ExtOut("                the dump file. For example, an ARM dump file must be debugged\n");
     ExtOut("                on an X86 or an ARM machine; an AMD64 dump file must be\n");
     ExtOut("                debugged on an AMD64 machine.\n");
     ExtOut("\n");
     ExtOut("You can also run the debugger command .cordll to control the debugger's\n");
-    ExtOut("load of mscordaccore.dll.  .cordll -ve -u -l will do a verbose reload.\n");
+    ExtOut("load of %s.dll. .cordll -ve -u -l will do a verbose reload.\n", GetDacDllName());
     ExtOut("If that succeeds, the SOS command should work on retry.\n");
     ExtOut("\n");
     ExtOut("If you are debugging a minidump, you need to make sure that your executable\n");
-    ExtOut("path is pointing to coreclr.dll as well.\n");
+    ExtOut("path is pointing to %s as well.\n", GetRuntimeDllName());
 #else // FEATURE_PAL
     if (Status == CORDBG_E_MISSING_DEBUGGER_EXPORTS)
     {
-        ExtOut("You can run the debugger command 'setclrpath' to control the load of %s.\n", MAKEDLLNAME_A("mscordaccore"));
+        ExtOut("You can run the debugger command 'setclrpath' to control the load of %s.\n", GetDacDllName());
         ExtOut("If that succeeds, the SOS command should work on retry.\n");
     }
     else
     {
-        ExtOut("Can not load or initialize %s. The target runtime may not be initialized.\n", MAKEDLLNAME_A("mscordaccore"));
+        ExtOut("Can not load or initialize %s. The target runtime may not be initialized.\n", GetDacDllName());
     }
 #endif // FEATURE_PAL
 }
@@ -288,12 +288,12 @@ HRESULT CheckEEDll();
     INIT_API_NOEE()                                             \
     if ((Status = CheckEEDll()) != S_OK)                        \
     {                                                           \
-        ExtOut("Failed to find runtime module (%s), 0x%08x\n", MAKEDLLNAME_A("coreclr"), Status); \
+        ExtOut("Failed to find runtime module (%s), 0x%08x\n", GetRuntimeDllName(), Status); \
         ExtOut("Some functionality may be impaired\n");         \
     }                                                           \
     else if ((Status = LoadClrDebugDll()) != S_OK)              \
     {                                                           \
-        ExtOut("Failed to load data access module (%s), 0x%08x\n", MAKEDLLNAME_A("mscordaccore"), Status); \
+        ExtOut("Failed to load data access module (%s), 0x%08x\n", GetDacDllName(), Status); \
         ExtOut("Some functionality may be impaired\n");         \
     }                                                           \
     else                                                        \

--- a/src/SOS/Strike/hostcoreclr.h
+++ b/src/SOS/Strike/hostcoreclr.h
@@ -65,8 +65,8 @@ extern LPCSTR g_dbiFilePath;
 extern LPCSTR g_tmpPath;
 extern SOSNetCoreCallbacks g_SOSNetCoreCallbacks;
 
-extern HRESULT GetCoreClrDirectory(LPWSTR modulePath, int modulePathSize);
-extern HRESULT GetCoreClrDirectory(std::string& coreClrDirectory);
+extern HRESULT GetRuntimeDirectory(std::string& runtimeDirectory);
+extern HRESULT GetRuntimeDirectory(LPWSTR modulePath, int modulePathSize);
 extern LPCSTR GetDacFilePath();
 extern LPCSTR GetDbiFilePath();
 extern BOOL IsHostingInitialized();

--- a/src/SOS/Strike/sos.def
+++ b/src/SOS/Strike/sos.def
@@ -203,7 +203,7 @@ EXPORTS
     gchandleleaks=GCHandleLeaks
     Gchandleleaks=GCHandleLeaks
     GCHandleleaks=GCHandleLeaks
-    HandleCLRN
+    SOSHandleCLRN
     MinidumpMode
     minidumpmode=MinidumpMode
     Minidumpmode=MinidumpMode

--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -7585,6 +7585,8 @@ public:
     STDMETHODIMP OnCodeGenerated(IXCLRDataMethodInstance* method)
     {
 #ifndef FEATURE_PAL
+        // This is only needed for desktop runtime because OnCodeGenerated2
+        // isn't supported by the desktop DAC.
         if (g_isDesktopRuntime)
         {
             // Some method has been generated, make a breakpoint and remove it.

--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -159,10 +159,7 @@ const UINT kcMaxMethodDescsForProfiler = 100;
 #include <memory>
 #include <functional>
 
-BOOL CallStatus;
 BOOL ControlC = FALSE;
-
-IMetaDataDispenserEx *pDisp = NULL;
 WCHAR g_mdName[mdNameLen];
 
 #ifndef FEATURE_PAL
@@ -7587,6 +7584,38 @@ public:
      */
     STDMETHODIMP OnCodeGenerated(IXCLRDataMethodInstance* method)
     {
+#ifndef FEATURE_PAL
+        if (g_isDesktopRuntime)
+        {
+            // Some method has been generated, make a breakpoint and remove it.
+            ULONG32 len = mdNameLen;
+            LPWSTR szModuleName = (LPWSTR)alloca(mdNameLen * sizeof(WCHAR));
+            if (method->GetName(0, mdNameLen, &len, g_mdName) == S_OK)
+            {
+                ToRelease<IXCLRDataModule> pMod;
+                HRESULT hr = method->GetTokenAndScope(NULL, &pMod);
+                if (SUCCEEDED(hr))
+                {
+                    len = mdNameLen;
+                    if (pMod->GetName(mdNameLen, &len, szModuleName) == S_OK)
+                    {
+                        ExtOut("JITTED %S!%S\n", szModuleName, g_mdName);
+
+                        // Add breakpoint, perhaps delete pending breakpoint
+                        DacpGetModuleAddress dgma;
+                        if (SUCCEEDED(dgma.Request(pMod)))
+                        {
+                            g_bpoints.Update(TO_TADDR(dgma.ModulePtr), FALSE);
+                        }
+                        else
+                        {
+                            ExtOut("Failed to request module address.\n");
+                        }
+                    }
+                }
+            }
+        }
+#endif
         m_dbgStatus = DEBUG_STATUS_GO_HANDLED;
         return S_OK;
     }
@@ -7881,7 +7910,7 @@ void EnableModuleLoadUnloadCallbacks()
 
 #ifndef FEATURE_PAL
 
-DECLARE_API(HandleCLRN)
+DECLARE_API(SOSHandleCLRN)
 {
     INIT_API();    
     MINIDUMP_NOT_SUPPORTED();    
@@ -7892,7 +7921,7 @@ HRESULT HandleRuntimeLoadedNotification(IDebugClient* client)
 {
     INIT_API();
     EnableModuleLoadUnloadCallbacks();
-    return g_ExtControl->Execute(DEBUG_EXECUTE_NOT_LOGGED, "sxe -c \"!HandleCLRN\" clrn", 0);
+    return g_ExtControl->Execute(DEBUG_EXECUTE_NOT_LOGGED, "sxe -c \"!SOSHandleCLRN\" clrn", 0);
 }
 
 #else // FEATURE_PAL
@@ -8216,7 +8245,7 @@ DECLARE_API(bpmd)
     }
     else /* We were given a MethodDesc already */
     {
-        // if we've got an explicit MD, then we better have CLR and mscordacwks loaded
+        // if we've got an explicit MD, then we better have runtime and dac loaded
         INIT_API_EE()
         INIT_API_DAC();
 
@@ -8283,7 +8312,7 @@ DECLARE_API(bpmd)
     {
         ExtOut("Adding pending breakpoints...\n");
 #ifndef FEATURE_PAL
-        Status = g_ExtControl->Execute(DEBUG_EXECUTE_NOT_LOGGED, "sxe -c \"!HandleCLRN\" clrn", 0);
+        Status = g_ExtControl->Execute(DEBUG_EXECUTE_NOT_LOGGED, "sxe -c \"!SOSHandleCLRN\" clrn", 0);
 #else
         Status = g_ExtServices->SetExceptionCallback(HandleExceptionNotification);
 #endif // FEATURE_PAL
@@ -9837,7 +9866,7 @@ DECLARE_API(DumpLog)
             return E_FAIL;
 #else
             // Try to find stress log symbols
-            DWORD_PTR dwAddr = GetValueFromExpression(MAIN_CLR_MODULE_NAME_A "!StressLog::theLog");
+            DWORD_PTR dwAddr = GetValueFromExpression("StressLog::theLog");
             StressLogAddress = dwAddr;        
 #endif
         }
@@ -9891,12 +9920,12 @@ DECLARE_API (DumpGCLog)
     if (*args != 0)
         fileName = args;
     
-    DWORD_PTR dwAddr = GetValueFromExpression(MAIN_CLR_MODULE_NAME_A "!SVR::gc_log_buffer");
+    DWORD_PTR dwAddr = GetValueFromExpression("SVR::gc_log_buffer");
     moveN (dwAddr, dwAddr);
 
     if (dwAddr == 0)
     {
-        dwAddr = GetValueFromExpression(MAIN_CLR_MODULE_NAME_A "!WKS::gc_log_buffer");
+        dwAddr = GetValueFromExpression("WKS::gc_log_buffer");
         moveN (dwAddr, dwAddr);
         if (dwAddr == 0)
         {
@@ -10010,13 +10039,13 @@ DECLARE_API (DumpGCConfigLog)
     
     if (fIsServerGC) 
     {
-        dwAddr = GetValueFromExpression(MAIN_CLR_MODULE_NAME_A "!SVR::gc_config_log_buffer");
-        dwAddrOffset = GetValueFromExpression(MAIN_CLR_MODULE_NAME_A "!SVR::gc_config_log_buffer_offset");
+        dwAddr = GetValueFromExpression("SVR::gc_config_log_buffer");
+        dwAddrOffset = GetValueFromExpression("SVR::gc_config_log_buffer_offset");
     }
     else
     {
-        dwAddr = GetValueFromExpression(MAIN_CLR_MODULE_NAME_A "!WKS::gc_config_log_buffer");
-        dwAddrOffset = GetValueFromExpression(MAIN_CLR_MODULE_NAME_A "!WKS::gc_config_log_buffer_offset");
+        dwAddr = GetValueFromExpression("WKS::gc_config_log_buffer");
+        dwAddrOffset = GetValueFromExpression("WKS::gc_config_log_buffer_offset");
     }
 
     moveN (dwAddr, dwAddr);
@@ -10386,9 +10415,9 @@ DECLARE_API(SOSStatus)
     if (g_hostRuntimeDirectory != nullptr) {
         ExtOut("Host runtime path: %s\n", g_hostRuntimeDirectory);
     }
-    std::string coreclrDirectory;
-    if (SUCCEEDED(GetCoreClrDirectory(coreclrDirectory))) {
-        ExtOut("Runtime path: %s\n", coreclrDirectory.c_str());
+    std::string runtimeDirectory;
+    if (SUCCEEDED(GetRuntimeDirectory(runtimeDirectory))) {
+        ExtOut("Runtime path: %s\n", runtimeDirectory.c_str());
     }
     DisplaySymbolStore();
 
@@ -11180,7 +11209,7 @@ DECLARE_API(FindRoots)
         GcEvtArgs gea = { GC_MARK_END, { ((gen == -1) ? 7 : (1 << gen)) } };
         idp2->SetGcNotification(gea);
         // ... and register the notification handler
-        g_ExtControl->Execute(DEBUG_EXECUTE_NOT_LOGGED, "sxe -c \"!HandleCLRN\" clrn", 0);
+        g_ExtControl->Execute(DEBUG_EXECUTE_NOT_LOGGED, "sxe -c \"!SOSHandleCLRN\" clrn", 0);
         // the above notification is removed in CNotification::OnGcEvent()
     }
     else
@@ -12080,7 +12109,7 @@ DECLARE_API(GCHandleLeaks)
     if (LoadClrDebugDll() != S_OK)
     {
         // Try to find stress log symbols
-        DWORD_PTR dwAddr = GetValueFromExpression(MAIN_CLR_MODULE_NAME_A "!StressLog::theLog");
+        DWORD_PTR dwAddr = GetValueFromExpression("StressLog::theLog");
         StressLogAddress = dwAddr;        
         g_bDacBroken = TRUE;
     }
@@ -15456,7 +15485,7 @@ DECLARE_API(SuppressJitOptimization)
         else
         {
             g_fAllowJitOptimization = FALSE;
-            g_ExtControl->Execute(DEBUG_EXECUTE_NOT_LOGGED, "sxe -c \"!HandleCLRN\" clrn", 0);
+            g_ExtControl->Execute(DEBUG_EXECUTE_NOT_LOGGED, "sxe -c \"!SOSHandleCLRN\" clrn", 0);
             ExtOut("JIT optimization will be suppressed\n");
         }
 
@@ -15887,8 +15916,8 @@ DECLARE_API(SetSymbolServer)
         {"-directory", &searchDirectory.data, COSTRING, TRUE},
         {"-ms", &msdl, COBOOL, FALSE},
         {"-log", &logging, COBOOL, FALSE},
-#ifdef FEATURE_PAL
         {"-loadsymbols", &loadNative, COBOOL, FALSE},
+#ifdef FEATURE_PAL
         {"-sympath", &windowsSymbolPath.data, COSTRING, TRUE},
 #else
         {"-mi", &symweb, COBOOL, FALSE},

--- a/src/SOS/Strike/strike.h
+++ b/src/SOS/Strike/strike.h
@@ -123,9 +123,6 @@
 #define plug_skew           SIZEOF_OBJHEADER
 #define min_obj_size        (sizeof(BYTE*)+plug_skew+sizeof(size_t))
 
-extern BOOL CallStatus;
-
-
 #ifndef NT_SUCCESS
 #define NT_SUCCESS(Status) (((NTSTATUS)(Status)) >= 0)
 #endif

--- a/src/SOS/Strike/util.cpp
+++ b/src/SOS/Strike/util.cpp
@@ -163,16 +163,14 @@ void ReportOOM()
     ExtOut("SOS Error: Out of memory\n");
 }
 
-#ifndef FEATURE_PAL
 // This is set as a side-effect of CheckEEDll()/GetRuntimeModuleInfo().
 bool g_isDesktopRuntime = false;
-#endif
 
 HRESULT GetRuntimeModuleInfo(PULONG moduleIndex, PULONG64 moduleBase)
 {
+    g_isDesktopRuntime = false;
     HRESULT hr = g_ExtSymbols->GetModuleByModuleName(NETCORE_RUNTIME_MODULE_NAME_A, 0, moduleIndex, moduleBase);
 #ifndef FEATURE_PAL
-    g_isDesktopRuntime = false;
     if (FAILED(hr)) {
         hr = g_ExtSymbols->GetModuleByModuleName(DESKTOP_RUNTIME_MODULE_NAME_A, 0, moduleIndex, moduleBase);
         g_isDesktopRuntime = SUCCEEDED(hr);
@@ -3277,9 +3275,9 @@ void ReloadSymbolWithLineInfo()
         if (!(Options & SYMOPT_LOAD_LINES))
         {
             g_ExtSymbols->AddSymbolOptions(SYMOPT_LOAD_LINES);
-            if (SUCCEEDED(g_ExtSymbols->GetModuleByModuleName("mscoree.dll", 0, NULL, NULL)))
+            if (SUCCEEDED(g_ExtSymbols->GetModuleByModuleName(MSCOREE_SHIM_A, 0, NULL, NULL)))
             {
-                g_ExtSymbols->Reload("/f mscoree.dll");
+                g_ExtSymbols->Reload("/f" MSCOREE_SHIM_A);
             }
             EEFLAVOR flavor = GetEEFlavor();
             if (flavor == MSCORWKS)

--- a/src/SOS/Strike/util.cpp
+++ b/src/SOS/Strike/util.cpp
@@ -97,8 +97,13 @@ void __cdecl operator delete[](void* pObj) throw()
 \**********************************************************************/
 DWORD_PTR GetValueFromExpression(___in __in_z const char *const instr)
 {
+    std::string symbol;
+    symbol.append(GetRuntimeModuleName());
+    symbol.append("!");
+    symbol.append(instr);
+
     ULONG64 dwAddr;
-    const char *str = instr;
+    const char* str = symbol.c_str();
     char name[256];
 
     dwAddr = 0;
@@ -158,13 +163,22 @@ void ReportOOM()
     ExtOut("SOS Error: Out of memory\n");
 }
 
+#ifndef FEATURE_PAL
+// This is set as a side-effect of CheckEEDll()/GetRuntimeModuleInfo().
+bool g_isDesktopRuntime = false;
+#endif
+
 HRESULT GetRuntimeModuleInfo(PULONG moduleIndex, PULONG64 moduleBase)
 {
-#ifdef FEATURE_PAL
-    return g_ExtSymbols->GetModuleByModuleName(MAIN_CLR_DLL_NAME_A, 0, moduleIndex, moduleBase);
-#else
-    return g_ExtSymbols->GetModuleByModuleName(MAIN_CLR_MODULE_NAME_A, 0, moduleIndex, moduleBase);
+    HRESULT hr = g_ExtSymbols->GetModuleByModuleName(NETCORE_RUNTIME_MODULE_NAME_A, 0, moduleIndex, moduleBase);
+#ifndef FEATURE_PAL
+    g_isDesktopRuntime = false;
+    if (FAILED(hr)) {
+        hr = g_ExtSymbols->GetModuleByModuleName(DESKTOP_RUNTIME_MODULE_NAME_A, 0, moduleIndex, moduleBase);
+        g_isDesktopRuntime = SUCCEEDED(hr);
+    }
 #endif
+    return hr;
 }
 
 HRESULT CheckEEDll()
@@ -191,7 +205,10 @@ HRESULT CheckEEDll()
             {
                 if (params.SymbolType == SymDeferred)
                 {
-                    g_ExtSymbols->Reload("/f " MAIN_CLR_DLL_NAME_A);
+                    std::string reloadCommand;
+                    reloadCommand.append("/f ");
+                    reloadCommand.append(GetRuntimeDllName());
+                    g_ExtSymbols->Reload(reloadCommand.c_str());
                     g_ExtSymbols->GetModuleParameters(1, &g_moduleInfo[MSCORWKS].baseAddr, 0, &params);
                 }
                 if (params.SymbolType == SymPdb || params.SymbolType == SymDia)
@@ -203,7 +220,7 @@ HRESULT CheckEEDll()
         }
         if (g_moduleInfo[MSCORWKS].baseAddr != 0 && g_moduleInfo[MSCORWKS].hasPdb == FALSE) 
         {
-            ExtOut("PDB symbol for coreclr.dll not loaded\n");
+            ExtOut("PDB symbol for %s not loaded\n", GetRuntimeDllName());
         }
 #endif // FEATURE_PAL
     }
@@ -2255,7 +2272,7 @@ DWORD_PTR *ModuleFromName(__in_opt LPSTR mName, int *numModule)
             // >sxe ld:clr
             // >g
             // ...
-            // ModLoad: coreclr.dll
+            // ModLoad: runtime dll 
             // >!bpmd Foo.dll Foo.Bar
 
             // we will correctly give the answer that whatever module you were looking for, it isn't loaded yet
@@ -2347,6 +2364,48 @@ Failure:
     return NULL;
 }
 
+#ifndef FEATURE_PAL
+
+/**********************************************************************\
+* Routine Description:                                                 *
+*                                                                      *
+*    Retrieve module base associated with the IXCLRDataModule          *
+*    instance passed in, and the extent type requested.                *
+*                                                                      *
+\**********************************************************************/
+HRESULT GetClrModuleImages(__in IXCLRDataModule* module, __in CLRDataModuleExtentType desiredType, __out PULONG64 firstAdd)
+{
+    CLRDATA_ENUM enumExtents;
+    HRESULT hr;
+
+    _ASSERTE(firstAdd != nullptr);
+    *firstAdd = 0;
+
+    if (FAILED(hr = module->StartEnumExtents(&enumExtents)))
+    {
+        return hr;
+    }
+    CLRDATA_MODULE_EXTENT extent;
+    while (module->EnumExtent(&enumExtents, &extent) == S_OK)
+    {
+        if ((desiredType == CLRDATA_MODULE_OTHER) || (desiredType == extent.type))
+        {
+            ULONG64 modBase;
+            if (FAILED(hr = g_ExtSymbols->GetModuleByOffset(extent.base, 0, nullptr, &modBase)))
+            {
+                break;
+            }
+            *firstAdd = modBase;
+            hr = S_OK;
+            break;
+        }
+    }
+    module->EndEnumExtents(enumExtents);
+    return hr;
+}
+
+#endif // FEATURE_PAL
+
 /**********************************************************************\
 * Routine Description:                                                 *
 *                                                                      *
@@ -2355,7 +2414,6 @@ Failure:
 \**********************************************************************/
 HRESULT GetModuleFromAddress(___in CLRDATA_ADDRESS peAddress, ___out IXCLRDataModule** ppModule)
 {
-    HRESULT hr = E_FAIL;
     *ppModule = nullptr;
 
     int numModule;
@@ -2365,9 +2423,9 @@ HRESULT GetModuleFromAddress(___in CLRDATA_ADDRESS peAddress, ___out IXCLRDataMo
         for (int i = 0; i < numModule; i++)
         {
             ToRelease<IXCLRDataModule> module;
-            hr = g_sos->GetModule(moduleList[i], &module);
+            HRESULT hr = g_sos->GetModule(moduleList[i], &module);
             if (FAILED(hr)) {
-                break;
+                return hr;
             }
             ULONG32 flags;
             if ((hr = module->GetFlags(&flags)) != S_OK) {
@@ -2377,19 +2435,27 @@ HRESULT GetModuleFromAddress(___in CLRDATA_ADDRESS peAddress, ___out IXCLRDataMo
                 continue;
             }
             DacpGetModuleData moduleData;
-            HRESULT hr = moduleData.Request(module);
+            hr = moduleData.Request(module);
             if (FAILED(hr)) {
-                break;
+#ifdef FEATURE_PAL
+                return hr;
+#else
+                hr = GetClrModuleImages(module, CLRDATA_MODULE_PE_FILE, &moduleData.LoadedPEAddress);
+                if (FAILED(hr))
+                {
+                    return hr;
+                }
+#endif
             }
             if (peAddress == moduleData.LoadedPEAddress)
             {
                 *ppModule = module.Detach();
-                break;
+                return S_OK;
             }
         }
     }
 
-    return hr;
+    return E_INVALIDARG;
 }
 
 /**********************************************************************\
@@ -2817,6 +2883,8 @@ const char *EHTypeName(EHClauseType et)
 // 2.x version
 void DumpTieredNativeCodeAddressInfo_2x(struct DacpTieredVersionData_2x * pTieredVersionData, const UINT cTieredVersionData)
 {
+    ExtOut("Code Version History:\n");
+
     for(int i = cTieredVersionData - 1; i >= 0; --i)
     {
         const char *descriptor = NULL;
@@ -3209,13 +3277,18 @@ void ReloadSymbolWithLineInfo()
         if (!(Options & SYMOPT_LOAD_LINES))
         {
             g_ExtSymbols->AddSymbolOptions(SYMOPT_LOAD_LINES);
-            
-            if (SUCCEEDED(g_ExtSymbols->GetModuleByModuleName(MSCOREE_SHIM_A, 0, NULL, NULL)))
-                g_ExtSymbols->Reload("/f " MSCOREE_SHIM_A);
-            
+            if (SUCCEEDED(g_ExtSymbols->GetModuleByModuleName("mscoree.dll", 0, NULL, NULL)))
+            {
+                g_ExtSymbols->Reload("/f mscoree.dll");
+            }
             EEFLAVOR flavor = GetEEFlavor();
             if (flavor == MSCORWKS)
-                g_ExtSymbols->Reload("/f " MAIN_CLR_DLL_NAME_A);
+            {
+                std::string reloadCommand;
+                reloadCommand.append("/f ");
+                reloadCommand.append(GetRuntimeDllName());
+                g_ExtSymbols->Reload(reloadCommand.c_str());
+            }
         }
         
         // reload mscoree.pdb and clrjit.pdb to get line info
@@ -3279,9 +3352,8 @@ size_t FunctionType (size_t EIP)
 BOOL GetEEVersion(VS_FIXEDFILEINFO* pFileInfo, char* fileVersionBuffer, int fileVersionBufferSizeInBytes)
 {
     _ASSERTE(pFileInfo);
-    if (g_ExtSymbols2 == nullptr) {
-        return FALSE;
-    }
+    _ASSERTE(g_ExtSymbols2 != nullptr);
+
     ModuleInfo moduleInfo = g_moduleInfo[GetEEFlavor()];
     _ASSERTE(moduleInfo.index != DEBUG_ANY_ID);
 
@@ -4006,8 +4078,7 @@ LoadLibraryAndCheck(
 #endif // FEATURE_PAL
 
 //---------------------------------------------------------------------------------------
-// Provides a way for the public CLR debugging interface to find the appropriate
-// mscordbi.dll, DAC, etc.
+// Provides a way for the public CLR debugging interface to find the appropriate mscordbi.dll, DAC, etc.
 class SOSLibraryProvider : public ICLRDebuggingLibraryProvider, ICLRDebuggingLibraryProvider2
 {
 public:
@@ -4069,11 +4140,11 @@ public:
     {
         const char* filePath = nullptr;
 
-        if (_wcsncmp(pwszFileName, MAKEDLLNAME_W(CORECLR_DAC_MODULE_NAME_W), _wcslen(MAKEDLLNAME_W(CORECLR_DAC_MODULE_NAME_W))) == 0)
+        if (_wcsncmp(pwszFileName, GetDacDllNameW(), _wcslen(GetDacDllNameW())) == 0)
         {
             filePath = GetDacFilePath();
         }
-        else if (_wcsncmp(pwszFileName, MAKEDLLNAME_W(MAIN_DBI_MODULE_NAME_W), _wcslen(MAKEDLLNAME_W(MAIN_DBI_MODULE_NAME_W))) == 0)
+        else if (_wcsncmp(pwszFileName, NET_DBI_DLL_NAME_W, _wcslen(NET_DBI_DLL_NAME_W)) == 0)
         {
             filePath = GetDbiFilePath();
         }
@@ -4090,7 +4161,7 @@ public:
         }
         else
         {
-            HRESULT hr = GetCoreClrDirectory(modulePath, MAX_LONGPATH);
+            HRESULT hr = GetRuntimeDirectory(modulePath, MAX_LONGPATH);
             if (FAILED(hr))
             {
                 return hr;
@@ -4113,7 +4184,7 @@ public:
         return S_OK;
     }
 
-    // Called by the shim to locate and load mscordaccore and mscordbi
+    // Called by the shim to locate and load dac and dbi
     // Parameters:
     //    pwszFileName - the name of the file to load
     //    dwTimestamp - the expected timestamp of the file
@@ -4272,7 +4343,12 @@ public:
             }
         }
 #endif
-        return g_ExtData->ReadVirtual(address, pBuffer, request, (PULONG) pcbRead);
+        HRESULT hr = g_ExtData->ReadVirtual(address, pBuffer, request, (PULONG) pcbRead);
+        if (FAILED(hr)) 
+        {
+            ExtDbgOut("SOSDataTarget::ReadVirtual FAILED %08x address %p size %08x\n", hr, address, request);
+        }
+        return hr;
     }
 
     virtual HRESULT STDMETHODCALLTYPE GetThreadContext(
@@ -4496,6 +4572,12 @@ HRESULT InitCorDebugInterface()
     GUID skuId = CLR_ID_ONECORE_CLR;
 #else
     GUID skuId = CLR_ID_CORECLR;
+#endif
+#ifndef FEATURE_PAL
+    if (g_isDesktopRuntime)
+    {
+        skuId = CLR_ID_V4_DESKTOP;
+    }
 #endif
     CLRDebuggingImpl* pDebuggingImpl = new CLRDebuggingImpl(skuId);
     hr = pDebuggingImpl->QueryInterface(IID_ICLRDebugging, (LPVOID *)&pClrDebugging);

--- a/src/SOS/Strike/util.h
+++ b/src/SOS/Strike/util.h
@@ -1589,63 +1589,37 @@ private:
 
 #endif // FEATURE_PAL
 
-#ifndef FEATURE_PAL
 // This is set as a side-effect of CheckEEDll()/GetRuntimeModuleInfo().
 extern bool g_isDesktopRuntime;
-#endif
 
 inline const char* GetRuntimeModuleName()
 {
-    return 
-#ifndef FEATURE_PAL
-        g_isDesktopRuntime ? DESKTOP_RUNTIME_MODULE_NAME_A : 
-#endif
-            NETCORE_RUNTIME_MODULE_NAME_A;
+    return g_isDesktopRuntime ? DESKTOP_RUNTIME_MODULE_NAME_A : NETCORE_RUNTIME_MODULE_NAME_A;
 }
 
 inline const char* GetRuntimeDllName()
 {
-    return 
-#ifndef FEATURE_PAL
-        g_isDesktopRuntime ? DESKTOP_RUNTIME_DLL_NAME_A : 
-#endif
-            NETCORE_RUNTIME_DLL_NAME_A;
+    return g_isDesktopRuntime ? DESKTOP_RUNTIME_DLL_NAME_A : NETCORE_RUNTIME_DLL_NAME_A;
 }
 
 inline const char* GetDacModuleName()
 {
-    return 
-#ifndef FEATURE_PAL
-        g_isDesktopRuntime ? DESKTOP_DAC_MODULE_NAME_A : 
-#endif
-            NETCORE_DAC_MODULE_NAME_A;
+    return g_isDesktopRuntime ? DESKTOP_DAC_MODULE_NAME_A : NETCORE_DAC_MODULE_NAME_A;
 }
 
 inline const char* GetDacDllName()
 {
-    return 
-#ifndef FEATURE_PAL
-        g_isDesktopRuntime ? DESKTOP_DAC_DLL_NAME_A : 
-#endif
-            NETCORE_DAC_DLL_NAME_A;
+    return g_isDesktopRuntime ? DESKTOP_DAC_DLL_NAME_A : NETCORE_DAC_DLL_NAME_A;
 }
 
 inline const WCHAR* GetDacModuleNameW()
 {
-    return 
-#ifndef FEATURE_PAL
-        g_isDesktopRuntime ? DESKTOP_DAC_MODULE_NAME_W : 
-#endif
-            NETCORE_DAC_MODULE_NAME_W;
+    return g_isDesktopRuntime ? DESKTOP_DAC_MODULE_NAME_W : NETCORE_DAC_MODULE_NAME_W;
 }
 
 inline const WCHAR* GetDacDllNameW()
 {
-    return 
-#ifndef FEATURE_PAL
-        g_isDesktopRuntime ? DESKTOP_DAC_DLL_NAME_W : 
-#endif
-            NETCORE_DAC_DLL_NAME_W;
+    return g_isDesktopRuntime ? DESKTOP_DAC_DLL_NAME_W : NETCORE_DAC_DLL_NAME_W;
 }
 
 struct ModuleInfo

--- a/src/SOS/Strike/util.h
+++ b/src/SOS/Strike/util.h
@@ -1389,7 +1389,10 @@ private:
     int *mWidths;
     Alignment *mAlignments;
 };
-
+ 
+#ifndef FEATURE_PAL
+HRESULT GetClrModuleImages(__in IXCLRDataModule* module, __in CLRDataModuleExtentType desiredType, __out PULONG64 firstAdd);
+#endif
 HRESULT GetMethodDefinitionsFromName(DWORD_PTR ModulePtr, IXCLRDataModule* mod, const char* name, IXCLRDataMethodDefinition **ppMethodDefinitions, int numMethods, int *numMethodsNeeded);
 HRESULT GetMethodDescsFromName(DWORD_PTR ModulePtr, IXCLRDataModule* mod, const char* name, DWORD_PTR **pOut, int *numMethodDescs);
 
@@ -1536,6 +1539,115 @@ private:
     T* m_ptr;    
 };
 
+// SOS's runtime, dac and dbi module name defines. *MODULE* is just the 
+// module name on Windows, *DLL* has the .dll extension. On Linux/MacOS, 
+// *MODULE* and *DLL* are the same.
+
+#ifdef FEATURE_PAL
+
+#define NETCORE_RUNTIME_MODULE_NAME_W   MAKEDLLNAME_W(W("coreclr"))
+#define NETCORE_RUNTIME_MODULE_NAME_A   MAKEDLLNAME_A("coreclr")
+#define NETCORE_RUNTIME_DLL_NAME_W      NETCORE_RUNTIME_MODULE_NAME_W
+#define NETCORE_RUNTIME_DLL_NAME_A      NETCORE_RUNTIME_MODULE_NAME_A
+
+#define NETCORE_DAC_MODULE_NAME_W       MAKEDLLNAME_W(W("mscordaccore"))
+#define NETCORE_DAC_MODULE_NAME_A       MAKEDLLNAME_A("mscordaccore")
+#define NETCORE_DAC_DLL_NAME_W          NETCORE_DAC_MODULE_NAME_W
+#define NETCORE_DAC_DLL_NAME_A          NETCORE_DAC_MODULE_NAME_A
+
+#define NET_DBI_MODULE_NAME_W           MAKEDLLNAME_W(W("mscordbi"))
+#define NET_DBI_MODULE_NAME_A           MAKEDLLNAME_A("mscordbi")
+#define NET_DBI_DLL_NAME_W              NET_DBI_MODULE_NAME_W       
+#define NET_DBI_DLL_NAME_A              NET_DBI_MODULE_NAME_A       
+
+#else
+
+#define NETCORE_RUNTIME_MODULE_NAME_W   W("coreclr")
+#define NETCORE_RUNTIME_MODULE_NAME_A   "coreclr"
+#define NETCORE_RUNTIME_DLL_NAME_W      MAKEDLLNAME_W(NETCORE_RUNTIME_MODULE_NAME_W)
+#define NETCORE_RUNTIME_DLL_NAME_A      MAKEDLLNAME_A(NETCORE_RUNTIME_MODULE_NAME_A)
+
+#define NETCORE_DAC_MODULE_NAME_W       W("mscordaccore")
+#define NETCORE_DAC_MODULE_NAME_A       "mscordaccore"
+#define NETCORE_DAC_DLL_NAME_W          MAKEDLLNAME_W(NETCORE_DAC_MODULE_NAME_W)
+#define NETCORE_DAC_DLL_NAME_A          MAKEDLLNAME_A(NETCORE_DAC_MODULE_NAME_A)
+
+#define NET_DBI_MODULE_NAME_W           W("mscordbi")
+#define NET_DBI_MODULE_NAME_A           "mscordbi"
+#define NET_DBI_DLL_NAME_W              MAKEDLLNAME_W(W("mscordbi"))
+#define NET_DBI_DLL_NAME_A              MAKEDLLNAME_A("mscordbi")
+
+#define DESKTOP_RUNTIME_MODULE_NAME_W   W("clr")
+#define DESKTOP_RUNTIME_MODULE_NAME_A   "clr"
+#define DESKTOP_RUNTIME_DLL_NAME_W      MAKEDLLNAME_W(DESKTOP_RUNTIME_MODULE_NAME_W)
+#define DESKTOP_RUNTIME_DLL_NAME_A      MAKEDLLNAME_A(DESKTOP_RUNTIME_MODULE_NAME_A)
+
+#define DESKTOP_DAC_MODULE_NAME_W       W("mscordacwks")
+#define DESKTOP_DAC_MODULE_NAME_A       "mscordacwks"
+#define DESKTOP_DAC_DLL_NAME_W          MAKEDLLNAME_W(W("mscordacwks"))
+#define DESKTOP_DAC_DLL_NAME_A          MAKEDLLNAME_A("mscordacwks")
+
+#endif // FEATURE_PAL
+
+#ifndef FEATURE_PAL
+// This is set as a side-effect of CheckEEDll()/GetRuntimeModuleInfo().
+extern bool g_isDesktopRuntime;
+#endif
+
+inline const char* GetRuntimeModuleName()
+{
+    return 
+#ifndef FEATURE_PAL
+        g_isDesktopRuntime ? DESKTOP_RUNTIME_MODULE_NAME_A : 
+#endif
+            NETCORE_RUNTIME_MODULE_NAME_A;
+}
+
+inline const char* GetRuntimeDllName()
+{
+    return 
+#ifndef FEATURE_PAL
+        g_isDesktopRuntime ? DESKTOP_RUNTIME_DLL_NAME_A : 
+#endif
+            NETCORE_RUNTIME_DLL_NAME_A;
+}
+
+inline const char* GetDacModuleName()
+{
+    return 
+#ifndef FEATURE_PAL
+        g_isDesktopRuntime ? DESKTOP_DAC_MODULE_NAME_A : 
+#endif
+            NETCORE_DAC_MODULE_NAME_A;
+}
+
+inline const char* GetDacDllName()
+{
+    return 
+#ifndef FEATURE_PAL
+        g_isDesktopRuntime ? DESKTOP_DAC_DLL_NAME_A : 
+#endif
+            NETCORE_DAC_DLL_NAME_A;
+}
+
+inline const WCHAR* GetDacModuleNameW()
+{
+    return 
+#ifndef FEATURE_PAL
+        g_isDesktopRuntime ? DESKTOP_DAC_MODULE_NAME_W : 
+#endif
+            NETCORE_DAC_MODULE_NAME_W;
+}
+
+inline const WCHAR* GetDacDllNameW()
+{
+    return 
+#ifndef FEATURE_PAL
+        g_isDesktopRuntime ? DESKTOP_DAC_DLL_NAME_W : 
+#endif
+            NETCORE_DAC_DLL_NAME_W;
+}
+
 struct ModuleInfo
 {
     ULONG64 baseAddr;
@@ -1543,6 +1655,7 @@ struct ModuleInfo
     ULONG index;
     BOOL hasPdb;
 };
+
 extern ModuleInfo g_moduleInfo[];
 
 BOOL InitializeHeapData();
@@ -3067,11 +3180,6 @@ struct Flags
 
 private:
     UnderlyingType m_val;
-};
-
-struct ImageInfo
-{
-    ULONG64 modBase;
 };
 
 // Helper class used in ClrStackFromPublicInterface() to keep track of explicit EE Frames

--- a/src/SOS/Strike/util.h
+++ b/src/SOS/Strike/util.h
@@ -1577,6 +1577,8 @@ private:
 #define NET_DBI_DLL_NAME_W              MAKEDLLNAME_W(W("mscordbi"))
 #define NET_DBI_DLL_NAME_A              MAKEDLLNAME_A("mscordbi")
 
+#endif // FEATURE_PAL
+
 #define DESKTOP_RUNTIME_MODULE_NAME_W   W("clr")
 #define DESKTOP_RUNTIME_MODULE_NAME_A   "clr"
 #define DESKTOP_RUNTIME_DLL_NAME_W      MAKEDLLNAME_W(DESKTOP_RUNTIME_MODULE_NAME_W)
@@ -1586,8 +1588,6 @@ private:
 #define DESKTOP_DAC_MODULE_NAME_A       "mscordacwks"
 #define DESKTOP_DAC_DLL_NAME_W          MAKEDLLNAME_W(W("mscordacwks"))
 #define DESKTOP_DAC_DLL_NAME_A          MAKEDLLNAME_A("mscordacwks")
-
-#endif // FEATURE_PAL
 
 // This is set as a side-effect of CheckEEDll()/GetRuntimeModuleInfo().
 extern bool g_isDesktopRuntime;

--- a/src/SOS/lldbplugin.tests/TestDebuggee/TestDebuggee.csproj
+++ b/src/SOS/lldbplugin.tests/TestDebuggee/TestDebuggee.csproj
@@ -2,6 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp1.1;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/src/Tools/dotnet-dump/Dumper.Windows.cs
+++ b/src/Tools/dotnet-dump/Dumper.Windows.cs
@@ -2,13 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Win32.SafeHandles;
 using System;
 using System.Diagnostics;
 using System.IO;
-using System.Net.Http.Headers;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
-using Microsoft.Win32.SafeHandles;
 
 namespace Microsoft.Diagnostics.Tools.Dump
 {

--- a/src/inc/cor.h
+++ b/src/inc/cor.h
@@ -134,6 +134,9 @@ typedef UNALIGNED void const *UVCP_CONSTANT;
 #define INVALID_TASK_ID         0x0 
 #define MAX_CONNECTION_NAME     MAX_PATH
 
+#define MSCOREE_SHIM_W                L"mscoree.dll"
+#define MSCOREE_SHIM_A                "mscoree.dll"
+
 #define SWITCHOUT_HANDLE_VALUE ((HANDLE)(LONG_PTR)-2)
 
 //

--- a/src/inc/cor.h
+++ b/src/inc/cor.h
@@ -134,17 +134,6 @@ typedef UNALIGNED void const *UVCP_CONSTANT;
 #define INVALID_TASK_ID         0x0 
 #define MAX_CONNECTION_NAME     MAX_PATH
 
-
-#define MAIN_CLR_MODULE_NAME_W        W("coreclr")
-#define MAIN_CLR_MODULE_NAME_A         "coreclr"
-
-#define MAIN_CLR_DLL_NAME_W           MAKEDLLNAME_W(MAIN_CLR_MODULE_NAME_W)
-#define MAIN_CLR_DLL_NAME_A           MAKEDLLNAME_A(MAIN_CLR_MODULE_NAME_A)
-
-
-#define MSCOREE_SHIM_W               MAIN_CLR_DLL_NAME_W
-#define MSCOREE_SHIM_A               MAIN_CLR_DLL_NAME_A
-
 #define SWITCHOUT_HANDLE_VALUE ((HANDLE)(LONG_PTR)-2)
 
 //


### PR DESCRIPTION
Lays the ground work for SOS single file support by abstracting all the special module names in varous helper functions. Adds support for desktop CLR as a part of this.

Add defines and functions for the runtime, dac and dbi modules/dlls names.

Add minidump retry for ERROR_PARTIAL_COPY