### PR TITLE
Fix EventPipe tests to use the new DiagnosticsClient library

### DIFF
--- a/eng/build.yml
+++ b/eng/build.yml
@@ -84,6 +84,7 @@ jobs:
     - _PhaseName : ${{ parameters.name }}
     - _HelixType: build/product
     - _HelixBuildConfig: $(_BuildConfig)
+    - _Pipeline_StreamDumpDir: $(Build.SourcesDirectory)/artifacts/tmp/$(_BuildConfig)/streams
 
     # Only enable publishing in non-public, non PR scenarios.
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
@@ -171,7 +172,7 @@ jobs:
     - task: PublishBuildArtifacts@1
       displayName: Publish Stream Artifacts on failure
       inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)/artifacts/tmp/$(_BuildConfig)/streams'
+        PathtoPublish: $(_Pipeline_StreamDumpDir)
         PublishLocation: Container
         ArtifactName: Streams_$(_PhaseName)_$(_BuildArch)_$(_BuildConfig)
       continueOnError: true

--- a/src/tests/eventpipe/ContentionEvents.cs
+++ b/src/tests/eventpipe/ContentionEvents.cs
@@ -6,10 +6,10 @@ using System;
 using Xunit;
 using Xunit.Abstractions;
 using System.Threading;
-using Microsoft.Diagnostics.Tools.RuntimeClient;
 using System.Collections.Generic;
 using System.Diagnostics.Tracing;
 using EventPipe.UnitTests.Common;
+using Microsoft.Diagnostics.NETCore.Client;
 using Microsoft.Diagnostics.Tracing;
 
 namespace EventPipe.UnitTests.ContentionValidation
@@ -26,11 +26,11 @@ namespace EventPipe.UnitTests.ContentionValidation
             }
         } 
     }
-    public class ProviderTests
+    public class ContentionEventsTests
     {
         private readonly ITestOutputHelper output;
 
-        public ProviderTests(ITestOutputHelper outputHelper)
+        public ContentionEventsTests(ITestOutputHelper outputHelper)
         {
             output = outputHelper;
         }
@@ -45,10 +45,10 @@ namespace EventPipe.UnitTests.ContentionValidation
                     { "Microsoft-Windows-DotNETRuntimeRundown", -1 }
                 };
 
-                var providers = new List<Provider>()
+                var providers = new List<EventPipeProvider>()
                 {
                     //ContentionKeyword (0x4000): 0b100_0000_0000_0000                
-                    new Provider("Microsoft-Windows-DotNETRuntime", 0b100_0000_0000_0000, EventLevel.Informational)
+                    new EventPipeProvider("Microsoft-Windows-DotNETRuntime", EventLevel.Informational, 0b100_0000_0000_0000)
                 };
 
                 Action _eventGeneratingAction = () => 
@@ -80,9 +80,7 @@ namespace EventPipe.UnitTests.ContentionValidation
                         return ContentionStartEvents > 0 && ContentionStopEvents > 0 ? 100 : -1;
                     };
                 };
-                var config = new SessionConfiguration(circularBufferSizeMB: (uint)Math.Pow(2, 10), format: EventPipeSerializationFormat.NetTrace,  providers: providers);
-
-                var ret = IpcTraceTest.RunAndValidateEventCounts(_expectedEventCounts, _eventGeneratingAction, config, _DoesTraceContainEvents);
+                var ret = IpcTraceTest.RunAndValidateEventCounts(_expectedEventCounts, _eventGeneratingAction, providers, 1024, _DoesTraceContainEvents);
                 Assert.Equal(100, ret);
             }, output);
         }

--- a/src/tests/eventpipe/EventPipe.UnitTests.csproj
+++ b/src/tests/eventpipe/EventPipe.UnitTests.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Microsoft.DotNet.RemoteExecutor" Version="$(MicrosoftDotNetRemoteExecutorVersion)" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="$(MicrosoftDiagnosticsTracingTraceEventVersion)" />
     <PackageReference Include="xunit.abstractions" Version="$(XUnitAbstractionsVersion)" />
-    <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Microsoft.Diagnostics.Tools.RuntimeClient\Microsoft.Diagnostics.Tools.RuntimeClient.csproj" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Microsoft.Diagnostics.NETCore.Client\Microsoft.Diagnostics.NETCore.Client.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/tests/eventpipe/GCEvents.cs
+++ b/src/tests/eventpipe/GCEvents.cs
@@ -5,12 +5,11 @@
 using System;
 using Xunit;
 using Xunit.Abstractions;
