### PR TITLE
Initial commit for Grape - a testing framework for trace generation on .NET 

### DIFF
--- a/src/tests/Grape/Grape.csproj
+++ b/src/tests/Grape/Grape.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Tracee/Tracee.csproj" PrivateAssets="all" />
+    <ProjectReference Include="../../Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.47" />
+  </ItemGroup>
+
+</Project>

--- a/src/tests/Grape/Program.cs
+++ b/src/tests/Grape/Program.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using Microsoft.Diagnostics.NETCore.Client;
+
+namespace Microsoft.Diagnostics.Grape
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            if (args.Length < 1)
+            {
+                return;
+            }
+
+            var pathToExe = args[0];
+            var pathToConfig = args[1];
+            TraceGeneratorConfiguration traceConfig;
+
+            try
+            {
+                traceConfig = JsonSerializer.Deserialize<TraceGeneratorConfiguration>(File.ReadAllText(pathToConfig));
+                var providers = new List<EventPipeProvider>();
+
+                foreach (var configProvider in traceConfig.eventProviders)
+                {
+                    providers.Add(ToEventPipeProvider(configProvider));
+                }
+                var eventpipeTracer = new EventPipeTraceGenerator(pathToExe, $"{traceConfig.traceName}.nettrace", providers);
+                Console.WriteLine("Collecting EventPipe trace");
+                eventpipeTracer.Collect(traceConfig.duration);
+
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    var etwTracer = new EtwTraceGenerator(pathToExe, $"{traceConfig.traceName}.etl", providers);
+                    Console.WriteLine("Collecting ETW trace");
+                    etwTracer.Collect(traceConfig.duration);
+                }
+
+                // TODO: Add Linux/LTTng trace generation here once I figure out how to make perfcollect more friendly...
+                Console.WriteLine("Done!");         
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine($"Failed to parse the trace configuration file {pathToConfig}");
+                Console.WriteLine(e.ToString());
+            }
+        }
+
+        private static EventPipeProvider ToEventPipeProvider(EventProvider configProvider)
+        {
+            return new EventPipeProvider(
+                configProvider.Name,
+                (EventLevel)configProvider.Level,
+                configProvider.Keywords.Length > 2 && configProvider.Keywords.StartsWith("0x") ? Convert.ToInt64(configProvider.Keywords.Substring(2), 16) : Convert.ToInt64(configProvider.Keywords, 10),
+                ParseArgumentString(configProvider.Arguments)
+            );
+        }
+
+
+        private static Dictionary<string, string> ParseArgumentString(string argument)
+        {
+            if (argument == "")
+            {
+                return null;
+            }
+            var argumentDict = new Dictionary<string, string>();
+
+            int keyStart = 0;
+            int keyEnd = 0;
+            int valStart = 0;
+            int valEnd = 0;
+            int curIdx = 0;
+            bool inQuote = false;
+            foreach (var c in argument)
+            {
+                if (inQuote)
+                {
+                    if (c == '\"')
+                    {
+                        inQuote = false;
+                    }
+                }
+                else
+                {
+                    if (c == '=')
+                    {
+                        keyEnd = curIdx;
+                        valStart = curIdx + 1;
+                    }
+                    else if (c == ';')
+                    {
+                        valEnd = curIdx;
+                        argumentDict.Add(argument.Substring(keyStart, keyEnd - keyStart), argument.Substring(valStart, valEnd - valStart));
+                        keyStart = curIdx + 1; // new key starts
+                    }
+                    else if (c == '\"')
+                    {
+                        inQuote = true;
+                    }
+                }
+                curIdx += 1;
+            }
+            string key = argument.Substring(keyStart, keyEnd - keyStart);
+            string val = argument.Substring(valStart);
+            argumentDict.Add(key, val);
+            return argumentDict;
+        }
+    }
+}

