### PR TITLE
Handle glibc sys/sysctl.h deprecation (#27048)

### DIFF
--- a/src/pal/src/misc/sysinfo.cpp
+++ b/src/pal/src/misc/sysinfo.cpp
@@ -26,9 +26,12 @@ Revision History:
 #include <errno.h>
 #include <unistd.h>
 #include <sys/types.h>
-#if HAVE_SYSCTL
+
+#if HAVE_SYSCONF
+// <unistd.h> already included above
+#elif HAVE_SYSCTL
 #include <sys/sysctl.h>
-#elif !HAVE_SYSCONF
+#else
 #error Either sysctl or sysconf is required for GetSystemInfo.
 #endif
 


### PR DESCRIPTION
glibc has deprecated sys/sysctl.h:

    In file included from /coreclr/src/pal/src/misc/sysinfo.cpp:32:
    /usr/include/sys/sysctl.h:21:2: error: "The <sys/sysctl.h> header is deprecated and will be removed." [-Werror,-W#warnings]
    #warning "The <sys/sysctl.h> header is deprecated and will be removed."
     ^
    1 error generated.

Fix that by preferring sysconf and only including sys/sysctl.h if
HAVE_SYSCONF is not true. This mirrors the order of the implementation
code in this file (sysinfo.cpp) which checks for HAVE_SYSCONF
before HAVE_SYSCTL.

Fixes #27008