-using Microsoft.Diagnostics.Tools.RuntimeClient;
 using System.Collections.Generic;
 using System.Diagnostics.Tracing;
 using EventPipe.UnitTests.Common;
+using Microsoft.Diagnostics.NETCore.Client;
 using Microsoft.Diagnostics.Tracing;
-using System.Threading;
 
 namespace EventPipe.UnitTests.GCEventsValidation
 {
@@ -26,11 +25,11 @@ namespace EventPipe.UnitTests.GCEventsValidation
             b = "";
         }
     }
-    public class ProviderTests
+    public class GCEventsTests
     {
         private readonly ITestOutputHelper output;
 
-        public ProviderTests(ITestOutputHelper outputHelper)
+        public GCEventsTests(ITestOutputHelper outputHelper)
         {
             output = outputHelper;
         }
@@ -47,11 +46,11 @@ namespace EventPipe.UnitTests.GCEventsValidation
                     { "Microsoft-DotNETCore-SampleProfiler", -1 }
                 };
 
-                var providers = new List<Provider>()
+                var GCProviders = new List<EventPipeProvider>()
                 {
-                    new Provider("Microsoft-DotNETCore-SampleProfiler"),
+                    new EventPipeProvider("Microsoft-DotNETCore-SampleProfiler", EventLevel.Informational),
                     //GCKeyword (0x1): 0b1
-                    new Provider("Microsoft-Windows-DotNETRuntime", 0b1, EventLevel.Informational)
+                    new EventPipeProvider("Microsoft-Windows-DotNETRuntime", EventLevel.Verbose, 0x1)
                 };
 
                 Action _eventGeneratingAction = () => 
@@ -91,7 +90,7 @@ namespace EventPipe.UnitTests.GCEventsValidation
 
                         Logger.logger.Log("GCStartEvents: " + GCStartEvents);
                         Logger.logger.Log("GCEndEvents: " + GCEndEvents);
-                        bool GCStartStopResult = GCStartEvents >= 50 && GCEndEvents >= 50 && Math.Abs(GCStartEvents - GCEndEvents) <=2;
+                        bool GCStartStopResult = GCStartEvents >= 50 && GCEndEvents >= 50 && Math.Abs(GCStartEvents - GCEndEvents) <= 2;
                         Logger.logger.Log("GCStartStopResult check: " + GCStartStopResult);
 
                         Logger.logger.Log("GCRestartEEStartEvents: " + GCRestartEEStartEvents);
@@ -112,9 +111,7 @@ namespace EventPipe.UnitTests.GCEventsValidation
                     };
                 };
 
-                var config = new SessionConfiguration(circularBufferSizeMB: (uint)Math.Pow(2, 10), format: EventPipeSerializationFormat.NetTrace,  providers: providers);
-
-                var ret = IpcTraceTest.RunAndValidateEventCounts(_expectedEventCounts, _eventGeneratingAction, config, _DoesTraceContainEvents);
+                var ret = IpcTraceTest.RunAndValidateEventCounts(_expectedEventCounts, _eventGeneratingAction, GCProviders, 1024, _DoesTraceContainEvents);
                 Assert.Equal(100, ret);
             }, output);
         }
@@ -130,12 +127,12 @@ namespace EventPipe.UnitTests.GCEventsValidation
                     { "Microsoft-Windows-DotNETRuntimeRundown", -1 },
                     { "Microsoft-DotNETCore-SampleProfiler", -1 }
                 };
-                
-                var providers = new List<Provider>()
+
+                var GCProviders = new List<EventPipeProvider>()
                 {
-                    new Provider("Microsoft-DotNETCore-SampleProfiler"),
+                    new EventPipeProvider("Microsoft-DotNETCore-SampleProfiler", EventLevel.Informational),
                     //GCKeyword (0x1): 0b1
-                    new Provider("Microsoft-Windows-DotNETRuntime", 0b1, EventLevel.Informational)
+                    new EventPipeProvider("Microsoft-Windows-DotNETRuntime", EventLevel.Verbose, 0x1)
                 };
 
                 Action _eventGeneratingAction = () => 