--- a/src/tests/Grape/TestRunner.cs
+++ b/src/tests/Grape/TestRunner.cs
@@ -1,0 +1,65 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+
+
+using Microsoft.Diagnostics.NETCore.Client;
+
+namespace Microsoft.Diagnostics.Grape
+{
+    public class TestRunner
+    {
+        private Process testProcess;
+        private ProcessStartInfo startInfo;
+
+        public TestRunner(string testExePath, string argument=null)
+        {
+            startInfo = new ProcessStartInfo(testExePath, argument);
+            startInfo.UseShellExecute = false;
+            startInfo.RedirectStandardOutput = true;
+        }
+
+        public void AddEnvVar(string key, string value)
+        {
+            startInfo.EnvironmentVariables[key] = value;
+        }
+
+        public void Start(int timeoutInMS=0)
+        {
+            Debug.WriteLine("$[{DateTime.Now.ToString()}] Launching test: " + startInfo.FileName);
+            testProcess = Process.Start(startInfo);
+
+            if (testProcess == null)
+            {
+                Debug.WriteLine($"Could not start process: " + startInfo.FileName);
+            }
+
+            if (testProcess.HasExited)
+            {
+                Debug.WriteLine($"Process " + startInfo.FileName + " came back as exited");
+            }
+
+            Debug.WriteLine($"[{DateTime.Now.ToString()}] Successfuly started process {testProcess.Id}");
+            Debug.WriteLine($"Have total {testProcess.Modules.Count} modules loaded");
+
+            Debug.WriteLine($"[{DateTime.Now.ToString()}] Sleeping for {timeoutInMS} ms.");
+            Thread.Sleep(timeoutInMS);
+            Debug.WriteLine($"[{DateTime.Now.ToString()}] Done sleeping. Ready to test.");
+        }
+
+        public void Stop()
+        {
+            testProcess.Kill();
+        }
+
+        public int Pid {
+            get { return testProcess.Id; }
+        }
+
+    }
+}

--- a/src/tests/Grape/TraceGeneratorConfiguration.cs
+++ b/src/tests/Grape/TraceGeneratorConfiguration.cs
@@ -1,0 +1,21 @@
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Diagnostics.Grape
+{
+	public class TraceGeneratorConfiguration
+	{
+    	public int duration { get; set; }
+    	public IList<EventProvider> eventProviders { get; set; }
+    	public string traceName { get; set; }
+	}
+
+	public class EventProvider
+	{
+	    public string Name { get; set; }
+	    public int Level { get; set; }
+	    public string Keywords { get; set; } // Essentially this should be a string representation of a hex number
+	    public string Arguments { get; set; }
+	}
+}

--- a/src/tests/Grape/TraceGenerators/EtwTraceGenerator.cs
+++ b/src/tests/Grape/TraceGenerators/EtwTraceGenerator.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Diagnostics.Tracing;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.IO;
+using Microsoft.Diagnostics.NETCore.Client;
+using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tracing.Parsers;
+using Microsoft.Diagnostics.Tracing.Parsers.Kernel;
+using Microsoft.Diagnostics.Tracing.Session;
+
+
+
+namespace Microsoft.Diagnostics.Grape
+{
+	public class EtwTraceGenerator
+	{
+		TestRunner _runner;
+		string _pathToExe;
+		string _traceName;
+		List<EventPipeProvider> _providers;
+
+		public EtwTraceGenerator(string pathToExe, string traceName, List<EventPipeProvider> providers)
+		{
+			_pathToExe = pathToExe;
+			_traceName = traceName;
+            _providers = providers;
+		}
+
+	    public void Collect(int duration)
+	    {
+	    	var pid = LaunchProcess(_pathToExe);
+	    	TraceProcessForDuration(duration, _traceName);
+	    }
+
+		private int LaunchProcess(string pathToExe)
+	    {
+	        _runner = new TestRunner(pathToExe);
+	         // Technically this doesn't have to sleep but I'm keeping it here to keep it consistent with EventPipe until we have EventPipe startup tracing.
+	        _runner.Start(2000);
+	    	return _runner.Pid;
+	    }
+
+	    public void TraceProcessForDuration(int duration, string traceName)
+		{
+            var tracesession = new TraceEventSession("testname", _traceName);
+
+            foreach (var provider in _providers)
+            {
+                tracesession.EnableProvider(provider.Name, (TraceEventLevel)provider.EventLevel, (ulong)provider.Keywords);
+            }
+            
+            tracesession.EnableProvider("My-Test-EventSource");
+
+            System.Threading.Thread.Sleep(duration * 1000);
+            tracesession.Flush();
+
+            tracesession.DisableProvider("My-Test-EventSource");
+            tracesession.Dispose();
+		}
+	}
+}

