### PR TITLE
Allow tools to specify a specific OS transport

### DIFF
--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
@@ -25,9 +25,9 @@ namespace Microsoft.Diagnostics.NETCore.Client
             _transport = new IpcTransport(processId);
         }
 
-        public DiagnosticsClient(string transportPath)
+        public DiagnosticsClient(string address)
         {
-            _transport = new IpcTransport(transportPath);
+            _transport = new IpcTransport(address);
         }
 
         /// <summary>

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/EventPipeSession.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/EventPipeSession.cs
@@ -15,19 +15,19 @@ namespace Microsoft.Diagnostics.NETCore.Client
         private bool _requestRundown;
         private int _circularBufferMB;
         private long _sessionId;
-        private int _processId;
+        private IpcTransport _transport;
         private bool disposedValue = false; // To detect redundant calls
 
-        internal EventPipeSession(int processId, IEnumerable<EventPipeProvider> providers, bool requestRundown, int circularBufferMB)
+        internal EventPipeSession(IpcTransport transport, IEnumerable<EventPipeProvider> providers, bool requestRundown, int circularBufferMB)
         {
-            _processId = processId;
+            _transport = transport;
             _providers = providers;
             _requestRundown = requestRundown;
             _circularBufferMB = circularBufferMB;
             
             var config = new EventPipeSessionConfiguration(circularBufferMB, EventPipeSerializationFormat.NetTrace, providers, requestRundown);
             var message = new IpcMessage(DiagnosticsServerCommandSet.EventPipe, (byte)EventPipeCommandId.CollectTracing2, config.SerializeV2());
-            EventStream = IpcClient.SendMessage(processId, message, out var response);
+            EventStream = IpcClient.SendMessage(transport, message, out var response);
             switch ((DiagnosticsServerCommandId)response.Header.CommandId)
             {
                 case DiagnosticsServerCommandId.OK:
@@ -51,7 +51,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
             Debug.Assert(_sessionId > 0);
 
             byte[] payload = BitConverter.GetBytes(_sessionId);
-            var response = IpcClient.SendMessage(_processId, new IpcMessage(DiagnosticsServerCommandSet.EventPipe, (byte)EventPipeCommandId.StopTracing, payload));
+            var response = IpcClient.SendMessage(_transport, new IpcMessage(DiagnosticsServerCommandSet.EventPipe, (byte)EventPipeCommandId.StopTracing, payload));
 
             switch ((DiagnosticsServerCommandId)response.Header.CommandId)
             {

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcTransport.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcTransport.cs
@@ -1,0 +1,156 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Pipes;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using System.Security.Principal;
+
+namespace Microsoft.Diagnostics.NETCore.Client
+{
+    internal class IpcTransport
+    {
+        private string _ipcTransportPath = null;
+        private int? _pid = null;
+
+        private static double ConnectTimeoutMilliseconds { get; } = TimeSpan.FromSeconds(3).TotalMilliseconds;
+        public static string IpcRootPath { get; } = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? @"\\.\pipe\" : Path.GetTempPath();
+        public static string DiagnosticsPortPattern { get; } = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? @"^dotnet-diagnostic-(\d+)$" : @"^dotnet-diagnostic-(\d+)-(\d+)-socket$";
+
+        /// <summary>
+        /// Creates a reference to a .NET process's IPC Transport
+        /// by getting a reference to the Named Pipe or Socket
+        /// specified in ipcTransportPath
+        /// </summary>
+        /// <param name="ipcTransportPath">The fully qualified path, including filename, of the IPC Transport</param>
+        /// <returns>A reference to the IPC Transport</returns>
+        public IpcTransport(string ipcTransportPath)
+        {
+            _ipcTransportPath = ipcTransportPath;
+        }
+
+        /// <summary>
+        /// Creates a reference to a .NET process's IPC Transport
+        /// using the default rules for a given pid
+        /// </summary>
+        /// <param name="pid">The pid of the target process</param>
+        /// <returns>A reference to the IPC Transport</returns>
+        public IpcTransport(int pid)
+        {
+            _pid = pid;
+        }
+
+        /// <summary>
+        /// Connects to the underlying IPC Transport and opens a read/write-able Stream
+        /// </summary>
+        /// <returns>A Stream for writing and reading data to and from the target .NET process</returns>
+        public Stream Connect()
+        {
+            if (!string.IsNullOrEmpty(_ipcTransportPath))
+            {
+                return ConnectViaPath();
+            }
+            else if (_pid.HasValue)
+            {
+                return ConnectViaPid();
+            }
+            else
+            {
+                throw new ApplicationException("Cannot connect to Diagnostics IPC Transport without a PID or specific path");
+            }
+        }
+
+        private Stream ConnectViaPath()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                var normalizedPath = _ipcTransportPath.StartsWith(@"\\.\pipe\") ? _ipcTransportPath.Substring(9) : _ipcTransportPath;
+                var namedPipe = new NamedPipeClientStream(
+                    ".", normalizedPath, PipeDirection.InOut, PipeOptions.None, TokenImpersonationLevel.Impersonation);
+                namedPipe.Connect((int)ConnectTimeoutMilliseconds);
+                return namedPipe;
+            }
+            else
+            {
+                var remoteEP = CreateUnixDomainSocketEndPoint(_ipcTransportPath);
+
+                var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+                socket.Connect(remoteEP);
+                return new NetworkStream(socket);
+            }
+        }
+
+        private Stream ConnectViaPid()
+        {
+            Debug.Assert(_pid.HasValue);
+            try
+            {
+                var process = Process.GetProcessById(_pid.Value);
+            }
+            catch (System.ArgumentException)
+            {
+                throw new ServerNotAvailableException($"Process {_pid.Value} is not running.");
+            }
+            catch (System.InvalidOperationException)
+            {
+                throw new ServerNotAvailableException($"Process {_pid.Value} seems to be elevated.");
+            }
+ 
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                string pipeName = $"dotnet-diagnostic-{_pid.Value}";
+                var namedPipe = new NamedPipeClientStream(
+                    ".", pipeName, PipeDirection.InOut, PipeOptions.None, TokenImpersonationLevel.Impersonation);
+                namedPipe.Connect((int)ConnectTimeoutMilliseconds);
+                return namedPipe;
+            }
+            else
+            {
+                string ipcPort;
+                try
+                {
+                    ipcPort = Directory.GetFiles(IpcRootPath, $"dotnet-diagnostic-{_pid.Value}-*-socket") // Try best match.
+                                .OrderByDescending(f => new FileInfo(f).LastWriteTime)
+                                .FirstOrDefault();
+                    if (ipcPort == null)
+                    {
+                        throw new ServerNotAvailableException($"Process {_pid.Value} not running compatible .NET Core runtime.");
+                    }
+                }
+                catch (InvalidOperationException)
+                {
+                    throw new ServerNotAvailableException($"Process {_pid.Value} not running compatible .NET Core runtime.");
+                }
+                string path = Path.Combine(IpcRootPath, ipcPort);
+                var remoteEP = CreateUnixDomainSocketEndPoint(path);
+
+                var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+                socket.Connect(remoteEP);
+                return new NetworkStream(socket);
+            }
+        }
+
+        private static EndPoint CreateUnixDomainSocketEndPoint(string path)
+        {
+#if NETCOREAPP
+            return new UnixDomainSocketEndPoint(path);
+#elif NETSTANDARD2_0
+            // UnixDomainSocketEndPoint is not part of .NET Standard 2.0
+            var type = typeof(Socket).Assembly.GetType("System.Net.Sockets.UnixDomainSocketEndPoint")
+                       ?? Type.GetType("System.Net.Sockets.UnixDomainSocketEndPoint, System.Core");
+            if (type == null)
+            {
+                throw new PlatformNotSupportedException("Current process is not running a compatible .NET Core runtime.");
+            }
+            var ctor = type.GetConstructor(new[] { typeof(string) });
+            return (EndPoint)ctor.Invoke(new object[] { path });
+#endif
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcTransport.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcTransport.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
             }
             else
             {
-                throw new ApplicationException("Cannot connect to Diagnostics IPC Transport without a PID or specific path");
+                throw new DiagnosticsClientException("Cannot connect to Diagnostics IPC Transport without a PID or specific path");
             }
         }
 
@@ -70,7 +70,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                var normalizedPath = _ipcTransportPath.StartsWith(@"\\.\pipe\") ? _ipcTransportPath.Substring(9) : _ipcTransportPath;
+                var normalizedPath = _ipcTransportPath.StartsWith(IpcRootPath) ? _ipcTransportPath.Substring(IpcRootPath.Length) : _ipcTransportPath;
                 var namedPipe = new NamedPipeClientStream(
                     ".", normalizedPath, PipeDirection.InOut, PipeOptions.None, TokenImpersonationLevel.Impersonation);
                 namedPipe.Connect((int)ConnectTimeoutMilliseconds);

--- a/src/Tools/dotnet-counters/CounterMonitor.cs
+++ b/src/Tools/dotnet-counters/CounterMonitor.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
     public class CounterMonitor
     {
         private int _processId;
-        private string _transportPath;
+        private string _diagnosticsServerAddress;
         private int _interval;
         private List<string> _counterList;
         private CancellationToken _ct;
@@ -83,9 +83,9 @@ namespace Microsoft.Diagnostics.Tools.Counters
             _renderer.Stop();
         }
 
-        private bool ValidateProcessIdAndTransportPath()
+        private bool ValidateProcessIdAndDiagnosticsServerAddress()
         {
-            if (string.IsNullOrEmpty(_transportPath))
+            if (string.IsNullOrEmpty(_diagnosticsServerAddress))
             {
                 if (_processId == 0)
                 {
@@ -95,7 +95,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
             }
             else
             {
-                if (!File.Exists(_transportPath) && !File.Exists(@"\\.pipe\" + _transportPath))
+                if (!File.Exists(_diagnosticsServerAddress) && !File.Exists(@"\\.\pipe\" + _diagnosticsServerAddress))
                 {
                     Console.Error.WriteLine("Requested transport does not exist");
                     return false;
@@ -110,7 +110,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
             return true;
         }
 
-        public async Task<int> Monitor(CancellationToken ct, List<string> counter_list, IConsole console, int processId, string transportPath, int refreshInterval)
+        public async Task<int> Monitor(CancellationToken ct, List<string> counter_list, IConsole console, int processId, string diagnosticsServerAddress, int refreshInterval)
         {
             try
             {
@@ -118,16 +118,16 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 _counterList = counter_list; // NOTE: This variable name has an underscore because that's the "name" that the CLI displays. System.CommandLine doesn't like it if we change the variable to camelcase. 
                 _console = console;
                 _processId = processId;
-                _transportPath = transportPath;
+                _diagnosticsServerAddress = diagnosticsServerAddress;
                 _interval = refreshInterval;
                 _renderer = new ConsoleWriter();
 
-                if (!ValidateProcessIdAndTransportPath())
+                if (!ValidateProcessIdAndDiagnosticsServerAddress())
                     return 1;
 
-                _diagnosticsClient = string.IsNullOrEmpty(_transportPath) ? 
+                _diagnosticsClient = string.IsNullOrEmpty(_diagnosticsServerAddress) ? 
                     new DiagnosticsClient(_processId) : 
-                    new DiagnosticsClient(_transportPath);
+                    new DiagnosticsClient(_diagnosticsServerAddress);
 
                 return await Start();
             }
@@ -145,7 +145,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
             }
         }
 
-        public async Task<int> Collect(CancellationToken ct, List<string> counter_list, IConsole console, int processId, string transportPath, int refreshInterval, CountersExportFormat format, string output)
+        public async Task<int> Collect(CancellationToken ct, List<string> counter_list, IConsole console, int processId, string diagnosticsServerAddress, int refreshInterval, CountersExportFormat format, string output)
         {
             try
             {
@@ -153,7 +153,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 _counterList = counter_list; // NOTE: This variable name has an underscore because that's the "name" that the CLI displays. System.CommandLine doesn't like it if we change the variable to camelcase. 
                 _console = console;
                 _processId = processId;
-                _transportPath = transportPath;
+                _diagnosticsServerAddress = diagnosticsServerAddress;
                 _interval = refreshInterval;
                 _output = output;
                 _diagnosticsClient = new DiagnosticsClient(processId);

--- a/src/Tools/dotnet-counters/CounterMonitor.cs
+++ b/src/Tools/dotnet-counters/CounterMonitor.cs
@@ -85,10 +85,13 @@ namespace Microsoft.Diagnostics.Tools.Counters
 
         private bool ValidateProcessIdAndDiagnosticsServerAddress()
         {
-            if (string.IsNullOrEmpty(_diagnosticsServerAddress) && _processId ==0)
+            if (string.IsNullOrEmpty(_diagnosticsServerAddress))
             {
-                _console.Error.WriteLine("--process-id is required.");
-                return false;
+                if (_processId == 0)
+                {
+                    _console.Error.WriteLine("--process-id is required.");
+                    return false;
+                }
             }
             else
             {

--- a/src/Tools/dotnet-counters/CounterMonitor.cs
+++ b/src/Tools/dotnet-counters/CounterMonitor.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
     public class CounterMonitor
     {
         private int _processId;
-        private int _transportPath;
+        private string _transportPath;
         private int _interval;
         private List<string> _counterList;
         private CancellationToken _ct;
@@ -95,12 +95,12 @@ namespace Microsoft.Diagnostics.Tools.Counters
             }
             else
             {
-                if (!File.Exists(transportPath) && !File.Exists(@"\\.pipe\" + transportPath))
+                if (!File.Exists(_transportPath) && !File.Exists(@"\\.pipe\" + _transportPath))
                 {
                     Console.Error.WriteLine("Requested transport does not exist");
                     return false;
                 }
-                else if (processId != 0)
+                else if (_processId != 0)
                 {
                     Console.Error.WriteLine("Cannot specify both a PID and specific transport");
                     return false;

--- a/src/Tools/dotnet-counters/CounterMonitor.cs
+++ b/src/Tools/dotnet-counters/CounterMonitor.cs
@@ -85,13 +85,10 @@ namespace Microsoft.Diagnostics.Tools.Counters
 
         private bool ValidateProcessIdAndDiagnosticsServerAddress()
         {
-            if (string.IsNullOrEmpty(_diagnosticsServerAddress))
+            if (string.IsNullOrEmpty(_diagnosticsServerAddress) && _processId ==0)
             {
-                if (_processId == 0)
-                {
-                    _console.Error.WriteLine("--process-id is required.");
-                    return false;
-                }
+                _console.Error.WriteLine("--process-id is required.");
+                return false;
             }
             else
             {

--- a/src/Tools/dotnet-counters/Program.cs
+++ b/src/Tools/dotnet-counters/Program.cs
@@ -29,9 +29,9 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 description: "Start monitoring a .NET application")
             {
                 // Handler
-                CommandHandler.Create<CancellationToken, List<string>, IConsole, int, int>(new CounterMonitor().Monitor),
+                CommandHandler.Create<CancellationToken, List<string>, IConsole, int, string, int>(new CounterMonitor().Monitor),
                 // Arguments and Options
-                CounterList(), ProcessIdOption(), RefreshIntervalOption()
+                CounterList(), ProcessIdOption(), TransportPathOption(), RefreshIntervalOption()
             };
 
         private static Command CollectCommand() =>
@@ -42,7 +42,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 // Handler
                 HandlerDescriptor.FromDelegate((ExportDelegate)new CounterMonitor().Collect).GetCommandHandler(),
                 // Arguments and Options
-                CounterList(), ProcessIdOption(), RefreshIntervalOption(), ExportFormatOption(), ExportFileNameOption()
+                CounterList(), ProcessIdOption(), TransportPathOption(), RefreshIntervalOption(), ExportFormatOption(), ExportFileNameOption()
             };
 
         private static Option ProcessIdOption() =>
@@ -51,6 +51,14 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 description: "The process id that will be monitored.")
             {
                 Argument = new Argument<int>(name: "pid")
+            };
+
+        private static Option TransportPathOption() =>
+            new Option(
+                alias: "--transport-path",
+                description: "A fully qualified path and filename for the OS transport to communicate over.  Supersedes the pid argument if provided.")
+            {
+                Argument = new Argument<string>(name: "transportPath")
             };
 
         private static Option RefreshIntervalOption() =>

--- a/src/Tools/dotnet-counters/Program.cs
+++ b/src/Tools/dotnet-counters/Program.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
 
     internal class Program
     {
-        delegate Task<int> ExportDelegate(CancellationToken ct, List<string> counter_list, IConsole console, int processId, int refreshInterval, CountersExportFormat format, string output);
+        delegate Task<int> ExportDelegate(CancellationToken ct, List<string> counter_list, IConsole console, int processId, string transportPath, int refreshInterval, CountersExportFormat format, string output);
 
         private static Command MonitorCommand() =>
             new Command(

--- a/src/Tools/dotnet-counters/Program.cs
+++ b/src/Tools/dotnet-counters/Program.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 // Handler
                 HandlerDescriptor.FromDelegate((ExportDelegate)new CounterMonitor().Collect).GetCommandHandler(),
                 // Arguments and Options
-                CounterList(), ProcessIdOption(), TransportPathOption(), RefreshIntervalOption(), ExportFormatOption(), ExportFileNameOption()
+                CounterList(), ProcessIdOption(), DiagnosticsServerAddressOption(), RefreshIntervalOption(), ExportFormatOption(), ExportFileNameOption()
             };
 
         private static Option ProcessIdOption() =>

--- a/src/Tools/dotnet-counters/Program.cs
+++ b/src/Tools/dotnet-counters/Program.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 // Handler
                 CommandHandler.Create<CancellationToken, List<string>, IConsole, int, string, int>(new CounterMonitor().Monitor),
                 // Arguments and Options
-                CounterList(), ProcessIdOption(), TransportPathOption(), RefreshIntervalOption()
+                CounterList(), ProcessIdOption(), DiagnosticsServerAddressOption(), RefreshIntervalOption()
             };
 
         private static Command CollectCommand() =>
@@ -53,12 +53,12 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 Argument = new Argument<int>(name: "pid")
             };
 
-        private static Option TransportPathOption() =>
+        private static Option DiagnosticsServerAddressOption() =>
             new Option(
-                alias: "--transport-path",
-                description: "A fully qualified path and filename for the OS transport to communicate over.  Supersedes the pid argument if provided.")
+                aliases: new string[] { "--address", "--diagnostics-server-address" },
+                description: "A fully qualified path for the OS transport the diagnostics server is using.")
             {
-                Argument = new Argument<string>(name: "transportPath")
+                Argument = new Argument<string>(name: "diagnosticsServerAddress")
             };
 
         private static Option RefreshIntervalOption() =>

--- a/src/Tools/dotnet-dump/Dumper.cs
+++ b/src/Tools/dotnet-dump/Dumper.cs
@@ -29,9 +29,9 @@ namespace Microsoft.Diagnostics.Tools.Dump
         {
         }
 
-        public async Task<int> Collect(IConsole console, int processId, string transportPath, string output, bool diag, DumpTypeOption type)
+        public async Task<int> Collect(IConsole console, int processId, string diagnosticsServerAddress, string output, bool diag, DumpTypeOption type)
         {
-            if (string.IsNullOrEmpty(transportPath))
+            if (string.IsNullOrEmpty(diagnosticsServerAddress))
             {
                 if (processId == 0) {
                     console.Error.WriteLine("ProcessId is required.");
@@ -42,10 +42,10 @@ namespace Microsoft.Diagnostics.Tools.Dump
             {
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
-                    Console.Error.WriteLine("Cannot create dumps via trasnportPath on Windows");
+                    Console.Error.WriteLine("Cannot create dumps via the Diagnostics Server on Windows");
                     return 1;
                 }
-                else if (!File.Exists(transportPath) && !File.Exists(@"\\.pipe\" + transportPath))
+                else if (!File.Exists(diagnosticsServerAddress) && !File.Exists(@"\\.\pipe\" + diagnosticsServerAddress))
                 {
                     Console.Error.WriteLine("Requested transport does not exist");
                     return 1;
@@ -82,7 +82,7 @@ namespace Microsoft.Diagnostics.Tools.Dump
                 }
                 else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 {
-                    var client = string.IsNullOrEmpty(transportPath) ? new DiagnosticsClient(processId) : new DiagnosticsClient(transportPath);
+                    var client = string.IsNullOrEmpty(diagnosticsServerAddress) ? new DiagnosticsClient(processId) : new DiagnosticsClient(diagnosticsServerAddress);
                     DumpType dumpType = type == DumpTypeOption.Heap ? DumpType.WithHeap : DumpType.Normal;
 
                     // Send the command to the runtime to initiate the core dump

--- a/src/Tools/dotnet-dump/Dumper.cs
+++ b/src/Tools/dotnet-dump/Dumper.cs
@@ -31,12 +31,10 @@ namespace Microsoft.Diagnostics.Tools.Dump
 
         public async Task<int> Collect(IConsole console, int processId, string diagnosticsServerAddress, string output, bool diag, DumpTypeOption type)
         {
-            if (string.IsNullOrEmpty(diagnosticsServerAddress))
+            if (string.IsNullOrEmpty(diagnosticsServerAddress) && processId == 0)
             {
-                if (processId == 0) {
-                    console.Error.WriteLine("ProcessId is required.");
-                    return 1;
-                }
+                console.Error.WriteLine("ProcessId is required.");
+                return 1;
             }
             else
             {

--- a/src/Tools/dotnet-dump/Dumper.cs
+++ b/src/Tools/dotnet-dump/Dumper.cs
@@ -31,12 +31,15 @@ namespace Microsoft.Diagnostics.Tools.Dump
 
         public async Task<int> Collect(IConsole console, int processId, string diagnosticsServerAddress, string output, bool diag, DumpTypeOption type)
         {
-            if (string.IsNullOrEmpty(diagnosticsServerAddress) && processId == 0)
+            if (string.IsNullOrEmpty(diagnosticsServerAddress))
             {
-                console.Error.WriteLine("ProcessId is required.");
-                return 1;
+                if (processId == 0)
+                {
+                    console.Error.WriteLine("ProcessId is required.");
+                    return 1;
+                }
             }
-            else
+            else if (!string.IsNullOrEmpty(diagnosticsServerAddress))
             {
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {

--- a/src/Tools/dotnet-dump/Program.cs
+++ b/src/Tools/dotnet-dump/Program.cs
@@ -31,9 +31,9 @@ namespace Microsoft.Diagnostics.Tools.Dump
             new Command( name: "collect", description: "Capture dumps from a process")
             {
                 // Handler
-                CommandHandler.Create<IConsole, int, string, bool, Dumper.DumpTypeOption>(new Dumper().Collect),
+                CommandHandler.Create<IConsole, int, string, string, bool, Dumper.DumpTypeOption>(new Dumper().Collect),
                 // Options
-                ProcessIdOption(), OutputOption(), DiagnosticLoggingOption(), TypeOption()
+                ProcessIdOption(), TransportPathOption(), OutputOption(), DiagnosticLoggingOption(), TypeOption()
             };
 
         private static Option ProcessIdOption() =>
@@ -42,6 +42,14 @@ namespace Microsoft.Diagnostics.Tools.Dump
                 description: "The process id to collect a memory dump.")
             {
                 Argument = new Argument<int>(name: "pid")
+            };
+
+        private static Option TransportPathOption() =>
+            new Option(
+                alias: "--transport-path",
+                description: "A fully qualified path and filename for the OS transport to communicate over.  Supersedes the pid argument if provided.")
+            {
+                Argument = new Argument<string>(name: "transportPath")
             };
 
         private static Option OutputOption() =>

--- a/src/Tools/dotnet-dump/Program.cs
+++ b/src/Tools/dotnet-dump/Program.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Diagnostics.Tools.Dump
         private static Option TransportPathOption() =>
             new Option(
                 alias: "--transport-path",
-                description: "A fully qualified path and filename for the OS transport to communicate over.  Supersedes the pid argument if provided.")
+                description: "A fully qualified path and filename for the OS transport to communicate over. ")
             {
                 Argument = new Argument<string>(name: "transportPath")
             };

--- a/src/Tools/dotnet-dump/Program.cs
+++ b/src/Tools/dotnet-dump/Program.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Diagnostics.Tools.Dump
                 // Handler
                 CommandHandler.Create<IConsole, int, string, string, bool, Dumper.DumpTypeOption>(new Dumper().Collect),
                 // Options
-                ProcessIdOption(), TransportPathOption(), OutputOption(), DiagnosticLoggingOption(), TypeOption()
+                ProcessIdOption(), DiagnosticsServerAddressOption(), OutputOption(), DiagnosticLoggingOption(), TypeOption()
             };
 
         private static Option ProcessIdOption() =>
@@ -44,12 +44,12 @@ namespace Microsoft.Diagnostics.Tools.Dump
                 Argument = new Argument<int>(name: "pid")
             };
 
-        private static Option TransportPathOption() =>
+        private static Option DiagnosticsServerAddressOption() =>
             new Option(
-                alias: "--transport-path",
-                description: "A fully qualified path and filename for the OS transport to communicate over. ")
+                aliases: new string[] { "--address", "--diagnostics-server-address" },
+                description: "A fully qualified path for the OS transport the diagnostics server is using.")
             {
-                Argument = new Argument<string>(name: "transportPath")
+                Argument = new Argument<string>(name: "diagnosticsServerAddress")
             };
 
         private static Option OutputOption() =>

--- a/src/Tools/dotnet-gcdump/CommandLine/CollectCommandHandler.cs
+++ b/src/Tools/dotnet-gcdump/CommandLine/CollectCommandHandler.cs
@@ -140,7 +140,7 @@ namespace Microsoft.Diagnostics.Tools.GCDump
         private static Option DiagnosticsServerAddressOption() =>
             new Option(
                 aliases: new string[] { "--address", "--diagnostics-server-address" },
-                description: "A fully qualified path for the OS transport the diagnostics server is using. Supersedes the pid argument if provided.")
+                description: "A fully qualified path for the OS transport the diagnostics server is using.")
             {
                 Argument = new Argument<string>(name: "diagnosticsServerAddress")
             };

--- a/src/Tools/dotnet-gcdump/DotNetHeapDump/EventPipeDotNetHeapDumper.cs
+++ b/src/Tools/dotnet-gcdump/DotNetHeapDump/EventPipeDotNetHeapDumper.cs
@@ -217,19 +217,16 @@ namespace Microsoft.Diagnostics.Tools.GCDump
             if (int.TryParse(processIdOrDiagnosticsServerAddress, out int pid))
             {
                 _pid = pid;
-                _providers = providers;
                 _client = new DiagnosticsClient(pid);
-                _session = _client.StartEventPipeSession(providers, requestRundown, 1024);
-                _source = new EventPipeEventSource(_session.EventStream);
             }
             else
             {
                 _pid = -1;
-                _providers = providers;
                 _client = new DiagnosticsClient(processIdOrDiagnosticsServerAddress);
-                _session = _client.StartEventPipeSession(providers, requestRundown, 1024);
-                _source = new EventPipeEventSource(_session.EventStream);
             }
+            _providers = providers;
+            _session = _client.StartEventPipeSession(providers, requestRundown, 1024);
+            _source = new EventPipeEventSource(_session.EventStream);
         }
 
         public void EndSession()

--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 {
                     if (!File.Exists(diagnosticsServerAddress) && !File.Exists(@"\\.\pipe\" + diagnosticsServerAddress))
                     {
-                        Console.Error.WriteLine($"Requested transport does not exist: '{(diagnosticsServerAddress.StartsWith(@"\\.\pipe") ? diagnosticsServerAddress : @"\\.\pipe\" + diagnosticsServerAddress)}'");
+                        Console.Error.WriteLine("Requested transport does not exist");
                         return ErrorCodes.ArgumentError;
                     }
                     else if (processId != 0)

--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
@@ -345,7 +345,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
 
         private static Option TransportPathOption() =>
             new Option(
-                alias: "--transportPath",
+                alias: "--transport-path",
                 description: "A fully qualified path and filename for the OS transport to communicate over.  Supersedes the pid argument if provided.")
             {
                 Argument = new Argument<string>(name: "transportPath")

--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
@@ -19,13 +19,14 @@ namespace Microsoft.Diagnostics.Tools.Trace
 {
     internal static class CollectCommandHandler
     {
-        delegate Task<int> CollectDelegate(CancellationToken ct, IConsole console, int processId, FileInfo output, uint buffersize, string providers, string profile, TraceFileFormat format, TimeSpan duration, string clrevents, string clreventlevel);
+        delegate Task<int> CollectDelegate(CancellationToken ct, IConsole console, string transportPath, int processId, FileInfo output, uint buffersize, string providers, string profile, TraceFileFormat format, TimeSpan duration, string clrevents, string clreventlevel);
 
         /// <summary>
         /// Collects a diagnostic trace from a currently running process.
         /// </summary>
         /// <param name="ct">The cancellation token</param>
         /// <param name="console"></param>
+        /// <param name="transportPath">A path to a named pipe on Windows or a Unix Domain Socket on Linux based systems</param>
         /// <param name="processId">The process to collect the trace from.</param>
         /// <param name="output">The output path for the collected trace data.</param>
         /// <param name="buffersize">Sets the size of the in-memory circular buffer in megabytes.</param>
@@ -36,22 +37,44 @@ namespace Microsoft.Diagnostics.Tools.Trace
         /// <param name="clrevents">A list of CLR events to be emitted.</param>
         /// <param name="clreventlevel">The verbosity level of CLR events</param>
         /// <returns></returns>
-        private static async Task<int> Collect(CancellationToken ct, IConsole console, int processId, FileInfo output, uint buffersize, string providers, string profile, TraceFileFormat format, TimeSpan duration, string clrevents, string clreventlevel)
+        private static async Task<int> Collect(CancellationToken ct, IConsole console, string transportPath, int processId, FileInfo output, uint buffersize, string providers, string profile, TraceFileFormat format, TimeSpan duration, string clrevents, string clreventlevel)
         {
             try
             {
                 Debug.Assert(output != null);
                 Debug.Assert(profile != null);
 
-                if (processId < 0)
+                bool hasConsole = console.GetTerminal() != null;
+
+                if (hasConsole)
+                    Console.Clear();
+
+                if (string.IsNullOrEmpty(transportPath))
                 {
-                    Console.Error.WriteLine("Process ID should not be negative.");
-                    return ErrorCodes.ArgumentError;
+                    if (processId < 0)
+                    {
+                        Console.Error.WriteLine("Process ID should not be negative.");
+                        return ErrorCodes.ArgumentError;
+                    }
+                    else if (processId == 0)
+                    {
+                        Console.Error.WriteLine("--process-id is required");
+                        return ErrorCodes.ArgumentError;
+                    }
                 }
-                else if (processId == 0)
+                else
                 {
-                    Console.Error.WriteLine("--process-id is required");
-                    return ErrorCodes.ArgumentError;
+
+                    if (!File.Exists(transportPath) || !File.Exists(@"\\.pipe\" + transportPath))
+                    {
+                        Console.Error.WriteLine("Requested transport does not exist");
+                        return ErrorCodes.ArgumentError;
+                    }
+                    else if (processId != 0)
+                    {
+                        Console.Error.WriteLine("Cannot specify both a PID and specific transport");
+                        return ErrorCodes.ArgumentError;
+                    }
                 }
 
                 bool hasConsole = console.GetTerminal() != null;
@@ -111,7 +134,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
 
                 PrintProviders(providerCollection, enabledBy);
 
-                var process = Process.GetProcessById(processId);
+                Process process = string.IsNullOrEmpty(transportPath) ? Process.GetProcessById(processId) : null;
                 var shouldExit = new ManualResetEvent(false);
                 var shouldStopAfterDuration = duration != default(TimeSpan);
                 var failed = false;
@@ -121,7 +144,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
 
                 ct.Register(() => shouldExit.Set());
 
-                var diagnosticsClient = new DiagnosticsClient(processId);
+                var diagnosticsClient = string.IsNullOrEmpty(transportPath) ? new DiagnosticsClient(processId) : new DiagnosticsClient(transportPath);
                 using (VirtualTerminalMode vTermMode = VirtualTerminalMode.TryEnable())
                 {
                     EventPipeSession session = null;
@@ -157,7 +180,8 @@ namespace Microsoft.Diagnostics.Tools.Trace
 
                             using (var fs = new FileStream(output.FullName, FileMode.Create, FileAccess.Write))
                             {
-                                Console.Out.WriteLine($"Process        : {process.MainModule.FileName}");
+                                if (process != null)
+                                    Console.Out.WriteLine($"Process        : {process.MainModule.FileName}");
                                 Console.Out.WriteLine($"Output File    : {fs.Name}");
                                 if (shouldStopAfterDuration)
                                     Console.Out.WriteLine($"Trace Duration : {duration.ToString(@"dd\:hh\:mm\:ss")}");
@@ -298,6 +322,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 HandlerDescriptor.FromDelegate((CollectDelegate)Collect).GetCommandHandler(),
                 // Options
                 CommonOptions.ProcessIdOption(),
+                TransportPathOption(),
                 CircularBufferOption(),
                 OutputPathOption(),
                 ProvidersOption(),
@@ -316,6 +341,14 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 description: $"Sets the size of the in-memory circular buffer in megabytes. Default {DefaultCircularBufferSizeInMB} MB.")
             {
                 Argument = new Argument<uint>(name: "size", defaultValue: DefaultCircularBufferSizeInMB)
+            };
+
+        private static Option TransportPathOption() =>
+            new Option(
+                alias: "--transportPath",
+                description: "A fully qualified path and filename for the OS transport to communicate over.  Supersedes the pid argument if provided.")
+            {
+                Argument = new Argument<string>(name: "transportPath")
             };
 
         public static string DefaultTraceName => "trace.nettrace";

--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 else
                 {
 
-                    if (!File.Exists(transportPath) || !File.Exists(@"\\.pipe\" + transportPath))
+                    if (!File.Exists(transportPath) && !File.Exists(@"\\.pipe\" + transportPath))
                     {
                         Console.Error.WriteLine("Requested transport does not exist");
                         return ErrorCodes.ArgumentError;

--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
@@ -44,11 +44,6 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 Debug.Assert(output != null);
                 Debug.Assert(profile != null);
 
-                bool hasConsole = console.GetTerminal() != null;
-
-                if (hasConsole)
-                    Console.Clear();
-
                 if (string.IsNullOrEmpty(diagnosticsServerAddress))
                 {
                     if (processId < 0)

--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
@@ -345,7 +345,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
         private static Option DiagnosticsServerAddressOption() =>
             new Option(
                 aliases: new string[] { "--address", "--diagnostics-server-address" },
-                description: "A fully qualified path for the OS transport the diagnostics server is using. Supersedes the pid argument if provided.")
+                description: "A fully qualified path for the OS transport the diagnostics server is using.")
             {
                 Argument = new Argument<string>(name: "diagnosticsServerAddress")
             };


### PR DESCRIPTION
Once dotnet/runtime#1600 is merged in, the runtime will be able to create the diagnostics server transport at a specific location.  This change allows the tools to consume the path to a Unix Domain Socket or a specific Named Pipe.

Example: `dotnet trace collect --transport-path /diagnostics/myapp.sock`

The client library is also updated to allow for creating a `DiagnosticsClient` using a `string` (for path) instead of an `int` (for pid).

CC - @shirhatti @tommcdon 