### PR TITLE
[Proposal] add .NET Standard 2.0 for diagnostics client library

### DIFF
--- a/src/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj
+++ b/src/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netcoreapp2.1</TargetFrameworks>
     <RootNamespace>Microsoft.Diagnostics.NETCore.Client</RootNamespace>
     <Description>.NET Core Diagnostics Client Library</Description>
     <VersionPrefix>0.1.0</VersionPrefix>


### PR DESCRIPTION
As you know we want to add a new profiling plugin to BenchmarkDotNet based on EventPipe and SpeedScope (https://github.com/dotnet/BenchmarkDotNet/pull/1321)

Every BenchmarkDotNet library targets .NET Standard 2.0. Currently `Microsoft.Diagnostics.NETCore.Client` targets .NET Core 2.1 only. If we want to consume it, we either need to add .NET Core 2.1 to all our libraries or introduce a new library with the new plugin only (I would prefer to avoid that).

It would make our life easier if `Microsoft.Diagnostics.NETCore.Client` could target .NET Standard 2.0 as well.

This PR adds the .NET Standard 2.0 support. I've tested it on Ubuntu and it works fine.