### PR TITLE
Fix the Windows private runtime build testing problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,62 +27,22 @@ To install the platform's prerequisites and build:
  * [MacOS Instructions](documentation/building/osx-instructions.md)
  * [FreeBSD Instructions](documentation/building/freebsd-instructions.md)
  * [NetBSD Instructions](documentation/building/netbsd-instructions.md)
+ * [Testing on private runtime builds](documentation/privatebuildtesting.md)
 
-## Getting lldb
+## SOS and Other Diagnostic Tools
 
-Getting a version of lldb that works for your platform can be a problem sometimes. The version has to be at least 3.9 or greater because of a bug running SOS on a core dump that was fixed. Some Linux distros like Ubuntu it is easy as `sudo apt-get install lldb-3.9 python-lldb-3.9`. On other distros, you will need to build lldb. The directions below should give you some guidance.
-
-* [Linux Instructions](documentation/lldb/linux-instructions.md)
-* [MacOS Instructions](documentation/lldb/osx-instructions.md)
-* [FreeBSD Instructions](documentation/lldb/freebsd-instructions.md)
-* [NetBSD Instructions](documentation/lldb/netbsd-instructions.md)
-
-## Installing SOS
-
-* [Linux and MacOS Instructions](documentation/installing-sos-instructions.md)
-* [Windows Instructions](documentation/installing-sos-windows-instructions.md)
-
-## Using SOS
-
-* [SOS debugging for Linux/MacOS](documentation/sos-debugging-extension.md)
-* [SOS debugging for Windows](documentation/sos-debugging-extension-windows.md)
-* [Debugging a core dump](documentation/debugging-coredump.md)
-
-## Tools
-
+* [SOS](documentation/sos.md) - About the SOS debugger extension.
 * [dotnet-dump](documentation/dotnet-dump-instructions.md) - Dump collection and analysis utility.
 * [dotnet-trace](documentation/dotnet-trace-instructions.md) - Enable the collection of events for a running .NET Core Application to a local trace file.
 * [dotnet-counters](documentation/dotnet-counters-instructions.md) - Monitor performance counters of a .NET Core application in real time. 