@@ -164,10 +161,7 @@ namespace EventPipe.UnitTests.GCEventsValidation
                         return GCFinalizersEndEvents >= 50 && GCFinalizersStartEvents >= 50 ? 100 : -1;
                     };
                 };
-
-                var config = new SessionConfiguration(circularBufferSizeMB: (uint)Math.Pow(2, 10), format: EventPipeSerializationFormat.NetTrace,  providers: providers);
-
-                var ret = IpcTraceTest.RunAndValidateEventCounts(_expectedEventCounts, _eventGeneratingAction, config, _DoesTraceContainEvents);
+                var ret = IpcTraceTest.RunAndValidateEventCounts(_expectedEventCounts, _eventGeneratingAction, GCProviders, 1024, _DoesTraceContainEvents);
                 Assert.Equal(100, ret);
             }, output);
         }
@@ -183,12 +177,12 @@ namespace EventPipe.UnitTests.GCEventsValidation
                     { "Microsoft-Windows-DotNETRuntimeRundown", -1 },
                     { "Microsoft-DotNETCore-SampleProfiler", -1 }
                 };
-                
-                var providers = new List<Provider>()
+
+                var GCProviders = new List<EventPipeProvider>()
                 {
-                    new Provider("Microsoft-DotNETCore-SampleProfiler"),
+                    new EventPipeProvider("Microsoft-DotNETCore-SampleProfiler", EventLevel.Informational),
                     //GCKeyword (0x1): 0b1
-                    new Provider("Microsoft-Windows-DotNETRuntime", 0b1, EventLevel.Verbose)
+                    new EventPipeProvider("Microsoft-Windows-DotNETRuntime", EventLevel.Verbose, 0x1)
                 };
 
                 Action _eventGeneratingAction = () => 
@@ -236,9 +230,7 @@ namespace EventPipe.UnitTests.GCEventsValidation
                     };
                 };
 
-                var config = new SessionConfiguration(circularBufferSizeMB: (uint)Math.Pow(2, 10), format: EventPipeSerializationFormat.NetTrace,  providers: providers);
-
-                var ret = IpcTraceTest.RunAndValidateEventCounts(_expectedEventCounts, _eventGeneratingAction, config, _DoesTraceContainEvents);
+                var ret = IpcTraceTest.RunAndValidateEventCounts(_expectedEventCounts, _eventGeneratingAction, GCProviders, 1024, _DoesTraceContainEvents);
                 Assert.Equal(100, ret);
             }, output);
         }

--- a/src/tests/eventpipe/LoaderEvents.cs
+++ b/src/tests/eventpipe/LoaderEvents.cs
@@ -6,13 +6,12 @@ using System;
 using Xunit;
 using System.IO;
 using System.Runtime.Loader;
-using System.Threading;
 using System.Reflection;
 using Xunit.Abstractions;
-using Microsoft.Diagnostics.Tools.RuntimeClient;
 using System.Collections.Generic;
 using System.Diagnostics.Tracing;
 using EventPipe.UnitTests.Common;
+using Microsoft.Diagnostics.NETCore.Client;
 using Microsoft.Diagnostics.Tracing;
 
 namespace EventPipe.UnitTests.LoaderEventsValidation
@@ -23,11 +22,11 @@ namespace EventPipe.UnitTests.LoaderEventsValidation
         {
         }
     }
-    public class ProviderTests
+    public class LoaderEventsTests
     {
         private readonly ITestOutputHelper output;
 
-        public ProviderTests(ITestOutputHelper outputHelper)
+        public LoaderEventsTests(ITestOutputHelper outputHelper)
         {
             output = outputHelper;
         }
@@ -43,10 +42,10 @@ namespace EventPipe.UnitTests.LoaderEventsValidation
                     { "Microsoft-Windows-DotNETRuntimeRundown", -1 }
                 };
 
-                var providers = new List<Provider>()
+                var providers = new List<EventPipeProvider>()
                 {
                     //LoaderKeyword (0x8): 0b1000
-                    new Provider("Microsoft-Windows-DotNETRuntime", 0b1000, EventLevel.Informational)
+                    new EventPipeProvider("Microsoft-Windows-DotNETRuntime", EventLevel.Informational, 0b1000)
                 };
 
                 string assemblyPath=null;
