### PR TITLE
[WIP] Live viewer for events from event pipe

### DIFF
--- a/src/Tools/dotnet-trace/CommandLine/Commands/CommandHelpers.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CommandHelpers.cs
@@ -1,0 +1,218 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Tools.RuntimeClient;
+using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.Rendering;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.Tools.Trace
+{
+    internal static class CommandHelpers
+    {
+        public static async Task<int> Trace(
+            CancellationToken ct, 
+            IConsole console, 
+            int processId, 
+            uint buffersize, 
+            string providers, 
+            string profile, 
+            TimeSpan duration,
+            Action onBeforeStart,
+            Action<TraceCommandInfo> onStart,
+            Action onSuccess)
+        {
+            try
+            {
+                onBeforeStart();
+                Debug.Assert(profile != null);
+
+                bool hasConsole = console.GetTerminal() != null;
+
+                if (hasConsole)
+                    Console.Clear();
+
+                if (processId < 0)
+                {
+                    Console.Error.WriteLine("Process ID should not be negative.");
+                    return ErrorCodes.ArgumentError;
+                }
+                else if (processId == 0)
+                {
+                    Console.Error.WriteLine("--process-id is required");
+                    return ErrorCodes.ArgumentError;
+                }
+
+                if (profile.Length == 0 && providers.Length == 0)
+                {
+                    Console.Out.WriteLine("No profile or providers specified, defaulting to trace profile 'cpu-sampling'");
+                    profile = "cpu-sampling";
+                }
+
+                Dictionary<string, string> enabledBy = new Dictionary<string, string>();
+
+                var providerCollection = Extensions.ToProviders(providers);
+                foreach (Provider providerCollectionProvider in providerCollection)
+                {
+                    enabledBy[providerCollectionProvider.Name] = "--providers ";
+                }
+
+                if (profile.Length != 0)
+                {
+                    var selectedProfile = ListProfilesCommandHandler.DotNETRuntimeProfiles
+                        .FirstOrDefault(p => p.Name.Equals(profile, StringComparison.OrdinalIgnoreCase));
+                    if (selectedProfile == null)
+                    {
+                        Console.Error.WriteLine($"Invalid profile name: {profile}");
+                        return ErrorCodes.ArgumentError;
+                    }
+
+                    Profile.MergeProfileAndProviders(selectedProfile, providerCollection, enabledBy);
+                }
+
+                if (providerCollection.Count <= 0)
+                {
+                    Console.Error.WriteLine("No providers were specified to start a trace.");
+                    return ErrorCodes.ArgumentError;
+                }
+
+                PrintProviders(providerCollection, enabledBy);
+
+                var process = Process.GetProcessById(processId);
+                var configuration = new SessionConfiguration(
+                    circularBufferSizeMB: buffersize,
+                    format: EventPipeSerializationFormat.NetTrace,
+                    providers: providerCollection);
+
+                var shouldExit = new ManualResetEvent(false);
+                var shouldStopAfterDuration = duration != default(TimeSpan);
+                var failed = false;
+                var terminated = false;
+                System.Timers.Timer durationTimer = null;
+
+                ct.Register(() => shouldExit.Set());
+
+                ulong sessionId = 0;
+                using (Stream stream = EventPipeClient.CollectTracing(processId, configuration, out sessionId))
+                using (VirtualTerminalMode vTermMode = VirtualTerminalMode.TryEnable())
+                {
+                    if (sessionId == 0)
+                    {
+                        Console.Error.WriteLine("Unable to create session.");
+                        return ErrorCodes.SessionCreationError;
+                    }
+
+                    if (shouldStopAfterDuration)
+                    {
+                        durationTimer = new System.Timers.Timer(duration.TotalMilliseconds);
+                        durationTimer.Elapsed += (s, e) => shouldExit.Set();
+                        durationTimer.AutoReset = false;
+                    }
+
+                    var collectingTask = new Task(() =>
+                    {
+                        try
+                        {
+                            var stopwatch = new Stopwatch();
+                            durationTimer?.Start();
+                            stopwatch.Start();
+
+                            onStart(
+                                new TraceCommandInfo(
+                                    stream, 
+                                    process.MainModule.FileName, 
+                                    shouldStopAfterDuration, 
+                                    hasConsole, 
+                                    vTermMode.IsEnabled,
+                                    stopwatch.Elapsed));
+                        }
+                        catch (Exception ex)
+                        {
+                            failed = true;
+                            Console.Error.WriteLine($"[ERROR] {ex.ToString()}");
+                        }
+                        finally
+                        {
+                            terminated = true;
+                            shouldExit.Set();
+                        }
+                    });
+                    collectingTask.Start();
+
+                    do
+                    {
+                        while (!Console.KeyAvailable && !shouldExit.WaitOne(250)) { }
+                    } while (!shouldExit.WaitOne(0) && Console.ReadKey(true).Key != ConsoleKey.Enter);
+
+                    if (!terminated)
+                    {
+                        durationTimer?.Stop();
+                        EventPipeClient.StopTracing(processId, sessionId);
+                    }
+                    await collectingTask;
+                }
+
+                onSuccess();
+
+                return failed ? ErrorCodes.TracingError : 0;
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"[ERROR] {ex.ToString()}");
+                return ErrorCodes.UnknownError;
+            }
+        }
+
+        private static void PrintProviders(IReadOnlyList<Provider> providers, IReadOnlyDictionary<string, string> enabledBy)
+        {
+            Console.Out.WriteLine("");
+            Console.Out.Write(String.Format("{0, -40}", "Provider Name"));  // +4 is for the tab
+            Console.Out.Write(String.Format("{0, -20}", "Keywords"));
+            Console.Out.Write(String.Format("{0, -20}", "Level"));
+            Console.Out.Write("Enabled By\n");
+            foreach (var provider in providers)
+            {
+                Console.Out.WriteLine(String.Format("{0, -80}", $"{provider.ToDisplayString()}") + $"{enabledBy[provider.Name]}");
+            }
+            Console.Out.WriteLine();
+        }
+    }
+
+    internal sealed class TraceCommandInfo
+    {
+        public TraceCommandInfo(
+            Stream eventPipeStream, 
+            string processFileName, 
+            bool shouldStopAfterDuration, 
+            bool hasConsole, 
+            bool isVTermEnabled,
+            TimeSpan elapsed)
+        {
+            EventPipeStream = eventPipeStream;
+            ProcessFileName = processFileName;
+            ShouldStopAfterDuration = shouldStopAfterDuration;
+            HasConsole = hasConsole;
+            IsVirtualTerminalModeEnabled = isVTermEnabled;
+            Elapsed = elapsed;
+        }
+
+        public Stream EventPipeStream { get; }
+
+        public string ProcessFileName { get; }
+
+        public bool ShouldStopAfterDuration { get; }
+
+        public bool HasConsole { get; }
+
+        public bool IsVirtualTerminalModeEnabled { get; }
+
+        public TimeSpan Elapsed { get; }
+    }
+}

