### PR TITLE
Make diagnostics client library tests not sleep

### DIFF
--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/EventPipeSessionTests.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/EventPipeSessionTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
         public void EventPipeSessionStreamTest()
         {
             TestRunner runner = new TestRunner(CommonHelper.GetTraceePath(), output);
-            runner.Start(5000);
+            runner.Start(3000);
             DiagnosticsClient client = new DiagnosticsClient(runner.Pid);
             runner.PrintStatus();
             output.WriteLine($"[{DateTime.Now.ToString()}] Trying to start an EventPipe session on process {runner.Pid}");

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/GetPublishedProcessesTests.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/GetPublishedProcessesTests.cs
@@ -48,7 +48,6 @@ namespace Microsoft.Diagnostics.NETCore.Client
                 runner[i].Start();
                 pids[i] = runner[i].Pid;
             }
-            System.Threading.Thread.Sleep(2000);
             List<int> publishedProcesses = new List<int>(DiagnosticsClient.GetPublishedProcesses());
             foreach (int p in publishedProcesses)
             {

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/GetPublishedProcessesTests.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/GetPublishedProcessesTests.cs
@@ -4,6 +4,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Threading;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -27,6 +29,13 @@ namespace Microsoft.Diagnostics.NETCore.Client
         {
             TestRunner runner = new TestRunner(CommonHelper.GetTraceePath(), output);
             runner.Start(3000);
+            // On Windows, runner.Start will not wait for named pipe creation since for other tests, NamedPipeClientStream will
+            // just wait until the named pipe is created.
+            // For these tests, we need to sleep an arbitrary time before pipe is created.
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Thread.Sleep(5000);
+            }
             List<int> publishedProcesses = new List<int>(DiagnosticsClient.GetPublishedProcesses());
             foreach (int p in publishedProcesses)
             {
@@ -47,6 +56,10 @@ namespace Microsoft.Diagnostics.NETCore.Client
                 runner[i] = new TestRunner(CommonHelper.GetTraceePath(), output);
                 runner[i].Start();
                 pids[i] = runner[i].Pid;
+            }
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Thread.Sleep(5000);
             }
             List<int> publishedProcesses = new List<int>(DiagnosticsClient.GetPublishedProcesses());
             foreach (int p in publishedProcesses)

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/TestRunner.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/TestRunner.cs
@@ -2,20 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+
+using Microsoft.Diagnostics.NETCore.Client;
+using Microsoft.Diagnostics.TestHelpers;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
-
-using Microsoft.Diagnostics.TestHelpers;
-
-using Microsoft.Diagnostics.NETCore.Client;
-using System.Threading.Tasks;
-using System.Runtime.InteropServices;
-using System.IO;
 
 namespace Microsoft.Diagnostics.NETCore.Client
 {
@@ -38,7 +37,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
             startInfo.EnvironmentVariables[key] = value;
         }
 
-        public void Start(int timeoutInMS=0)
+        public void Start(int timeoutInMS=15000)
         {
             if (outputHelper != null)
                 outputHelper.WriteLine("$[{DateTime.Now.ToString()}] Launching test: " + startInfo.FileName);
@@ -80,7 +79,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
                             break;
                         }
                     }
-                    Thread.Sleep(100);
+                    Task.Delay(100);
                 }
             });
 


### PR DESCRIPTION
Change TestRunner to not rely on having arbitrary sleep and instead poll for the socket file creation.