--- a/src/tests/Grape/TraceGenerators/EventPipeTraceGenerator.cs
+++ b/src/tests/Grape/TraceGenerators/EventPipeTraceGenerator.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Diagnostics.Tracing;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.IO;
+using Microsoft.Diagnostics.NETCore.Client;
+using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tracing.Parsers;
+using Microsoft.Diagnostics.Tracing.Parsers.Kernel;
+
+
+
+namespace Microsoft.Diagnostics.Grape
+{
+	public class EventPipeTraceGenerator
+	{
+		TestRunner _runner;
+		string _pathToExe;
+		string _traceName;
+		List<EventPipeProvider> _providers;
+
+		public EventPipeTraceGenerator(string pathToExe, string traceName, List<EventPipeProvider> providers)
+		{
+			_pathToExe = pathToExe;
+			_traceName = traceName;
+			_providers = providers;
+		}
+
+	    public void Collect(int duration)
+	    {
+	    	var pid = LaunchProcess(_pathToExe);
+	    	TraceProcessForDuration(pid, duration, _traceName);
+	    }
+
+		private int LaunchProcess(string pathToExe)
+	    {
+	        _runner = new TestRunner(pathToExe);
+	        // Sleep for some time until diagnostics server pipe gets created
+	        _runner.Start(2000); 
+	    	return _runner.Pid;
+	    }
+
+	    public void TraceProcessForDuration(int processId, int duration, string traceName)
+		{
+		    var client = new DiagnosticsClient(processId);
+		    using (var traceSession = client.StartEventPipeSession(_providers))
+		    {
+		        Task copyTask = Task.Run(async () =>
+		        {
+		            using (FileStream fs = new FileStream(traceName, FileMode.Create, FileAccess.Write))
+		            {
+		                await traceSession.EventStream.CopyToAsync(fs);
+		            }
+		        });
+		        copyTask.Wait(duration * 1000);
+		        traceSession.Stop();
+		    }
+		}
+	}
+}

--- a/src/tests/Grape/config.json
+++ b/src/tests/Grape/config.json
@@ -1,0 +1,19 @@
+{
+    "traceName": "test",
+    "duration": 60,
+    "eventProviders":
+    [
+        {
+            "Name" : "Microsoft-Windows-DotNETRuntime",
+            "Level": 4,
+            "Keywords": "0xffffffffffffffff",
+            "Arguments": ""
+        },
+        {
+            "Name" : "System.Runtime",
+            "Level": 4,
+            "Keywords": "0xffffffffffffffff",
+            "Arguments": "EventCounterIntervalSec=1"
+        }
+    ]
+}


### PR DESCRIPTION
This is the first of many steps involved to achieve #571. To prevent myself from checking in a PR that's too large to review I'm breaking it down to small pieces.

This PR adds a way to generate EventPipe and ETW traces. I ripped out LTTng trace generation for now because I ran into some issues regarding piping out perfcollect and haven't figured out how to consume perfcollect (download it manually per each run from aka.ms/perfcollect or check in the script to this repo, etc.).

Following this PR will be:
- LTTng trace generation
- Trace validation (Consuming & Validating the events from the generated trace)
- Trace comparison (Comparing two different traces generated from private builds of runtime)
- Integration with the diagnostics CI for automation
- Docs on how to use this