@@ -106,10 +105,7 @@ namespace EventPipe.UnitTests.LoaderEventsValidation
                         return LoaderAssemblyResult && LoaderModuleResult ? 100 : -1;
                     };
                 };
-
-                var config = new SessionConfiguration(circularBufferSizeMB: (uint)Math.Pow(2, 10), format: EventPipeSerializationFormat.NetTrace,  providers: providers);
-
-                var ret = IpcTraceTest.RunAndValidateEventCounts(_expectedEventCounts, _eventGeneratingAction, config, _DoesTraceContainEvents);
+                var ret = IpcTraceTest.RunAndValidateEventCounts(_expectedEventCounts, _eventGeneratingAction, providers, 1024, _DoesTraceContainEvents);
                 Assert.Equal(100, ret);
             }, output);
         }

--- a/src/tests/eventpipe/MethodEvents.cs
+++ b/src/tests/eventpipe/MethodEvents.cs
@@ -93,7 +93,7 @@ namespace EventPipe.UnitTests.MethodEventsValidation
                     };
                 };
 
-                var ret = IpcTraceTest.RunAndValidateEventCounts(_expectedEventCounts, _eventGeneratingAction, providers, 1024, null);
+                var ret = IpcTraceTest.RunAndValidateEventCounts(_expectedEventCounts, _eventGeneratingAction, providers, 1024, _DoesTraceContainEvents);
                 Assert.Equal(100, ret);
             }, output);
         }

--- a/src/tests/eventpipe/MethodEvents.cs
+++ b/src/tests/eventpipe/MethodEvents.cs
@@ -6,10 +6,10 @@ using System;
 using Xunit;
 using System.ComponentModel;
 using Xunit.Abstractions;
-using Microsoft.Diagnostics.Tools.RuntimeClient;
 using System.Collections.Generic;
 using System.Diagnostics.Tracing;
 using EventPipe.UnitTests.Common;
+using Microsoft.Diagnostics.NETCore.Client;
 using Microsoft.Diagnostics.Tracing;
 
 namespace EventPipe.UnitTests.MethodEventsValidation
@@ -25,11 +25,11 @@ namespace EventPipe.UnitTests.MethodEventsValidation
             GC.SuppressFinalize(this);
         }
     }
-    public class ProviderTests
+    public class MethodEventsTests
     {
         private readonly ITestOutputHelper output;
 
-        public ProviderTests(ITestOutputHelper outputHelper)
+        public MethodEventsTests(ITestOutputHelper outputHelper)
         {
             output = outputHelper;
         }
@@ -46,11 +46,11 @@ namespace EventPipe.UnitTests.MethodEventsValidation
                     { "Microsoft-DotNETCore-SampleProfiler", -1 }
                 };
 
-                var providers = new List<Provider>()
+                var providers = new List<EventPipeProvider>()
                 {
-                    new Provider("Microsoft-DotNETCore-SampleProfiler"),
+                    new EventPipeProvider("Microsoft-DotNETCore-SampleProfiler", EventLevel.Informational),
                     //MethodVerboseKeyword (0x10): 0b10000
-                    new Provider("Microsoft-Windows-DotNETRuntime", 0b10000, EventLevel.Verbose)
+                    new EventPipeProvider("Microsoft-Windows-DotNETRuntime", EventLevel.Verbose, 0b10000)
                 };
                 
                 Action _eventGeneratingAction = () => 
@@ -93,9 +93,7 @@ namespace EventPipe.UnitTests.MethodEventsValidation
                     };
                 };
 
-                var config = new SessionConfiguration(circularBufferSizeMB: (uint)Math.Pow(2, 10), format: EventPipeSerializationFormat.NetTrace,  providers: providers);
-
-                var ret = IpcTraceTest.RunAndValidateEventCounts(_expectedEventCounts, _eventGeneratingAction, config, _DoesTraceContainEvents);
+                var ret = IpcTraceTest.RunAndValidateEventCounts(_expectedEventCounts, _eventGeneratingAction, providers, 1024, null);
                 Assert.Equal(100, ret);
             }, output);
         }

--- a/src/tests/eventpipe/ThreadPoolEvents.cs
+++ b/src/tests/eventpipe/ThreadPoolEvents.cs
@@ -8,19 +8,19 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit.Abstractions;
-using Microsoft.Diagnostics.Tools.RuntimeClient;
 using System.Collections.Generic;
 using System.Diagnostics.Tracing;
 using EventPipe.UnitTests.Common;
