### PR TITLE
Build Windows arm64 version of SOS.

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -29,6 +29,11 @@ jobs:
           _BuildConfig: Release
           _BuildArch: arm
           _PublishArtifacts: bin/Windows_NT.arm.Release
+        Build_Release_arm64:
+          _BuildOnly: true
+          _BuildConfig: Release
+          _BuildArch: arm64
+          _PublishArtifacts: bin/Windows_NT.arm64.Release
 
 - template: /eng/build.yml
   parameters:
@@ -251,6 +256,15 @@ jobs:
       inputs:
         artifactName: Windows_arm_Release
         targetPath: '$(Build.SourcesDirectory)/artifacts/bin/Windows_NT.arm.Release'
+      condition: succeeded()
+
+    # Windows arm64 download
+
+    - task: DownloadPipelineArtifact@2
+      displayName: Download Windows Arm64 Artifacts
+      inputs:
+        artifactName: Windows_arm64_Release
+        targetPath: '$(Build.SourcesDirectory)/artifacts/bin/Windows_NT.arm64.Release'
       condition: succeeded()
 
     # Linux x64 download

--- a/eng/Build-Native.cmd
+++ b/eng/Build-Native.cmd
@@ -174,13 +174,13 @@ if /i %__BuildCrossArch% EQU 1 (
 
     echo Generating Version Header
     set __GenerateVersionRestoreLog="%__LogDir%\GenerateVersionRestore.binlog"
-    "%__DotNetCli%" msbuild "%__ProjectDir%\eng\CreateVersionFile.csproj" /v:!__Verbosity! /bl:!__GenerateVersionRestoreLog! /t:Restore /p:Configuration=%__BuildType% /p:Platform=%__BuildArch% %__UnprocessedBuildArgs%
+    "%__DotNetCli%" msbuild "%__ProjectDir%\eng\CreateVersionFile.csproj" /v:!__Verbosity! /bl:!__GenerateVersionRestoreLog! /t:Restore /p:Configuration=%__BuildType% /p:BuildArch=%__BuildArch% /p:Platform=%__BuildArch% %__UnprocessedBuildArgs%
     if not !errorlevel! == 0 (
         echo Generate Version Restore FAILED
         exit /b 1
     )
     set __GenerateVersionLog="%__LogDir%\GenerateVersion.binlog"
-    "%__DotNetCli%" msbuild "%__ProjectDir%\eng\CreateVersionFile.csproj" /v:!__Verbosity! /bl:!__GenerateVersionLog! /t:GenerateVersionFiles /p:FileVersionFile=%__RootBinDir%\bin\FileVersion.txt /p:GenerateVersionHeader=true /p:NativeVersionHeaderFile=%__CrossCompIntermediatesDir%\_version.h /p:Configuration=%__BuildType% /p:Platform=%__BuildArch% %__UnprocessedBuildArgs%
+    "%__DotNetCli%" msbuild "%__ProjectDir%\eng\CreateVersionFile.csproj" /v:!__Verbosity! /bl:!__GenerateVersionLog! /t:GenerateVersionFiles /p:FileVersionFile=%__RootBinDir%\bin\FileVersion.txt /p:GenerateVersionHeader=true /p:NativeVersionHeaderFile=%__CrossCompIntermediatesDir%\_version.h /p:Configuration=%__BuildType% /p:BuildArch=%__BuildArch% /p:Platform=%__BuildArch% %__UnprocessedBuildArgs%
     if not !errorlevel! == 0 (
         echo Generate Version Header FAILED
         exit /b 1
@@ -258,13 +258,13 @@ if %__Build% EQU 1 (
 
     echo Generating Version Header
     set __GenerateVersionRestoreLog="%__LogDir%\GenerateVersionRestore.binlog"
-    "%__DotNetCli%" msbuild "%__ProjectDir%\eng\CreateVersionFile.csproj" /v:!__Verbosity! /bl:!__GenerateVersionRestoreLog! /t:Restore /p:Configuration=%__BuildType% /p:Platform=%__BuildArch% %__UnprocessedBuildArgs%
+    "%__DotNetCli%" msbuild "%__ProjectDir%\eng\CreateVersionFile.csproj" /v:!__Verbosity! /bl:!__GenerateVersionRestoreLog! /t:Restore /p:Configuration=%__BuildType% /p:BuildArch=%__BuildArch% /p:Platform=%__BuildArch% %__UnprocessedBuildArgs%
     if not !errorlevel! == 0 (
         echo Generate Version Restore FAILED
         exit /b 1
     )
     set __GenerateVersionLog="%__LogDir%\GenerateVersion.binlog"
-    "%__DotNetCli%" msbuild "%__ProjectDir%\eng\CreateVersionFile.csproj" /v:!__Verbosity! /bl:!__GenerateVersionLog! /t:GenerateVersionFiles /p:FileVersionFile=%__RootBinDir%\bin\FileVersion.txt /p:GenerateVersionHeader=true /p:NativeVersionHeaderFile=%__IntermediatesDir%\_version.h /p:Configuration=%__BuildType% /p:Platform=%__BuildArch% %__UnprocessedBuildArgs%
+    "%__DotNetCli%" msbuild "%__ProjectDir%\eng\CreateVersionFile.csproj" /v:!__Verbosity! /bl:!__GenerateVersionLog! /t:GenerateVersionFiles /p:FileVersionFile=%__RootBinDir%\bin\FileVersion.txt /p:GenerateVersionHeader=true /p:NativeVersionHeaderFile=%__IntermediatesDir%\_version.h /p:Configuration=%__BuildType% /p:BuildArch=%__BuildArch% /p:Platform=%__BuildArch% %__UnprocessedBuildArgs%
     if not !errorlevel! == 0 (
         echo Generate Version Header FAILED
         exit /b 1
@@ -292,7 +292,7 @@ if %__Build% EQU 1 (
     set __BuildLog="%__LogDir%\Native.Build.binlog"
 
     :: MSBuild.exe is the only one that has the C++ targets. "%__DotNetCli% msbuild" fails because VCTargetsPath isn't defined.
-    msbuild.exe %__IntermediatesDir%\install.vcxproj /v:!__Verbosity! /bl:!__BuildLog! /p:Configuration=%__BuildType% /p:Platform=%__BuildArch% %__UnprocessedBuildArgs%
+    msbuild.exe %__IntermediatesDir%\install.vcxproj /v:!__Verbosity! /bl:!__BuildLog! /p:Configuration=%__BuildType% /p:BuildArch=%__BuildArch% /p:Platform=%__BuildArch% %__UnprocessedBuildArgs%
 
     if not !ERRORLEVEL! == 0 (
         echo %__MsgPrefix%Error: native component build failed. Refer to the build log files for details:

--- a/eng/Build-Native.cmd
+++ b/eng/Build-Native.cmd
@@ -123,6 +123,9 @@ if NOT "%__CrossArch%" == "" set __CrossComponentBinDir=%__CrossComponentBinDir%
 set "__CMakeBinDir=%__BinDir%"
 set "__CMakeBinDir=%__CMakeBinDir:\=/%"
 
+:: Common msbuild arguments
+set "__CommonBuildArgs=/v:!__Verbosity! /p:Configuration=%__BuildType% /p:BuildArch=%__BuildArch% %__UnprocessedBuildArgs%"
+
 if not exist "%__BinDir%"           md "%__BinDir%"
 if not exist "%__IntermediatesDir%" md "%__IntermediatesDir%"
 if not exist "%__LogDir%"           md "%__LogDir%"
@@ -174,13 +177,13 @@ if /i %__BuildCrossArch% EQU 1 (
 
     echo Generating Version Header
     set __GenerateVersionRestoreLog="%__LogDir%\GenerateVersionRestore.binlog"
-    "%__DotNetCli%" msbuild "%__ProjectDir%\eng\CreateVersionFile.csproj" /v:!__Verbosity! /bl:!__GenerateVersionRestoreLog! /t:Restore /p:Configuration=%__BuildType% /p:BuildArch=%__BuildArch% /p:Platform=%__BuildArch% %__UnprocessedBuildArgs%
+    "%__DotNetCli%" msbuild "%__ProjectDir%\eng\CreateVersionFile.csproj" /bl:!__GenerateVersionRestoreLog! /t:Restore %__CommonBuildArgs%
     if not !errorlevel! == 0 (
         echo Generate Version Restore FAILED
         exit /b 1
     )
     set __GenerateVersionLog="%__LogDir%\GenerateVersion.binlog"
-    "%__DotNetCli%" msbuild "%__ProjectDir%\eng\CreateVersionFile.csproj" /v:!__Verbosity! /bl:!__GenerateVersionLog! /t:GenerateVersionFiles /p:FileVersionFile=%__RootBinDir%\bin\FileVersion.txt /p:GenerateVersionHeader=true /p:NativeVersionHeaderFile=%__CrossCompIntermediatesDir%\_version.h /p:Configuration=%__BuildType% /p:BuildArch=%__BuildArch% /p:Platform=%__BuildArch% %__UnprocessedBuildArgs%
+    "%__DotNetCli%" msbuild "%__ProjectDir%\eng\CreateVersionFile.csproj" /bl:!__GenerateVersionLog! /t:GenerateVersionFiles /p:FileVersionFile=%__RootBinDir%\bin\FileVersion.txt /p:GenerateVersionHeader=true /p:NativeVersionHeaderFile=%__CrossCompIntermediatesDir%\_version.h %__CommonBuildArgs%
     if not !errorlevel! == 0 (
         echo Generate Version Header FAILED
         exit /b 1
@@ -209,7 +212,7 @@ if /i %__BuildCrossArch% EQU 1 (
     set __BuildLog="%__LogDir%\Cross.Build.binlog"
 
     :: MSBuild.exe is the only one that has the C++ targets. "%__DotNetCli% msbuild" fails because VCTargetsPath isn't defined.
-    msbuild.exe %__CrossCompIntermediatesDir%\install.vcxproj /v:!__Verbosity! /bl:!__BuildLog! /p:Configuration=%__BuildType% /p:Platform=%__CrossArch% %__UnprocessedBuildArgs%
+    msbuild.exe %__CrossCompIntermediatesDir%\install.vcxproj /bl:!__BuildLog! %__CommonBuildArgs%
 
     if not !ERRORLEVEL! == 0 (
         echo %__MsgPrefix%Error: cross-arch components build failed. Refer to the build log files for details:
@@ -258,13 +261,13 @@ if %__Build% EQU 1 (
 
     echo Generating Version Header
     set __GenerateVersionRestoreLog="%__LogDir%\GenerateVersionRestore.binlog"
-    "%__DotNetCli%" msbuild "%__ProjectDir%\eng\CreateVersionFile.csproj" /v:!__Verbosity! /bl:!__GenerateVersionRestoreLog! /t:Restore /p:Configuration=%__BuildType% /p:BuildArch=%__BuildArch% /p:Platform=%__BuildArch% %__UnprocessedBuildArgs%
+    "%__DotNetCli%" msbuild "%__ProjectDir%\eng\CreateVersionFile.csproj" /bl:!__GenerateVersionRestoreLog! /t:Restore %__CommonBuildArgs%
     if not !errorlevel! == 0 (
         echo Generate Version Restore FAILED
         exit /b 1
     )
     set __GenerateVersionLog="%__LogDir%\GenerateVersion.binlog"
-    "%__DotNetCli%" msbuild "%__ProjectDir%\eng\CreateVersionFile.csproj" /v:!__Verbosity! /bl:!__GenerateVersionLog! /t:GenerateVersionFiles /p:FileVersionFile=%__RootBinDir%\bin\FileVersion.txt /p:GenerateVersionHeader=true /p:NativeVersionHeaderFile=%__IntermediatesDir%\_version.h /p:Configuration=%__BuildType% /p:BuildArch=%__BuildArch% /p:Platform=%__BuildArch% %__UnprocessedBuildArgs%
+    "%__DotNetCli%" msbuild "%__ProjectDir%\eng\CreateVersionFile.csproj" /bl:!__GenerateVersionLog! /t:GenerateVersionFiles /p:FileVersionFile=%__RootBinDir%\bin\FileVersion.txt /p:GenerateVersionHeader=true /p:NativeVersionHeaderFile=%__IntermediatesDir%\_version.h %__CommonBuildArgs%
     if not !errorlevel! == 0 (
         echo Generate Version Header FAILED
         exit /b 1
@@ -292,7 +295,7 @@ if %__Build% EQU 1 (
     set __BuildLog="%__LogDir%\Native.Build.binlog"
 
     :: MSBuild.exe is the only one that has the C++ targets. "%__DotNetCli% msbuild" fails because VCTargetsPath isn't defined.
-    msbuild.exe %__IntermediatesDir%\install.vcxproj /v:!__Verbosity! /bl:!__BuildLog! /p:Configuration=%__BuildType% /p:BuildArch=%__BuildArch% /p:Platform=%__BuildArch% %__UnprocessedBuildArgs%
+    msbuild.exe %__IntermediatesDir%\install.vcxproj /bl:!__BuildLog! %__CommonBuildArgs%
 
     if not !ERRORLEVEL! == 0 (
         echo %__MsgPrefix%Error: native component build failed. Refer to the build log files for details:

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -52,7 +52,7 @@ if ($ci) {
 
 # Install sdk for building, restore and build managed components.
 if (-not $skipmanaged) {
-    Invoke-Expression "& `"$engroot\common\build.ps1`" -build -configuration $configuration -verbosity $verbosity /p:TestArchitectures=$architecture $remainingargs"
+    Invoke-Expression "& `"$engroot\common\build.ps1`" -build -binaryLog -configuration $configuration -verbosity $verbosity /p:BuildArch=$architecture /p:TestArchitectures=$architecture $remainingargs"
     if ($lastExitCode -ne 0) {
         exit $lastExitCode
     }
@@ -69,7 +69,7 @@ if (-not $skipnative) {
 # Run the xunit tests
 if ($test -or $dailytest) {
     if (-not $crossbuild) {
-        & "$engroot\common\build.ps1" -test -configuration $configuration -verbosity $verbosity -ci:$ci /bl:$logdir\Test.binlog /p:TestArchitectures=$architecture /p:BuildArch=$architecture /p:DailyTest=$dailyTest
+        & "$engroot\common\build.ps1" -test -configuration $configuration -verbosity $verbosity -ci:$ci /bl:$logdir\Test.binlog /p:BuildArch=$architecture /p:TestArchitectures=$architecture /p:DailyTest=$dailyTest
         if ($lastExitCode -ne 0) {
             exit $lastExitCode
         }

--- a/src/SOS/CMakeLists.txt
+++ b/src/SOS/CMakeLists.txt
@@ -11,7 +11,9 @@ if(WIN32)
   add_compile_options(/Zl) # omit default library name in .OBJ
 
   add_subdirectory(runcommand)
-  add_subdirectory(SOS.UnitTests/Debuggees/DesktopClrHost)
+  if(NOT CLR_CMAKE_TARGET_ARCH_ARM64)
+    add_subdirectory(SOS.UnitTests/Debuggees/DesktopClrHost)
+  endif()
 endif(WIN32)
 
 add_definitions(-D_SECURE_SCL=0)

--- a/src/SOS/SOS.NETCore/CMakeLists.txt
+++ b/src/SOS/SOS.NETCore/CMakeLists.txt
@@ -22,5 +22,8 @@ if(NOT ${NUGET_PACKAGES} STREQUAL "")
         set(DIASYMREADER_ARCH amd64)
     endif()
 
-    install(FILES ${NUGET_PACKAGES}/microsoft.diasymreader.native/1.7.0/runtimes/win/native/Microsoft.DiaSymReader.Native.${DIASYMREADER_ARCH}.dll DESTINATION . )
+    # Until issue https://github.com/dotnet/diagnostics/issues/324 is done there is no arm64 version of the diasymreader in this package
+    if(NOT CLR_CMAKE_TARGET_ARCH_ARM64)
+        install(FILES ${NUGET_PACKAGES}/microsoft.diasymreader.native/1.7.0/runtimes/win/native/Microsoft.DiaSymReader.Native.${DIASYMREADER_ARCH}.dll DESTINATION . )
+    endif()
 endif()

--- a/src/SOS/SOS.NETCore/SOS.NETCore.csproj
+++ b/src/SOS/SOS.NETCore/SOS.NETCore.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
     <PackageReference Include="Microsoft.SymbolStore" Version="$(MicrosoftSymbolStoreVersion)" />
-    <PackageReference Include="Microsoft.DiaSymReader.Native" Version="$(MicrosoftDiaSymReaderNativePackageVersion)" Condition="'$(OS)' == 'Windows_NT'" />
+    <!-- Until issue https://github.com/dotnet/diagnostics/issues/324 is done there is no arm64 version of the diasymreader in this package -->
+    <PackageReference Include="Microsoft.DiaSymReader.Native" Version="$(MicrosoftDiaSymReaderNativePackageVersion)" Condition="'$(OS)' == 'Windows_NT' and '$(BuildArch)' != 'arm64'" />
   </ItemGroup>
 </Project>

--- a/src/SOS/SOS.Package/SOS.Package.csproj
+++ b/src/SOS/SOS.Package/SOS.Package.csproj
@@ -41,6 +41,7 @@
                 <File Architecture="amd64" Module="win-x64\sos.dll" />
                 <File Architecture="x86"   Module="win-x86\sos.dll" />
                 <File Architecture="arm32" Module="win-arm\sos.dll" />
+                <File Architecture="arm64" Module="win-arm64\sos.dll" />
             </Files>
             <LoadTriggers>
                 <TriggerSet>
@@ -110,6 +111,18 @@
       <ZipSourceFiles Include="$(SOSNETCorePath)\*.dll">
          <TargetPath>$(GallerySubDir)\win-arm</TargetPath>
       </ZipSourceFiles>
+
+      <ZipSourceFiles Include="$(ArtifactsBinDir)Windows_NT.arm64.$(Configuration)\sos.dll">
+         <TargetPath>$(GallerySubDir)\win-arm64</TargetPath>
+      </ZipSourceFiles>
+      <!-- Commented out until issue https://github.com/dotnet/diagnostics/issues/324 is addressed
+      <ZipSourceFiles Include="$(ArtifactsBinDir)Windows_NT.arm64.$(Configuration)\Microsoft.DiaSymReader.Native.arm64.dll">
+         <TargetPath>$(GallerySubDir)\win-arm64</TargetPath>
+      </ZipSourceFiles>
+       -->
+      <ZipSourceFiles Include="$(SOSNETCorePath)\*.dll">
+         <TargetPath>$(GallerySubDir)\win-arm64</TargetPath>
+      </ZipSourceFiles>
     </ItemGroup>
 
     <Copy SourceFiles="@(ZipSourceFiles)" DestinationFolder="%(ZipSourceFiles.TargetPath)" />
@@ -137,6 +150,10 @@
 
       <ZipSymbolFiles Include="$(ArtifactsBinDir)Windows_NT.arm.$(Configuration)\sos.pdb">
          <TargetPath>$(SymbolsDir)\win-arm</TargetPath>
+      </ZipSymbolFiles>
+
+      <ZipSymbolFiles Include="$(ArtifactsBinDir)Windows_NT.arm64.$(Configuration)\sos.pdb">
+         <TargetPath>$(SymbolsDir)\win-arm64</TargetPath>
       </ZipSymbolFiles>
     </ItemGroup>
 

--- a/src/SOS/SOS.Package/SOS.Symbol.Package.csproj
+++ b/src/SOS/SOS.Package/SOS.Symbol.Package.csproj
@@ -27,6 +27,9 @@
     <None Include="$(ArtifactsBinDir)\Windows_NT.arm.$(Configuration)\sos.pdb" Pack="true" Visible="false">
       <PackagePath>$(SOSPackagePathPrefix)/win-arm</PackagePath>
     </None>
+    <None Include="$(ArtifactsBinDir)\Windows_NT.arm64.$(Configuration)\sos.pdb" Pack="true" Visible="false">
+      <PackagePath>$(SOSPackagePathPrefix)/win-arm64</PackagePath>
+    </None>
 
     <None Include="$(ArtifactsBinDir)\Linux.x64.$(Configuration)\libsosplugin.so.dbg" Pack="true" Visible="false">
       <PackagePath>$(SOSPackagePathPrefix)/linux-x64</PackagePath>

--- a/src/SOS/Strike/hostcoreclr.cpp
+++ b/src/SOS/Strike/hostcoreclr.cpp
@@ -992,7 +992,7 @@ HRESULT SymbolReader::LoadSymbolsForWindowsPDB(___in IMetaDataImport* pMD, ___in
         size_t lastSlash = diasymreaderPath.rfind(DIRECTORY_SEPARATOR_CHAR_A);
         if (lastSlash == std::string::npos)
         {
-            ExtErr("Error: Failed to parse sos module name\n");
+            ExtErr("Error: Failed to parse SOS module name\n");
             return E_FAIL;
         }
         diasymreaderPath.erase(lastSlash + 1);
@@ -1001,7 +1001,7 @@ HRESULT SymbolReader::LoadSymbolsForWindowsPDB(___in IMetaDataImport* pMD, ___in
         // We now need a binder object that will take the module and return a 
         if (FAILED(Status = CreateInstanceFromPath(CLSID_CorSymBinder_SxS, IID_ISymUnmanagedBinder3, diasymreaderPath.c_str(), &g_hmoduleSymBinder, (void**)&g_pSymBinder)))
         {
-            ExtOut("SOS error: Unable to find the diasymreader module/interface %08x at %s\n", Status, diasymreaderPath.c_str());
+            ExtDbgOut("SOS error: Unable to find the diasymreader module/interface %08x at %s\n", Status, diasymreaderPath.c_str());
             return Status;
         }
         OnUnloadTask::Register(CleanupSymBinder);

--- a/src/SOS/Strike/util.h
+++ b/src/SOS/Strike/util.h
@@ -97,9 +97,7 @@ DECLARE_HANDLE(OBJECTHANDLE);
 #elif defined(_ARM_)
 #define NATIVE_SYMBOL_READER_DLL "Microsoft.DiaSymReader.Native.arm.dll"
 #elif defined(_ARM64_)
-// Use diasymreader until the package has an arm64 version - issue #7360
-//#define NATIVE_SYMBOL_READER_DLL "Microsoft.DiaSymReader.Native.arm64.dll"
-#define NATIVE_SYMBOL_READER_DLL "diasymreader.dll"
+#define NATIVE_SYMBOL_READER_DLL "Microsoft.DiaSymReader.Native.arm64.dll"
 #endif
 
 // PREFIX macros - Begin

--- a/src/sos-packaging.props
+++ b/src/sos-packaging.props
@@ -40,6 +40,18 @@
     </None>
 
     <None Include="$(SOSNETCoreBinaries)" Pack="true" Visible="false">
+      <PackagePath>$(SOSPackagePathPrefix)/win-arm64</PackagePath>
+    </None>
+    <None Include="$(ArtifactsBinDir)\Windows_NT.arm64.$(Configuration)\sos.dll" Pack="true" Visible="false">
+      <PackagePath>$(SOSPackagePathPrefix)/win-arm64</PackagePath>
+    </None>
+    <!-- Commented out until issue https://github.com/dotnet/diagnostics/issues/324 is addressed
+    <None Include="$(ArtifactsBinDir)\Windows_NT.arm64.$(Configuration)\Microsoft.DiaSymReader.Native.arm64.dll" Pack="true" Visible="false">
+      <PackagePath>$(SOSPackagePathPrefix)/win-arm64</PackagePath>
+    </None>
+     -->
+
+    <None Include="$(SOSNETCoreBinaries)" Pack="true" Visible="false">
       <PackagePath>$(SOSPackagePathPrefix)/linux-x64</PackagePath>
     </None>
     <None Include="$(ArtifactsBinDir)\Linux.x64.$(Configuration)\libsosplugin.so" Pack="true" Visible="false">


### PR DESCRIPTION
Make sure that the "BuildArch" msbuild property is always passed to managed and native builds.

Add the arm64 SOS to the various packages and zip files.

The diasymreader package for Windows PDB support is currently disabled for arm64 waiting
for issue https://github.com/dotnet/diagnostics/issues/324 to be addressed.

Issue: https://github.com/dotnet/diagnostics/issues/430