--- a/src/Tools/dotnet-trace/CommandLine/Commands/MonitorCommandHandler.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/MonitorCommandHandler.cs
@@ -12,12 +12,12 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Diagnostics.Tools.Trace
 {
-    internal static class PrintLiveCommandHandler
+    internal static class MonitorCommandHandler
     {
-        delegate Task<int> PrintLiveDelegate(CancellationToken ct, IConsole console, int processId, uint buffersize, string providers, string profile, TimeSpan duration);
+        delegate Task<int> MonitorDelegate(CancellationToken ct, IConsole console, int processId, uint buffersize, string providers, string profile, TimeSpan duration);
 
         /// <summary>
-        /// Collects a diagnostic trace from a currently running process.
+        /// Prints a diagnostic trace from a currently running process in real-time.
         /// </summary>
         /// <param name="ct">The cancellation token</param>
         /// <param name="console"></param>
@@ -26,7 +26,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
         /// <param name="providers">A list of EventPipe providers to be enabled. This is in the form 'Provider[,Provider]', where Provider is in the form: 'KnownProviderName[:Flags[:Level][:KeyValueArgs]]', and KeyValueArgs is in the form: '[key1=value1][;key2=value2]'</param>
         /// <param name="profile">A named pre-defined set of provider configurations that allows common tracing scenarios to be specified succinctly.</param>
         /// <returns></returns>
-        private static Task<int> PrintLive(CancellationToken ct, IConsole console, int processId, uint buffersize, string providers, string profile, TimeSpan duration)
+        private static Task<int> Monitor(CancellationToken ct, IConsole console, int processId, uint buffersize, string providers, string profile, TimeSpan duration)
         {
             Action<TraceEvent> eventCallback =
                 (traceEvent) =>
@@ -56,9 +56,9 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 onSuccess: () => { });
         }
 
-        public static Command PrintLiveCommand() =>
+        public static Command MonitorCommand() =>
             new Command(
-                name: "print-live",
+                name: "monitor",
                 description: "Prints a diagnostic trace from a currently running process in real-time",
                 symbols: new Option[] {
                     CommonOptions.ProcessIdOption(),
@@ -67,6 +67,6 @@ namespace Microsoft.Diagnostics.Tools.Trace
                     CommonOptions.ProfileOption(),
                     CommonOptions.DurationOption()
                 },
-                handler: HandlerDescriptor.FromDelegate((PrintLiveDelegate)PrintLive).GetCommandHandler());
+                handler: HandlerDescriptor.FromDelegate((MonitorDelegate)Monitor).GetCommandHandler());
     }
 }