+using Microsoft.Diagnostics.NETCore.Client;
 using Microsoft.Diagnostics.Tracing;
 
 namespace EventPipe.UnitTests.ThreadPoolValidation
 {
-    public class ProviderTests
+    public class ThreadPoolEventsTests
     {
         private readonly ITestOutputHelper output;
 
-        public ProviderTests(ITestOutputHelper outputHelper)
+        public ThreadPoolEventsTests(ITestOutputHelper outputHelper)
         {
             output = outputHelper;
         }
@@ -36,10 +36,10 @@ namespace EventPipe.UnitTests.ThreadPoolValidation
                     { "Microsoft-Windows-DotNETRuntimeRundown", -1 }
                 };
 
-                var providers = new List<Provider>()
+                var providers = new List<EventPipeProvider>()
                 {
                     //ThreadingKeyword (0x10000): 0b10000_0000_0000_0000
-                    new Provider("Microsoft-Windows-DotNETRuntime", 0b10000_0000_0000_0000, EventLevel.Informational)
+                    new EventPipeProvider("Microsoft-Windows-DotNETRuntime", EventLevel.Informational, 0b10000_0000_0000_0000)
                 };
 
                 Action _eventGeneratingAction = () => 
@@ -84,10 +84,7 @@ namespace EventPipe.UnitTests.ThreadPoolValidation
                         return ThreadStartStopResult && ThreadAdjustmentResult ? 100 : -1;
                     };
                 };
-
-                var config = new SessionConfiguration(circularBufferSizeMB: (uint)Math.Pow(2, 10), format: EventPipeSerializationFormat.NetTrace,  providers: providers);
-
-                var ret = IpcTraceTest.RunAndValidateEventCounts(_expectedEventCounts, _eventGeneratingAction, config, _DoesTraceContainEvents);
+                var ret = IpcTraceTest.RunAndValidateEventCounts(_expectedEventCounts, _eventGeneratingAction, providers, 1024, _DoesTraceContainEvents);
                 Assert.Equal(100, ret);
             }, output);
         }

--- a/src/tests/eventpipe/common/IpcTraceTest.cs
+++ b/src/tests/eventpipe/common/IpcTraceTest.cs
@@ -10,10 +10,10 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using Microsoft.Diagnostics.Tracing;
-using Microsoft.Diagnostics.Tools.RuntimeClient;
 using System.Runtime.InteropServices;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Microsoft.Diagnostics.NETCore.Client;
 
 namespace EventPipe.UnitTests.Common
 {
@@ -91,16 +91,6 @@ namespace EventPipe.UnitTests.Common
         public void SentinelEvent() { WriteEvent(1, "SentinelEvent"); }
     }
 
