### PR TITLE
SpeedScope handles only CPU samples, events are not supported

### DIFF
--- a/src/Tools/dotnet-trace/TraceFileFormatConverter.cs
+++ b/src/Tools/dotnet-trace/TraceFileFormatConverter.cs
@@ -72,7 +72,10 @@ namespace Microsoft.Diagnostics.Tools.Trace
                     OnlyManagedCodeStacks = true // EventPipe currently only has managed code stacks.
                 };
 
-                var computer = new SampleProfilerThreadTimeComputer(eventLog, symbolReader);
+                var computer = new SampleProfilerThreadTimeComputer(eventLog, symbolReader)
+                {
+                    IncludeEventSourceEvents = false // SpeedScope handles only CPU samples, events are not supported
+                };
                 computer.GenerateThreadTimeStacks(stackSource);
 
                 SpeedScopeStackSourceWriter.WriteStackViewAsJson(stackSource, outputFilename);


### PR DESCRIPTION
SpeedScope handles only CPU samples, events are not supported. Using a PerfView analogy, it has `CPU Stacks` view, but no `Events` view.

So when we are creating `SampleProfilerThreadTimeComputer` we need to filter out the events, otherwise every event is treated as CPU sample in https://github.com/microsoft/perfview/blob/8897bb64c2a252fff7282e89a4cfafabeb1e4ffc/src/TraceEvent/Stacks/SpeedScopeStackSourceWriter.cs#L58 and hence we get events in the output speedscope file.

Fixes #623