--- a/src/Tools/dotnet-trace/CommandLine/Commands/PrintLiveCommandHandler.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/PrintLiveCommandHandler.cs
@@ -1,0 +1,105 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tracing.Parsers;
+using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.Binding;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.Tools.Trace
+{
+    internal static class PrintLiveCommandHandler
+    {
+        delegate Task<int> PrintLiveDelegate(CancellationToken ct, IConsole console, int processId, uint buffersize, string providers, string profile, TimeSpan duration, string @event);
+
+        /// <summary>
+        /// Collects a diagnostic trace from a currently running process.
+        /// </summary>
+        /// <param name="ct">The cancellation token</param>
+        /// <param name="console"></param>
+        /// <param name="processId">The process to collect the trace from.</param>
+        /// <param name="buffersize">Sets the size of the in-memory circular buffer in megabytes.</param>
+        /// <param name="providers">A list of EventPipe providers to be enabled. This is in the form 'Provider[,Provider]', where Provider is in the form: 'KnownProviderName[:Flags[:Level][:KeyValueArgs]]', and KeyValueArgs is in the form: '[key1=value1][;key2=value2]'</param>
+        /// <param name="profile">A named pre-defined set of provider configurations that allows common tracing scenarios to be specified succinctly.</param>
+        /// <returns></returns>
+        private static Task<int> PrintLive(CancellationToken ct, IConsole console, int processId, uint buffersize, string providers, string profile, TimeSpan duration, string @event)
+        {
+            var eventNames = new HashSet<string>();
+            if (!String.IsNullOrWhiteSpace(@event))
+            {
+                foreach (var eventName in @event.Split(','))
+                {
+                    eventNames.Add(eventName);
+                }
+            }
+
+            Action<TraceEvent> eventCallback =
+                (traceEvent) =>
+                {
+                    if (FilterEvent(traceEvent, eventNames))
+                    {
+                        Console.Out.WriteLine(traceEvent);
+                    }
+                };
+
+            return CommandHelpers.Trace(ct, console, processId, buffersize, providers, profile, duration,
+                onBeforeStart: () => { },
+                onStart: (info) =>
+                {
+                    using (var pipeEventSource = new EventPipeEventSource(info.EventPipeStream))
+                    {
+                        var eventParser = new ClrTraceEventParser(pipeEventSource);
+                        eventParser.All += eventCallback;
+
+                        try
+                        {
+                            pipeEventSource.Process();
+                        }
+                        finally
+                        {
+                            eventParser.All -= eventCallback;
+                        }
+                    }
+                },
+                onSuccess: () => { });
+        }
+
+        public static Command PrintLiveCommand() =>
+            new Command(
+                name: "print-live",
+                description: "Prints a diagnostic trace from a currently running process in real-time",
+                symbols: new Option[] {
+                    CommonOptions.ProcessIdOption(),
+                    CommonOptions.CircularBufferOption(),
+                    CommonOptions.ProvidersOption(),
+                    CommonOptions.ProfileOption(),
+                    CommonOptions.DurationOption(),
+                    EventOption()
+                },
+                handler: HandlerDescriptor.FromDelegate((PrintLiveDelegate)PrintLive).GetCommandHandler());
+
+        private static bool FilterEvent(TraceEvent traceEvent, HashSet<string> eventNames)
+        {
+            if (eventNames.Count > 0)
+            {
+                return eventNames.Contains(traceEvent.EventName);
+            }
+            else
+            {
+                return true;
+            }
+        }
+
+        private static Option EventOption() =>
+            new Option(
+                alias: "--event",
+                description: "Filter only these events. For example: FileIO/Create,Process/Start",
+                argument: new Argument<string>(defaultValue: "") { Name = "event-filter" },
+                isHidden: true);
+    }
+}