-    public static class SessionConfigurationExtensions
-    {
-        public static SessionConfiguration InjectSentinel(this SessionConfiguration sessionConfiguration)
-        {
-            var newProviderList = new List<Provider>(sessionConfiguration.Providers);
-            newProviderList.Add(new Provider("SentinelEventSource"));
-            return new SessionConfiguration(sessionConfiguration.CircularBufferSizeInMB, sessionConfiguration.Format, newProviderList.AsReadOnly());
-        }
-    }
-
     public class IpcTraceTest
     {
         // This Action is executed while the trace is being collected.
@@ -112,7 +102,6 @@ namespace EventPipe.UnitTests.Common
         private Dictionary<string, ExpectedEventCount> _expectedEventCounts;
         private Dictionary<string, int> _actualEventCounts = new Dictionary<string, int>();
         private int _droppedEvents = 0;
-        private SessionConfiguration _sessionConfiguration;
 
         // A function to be called with the EventPipeEventSource _before_
         // the call to `source.Process()`.  The function should return another
@@ -120,21 +109,34 @@ namespace EventPipe.UnitTests.Common
         // Example in situ: providervalidation.cs
         private Func<EventPipeEventSource, Func<int>> _optionalTraceValidator;
 
+        /// <summary>
+        /// This is list of the EventPipe providers to turn on for the test execution
+        /// </summary>
+        private List<EventPipeProvider> _testProviders;
+
+        /// <summary>
+        /// This represents the current EventPipeSession 
+        /// </summary>
+        private EventPipeSession _eventPipeSession;
+
+        /// <summary>
+        /// This is the list of EventPipe providers for the sentinel EventSource that indicates that the process is ready
+        /// </summary>
+        private List<EventPipeProvider> _sentinelProviders = new List<EventPipeProvider>()
+        {
+            new EventPipeProvider("SentinelEventSource", EventLevel.Verbose)
+        };
+
         IpcTraceTest(
             Dictionary<string, ExpectedEventCount> expectedEventCounts,
             Action eventGeneratingAction,
-            SessionConfiguration sessionConfiguration = null,
+            List<EventPipeProvider> providers,
+            int circularBufferMB,
             Func<EventPipeEventSource, Func<int>> optionalTraceValidator = null)
         {
             _eventGeneratingAction = eventGeneratingAction;
             _expectedEventCounts = expectedEventCounts;
-            _sessionConfiguration = sessionConfiguration?.InjectSentinel() ?? new SessionConfiguration(
-                circularBufferSizeMB: 1000,
-                format: EventPipeSerializationFormat.NetTrace,
-                providers: new List<Provider> { 
-                    new Provider("Microsoft-Windows-DotNETRuntime"),
-                    new Provider("SentinelEventSource")
-                });
+            _testProviders = providers;
             _optionalTraceValidator = optionalTraceValidator;
         }
 
@@ -144,12 +146,7 @@ namespace EventPipe.UnitTests.Common
             Logger.logger.Log(message);
             Logger.logger.Log("Configuration:");
             Logger.logger.Log("{");
-            Logger.logger.Log($"\tbufferSize: {_sessionConfiguration.CircularBufferSizeInMB},");
             Logger.logger.Log("\tproviders: [");
-            foreach (var provider in _sessionConfiguration.Providers)
-            {
-                Logger.logger.Log($"\t\t{provider.ToString()},");
-            }
             Logger.logger.Log("\t]");
             Logger.logger.Log("}\n");
             Logger.logger.Log("Expected:");
@@ -192,25 +189,24 @@ namespace EventPipe.UnitTests.Common
             sentinelTask.Start();
 
             int processId = Process.GetCurrentProcess().Id;
-            object threadSync = new object(); // for locking eventpipeSessionId access
-            ulong eventpipeSessionId = 0;
+            object threadSync = new object(); // for locking eventpipeSession access
             Func<int> optionalTraceValidationCallback = null;
+            DiagnosticsClient client = new DiagnosticsClient(processId);
             var readerTask = new Task(() =>
             {
                 Logger.logger.Log("Connecting to EventPipe...");
-                using var eventPipeStream = new StreamProxy(EventPipeClient.CollectTracing(processId, _sessionConfiguration, out var sessionId));
-                if (sessionId == 0)
+                try
+                {
+                    _eventPipeSession = client.StartEventPipeSession(_testProviders.Concat(_sentinelProviders));
+                }
+                catch(DiagnosticsClientException ex)
                 {
                     Logger.logger.Log("Failed to connect to EventPipe!");
+                    Logger.logger.Log(ex.ToString());
                     throw new ApplicationException("Failed to connect to EventPipe");
                 }
-                Logger.logger.Log($"Connected to EventPipe with sessionID '0x{sessionId:x}'");
 
-                lock (threadSync)
-                {
-                    eventpipeSessionId = sessionId;
-                }
-
+                using var eventPipeStream = new StreamProxy(_eventPipeSession.EventStream);
                 Logger.logger.Log("Creating EventPipeEventSource...");
                 using EventPipeEventSource source = new EventPipeEventSource(eventPipeStream);
                 Logger.logger.Log("EventPipeEventSource created");
@@ -293,9 +289,9 @@ namespace EventPipe.UnitTests.Common
             var stopTask = Task.Run(() => 
             {
                 Logger.logger.Log("Sending StopTracing command...");
-                lock (threadSync) // eventpipeSessionId
+                lock (threadSync) // eventpipeSession
                 {
-                    EventPipeClient.StopTracing(processId, eventpipeSessionId);
+                    _eventPipeSession.Stop();
                 }
                 Logger.logger.Log("Finished StopTracing command");
             }, ct);
@@ -408,11 +404,12 @@ namespace EventPipe.UnitTests.Common
         public static int RunAndValidateEventCounts(
             Dictionary<string, ExpectedEventCount> expectedEventCounts,
             Action eventGeneratingAction,
-            SessionConfiguration sessionConfiguration = null,
+            List<EventPipeProvider> providers,
+            int circularBufferMB,
             Func<EventPipeEventSource, Func<int>> optionalTraceValidator = null)
         {
             Logger.logger.Log("==TEST STARTING==");
-            var test = new IpcTraceTest(expectedEventCounts, eventGeneratingAction, sessionConfiguration, optionalTraceValidator);
+            var test = new IpcTraceTest(expectedEventCounts, eventGeneratingAction, providers, circularBufferMB, optionalTraceValidator);
             var ret = test.Validate();
             if (ret == 100)
                 Logger.logger.Log("==TEST FINISHED: PASSED!==");

--- a/src/tests/eventpipe/common/IpcTraceTest.cs
+++ b/src/tests/eventpipe/common/IpcTraceTest.cs
@@ -124,7 +124,7 @@ namespace EventPipe.UnitTests.Common
         /// </summary>
         private List<EventPipeProvider> _sentinelProviders = new List<EventPipeProvider>()
         {
-            new EventPipeProvider("SentinelEventSource", EventLevel.Verbose)
+            new EventPipeProvider("SentinelEventSource", EventLevel.Verbose, -1)
         };
 
         IpcTraceTest(
@@ -405,7 +405,7 @@ namespace EventPipe.UnitTests.Common
             Dictionary<string, ExpectedEventCount> expectedEventCounts,
             Action eventGeneratingAction,
             List<EventPipeProvider> providers,
-            int circularBufferMB,
+            int circularBufferMB=1024,
             Func<EventPipeEventSource, Func<int>> optionalTraceValidator = null)
         {
             Logger.logger.Log("==TEST STARTING==");

--- a/src/tests/eventpipe/providers.cs
+++ b/src/tests/eventpipe/providers.cs
@@ -5,10 +5,10 @@
 using System;
 using Xunit;
 using Xunit.Abstractions;
-using Microsoft.Diagnostics.Tools.RuntimeClient;
 using System.Collections.Generic;
 using System.Diagnostics.Tracing;
 using EventPipe.UnitTests.Common;
+using Microsoft.Diagnostics.NETCore.Client;
 
 // Use this test as an example of how to write tests for EventPipe in
 // the dotnet/diagnostics repo
@@ -43,10 +43,10 @@ namespace EventPipe.UnitTests.ProviderValidation
                     { "Microsoft-DotNETCore-SampleProfiler", -1 }
                 };
 
-                var providers = new List<Provider>()
+                var providers = new List<EventPipeProvider>()
                 {
-                    new Provider("MyEventSource"),
-                    new Provider("Microsoft-DotNETCore-SampleProfiler")
+                    new EventPipeProvider("MyEventSource", EventLevel.Verbose),
+                    new EventPipeProvider("Microsoft-DotNETCore-SampleProfiler", EventLevel.Informational)
                 };
 
                 Action eventGeneratingAction = () => 
@@ -58,10 +58,7 @@ namespace EventPipe.UnitTests.ProviderValidation
                         MyEventSource.Log.MyEvent();
                     }
                 };
-
-                var config = new SessionConfiguration(circularBufferSizeMB: (uint)Math.Pow(2, 10), format: EventPipeSerializationFormat.NetTrace,  providers: providers);
-
-                var ret = IpcTraceTest.RunAndValidateEventCounts(expectedEventCounts, eventGeneratingAction, config);
+                var ret = IpcTraceTest.RunAndValidateEventCounts(expectedEventCounts, eventGeneratingAction, providers, 1024, null);
                 Assert.Equal(100, ret);
             }, output);
         }

--- a/src/tests/eventpipe/providers.cs
+++ b/src/tests/eventpipe/providers.cs
@@ -45,7 +45,7 @@ namespace EventPipe.UnitTests.ProviderValidation
 
                 var providers = new List<EventPipeProvider>()
                 {
-                    new EventPipeProvider("MyEventSource", EventLevel.Verbose),
+                    new EventPipeProvider("MyEventSource", EventLevel.Verbose, -1),
                     new EventPipeProvider("Microsoft-DotNETCore-SampleProfiler", EventLevel.Informational)
                 };
 


### PR DESCRIPTION
This should resolve #677. 