-
-## New Features
-
-The `bpmd` command can now be used before the runtime is loaded. You can load SOS or the sos plugin on Linux and execute bpmd. Always add the module extension for the first parameter.
-
-    bpmd SymbolTestApp.dll SymbolTestApp.Program.Main
-
-You can set a source file/line number breakpoint like this (the fully qualified source file path is usually not necessary):
-
-    bpmd SymbolTestApp.cs:24
-
-Symbol server support - The `setsymbolserver` command enables downloading the symbol files (portable PDBs) for managed assemblies during commands like `clrstack`, etc. See `soshelp setsymbolserver` for more details.
-
-    (lldb) setsymbolserver -ms
-
-Before executing the "bt" command to dump native frames to load the native symbols (for live debugging only):
-
-    (lldb) loadsymbols
-
-To add a local directory to search for symbols:
-
-    (lldb) setsymbolserver -directory /tmp/symbols
 
 ## Useful Links
 
 * [FAQ](documentation/FAQ.md) - Frequently asked questions.
 * [The LLDB Debugger](http://lldb.llvm.org/index.html) - More information about lldb.
 * [SOS](https://msdn.microsoft.com/en-us/library/bb190764(v=vs.110).aspx) - More information about SOS.
-* [Debugging CoreCLR](https://github.com/dotnet/coreclr/blob/master/Documentation/building/debugging-instructions.md) - Instructions for debugging .NET Core and the CoreCLR runtime.
-* [dotnet/coreclr](https://github.com/dotnet/coreclr) - Source for the .NET Core runtime.
+* [Debugging CoreCLR](https://github.com/dotnet/runtime/blob/master/docs/workflow/debugging/coreclr/debugging.md) - Instructions for debugging .NET Core and the CoreCLR runtime.
+* [dotnet/runtime](https://github.com/dotnet/runtime) - Source for the .NET Core runtime.
 * [Official Build Instructions](documentation/building/official-build-instructions.md) - Internal official build instructions.
 
 [//]: # (Begin current test results)

--- a/documentation/privatebuildtesting.md
+++ b/documentation/privatebuildtesting.md
@@ -1,7 +1,7 @@
 Private runtime build testing
 =============================
 
-Here are some instructions on how to run the diagnostics repo's tests against a locally build private .NET Core runtime. These directions will work on Windows, Linux and MacOS. On Windows there are a couple of registry keys that need to be added so the tests can create proper mini-dumps.
+Here are some instructions on how to run the diagnostics repo's tests against a locally build private .NET Core runtime. These directions will work on Windows, Linux and MacOS. 
 
 1. Build the runtime repo (see [Workflow Guide](https://github.com/dotnet/runtime/blob/master/docs/workflow/README.md)).
 2. Build the diagnostics repo (see [Building the Repository](../README.md)).
@@ -12,15 +12,23 @@ On Windows:
 C:\diagnostics> test -privatebuildpath c:\runtime\artifacts\bin\coreclr\Windows_NT.x64.Debug
 ```
 
-There will be some popups from regedit asking for administrator permission to edit the registry (press Yes), warning about adding registry keys from PrivateTesting.reg (press Yes) and that the edit was successful (press OK).
+When you are all done with the private runtime testing, run this command to remove the Windows registry entries added in the above steps.
+
+```
+C:\diagnostics> test -cleanupprivatebuild
+```
+
+There will be some popups from regedit asking for administrator permission to edit the registry (press Yes), warning about adding registry keys from AddPrivateTesting.reg (press Yes) and that the edit was successful (press OK).
 
 On Linux/MacOS:
 ```
 ~/diagnostics$ ./test.sh --privatebuildpath /home/user/runtime/artifacts/bin/coreclr/Linux.x64.Debug
 ```
-The private runtime will be copied to the diagnostics repo and the tests started. It can be just the coreclr binaries but this assumes that the private build is close to the latest published master build. If not, you can pass the runtime's testhost directory containing all the shared runtime bits i.e. `c:\runtime\artifacts\bin\testhost\netcoreapp5.0-Windows_NT-Debug-x64\shared\Microsoft.NETCore.App\5.0.0`.
+The private runtime will be copied to the diagnostics repo and the tests started. It can be just the coreclr binaries but this assumes that the private build is close to the latest published master build. If not, you can pass the runtime's testhost directory containing all the shared runtime bits i.e. `c:\runtime\artifacts\bin\testhost\netcoreapp5.0-Windows_NT-Debug-x64\shared\Microsoft.NETCore.App\5.0.0` or `/home/user/runtime/artifacts/bin/testhost/netcoreapp5.0-Linux-Release-x64/shared/Microsoft.NETCore.App/5.0.0`
 
-The an example of the registry key values added on Windows:
+On Linux/MacOS it is recommended to test against Release runtime builds because of a benign assert in DAC (tracked by issue #[31897](https://github.com/dotnet/runtime/issues/31897)) that causes the tests to fail.
+
+On Windows the DAC is not properly signed for a private runtime build so there are a couple of registry keys that need to be added so Windows will load the DAC and the tests can create proper mini-dumps. An example of the registry key values added are:
 
 ```
 [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\KnownManagedDebuggingDlls]

--- a/documentation/privatebuildtesting.md
+++ b/documentation/privatebuildtesting.md
@@ -1,0 +1,31 @@
+Private runtime build testing
+=============================
+
+Here are some instructions on how to run the diagnostics repo's tests against a locally build private .NET Core runtime. These directions will work on Windows, Linux and MacOS. On Windows there are a couple of registry keys that need to be added so the tests can create proper mini-dumps.
+
+1. Build the runtime repo (see [Workflow Guide](https://github.com/dotnet/runtime/blob/master/docs/workflow/README.md)).
+2. Build the diagnostics repo (see [Building the Repository](../README.md)).
+3. Run the diagnostics repo tests with the -privatebuildpath option.
+
+On Windows:
+```
+C:\diagnostics> test -privatebuildpath c:\runtime\artifacts\bin\coreclr\Windows_NT.x64.Debug
+```
+
+There will be some popups from regedit asking for administrator permission to edit the registry (press Yes), warning about adding registry keys from PrivateTesting.reg (press Yes) and that the edit was successful (press OK).
+
+On Linux/MacOS:
+```
+~/diagnostics$ ./test.sh --privatebuildpath /home/user/runtime/artifacts/bin/coreclr/Linux.x64.Debug
+```
+The private runtime will be copied to the diagnostics repo and the tests started. It can be just the coreclr binaries but this assumes that the private build is close to the latest published master build. If not, you can pass the runtime's testhost directory containing all the shared runtime bits i.e. `c:\runtime\artifacts\bin\testhost\netcoreapp5.0-Windows_NT-Debug-x64\shared\Microsoft.NETCore.App\5.0.0`.
+
+The an example of the registry key values added on Windows:
+
+```
+[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\KnownManagedDebuggingDlls]
+"C:\diagnostics\.dotnet\shared\Microsoft.NETCore.App\5.0.0-alpha.1.20102.3\mscordaccore.dll"=dword:0
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\MiniDumpAuxiliaryDlls]
+"C:\diagnostics\.dotnet\shared\Microsoft.NETCore.App\5.0.0-alpha.1.20102.3\coreclr.dll"="C:\diagnostics\.dotnet\shared\Microsoft.NETCore.App\5.0.0-alpha.1.20102.3\mscordaccore.dll"
+```

--- a/documentation/sos.md
+++ b/documentation/sos.md
@@ -1,0 +1,46 @@
+SOS 
+===
+
+SOS is a debugger extension that allows a developer to inspect the managed state of a .NET Core and desktop runtime process. SOS can be loaded by WinDbg/cdb debuggers on Windows and lldb on Linux and MacOS.
+
+## Getting lldb
+
+Getting a version of lldb that works for your platform can be a problem sometimes. The version has to be at least 3.9 or greater because of a bug running SOS on a core dump that was fixed. Some Linux distros like Ubuntu it is easy as `sudo apt-get install lldb-3.9 python-lldb-3.9`. On other distros, you will need to build lldb. The directions below should give you some guidance.
+
+* [Linux Instructions](lldb/linux-instructions.md)
+* [MacOS Instructions](lldb/osx-instructions.md)
+* [FreeBSD Instructions](lldb/freebsd-instructions.md)
+* [NetBSD Instructions](lldb/netbsd-instructions.md)
+
+## Installing SOS
+
+* [Linux and MacOS Instructions](installing-sos-instructions.md)
+* [Windows Instructions](installing-sos-windows-instructions.md)
+
+## Using SOS
+
+* [SOS debugging for Linux/MacOS](sos-debugging-extension.md)
+* [SOS debugging for Windows](sos-debugging-extension-windows.md)
+* [Debugging a core dump](debugging-coredump.md)
+
+## New SOS Features
+
+The `bpmd` command can now be used before the runtime is loaded. You can load SOS or the sos plugin on Linux and execute bpmd. Always add the module extension for the first parameter.
+
+    bpmd SymbolTestApp.dll SymbolTestApp.Program.Main
+
+You can set a source file/line number breakpoint like this (the fully qualified source file path is usually not necessary):
+
+    bpmd SymbolTestApp.cs:24
+
+Symbol server support - The `setsymbolserver` command enables downloading the symbol files (portable PDBs) for managed assemblies during commands like `clrstack`, etc. See `soshelp setsymbolserver` for more details.
+
+    (lldb) setsymbolserver -ms
+
+Before executing the "bt" command to dump native frames to load the native symbols (for live debugging only):
+
+    (lldb) loadsymbols
+
+To add a local directory to search for symbols:
+
+    (lldb) setsymbolserver -directory /tmp/symbols

--- a/eng/CleanupPrivateBuild.csproj
+++ b/eng/CleanupPrivateBuild.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+  
+  <Import Project="$(RepositoryEngineeringDir)\InstallRuntimes.proj" />
+</Project>
+

--- a/eng/InstallRuntimes.proj
+++ b/eng/InstallRuntimes.proj
@@ -28,7 +28,8 @@
     <DotNetInstallRoot Condition="'$(BuildArch)' == 'x86'">$(DotNetRoot)x86\</DotNetInstallRoot>
     <DotNetInstallDir>$(DotNetInstallRoot.Replace("\", "\\"))shared\\Microsoft.NETCore.App\\$(MicrosoftNETCoreAppVersion)\\</DotNetInstallDir>
     <TestConfigFileName>$(DotNetInstallRoot)Debugger.Tests.Versions.txt</TestConfigFileName>
-    <RegeditFileName>$(DotNetInstallRoot)PrivateTesting.reg</RegeditFileName>
+    <AddRegeditFileName>$(DotNetInstallRoot)AddPrivateTesting.reg</AddRegeditFileName>
+    <RemoveRegeditFileName>$(DotNetInstallRoot)RemovePrivateTesting.reg</RemoveRegeditFileName>
   </PropertyGroup>
 
   <Choose>
@@ -53,22 +54,17 @@
     <TestVersions Include="21" RuntimeVersion="$(MicrosoftNETCoreApp21Version)" AspNetVersion="$(MicrosoftAspNetCoreApp21Version)" Install="true" />
   </ItemGroup>
 
+<!--
+    Installs the runtimes for the SOS tests, handles private runtime build support or cleans up the private build registry keys
+-->
+
   <Target Name="InstallTestRuntimes" 
           BeforeTargets="RunTests"
           DependsOnTargets="InstallRuntimesWindows;InstallRuntimesUnix;WriteTestVersionManifest;TestPrivateBuild" />
 
-  <Target Name="TestPrivateBuild"
-          Condition="'$(PrivateBuildPath)' != ''"
-          DependsOnTargets="ModifyRegistry">
-
-    <ItemGroup>
-      <PrivateBuildFiles Include="$(PrivateBuildPath)\*" />
-    </ItemGroup>
-
-    <Message Importance="High" Text="Copying private build binaries from $(PrivateBuildPath) to $(DotNetInstallDir.Replace('\\', '\'))" />
-
-    <Copy SourceFiles="@(PrivateBuildFiles)" DestinationFolder="$(DotNetInstallDir.Replace('\\', '\'))" />
-  </Target>
+<!--
+    Installs the test runtimes on Windows
+-->
 
   <Target Name="InstallRuntimesWindows"
           Condition="$([MSBuild]::IsOsPlatform(Windows))"
@@ -80,6 +76,10 @@
     <Exec Command="$(PowershellWrapper) &quot;&amp; { &amp;$(DotnetInstallScriptCmd) $(CommonInstallArgs) -version %(TestVersions.AspNetVersion) -runtime aspnetcore }&quot;"
           Condition="%(TestVersions.Install)" />
   </Target>
+
+<!--
+    Installs the test runtimes on Linux/MacOS
+-->
 
   <Target Name="InstallRuntimesUnix"
           Condition="!$([MSBuild]::IsOsPlatform(Windows))"
@@ -93,6 +93,10 @@
           IgnoreStandardErrorWarningFormat="true"
           Condition="%(TestVersions.Install)" />
    </Target>
+
+<!--
+    Writes the Debugger.Tests.Versions.txt file used by the SOS test harness
+-->
 
   <Target Name="WriteTestVersionManifest" 
           Inputs="$(VersionsPropsPath)" 
@@ -117,6 +121,7 @@
     </PropertyGroup>
 
     <WriteLinesToFile File="$(TestConfigFileName)" Lines="$(TestConfigFileLines)" Overwrite="true" WriteOnlyWhenDifferent="true" />
+
     <Message Importance="High" Text="Created config file $(TestConfigFileName)" />
 
     <ItemGroup>
@@ -124,13 +129,35 @@
     </ItemGroup>
   </Target>
 
+<!--
+    Copies the private runtime build binaries and on Windows adds registry keys
+-->
+
+  <Target Name="TestPrivateBuild"
+          Condition="'$(PrivateBuildPath)' != ''"
+          DependsOnTargets="ModifyRegistry">
+
+    <ItemGroup>
+      <PrivateBuildFiles Include="$(PrivateBuildPath)\*" />
+    </ItemGroup>
+
+    <Message Importance="High" Text="Copying private build binaries from $(PrivateBuildPath) to $(DotNetInstallDir.Replace('\\', '\'))" />
+
+    <Copy SourceFiles="@(PrivateBuildFiles)" DestinationFolder="$(DotNetInstallDir.Replace('\\', '\'))" />
+  </Target>
+
+<!--
+    On Windows adds the registry keys to allow the unsigned private build DAC to generate dumps
+-->
+
   <Target Name="ModifyRegistry"
           Condition="$([MSBuild]::IsOsPlatform(Windows))"
+          DependsOnTargets="CreateRemoveRegFile"
           Inputs="$(VersionsPropsPath)" 
-          Outputs="$(RegeditFileName)">
+          Outputs="$(AddRegeditFileName)">
 
     <PropertyGroup>
-      <RegeditFileLines>
+      <AddRegeditFileLines>
 <![CDATA[
 Windows Registry Editor Version 5.00
 
@@ -140,16 +167,42 @@ Windows Registry Editor Version 5.00
 [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\MiniDumpAuxiliaryDlls]
 "$(DotNetInstallDir)coreclr.dll"="$(DotNetInstallDir)mscordaccore.dll"
 ]]>
-      </RegeditFileLines>
+      </AddRegeditFileLines>
     </PropertyGroup>
 
-    <WriteLinesToFile File="$(RegeditFileName)" Lines="$(RegeditFileLines)" Overwrite="true" WriteOnlyWhenDifferent="true" />
+    <WriteLinesToFile File="$(AddRegeditFileName)" Lines="$(AddRegeditFileLines)" Overwrite="true" WriteOnlyWhenDifferent="true" />
 
     <ItemGroup>
-      <FileWrites Include="$(RegeditFileName)" />
+      <FileWrites Include="$(AddRegeditFileName)" />
     </ItemGroup>
 
-    <Exec Command="regedit $(RegeditFileName)" />
+    <Exec Command="regedit $(AddRegeditFileName)" />
+  </Target>
+
+<!--
+    Creates the reg file to remove the registry keys added in ModifyRegistry
+-->
+
+  <Target Name="CreateRemoveRegFile">
+    <PropertyGroup>
+      <RemoveRegeditFileLines>
+<![CDATA[
+Windows Registry Editor Version 5.00
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\KnownManagedDebuggingDlls]
+"$(DotNetInstallDir)mscordaccore.dll"=-
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\MiniDumpAuxiliaryDlls]
+"$(DotNetInstallDir)coreclr.dll"=-
+]]>
+      </RemoveRegeditFileLines>
+    </PropertyGroup>
+
+    <WriteLinesToFile File="$(RemoveRegeditFileName)" Lines="$(RemoveRegeditFileLines)" Overwrite="true" WriteOnlyWhenDifferent="true" />
+
+    <ItemGroup>
+      <FileWrites Include="$(RemoveRegeditFileName)" />
+    </ItemGroup>
   </Target>
 
 </Project>

--- a/eng/InstallRuntimes.proj
+++ b/eng/InstallRuntimes.proj
@@ -1,7 +1,9 @@
+<!-- All Rights Reserved. Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 <Project>
   <!--
      $(BuildArch) - architecture to test (x64, x86, arm, arm64). Defaults to x64.
      $(DailyTest) - if true, only install/test the latest (master branch) runtime
+     $(PrivateBuildPath) - if non-empty, path to private runtime build to copy/test
      
      From Versions.props:
 
@@ -22,8 +24,11 @@
     <BuildArch Condition="'$(BuildArch)' == ''">$(Platform)</BuildArch>
     <BuildArch Condition="'$(BuildArch)' == ''">x64</BuildArch>
     <CommonInstallArgs>-architecture $(BuildArch)</CommonInstallArgs>
-    <TestConfigFileName Condition="'$(BuildArch)' != 'x86'">$(DotNetRoot)Debugger.Tests.Versions.txt</TestConfigFileName>
-    <TestConfigFileName Condition="'$(BuildArch)' == 'x86'">$(DotNetRoot)x86\Debugger.Tests.Versions.txt</TestConfigFileName>
+    <DotNetInstallRoot Condition="'$(BuildArch)' != 'x86'">$(DotNetRoot)</DotNetInstallRoot>
+    <DotNetInstallRoot Condition="'$(BuildArch)' == 'x86'">$(DotNetRoot)x86\</DotNetInstallRoot>
+    <DotNetInstallDir>$(DotNetInstallRoot.Replace("\", "\\"))shared\\Microsoft.NETCore.App\\$(MicrosoftNETCoreAppVersion)\\</DotNetInstallDir>
+    <TestConfigFileName>$(DotNetInstallRoot)Debugger.Tests.Versions.txt</TestConfigFileName>
+    <RegeditFileName>$(DotNetInstallRoot)PrivateTesting.reg</RegeditFileName>
   </PropertyGroup>
 
   <Choose>
@@ -45,12 +50,25 @@
     <TestVersions Include="Latest" RuntimeVersion="$(MicrosoftNETCoreAppVersion)" AspNetVersion="$(MicrosoftAspNetCoreAppRefVersion)" Install="true" />
     <TestVersions Include="31" RuntimeVersion="$(MicrosoftNETCoreApp31Version)" AspNetVersion="$(MicrosoftAspNetCoreApp31Version)" Install="!$(DailyTest)" />
     <TestVersions Include="30" RuntimeVersion="$(MicrosoftNETCoreApp30Version)" AspNetVersion="$(MicrosoftAspNetCoreApp30Version)" Install="!$(DailyTest)" />
-    <TestVersions Include="21" RuntimeVersion="$(MicrosoftNETCoreApp21Version)" AspNetVersion="$(MicrosoftAspNetCoreApp21Version)" Install="!$(DailyTest)" />
+    <TestVersions Include="21" RuntimeVersion="$(MicrosoftNETCoreApp21Version)" AspNetVersion="$(MicrosoftAspNetCoreApp21Version)" Install="true" />
   </ItemGroup>
 
   <Target Name="InstallTestRuntimes" 
           BeforeTargets="RunTests"
-          DependsOnTargets="InstallRuntimesWindows;InstallRuntimesUnix;WriteTestVersionManifest" />
+          DependsOnTargets="InstallRuntimesWindows;InstallRuntimesUnix;WriteTestVersionManifest;TestPrivateBuild" />
+
+  <Target Name="TestPrivateBuild"
+          Condition="'$(PrivateBuildPath)' != ''"
+          DependsOnTargets="ModifyRegistry">
+
+    <ItemGroup>
+      <PrivateBuildFiles Include="$(PrivateBuildPath)\*" />
+    </ItemGroup>
+
+    <Message Importance="High" Text="Copying private build binaries from $(PrivateBuildPath) to $(DotNetInstallDir.Replace('\\', '\'))" />
+
+    <Copy SourceFiles="@(PrivateBuildFiles)" DestinationFolder="$(DotNetInstallDir.Replace('\\', '\'))" />
+  </Target>
 
   <Target Name="InstallRuntimesWindows"
           Condition="$([MSBuild]::IsOsPlatform(Windows))"
@@ -76,7 +94,10 @@
           Condition="%(TestVersions.Install)" />
    </Target>
 
-  <Target Name="WriteTestVersionManifest" Inputs="$(VersionsPropsPath)" Outputs="$(TestConfigFileName)">
+  <Target Name="WriteTestVersionManifest" 
+          Inputs="$(VersionsPropsPath)" 
+          Outputs="$(TestConfigFileName)">
+
     <PropertyGroup>
       <TestConfigFileLines>
 <![CDATA[
@@ -92,7 +113,7 @@
   <AspNetCoreVersionLatest>$(MicrosoftAspNetCoreAppRefVersion)</AspNetCoreVersionLatest>
 </Configuration>
 ]]>
-     </TestConfigFileLines>
+      </TestConfigFileLines>
     </PropertyGroup>
 
     <WriteLinesToFile File="$(TestConfigFileName)" Lines="$(TestConfigFileLines)" Overwrite="true" WriteOnlyWhenDifferent="true" />
@@ -102,4 +123,33 @@
       <FileWrites Include="$(TestConfigFileName)" />
     </ItemGroup>
   </Target>
+
+  <Target Name="ModifyRegistry"
+          Condition="$([MSBuild]::IsOsPlatform(Windows))"
+          Inputs="$(VersionsPropsPath)" 
+          Outputs="$(RegeditFileName)">
+
+    <PropertyGroup>
+      <RegeditFileLines>
+<![CDATA[
+Windows Registry Editor Version 5.00
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\KnownManagedDebuggingDlls]
+"$(DotNetInstallDir)mscordaccore.dll"=dword:0
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\MiniDumpAuxiliaryDlls]
+"$(DotNetInstallDir)coreclr.dll"="$(DotNetInstallDir)mscordaccore.dll"
+]]>
+      </RegeditFileLines>
+    </PropertyGroup>
+
+    <WriteLinesToFile File="$(RegeditFileName)" Lines="$(RegeditFileLines)" Overwrite="true" WriteOnlyWhenDifferent="true" />
+
+    <ItemGroup>
+      <FileWrites Include="$(RegeditFileName)" />
+    </ItemGroup>
+
+    <Exec Command="regedit $(RegeditFileName)" />
+  </Target>
+
 </Project>

--- a/eng/InstallRuntimes.proj
+++ b/eng/InstallRuntimes.proj
@@ -23,13 +23,25 @@
     <DailyTest Condition="'$(DailyTest)' == ''">false</DailyTest>
     <BuildArch Condition="'$(BuildArch)' == ''">$(Platform)</BuildArch>
     <BuildArch Condition="'$(BuildArch)' == ''">x64</BuildArch>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(BuildArch)' != 'x86'">
+    <DotNetInstallRoot>$(DotNetRoot)</DotNetInstallRoot>
+    <RegistryRoot>HKEY_LOCAL_MACHINE\SOFTWARE</RegistryRoot>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(BuildArch)' == 'x86'">
+    <DotNetInstallRoot>$(DotNetRoot)x86\</DotNetInstallRoot>
+    <RegistryRoot>HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node</RegistryRoot>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <CommonInstallArgs>-architecture $(BuildArch)</CommonInstallArgs>
-    <DotNetInstallRoot Condition="'$(BuildArch)' != 'x86'">$(DotNetRoot)</DotNetInstallRoot>
-    <DotNetInstallRoot Condition="'$(BuildArch)' == 'x86'">$(DotNetRoot)x86\</DotNetInstallRoot>
     <DotNetInstallDir>$(DotNetInstallRoot.Replace("\", "\\"))shared\\Microsoft.NETCore.App\\$(MicrosoftNETCoreAppVersion)\\</DotNetInstallDir>
     <TestConfigFileName>$(DotNetInstallRoot)Debugger.Tests.Versions.txt</TestConfigFileName>
     <AddRegeditFileName>$(DotNetInstallRoot)AddPrivateTesting.reg</AddRegeditFileName>
     <RemoveRegeditFileName>$(DotNetInstallRoot)RemovePrivateTesting.reg</RemoveRegeditFileName>
+    <RegeditCommand>regedit.exe</RegeditCommand>
   </PropertyGroup>
 
   <Choose>
@@ -153,10 +165,10 @@
   <Target Name="CleanupPrivateBuild"
           Condition="Exists($(RemoveRegeditFileName))">
 
-    <Exec Command="regedit $(RemoveRegeditFileName)" />
+    <Exec Command="$(RegeditCommand) $(RemoveRegeditFileName)" />
     <!-- 
-        Deleting only the add reg key file so ModifyRegistry can run again. Leaving the
-        remove reg key file so this target can be run multiple times.
+        Delete only the AddRegeditFileName so the target ModifyRegistry will run on next 
+        build. Leaving the remove reg key file so this target can be run multiple times.
     -->
     <Delete Files="$(AddRegeditFileName)" />
   </Target>
@@ -176,10 +188,10 @@
 <![CDATA[
 Windows Registry Editor Version 5.00
 
-[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\KnownManagedDebuggingDlls]
+[$(RegistryRoot)\Microsoft\Windows NT\CurrentVersion\KnownManagedDebuggingDlls]
 "$(DotNetInstallDir)mscordaccore.dll"=dword:0
 
-[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\MiniDumpAuxiliaryDlls]
+[$(RegistryRoot)\Microsoft\Windows NT\CurrentVersion\MiniDumpAuxiliaryDlls]
 "$(DotNetInstallDir)coreclr.dll"="$(DotNetInstallDir)mscordaccore.dll"
 ]]>
       </AddRegeditFileLines>
@@ -191,7 +203,7 @@ Windows Registry Editor Version 5.00
       <FileWrites Include="$(AddRegeditFileName)" />
     </ItemGroup>
 
-    <Exec Command="regedit $(AddRegeditFileName)" />
+    <Exec Command="$(RegeditCommand) $(AddRegeditFileName)" />
   </Target>
 
 <!--
@@ -204,10 +216,10 @@ Windows Registry Editor Version 5.00
 <![CDATA[
 Windows Registry Editor Version 5.00
 
-[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\KnownManagedDebuggingDlls]
+[$(RegistryRoot)\Microsoft\Windows NT\CurrentVersion\KnownManagedDebuggingDlls]
 "$(DotNetInstallDir)mscordaccore.dll"=-
 
-[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\MiniDumpAuxiliaryDlls]
+[$(RegistryRoot)\Microsoft\Windows NT\CurrentVersion\MiniDumpAuxiliaryDlls]
 "$(DotNetInstallDir)coreclr.dll"=-
 ]]>
       </RemoveRegeditFileLines>

--- a/eng/InstallRuntimes.proj
+++ b/eng/InstallRuntimes.proj
@@ -147,6 +147,21 @@
   </Target>
 
 <!--
+    Removes the private build registry keys
+-->
+
+  <Target Name="CleanupPrivateBuild"
+          Condition="Exists($(RemoveRegeditFileName))">
+
+    <Exec Command="regedit $(RemoveRegeditFileName)" />
+    <!-- 
+        Deleting only the add reg key file so ModifyRegistry can run again. Leaving the
+        remove reg key file so this target can be run multiple times.
+    -->
+    <Delete Files="$(AddRegeditFileName)" />
+  </Target>
+
+<!--
     On Windows adds the registry keys to allow the unsigned private build DAC to generate dumps
 -->
 

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -8,6 +8,7 @@ Param(
   [switch] $skipmanaged,
   [switch] $skipnative,
   [switch] $dailytest,
+  [string] $privatebuildpath = "",
   [Parameter(ValueFromRemainingArguments=$true)][String[]] $remainingargs
 )
 
@@ -45,9 +46,14 @@ $engroot = Join-Path $reporoot "eng"
 $artifactsdir = Join-Path $reporoot "artifacts"
 $logdir = Join-Path $artifactsdir "log"
 $logdir = Join-Path $logdir Windows_NT.$architecture.$configuration
+$dailytestproperty = "false"
 
 if ($ci) {
     $remainingargs = "-ci " + $remainingargs
+}
+
+if ($dailytest -or $privatebuildpath -ne "") {
+    $dailytestproperty = "true"
 }
 
 # Install sdk for building, restore and build managed components.
@@ -69,7 +75,7 @@ if (-not $skipnative) {
 # Run the xunit tests
 if ($test -or $dailytest) {
     if (-not $crossbuild) {
-        & "$engroot\common\build.ps1" -test -configuration $configuration -verbosity $verbosity -ci:$ci /bl:$logdir\Test.binlog /p:BuildArch=$architecture /p:TestArchitectures=$architecture /p:DailyTest=$dailyTest
+        & "$engroot\common\build.ps1" -test -configuration $configuration -verbosity $verbosity -ci:$ci /bl:$logdir\Test.binlog /p:BuildArch=$architecture /p:TestArchitectures=$architecture /p:DailyTest=$dailytestproperty /p:PrivateBuildPath=$privatebuildpath
         if ($lastExitCode -ne 0) {
             exit $lastExitCode
         }

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -59,16 +59,8 @@ if ($dailytest -or $privatebuildpath -ne "") {
 
 # Remove the private build registry keys
 if ($cleanupprivatebuild) {
-    $dotnetinstallroot = Join-Path $reporoot ".dotnet"
-    if ($architecture -eq "x86") {
-        $dotnetinstallroot = Join-Path $dotnetinstallroot "x86"
-    }
-    if (Test-Path $dotnetinstallroot\RemovePrivateTesting.reg) {
-        regedit $dotnetinstallroot\RemovePrivateTesting.reg
-        # delete the add reg file so registry is edited again
-        del $dotnetinstallroot\AddPrivateTesting.reg
-    }
-    exit 0
+    Invoke-Expression "& `"$engroot\common\msbuild.ps1`" $engroot\CleanupPrivateBuild.csproj /v:$verbosity /t:CleanupPrivateBuild /p:BuildArch=$architecture /p:TestArchitectures=$architecture"
+    exit $lastExitCode
 }
 
 # Install sdk for building, restore and build managed components.

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -9,6 +9,7 @@ Param(
   [switch] $skipnative,
   [switch] $dailytest,
   [string] $privatebuildpath = "",
+  [switch] $cleanupprivatebuild,
   [Parameter(ValueFromRemainingArguments=$true)][String[]] $remainingargs
 )
 
@@ -54,6 +55,20 @@ if ($ci) {
 
 if ($dailytest -or $privatebuildpath -ne "") {
     $dailytestproperty = "true"
+}
+
+# Remove the private build registry keys
+if ($cleanupprivatebuild) {
+    $dotnetinstallroot = Join-Path $reporoot ".dotnet"
+    if ($architecture -eq "x86") {
+        $dotnetinstallroot = Join-Path $dotnetinstallroot "x86"
+    }
+    if (Test-Path $dotnetinstallroot\RemovePrivateTesting.reg) {
+        regedit $dotnetinstallroot\RemovePrivateTesting.reg
+        # delete the add reg file so registry is edited again
+        del $dotnetinstallroot\AddPrivateTesting.reg
+    }
+    exit 0
 }
 
 # Install sdk for building, restore and build managed components.

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -30,6 +30,7 @@ __NativeBuild=true
 __CrossBuild=false
 __Test=false
 __DailyTest=false
+__PrivateBuildPath=""
 __CI=false
 __Verbosity=minimal
 __ManagedBuildArgs=
@@ -43,6 +44,7 @@ usage()
     echo "--skipnative - Skip building native components"
     echo "--test - run xunit tests"
     echo "--dailytest - test components for daily build job"
+    echo "--privatebuildpath - path to local private runtime build to test"
     echo "--architecture <x64|x86|arm|armel|arm64>"
     echo "--configuration <debug|release>"
     echo "--rootfs <ROOTFS_DIR>"
@@ -175,6 +177,12 @@ while :; do
 
         -dailytest)
             __DailyTest=true
+            ;;
+
+        -privatebuildpath)
+            __PrivateBuildPath=$2
+            __DailyTest=true
+            shift
             ;;
 
         -ci)
@@ -498,7 +506,7 @@ if [ $__Test == true ]; then
 
       echo "lldb: '$LLDB_PATH' gdb: '$GDB_PATH'"
 
-      "$__ProjectRoot/eng/common/build.sh" --test --configuration "$__BuildType" --verbosity "$__Verbosity" /bl:$__LogDir/Test.binlog /p:BuildArch=$__BuildArch /p:DailyTest=$__DailyTest $__TestArgs
+      "$__ProjectRoot/eng/common/build.sh" --test --configuration "$__BuildType" --verbosity "$__Verbosity" /bl:$__LogDir/Test.binlog /p:BuildArch=$__BuildArch /p:DailyTest=$__DailyTest /p:PrivateBuildPath=$__PrivateBuildPath $__TestArgs
       if [ $? != 0 ]; then
           exit 1
       fi

--- a/src/SOS/SOS.UnitTests/ConfigFiles/Windows/Debugger.Tests.Config.txt
+++ b/src/SOS/SOS.UnitTests/ConfigFiles/Windows/Debugger.Tests.Config.txt
@@ -22,6 +22,9 @@
   <DumpDir>$(RootBinDir)\tmp\$(TargetConfiguration)\dumps</DumpDir>
   <CDBPath>$(RootBinDir)\bin\SOS.UnitTests\$(TargetConfiguration)\netcoreapp2.0\publish\runtimes\win-$(TargetArchitecture)\native\cdb.exe</CDBPath>
   <CDBHelperExtension>$(InstallDir)\runcommand.dll</CDBHelperExtension>
+
+  <DesktopFrameworkPath Condition="$(TargetArchitecture) == x64">$(WinDir)\Microsoft.Net\Framework64\v4.0.30319\</DesktopFrameworkPath>
+  <DesktopFrameworkPath Condition="$(TargetArchitecture) != x64">$(WinDir)\Microsoft.Net\Framework\v4.0.30319\</DesktopFrameworkPath>
   <DesktopFramework>net462</DesktopFramework>
 
   <DebuggeeSourceRoot>$(RepoRootDir)\src\SOS\SOS.UnitTests\Debuggees</DebuggeeSourceRoot>
@@ -163,9 +166,7 @@
       <BuildProjectFramework>$(DesktopFramework)</BuildProjectFramework>
       <BuildProjectRuntime>win-$(TargetArchitecture)</BuildProjectRuntime>
       <DebugType>full</DebugType>
-      <FrameworkDirPath Condition="$(TargetArchitecture) == x64">$(WinDir)\Microsoft.Net\Framework64\v4.0.30319\</FrameworkDirPath>
-      <FrameworkDirPath Condition="$(TargetArchitecture) != x64">$(WinDir)\Microsoft.Net\Framework\v4.0.30319\</FrameworkDirPath>
-      <RuntimeSymbolsPath>$(FrameworkDirPath)</RuntimeSymbolsPath>
+      <RuntimeSymbolsPath>$(DesktopFrameworkPath)</RuntimeSymbolsPath>
       <SOSHostRuntime>$(DotNetRoot)\shared\Microsoft.NETCore.App\$(RuntimeVersion21)</SOSHostRuntime>
     </Option>
   </Options>

--- a/src/SOS/SOS.UnitTests/Scripts/DualRuntimes.script
+++ b/src/SOS/SOS.UnitTests/Scripts/DualRuntimes.script
@@ -71,6 +71,10 @@ VERIFY:\s*Total\s+<DECVAL>\s+objects\s+
 SOSCOMMAND:SOSStatus
 VERIFY:.*\.NET Core runtime at.*\s+
 
+IFDEF:TRIAGE_DUMP
+SOSCOMMAND:setclrpath %DESKTOP_RUNTIME_PATH%
+ENDIF:TRIAGE_DUMP
+
 SOSCOMMAND:SOSStatus -desktop
 VERIFY:\s*Switched to desktop CLR runtime successfully\s+
 
@@ -83,12 +87,7 @@ VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestDll\.TestClass\.Foo6\(.*\)\s+\[(?i:.*[
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestDll\.TestClass\.Foo5\(.*\)\s+\[(?i:.*[\\|/]TestClass\.cs) @ 16\]\s*
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestDll\.TestClass\.ThrowException\(.*\)\s+\[(?i:.*[\\|/]TestClass\.cs) @ 10\]\s*
 
-IFDEF:DOTNETDUMP
 SOSCOMMAND:clrthreads
-ENDIF:DOTNETDUMP
-!IFDEF:DOTNETDUMP
-SOSCOMMAND:Threads
-ENDIF:DOTNETDUMP
 VERIFY:\s*ThreadCount:\s+<DECVAL>\s+
 VERIFY:\s+UnstartedThread:\s+<DECVAL>\s+
 VERIFY:\s+BackgroundThread:\s+<DECVAL>\s+

--- a/src/SOS/Strike/runtime.cpp
+++ b/src/SOS/Strike/runtime.cpp
@@ -37,6 +37,9 @@ bool Runtime::s_isDesktop = false;
 LPCSTR Runtime::s_dacFilePath = nullptr;
 LPCSTR Runtime::s_dbiFilePath = nullptr;
 
+// The runtime module path set by the "setclrpath" command
+LPCSTR g_runtimeModulePath = nullptr;
+
 // Current runtime instance
 IRuntime* g_pRuntime = nullptr;
 
@@ -267,10 +270,17 @@ LPCSTR Runtime::GetRuntimeDirectory()
 {
     if (m_runtimeDirectory == nullptr)
     {
-        std::string runtimeDirectory;
-        if (SUCCEEDED(GetRuntimeDirectory(runtimeDirectory)))
+        if (g_runtimeModulePath != nullptr)
         {
-            m_runtimeDirectory = _strdup(runtimeDirectory.c_str());
+            m_runtimeDirectory = _strdup(g_runtimeModulePath);
+        }
+        else 
+        {
+            std::string runtimeDirectory;
+            if (SUCCEEDED(GetRuntimeDirectory(runtimeDirectory)))
+            {
+                m_runtimeDirectory = _strdup(runtimeDirectory.c_str());
+            }
         }
     }
     return m_runtimeDirectory;

--- a/src/SOS/Strike/runtime.h
+++ b/src/SOS/Strike/runtime.h
@@ -88,6 +88,7 @@ public:
     virtual void DisplayStatus() = 0;
 };
 
+extern LPCSTR g_runtimeModulePath;
 extern IRuntime* g_pRuntime;
 
 /**********************************************************************\

--- a/src/SOS/Strike/sos.def
+++ b/src/SOS/Strike/sos.def
@@ -128,6 +128,8 @@ EXPORTS
     sethostruntime=SetHostRuntime
     SetSymbolServer
     setsymbolserver=SetSymbolServer
+    SetClrPath
+    setclrpath=SetClrPath
     SOSFlush
     sosflush=SOSFlush
     StopOnException

--- a/src/SOS/Strike/sosdocs.txt
+++ b/src/SOS/Strike/sosdocs.txt
@@ -62,9 +62,10 @@ Examining the GC history           Other
 -----------------------------      -----------------------------
 HistInit                           SetHostRuntime (sethostruntime)
 HistRoot                           SetSymbolServer (setsymbolserver)
-HistObj                            FAQ
+HistObj                            SetClrPath (setclrpath)
 HistObjFind                        SOSFlush
 HistClear                          SOSStatus (sosstatus)
+                                   FAQ
                                    Help (soshelp)
 \\
 
@@ -2638,10 +2639,21 @@ COMMAND: sosstatus.
 Display internal SOS status, reset the internal cached state, or change between desktop or 
 netcore runtimes when both are loaded in the process or dump.
 
-0:000> !sosstatus
-Target platform: 8664 Context size 04d0
-.NET Core runtime at 00007FFEE7230000 (005c2000)
-DAC file path: C:\Users\mikem\AppData\Local\Temp\SymbolCache\mscordaccore.dll/5d0707425c2000/mscordaccore.dll
-DBI file path: C:\Users\mikem\AppData\Local\Temp\SymbolCache\mscordbi.dll/5d0707425c2000/mscordbi.dll
-Cache: C:\Users\mikem\AppData\Local\Temp\SymbolCache
-Server: http://msdl.microsoft.com/download/symbols/
+    0:000> !sosstatus
+    Target platform: 8664 Context size 04d0
+    .NET Core runtime at 00007FFEE7230000 (005c2000)
+    DAC file path: C:\Users\mikem\AppData\Local\Temp\SymbolCache\mscordaccore.dll/5d0707425c2000/mscordaccore.dll
+    DBI file path: C:\Users\mikem\AppData\Local\Temp\SymbolCache\mscordbi.dll/5d0707425c2000/mscordbi.dll
+    Cache: C:\Users\mikem\AppData\Local\Temp\SymbolCache
+    Server: http://msdl.microsoft.com/download/symbols/
+//
+
+COMMAND: setclrpath.
+!setclrpath <path-to-runtime>
+
+Sets the path to load the runtime DAC/DBI files. This command may be necessary for dumps that were created
+on another machine or for triage dumps because there are no module paths included in the dump to infer the
+runtime directory.
+
+    0:000> !setclrpath "C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.0"
+//

--- a/src/SOS/Strike/sosdocsunix.txt
+++ b/src/SOS/Strike/sosdocsunix.txt
@@ -55,26 +55,14 @@ Examining the GC history           Other
 -----------------------------      -----------------------------
 HistInit (histinit)                SetHostRuntime (sethostruntime)
 HistRoot (histroot)                SetSymbolServer (setsymbolserver, loadsymbols)
-HistObj  (histobj)                 FAQ
+HistObj  (histobj)                 SetClrPath (setclrpath)
 HistObjFind (histobjfind)          SOSFlush (sosflush)
 HistClear (histclear)              SOSStatus (sosstatus)
+                                   FAQ
                                    Help (soshelp)
 \\
 
 COMMAND: faq.
->> Where can I get the right version of SOS for my build?
-
-If you are running a xplat version of coreclr, the sos module (exact name
-is platform dependent) is installed in the same directory as the main coreclr
-module. There is also an lldb sos plugin command that allows the path where
-the sos, dac and dbi modules are loaded:
-
-    "setclrpath /home/user/coreclr/bin/Product/Linux.x64.Debug""
-
-If you are using a dump file created on another machine, it is a little bit
-more complex. You need to make sure the dac module that came with that install
-is in the directory set with the above command.
-
 >> I have a chicken and egg problem. I want to use SOS commands, but the CLR
    isn't loaded yet. What can I do?
 
@@ -1963,3 +1951,13 @@ SOSStatus [-reset]
 -reset - reset all the cached internal SOS state.
 
 Display internal SOS status or reset the internal cached state.
+\\
+
+COMMAND: setclrpath.
+!setclrpath <path-to-runtime>
+
+Sets the path to load the runtime DAC/DBI files. This command may be necessary for dumps that were created
+on another machine or for triage dumps.
+
+    (lldb) setclrpath /home/user/coreclr/bin/Product/Linux.x64.Debug
+\\

--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -10470,6 +10470,9 @@ DECLARE_API(SOSStatus)
     if (g_targetMachine != nullptr) {
         ExtOut("Target platform: %04x Context size %04x\n", g_targetMachine->GetPlatform(), g_targetMachine->GetContextSize());
     }
+    if (g_runtimeModulePath != nullptr) {
+        ExtOut("Runtime module path: %s\n", g_runtimeModulePath);
+    }
     if (g_pRuntime != nullptr) {
         g_pRuntime->DisplayStatus();
     }
@@ -16076,6 +16079,38 @@ DECLARE_API(SetSymbolServer)
     }
 
     return Status;
+}
+
+//
+// Sets the runtime module path
+//
+DECLARE_API(SetClrPath)
+{
+    INIT_API_EXT();
+
+    StringHolder runtimeModulePath;
+    CMDValue arg[] =
+    {
+        {&runtimeModulePath.data, COSTRING},
+    };
+    size_t narg;
+    if (!GetCMDOption(args, nullptr, 0, arg, _countof(arg), &narg))
+    {
+        return E_FAIL;
+    }
+    if (narg > 0)
+    {
+        if (g_runtimeModulePath != nullptr)
+        {
+            free((void*)g_runtimeModulePath);
+        }
+        g_runtimeModulePath = _strdup(runtimeModulePath.data);
+    }
+    if (g_runtimeModulePath != nullptr)
+    {
+        ExtOut("Runtime module path: %s\n", g_runtimeModulePath);
+    }
+    return S_OK;
 }
 
 void PrintHelp (__in_z LPCSTR pszCmdName)

--- a/src/SOS/lldbplugin/setclrpathcommand.cpp
+++ b/src/SOS/lldbplugin/setclrpathcommand.cpp
@@ -48,6 +48,6 @@ bool
 setclrpathCommandInitialize(lldb::SBDebugger debugger)
 {
     lldb::SBCommandInterpreter interpreter = debugger.GetCommandInterpreter();
-    lldb::SBCommand command = interpreter.AddCommand("setclrpath", new setclrpathCommand(), "Set the path to load coreclr dac/dbi files. setclrpath <path>");
+    lldb::SBCommand command = interpreter.AddCommand("setclrpath", new setclrpathCommand(), "Set the path to load the runtime DAC/DBI files. setclrpath <path>");
     return true;
 }

--- a/src/Tools/dotnet-dump/Commands/SOSCommand.cs
+++ b/src/Tools/dotnet-dump/Commands/SOSCommand.cs
@@ -48,6 +48,7 @@ namespace Microsoft.Diagnostics.Tools.Dump
     [Command(Name = "histobjfind",      AliasExpansion = "HistObjFind",         Help = "Displays all the log entries that reference an object at the specified address.")]
     [Command(Name = "histroot",         AliasExpansion = "HistRoot",            Help = "Displays information related to both promotions and relocations of the specified root.")]
     [Command(Name = "setsymbolserver",  AliasExpansion = "SetSymbolServer",     Help = "Enables the symbol server support ")]
+    [Command(Name = "setclrpath",       AliasExpansion = "setclrpath",          Platform = CommandPlatform.Windows, Help = "Set the path to load the runtime DAC/DBI files.")]
     [Command(Name = "dumprcw",          AliasExpansion = "DumpRCW",             Platform = CommandPlatform.Windows, Help = "Displays information about a Runtime Callable Wrapper.")]
     [Command(Name = "dumpccw",          AliasExpansion = "DumpCCW",             Platform = CommandPlatform.Windows, Help = "Displays information about a COM Callable Wrapper.")]
     [Command(Name = "dumppermissionset",AliasExpansion = "DumpPermissionSet",   Platform = CommandPlatform.Windows, Help = "Displays a PermissionSet object (debug build only).")]


### PR DESCRIPTION
Enable the "setclrpath" for Windows.

Change the SOS test harness and scripts to set the runtime path for triage dumps.

Add -privatebuildpath option to build scripts that installs the test runtimes, copies
the private runtime build and on Windows regedit's the necessary keys to create dumps.