### PR TITLE
Properly encode semicolon in argument strings for EventPipeProvider

### DIFF
--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/EventPipeProvider.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/EventPipeProvider.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
             {
                 return "";
             }
-            return string.Join(";", Arguments.Select(a => $"{a.Key}={a.Value.Replace(";", "\";\"")}"));
+            return string.Join(";", Arguments.Select(a => (a.Value.Contains(";") || a.Value.Contains("=")) ? $"{a.Key}=\"{a.Value}\"" : $"{a.Key}={a.Value}"));
         }
 
     }

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/EventPipeProvider.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/EventPipeProvider.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
             {
                 return "";
             }
-            return string.Join(";", Arguments.Select(a => $"{a.Key}={a.Value}"));
+            return string.Join(";", Arguments.Select(a => $"{a.Key}={a.Value.Replace(";", "\";\"")}"));
         }
 
     }

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/EventPipeProviderTests.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/EventPipeProviderTests.cs
@@ -109,5 +109,41 @@ namespace Microsoft.Diagnostics.NETCore.Client
             Assert.Equal("MyProvider:0x00000000DEADBEEF:5:key1=value1", provider1.ToString());
             Assert.Equal("MyProvider:0x00000000DEADBEEF:5:key1=value1;key2=value2", provider2.ToString());
         }
+
+        [Fact]
+        public void DiagnosticSourceArgumentStringTest1()
+        {
+            string diagnosticFilterString = "Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.HttpRequestIn.Start@Activity1Start:-" +
+                "Request.Path" +
+                ";Request.Method" +
+                "\r\n";
+
+            var provider = new EventPipeProvider("DiagnosticSourceProvider", EventLevel.Verbose, (long)(0xdeadbeef),
+                new Dictionary<string, string>()
+                {
+                    { "FilterAndPayloadSpecs", diagnosticFilterString }
+                });
+
+            Assert.Equal("DiagnosticSourceProvider:0x00000000DEADBEEF:5:FilterAndPayloadSpecs=Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.HttpRequestIn.Start@Activity1Start:-Request.Path\";\"Request.Method\r\n",
+                provider.ToString());
+        }
+
+        [Fact]
+        public void DiagnosticSourceArgumentStringTest1()
+        {
+            string diagnosticFilterString = "Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.HttpRequestIn.Start@Activity1Start:-" +
+                "Request.Path" +
+                ";Request.Method" +
+                "\r\n";
+
+            var provider = new EventPipeProvider("DiagnosticSourceProvider", EventLevel.Verbose, (long)(0xdeadbeef),
+                new Dictionary<string, string>()
+                {
+                    { "FilterAndPayloadSpecs", diagnosticFilterString }
+                });
+
+            Assert.Equal("DiagnosticSourceProvider:0x00000000DEADBEEF:5:FilterAndPayloadSpecs=Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.HttpRequestIn.Start@Activity1Start:-Request.Path\";\"Request.Method\r\n",
+                provider.ToString());
+        }
     }
 }

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/EventPipeProviderTests.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/EventPipeProviderTests.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
         }
 
         [Fact]
-        public void DiagnosticSourceArgumentStringTest()
+        public void DiagnosticSourceArgumentStringTest1()
         {
             string diagnosticFilterString = "Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.HttpRequestIn.Start@Activity1Start:-" +
                 "Request.Path" +
@@ -125,6 +125,26 @@ namespace Microsoft.Diagnostics.NETCore.Client
                 });
 
             Assert.Equal("DiagnosticSourceProvider:0x00000000DEADBEEF:5:FilterAndPayloadSpecs=\"Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.HttpRequestIn.Start@Activity1Start:-Request.Path;Request.Method\r\n\"",
+                provider.ToString());
+        }
+
+
+        [Fact]
+        public void DiagnosticSourceArgumentStringTest2()
+        {
+            string diagnosticFilterString = "Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.HttpRequestIn.Start@Activity1Start:-" +
+                "Request.Path" +
+                ";Request.Method" +
+                ";RequestName=SomeRequest" +
+                "\r\n";
+
+            var provider = new EventPipeProvider("DiagnosticSourceProvider", EventLevel.Verbose, (long)(0xdeadbeef),
+                new Dictionary<string, string>()
+                {
+                    { "FilterAndPayloadSpecs", diagnosticFilterString }
+                });
+
+            Assert.Equal("DiagnosticSourceProvider:0x00000000DEADBEEF:5:FilterAndPayloadSpecs=\"Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.HttpRequestIn.Start@Activity1Start:-Request.Path;Request.Method;RequestName=SomeRequest\r\n\"",
                 provider.ToString());
         }
     }

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/EventPipeProviderTests.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/EventPipeProviderTests.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
                     { "FilterAndPayloadSpecs", diagnosticFilterString }
                 });
 
-            Assert.Equal("DiagnosticSourceProvider:0x00000000DEADBEEF:5:FilterAndPayloadSpecs=Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.HttpRequestIn.Start@Activity1Start:-Request.Path\";\"Request.Method\r\n",
+            Assert.Equal("DiagnosticSourceProvider:0x00000000DEADBEEF:5:FilterAndPayloadSpecs=\"Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.HttpRequestIn.Start@Activity1Start:-Request.Path;Request.Method\r\n\"",
                 provider.ToString());
         }
     }

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/EventPipeProviderTests.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/EventPipeProviderTests.cs
@@ -111,25 +111,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
         }
 
         [Fact]
-        public void DiagnosticSourceArgumentStringTest1()
-        {
-            string diagnosticFilterString = "Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.HttpRequestIn.Start@Activity1Start:-" +
-                "Request.Path" +
-                ";Request.Method" +
-                "\r\n";
-
-            var provider = new EventPipeProvider("DiagnosticSourceProvider", EventLevel.Verbose, (long)(0xdeadbeef),
-                new Dictionary<string, string>()
-                {
-                    { "FilterAndPayloadSpecs", diagnosticFilterString }
-                });
-
-            Assert.Equal("DiagnosticSourceProvider:0x00000000DEADBEEF:5:FilterAndPayloadSpecs=Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.HttpRequestIn.Start@Activity1Start:-Request.Path\";\"Request.Method\r\n",
-                provider.ToString());
-        }
-
-        [Fact]
-        public void DiagnosticSourceArgumentStringTest1()
+        public void DiagnosticSourceArgumentStringTest()
         {
             string diagnosticFilterString = "Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.HttpRequestIn.Start@Activity1Start:-" +
                 "Request.Path" +


### PR DESCRIPTION
Semicolon is a special character in EventSource argument parser. To embed a semicolon inside the argument string it needs to be wrapped with quotation.  

This fixes #753. 