### PR TITLE
Escape EventPipeProvider argument key as well

### DIFF
--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/EventPipeProvider.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/EventPipeProvider.cs
@@ -69,7 +69,11 @@ namespace Microsoft.Diagnostics.NETCore.Client
             {
                 return "";
             }
-            return string.Join(";", Arguments.Select(a => (a.Value.Contains(";") || a.Value.Contains("=")) ? $"{a.Key}=\"{a.Value}\"" : $"{a.Key}={a.Value}"));
+            return string.Join(";", Arguments.Select(a => {
+                var escapedKey = a.Key.Contains(";") || a.Key.Contains("=") ? $"\"{a.Key}\"" : a.Key;
+                var escapedValue = a.Value.Contains(";") || a.Value.Contains("=") ? $"\"{a.Value}\"" : a.Value;
+                return $"{escapedKey}={escapedValue}";
+            }));
         }
 
     }

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/EventPipeProviderTests.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/EventPipeProviderTests.cs
@@ -23,7 +23,8 @@ namespace Microsoft.Diagnostics.NETCore.Client
         {
             EventPipeProvider provider1 = new EventPipeProvider("myProvider", EventLevel.Informational);
             EventPipeProvider provider2 = new EventPipeProvider("myProvider", EventLevel.Informational);
-            Assert.True(provider1 == provider2); }
+            Assert.True(provider1 == provider2);
+        }
 
         [Fact]
         public void EqualTest2()

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/EventPipeProviderTests.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/EventPipeProviderTests.cs
@@ -23,8 +23,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
         {
             EventPipeProvider provider1 = new EventPipeProvider("myProvider", EventLevel.Informational);
             EventPipeProvider provider2 = new EventPipeProvider("myProvider", EventLevel.Informational);
-            Assert.True(provider1 == provider2);
-        }
+            Assert.True(provider1 == provider2); }
 
         [Fact]
         public void EqualTest2()
@@ -111,7 +110,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
         }
 
         [Fact]
-        public void DiagnosticSourceArgumentStringTest1()
+        public void DiagnosticSourceArgumentStringTestWithEscapedValue1()
         {
             string diagnosticFilterString = "Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.HttpRequestIn.Start@Activity1Start:-" +
                 "Request.Path" +
@@ -130,7 +129,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
 
 
         [Fact]
-        public void DiagnosticSourceArgumentStringTest2()
+        public void DiagnosticSourceArgumentStringTestWithEscapedValue2()
         {
             string diagnosticFilterString = "Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.HttpRequestIn.Start@Activity1Start:-" +
                 "Request.Path" +
@@ -145,6 +144,45 @@ namespace Microsoft.Diagnostics.NETCore.Client
                 });
 
             Assert.Equal("DiagnosticSourceProvider:0x00000000DEADBEEF:5:FilterAndPayloadSpecs=\"Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.HttpRequestIn.Start@Activity1Start:-Request.Path;Request.Method;RequestName=SomeRequest\r\n\"",
+                provider.ToString());
+        }
+
+        [Fact]
+        public void DiagnosticSourceArgumentStringTestWithEscapedKey()
+        {
+            string diagnosticFilterString = "Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.HttpRequestIn.Start@Activity1Start:-" +
+                "Request.Path" +
+                ";Request.Method" +
+                ";RequestName=SomeRequest" +
+                "\r\n";
+
+            var provider = new EventPipeProvider("DiagnosticSourceProvider", EventLevel.Verbose, (long)(0xdeadbeef),
+                new Dictionary<string, string>()
+                {
+                    { "ArgumentKeyWith;Semicolon=Equal", diagnosticFilterString }
+                });
+
+            Assert.Equal("DiagnosticSourceProvider:0x00000000DEADBEEF:5:\"ArgumentKeyWith;Semicolon=Equal\"=\"Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.HttpRequestIn.Start@Activity1Start:-Request.Path;Request.Method;RequestName=SomeRequest\r\n\"",
+                provider.ToString());
+        }
+
+        [Fact]
+        public void DiagnosticSourceArgumentStringTestWithManyArgs()
+        {
+            string diagnosticFilterString = "Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.HttpRequestIn.Start@Activity1Start:-" +
+                "Request.Path" +
+                ";Request.Method" +
+                ";RequestName=SomeRequest" +
+                "\r\n";
+
+            var provider = new EventPipeProvider("DiagnosticSourceProvider", EventLevel.Verbose, (long)(0xdeadbeef),
+                new Dictionary<string, string>()
+                {
+                    { "ArgumentKeyWith;Semicolon=Equal", diagnosticFilterString },
+                    { "ArgumentKeyWith;Semicolon=Equal2", diagnosticFilterString }
+                });
+
+            Assert.Equal("DiagnosticSourceProvider:0x00000000DEADBEEF:5:\"ArgumentKeyWith;Semicolon=Equal\"=\"Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.HttpRequestIn.Start@Activity1Start:-Request.Path;Request.Method;RequestName=SomeRequest\r\n\";\"ArgumentKeyWith;Semicolon=Equal2\"=\"Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.HttpRequestIn.Start@Activity1Start:-Request.Path;Request.Method;RequestName=SomeRequest\r\n\"",
                 provider.ToString());
         }
     }


### PR DESCRIPTION
This addresses the same issue as #824 but for the keys of the argument dictionary.