### PR TITLE
Misc SOS fixes

### DIFF
--- a/src/SOS/SOS.UnitTests/Scripts/OtherCommands.script
+++ b/src/SOS/SOS.UnitTests/Scripts/OtherCommands.script
@@ -95,7 +95,7 @@ SOSCOMMAND:DumpAssembly <POUT>\s*Assembly:\s+(<HEXVAL>)\s+\[.*<POUT>
 VERIFY:\s*Parent Domain:\s+<HEXVAL>\s+
 VERIFY:\s*Name:\s+.*(System\.Private\.CoreLib(\.ni)?\.dll|mscorlib.dll)\s+
 
-SOSCOMMAND:DumpModule <POUT>\s+Module Name\s+(<HEXVAL>)\s+.*<POUT>
+SOSCOMMAND:DumpModule <POUT>\s+Module\s+(<HEXVAL>)\s+.*<POUT>
 VERIFY:\s*PEFile:\s+<HEXVAL>\s+
 VERIFY:\s*ModuleId:\s+<HEXVAL>\s+
 VERIFY:\s*LoaderHeap:\s+<HEXVAL>\s+

--- a/src/SOS/Strike/runtime.cpp
+++ b/src/SOS/Strike/runtime.cpp
@@ -307,14 +307,23 @@ LPCSTR Runtime::GetDacFilePath()
                     std::string dacSymLink(tmpPath);
                     dacSymLink.append(NETCORE_DAC_DLL_NAME_A);
 
-                    int error = symlink(dacModulePath.c_str(), dacSymLink.c_str());
-                    if (error == 0)
+                    // Check if the DAC file already exists in the temp directory because
+                    // of a "loadsymbols" command which downloads everything.
+                    if (access(dacSymLink.c_str(), F_OK) == 0)
                     {
                         dacModulePath.assign(dacSymLink);
                     }
                     else
                     {
-                        ExtErr("symlink(%s, %s) FAILED %s\n", dacModulePath.c_str(), dacSymLink.c_str(), strerror(errno));
+                        int error = symlink(dacModulePath.c_str(), dacSymLink.c_str());
+                        if (error == 0)
+                        {
+                            dacModulePath.assign(dacSymLink);
+                        }
+                        else
+                        {
+                            ExtErr("symlink(%s, %s) FAILED %s\n", dacModulePath.c_str(), dacSymLink.c_str(), strerror(errno));
+                        }
                     }
                 }
 #endif

--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -14553,7 +14553,7 @@ end:
 
 DECLARE_API(dbgout)
 {
-    INIT_API();
+    INIT_API_EXT();
 
     BOOL bOff = FALSE;
 
@@ -16018,7 +16018,7 @@ DECLARE_API(SetSymbolServer)
         DisableSymbolStore();
     }
 
-    if (msdl || symweb || symbolServer.data != nullptr || symbolCache.data != nullptr || searchDirectory.data != nullptr || windowsSymbolPath.data != nullptr)
+    if (logging || msdl || symweb || symbolServer.data != nullptr || symbolCache.data != nullptr || searchDirectory.data != nullptr || windowsSymbolPath.data != nullptr)
     {
         Status = InitializeSymbolStore(logging, msdl, symweb, symbolServer.data, (int)timeoutInMinutes, symbolCache.data, searchDirectory.data, windowsSymbolPath.data);
         if (FAILED(Status))

--- a/src/SOS/Strike/util.cpp
+++ b/src/SOS/Strike/util.cpp
@@ -2256,7 +2256,7 @@ DWORD_PTR *ModuleFromName(__in_opt LPSTR mName, int *numModule)
                     DacpModuleData ModuleData;
                     if (FAILED(ModuleData.Request(g_sos, ModuleAddr)))
                     {
-                        ExtDbgOut("Failed to request module data from assembly for %p\n", ModuleAddr);
+                        ExtDbgOut("Failed to request module data from assembly at %p\n", ModuleAddr);
                         continue;
                     }
 


### PR DESCRIPTION
Change "dbgout" command not to require EE or DAC (use INIT_API_EXT).

Fix case where the DAC is already in the temp directory because of a
loadsymbols command when symlink'ing it on Linux.

Allow just setsymbolserver -log without any other options.