### PR TITLE
Fix GCEvent test being flakey

### DIFF
--- a/src/tests/eventpipe/GCEvents.cs
+++ b/src/tests/eventpipe/GCEvents.cs
@@ -229,7 +229,7 @@ namespace EventPipe.UnitTests.GCEventsValidation
                         bool GCAllocationTickResult = GCAllocationTickEvents > 0;
                         Logger.logger.Log("GCAllocationTickResult: " + GCAllocationTickResult); 
 
-                        bool GCCollectResults = GCSegmentResult && GCAllocationTickResult && GCConcurrentResult;
+                        bool GCCollectResults = GCSegmentResult && GCAllocationTickResult;
                         Logger.logger.Log("GCCollectResults: " + GCCollectResults);
 
                         return GCCollectResults ? 100 : -1;

--- a/src/tests/eventpipe/GCEvents.cs
+++ b/src/tests/eventpipe/GCEvents.cs
@@ -229,12 +229,6 @@ namespace EventPipe.UnitTests.GCEventsValidation
                         bool GCAllocationTickResult = GCAllocationTickEvents > 0;
                         Logger.logger.Log("GCAllocationTickResult: " + GCAllocationTickResult); 
 
-                        Logger.logger.Log("GCCreateConcurrentThreadEvents: " + GCCreateConcurrentThreadEvents);
-                        //GCTerminateConcurrentThreadEvents not stable, ignore the verification
-                        Logger.logger.Log("GCTerminateConcurrentThreadEvents: " + GCTerminateConcurrentThreadEvents);
-                        bool GCConcurrentResult = GCCreateConcurrentThreadEvents > 0 && GCTerminateConcurrentThreadEvents >= 0;
-                        Logger.logger.Log("GCConcurrentResult: " + GCConcurrentResult);
-
                         bool GCCollectResults = GCSegmentResult && GCAllocationTickResult && GCConcurrentResult;
                         Logger.logger.Log("GCCollectResults: " + GCCollectResults);
 


### PR DESCRIPTION
`GCCreateConcurrentThread` events may be fired before we see the first event from the runtime, so checking this always being > 0 causes this test to randomly fail. 
