### PR TITLE
Fix sample code in DiagnosticsClient library docs

### DIFF
--- a/documentation/design-docs/diagnostics-client-library.md
+++ b/documentation/design-docs/diagnostics-client-library.md
@@ -41,7 +41,7 @@ public void PrintRuntimeGCEvents(int processId)
     {
         var source = new EventPipeEventSource(session.EventStream);
 
-        source.Dynamic.All += (TraceEvent obj) => {
+        source.Clr.All += (TraceEvent obj) => {
             Console.WriteLine(obj.EventName);
         }
         try


### PR DESCRIPTION
This is a simple fix to the sample code to actually print string name of the CLR events (instead of printing it as "Task-something")