--- a/src/Tools/dotnet-trace/CommandLine/Options/CommonOptions.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Options/CommonOptions.cs
@@ -2,9 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.CommandLine;
-using System.IO;
-using System.Runtime.InteropServices;
 
 namespace Microsoft.Diagnostics.Tools.Trace
 {
@@ -32,5 +31,35 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 description: $"Sets the output format for the trace file conversion.",
                 argument: new Argument<TraceFileFormat> { Name = "trace-file-format" },
                 isHidden: false);
+
+        private static uint DefaultCircularBufferSizeInMB => 256;
+
+        public static Option CircularBufferOption() =>
+            new Option(
+                alias: "--buffersize",
+                description: $"Sets the size of the in-memory circular buffer in megabytes. Default {DefaultCircularBufferSizeInMB} MB.",
+                argument: new Argument<uint>(defaultValue: DefaultCircularBufferSizeInMB) { Name = "size" },
+                isHidden: false);
+
+        public static Option ProvidersOption() =>
+            new Option(
+                alias: "--providers",
+                description: @"A list of EventPipe providers to be enabled. This is in the form 'Provider[,Provider]', where Provider is in the form: 'KnownProviderName[:Flags[:Level][:KeyValueArgs]]', and KeyValueArgs is in the form: '[key1=value1][;key2=value2]'. These providers are in addition to any providers implied by the --profile argument. If there is any discrepancy for a particular provider, the configuration here takes precedence over the implicit configuration from the profile.",
+                argument: new Argument<string>(defaultValue: "") { Name = "list-of-comma-separated-providers" }, // TODO: Can we specify an actual type?
+                isHidden: false);
+
+        public static Option ProfileOption() =>
+            new Option(
+                alias: "--profile",
+                description: @"A named pre-defined set of provider configurations that allows common tracing scenarios to be specified succinctly.",
+                argument: new Argument<string>(defaultValue: "") { Name = "profile-name" },
+                isHidden: false);
+
+        public static Option DurationOption() =>
+            new Option(
+                alias: "--duration",
+                description: @"When specified, will trace for the given timespan and then automatically stop the trace. Provided in the form of dd:hh:mm:ss.",
+                argument: new Argument<TimeSpan>(defaultValue: default(TimeSpan)) { Name = "duration-timespan" },
+                isHidden: true);
     }
 }

--- a/src/Tools/dotnet-trace/Program.cs
+++ b/src/Tools/dotnet-trace/Program.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 .AddCommand(StopCommandHandler.StopCommand())
 #endif
                 .AddCommand(CollectCommandHandler.CollectCommand())
-                .AddCommand(PrintLiveCommandHandler.PrintLiveCommand())
+                .AddCommand(MonitorCommandHandler.MonitorCommand())
                 .AddCommand(ListProcessesCommandHandler.ListProcessesCommand())
                 .AddCommand(ListProfilesCommandHandler.ListProfilesCommand())
                 .AddCommand(ConvertCommandHandler.ConvertCommand())

--- a/src/Tools/dotnet-trace/Program.cs
+++ b/src/Tools/dotnet-trace/Program.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 .AddCommand(StopCommandHandler.StopCommand())
 #endif
                 .AddCommand(CollectCommandHandler.CollectCommand())
+                .AddCommand(PrintLiveCommandHandler.PrintLiveCommand())
                 .AddCommand(ListProcessesCommandHandler.ListProcessesCommand())
                 .AddCommand(ListProfilesCommandHandler.ListProfilesCommand())
                 .AddCommand(ConvertCommandHandler.ConvertCommand())


### PR DESCRIPTION
Implementing this feature: https://github.com/dotnet/diagnostics/issues/564

Currently a prototype and very much subject to change, but this an initial stab at the feature. At the time of writing, it adds a new command called `print-live` to `dotnet-trace`. Both `print-live` and `collect` share a lot of similarities so I tried to consolidate some of the implementation. I wanted a separate command from `collect` because `collect` directly pulls bytes off of the event pipe stream then puts it on disk; also, it can do format conversions. `print-live` uses an event source parser to deserialize the events and prints the information in real-time.