### PR TITLE
Get UnixDomainSocketEndPoint using Type.GetType() to avoid FileNotFoundException

### DIFF
--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcClient.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcClient.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
 #elif NETSTANDARD2_0
             // UnixDomainSocketEndPoint is not part of .NET Standard 2.0
             var type = typeof(Socket).Assembly.GetType("System.Net.Sockets.UnixDomainSocketEndPoint")
-                       ?? Assembly.Load("System.Core").GetType("System.Net.Sockets.UnixDomainSocketEndPoint");
+                       ?? Type.GetType("System.Net.Sockets.UnixDomainSocketEndPoint, System.Core");
             if (type == null)
             {
                 throw new PlatformNotSupportedException("Current process is not running a compatible .NET Core runtime.");


### PR DESCRIPTION
Get UnixDomainSocketEndPoint using Type.GetType() to avoid FileNotFoundException

Fixes #821