### PR TITLE
Updates tryrun.cmake for cross build

### DIFF
--- a/eng/cross/tryrun.cmake
+++ b/eng/cross/tryrun.cmake
@@ -3,6 +3,7 @@ set(TARGET_ARCH_NAME $ENV{TARGET_BUILD_ARCH})
 
 macro(set_cache_value)
   set(${ARGV0} ${ARGV1} CACHE STRING "Result from TRY_RUN" FORCE)
+  set(${ARGV0}__TRYRUN_OUTPUT "dummy output" CACHE STRING "Output from TRY_RUN" FORCE)
 endmacro()
 
 if(EXISTS ${CROSS_ROOTFS}/usr/lib/gcc/armv6-alpine-linux-musleabihf OR


### PR DESCRIPTION
Fix cross build:
```
...
-- Performing Test HAVE_COMPATIBLE_ACOS
CMake Error: TRY_RUN() invoked in cross-compiling mode, please set the following cache variables appropriately:
   HAVE_COMPATIBLE_ACOS_EXITCODE (advanced)
   HAVE_COMPATIBLE_ACOS_EXITCODE__TRYRUN_OUTPUT (advanced)
For details see /home/viewizard/Desktop/diagnostics/artifacts/obj/Linux.armel.Release/TryRunResults.cmake
-- Performing Test HAVE_COMPATIBLE_ACOS - Success
-- Performing Test HAVE_COMPATIBLE_ASIN
CMake Error: TRY_RUN() invoked in cross-compiling mode, please set the following cache variables appropriately:
   HAVE_COMPATIBLE_ASIN_EXITCODE (advanced)
   HAVE_COMPATIBLE_ASIN_EXITCODE__TRYRUN_OUTPUT (advanced)
For details see /home/viewizard/Desktop/diagnostics/artifacts/obj/Linux.armel.Release/TryRunResults.cmake
-- Performing Test HAVE_COMPATIBLE_ASIN - Success
-- Performing Test HAVE_COMPATIBLE_POW
CMake Error: TRY_RUN() invoked in cross-compiling mode, please set the following cache variables appropriately:
   HAVE_COMPATIBLE_POW_EXITCODE (advanced)
   HAVE_COMPATIBLE_POW_EXITCODE__TRYRUN_OUTPUT (advanced)
For details see /home/viewizard/Desktop/diagnostics/artifacts/obj/Linux.armel.Release/TryRunResults.cmake
-- Performing Test HAVE_COMPATIBLE_POW - Success
-- Performing Test HAVE_VALID_NEGATIVE_INF_POW
CMake Error: TRY_RUN() invoked in cross-compiling mode, please set the following cache variables appropriately:
   HAVE_VALID_NEGATIVE_INF_POW_EXITCODE (advanced)
   HAVE_VALID_NEGATIVE_INF_POW_EXITCODE__TRYRUN_OUTPUT (advanced)
For details see /home/viewizard/Desktop/diagnostics/artifacts/obj/Linux.armel.Release/TryRunResults.cmake
-- Performing Test HAVE_VALID_NEGATIVE_INF_POW - Success
-- Performing Test HAVE_VALID_POSITIVE_INF_POW
CMake Error: TRY_RUN() invoked in cross-compiling mode, please set the following cache variables appropriately:
   HAVE_VALID_POSITIVE_INF_POW_EXITCODE (advanced)
   HAVE_VALID_POSITIVE_INF_POW_EXITCODE__TRYRUN_OUTPUT (advanced)
For details see /home/viewizard/Desktop/diagnostics/artifacts/obj/Linux.armel.Release/TryRunResults.cmake
-- Performing Test HAVE_VALID_POSITIVE_INF_POW - Success
-- Performing Test HAVE_COMPATIBLE_ATAN2
CMake Error: TRY_RUN() invoked in cross-compiling mode, please set the following cache variables appropriately:
   HAVE_COMPATIBLE_ATAN2_EXITCODE (advanced)
   HAVE_COMPATIBLE_ATAN2_EXITCODE__TRYRUN_OUTPUT (advanced)
For details see /home/viewizard/Desktop/diagnostics/artifacts/obj/Linux.armel.Release/TryRunResults.cmake
-- Performing Test HAVE_COMPATIBLE_ATAN2 - Success
-- Performing Test HAVE_COMPATIBLE_EXP
-- Performing Test HAVE_COMPATIBLE_EXP - Failed
-- Performing Test HAVE_COMPATIBLE_LOG
CMake Error: TRY_RUN() invoked in cross-compiling mode, please set the following cache variables appropriately:
   HAVE_COMPATIBLE_LOG_EXITCODE (advanced)
   HAVE_COMPATIBLE_LOG_EXITCODE__TRYRUN_OUTPUT (advanced)
For details see /home/viewizard/Desktop/diagnostics/artifacts/obj/Linux.armel.Release/TryRunResults.cmake
-- Performing Test HAVE_COMPATIBLE_LOG - Success
-- Performing Test HAVE_COMPATIBLE_LOG10
CMake Error: TRY_RUN() invoked in cross-compiling mode, please set the following cache variables appropriately:
   HAVE_COMPATIBLE_LOG10_EXITCODE (advanced)
   HAVE_COMPATIBLE_LOG10_EXITCODE__TRYRUN_OUTPUT (advanced)
For details see /home/viewizard/Desktop/diagnostics/artifacts/obj/Linux.armel.Release/TryRunResults.cmake
-- Performing Test HAVE_COMPATIBLE_LOG10 - Success
-- Performing Test UNGETC_NOT_RETURN_EOF
CMake Error: TRY_RUN() invoked in cross-compiling mode, please set the following cache variables appropriately:
   UNGETC_NOT_RETURN_EOF_EXITCODE (advanced)
   UNGETC_NOT_RETURN_EOF_EXITCODE__TRYRUN_OUTPUT (advanced)
For details see /home/viewizard/Desktop/diagnostics/artifacts/obj/Linux.armel.Release/TryRunResults.cmake
-- Performing Test UNGETC_NOT_RETURN_EOF - Success
-- Performing Test HAS_POSIX_SEMAPHORES
CMake Error: TRY_RUN() invoked in cross-compiling mode, please set the following cache variables appropriately:
   HAS_POSIX_SEMAPHORES_EXITCODE (advanced)
   HAS_POSIX_SEMAPHORES_EXITCODE__TRYRUN_OUTPUT (advanced)
For details see /home/viewizard/Desktop/diagnostics/artifacts/obj/Linux.armel.Release/TryRunResults.cmake
-- Performing Test HAS_POSIX_SEMAPHORES - Success
-- Performing Test GETPWUID_R_SETS_ERRNO
CMake Error: TRY_RUN() invoked in cross-compiling mode, please set the following cache variables appropriately:
   GETPWUID_R_SETS_ERRNO_EXITCODE (advanced)
   GETPWUID_R_SETS_ERRNO_EXITCODE__TRYRUN_OUTPUT (advanced)
For details see /home/viewizard/Desktop/diagnostics/artifacts/obj/Linux.armel.Release/TryRunResults.cmake
-- Performing Test GETPWUID_R_SETS_ERRNO - Success
-- Performing Test FILE_OPS_CHECK_FERROR_OF_PREVIOUS_CALL
CMake Error: TRY_RUN() invoked in cross-compiling mode, please set the following cache variables appropriately:
   FILE_OPS_CHECK_FERROR_OF_PREVIOUS_CALL_EXITCODE (advanced)
   FILE_OPS_CHECK_FERROR_OF_PREVIOUS_CALL_EXITCODE__TRYRUN_OUTPUT (advanced)
For details see /home/viewizard/Desktop/diagnostics/artifacts/obj/Linux.armel.Release/TryRunResults.cmake
-- Performing Test FILE_OPS_CHECK_FERROR_OF_PREVIOUS_CALL - Failed
-- Performing Test UNWIND_CONTEXT_IS_UCONTEXT_T
-- Performing Test UNWIND_CONTEXT_IS_UCONTEXT_T - Failed
-- Performing Test HAVE_UNW_GET_SAVE_LOC
-- Performing Test HAVE_UNW_GET_SAVE_LOC - Success
-- Performing Test HAVE_UNW_GET_ACCESSORS
-- Performing Test HAVE_UNW_GET_ACCESSORS - Success
-- Performing Test HAVE_XSWDEV
-- Performing Test HAVE_XSWDEV - Failed
-- Performing Test HAVE_XSW_USAGE
-- Performing Test HAVE_XSW_USAGE - Failed
-- Performing Test HAVE_PUBLIC_XSTATE_STRUCT
-- Performing Test HAVE_PUBLIC_XSTATE_STRUCT - Failed
-- Performing Test HAVE_PR_SET_PTRACER
-- Performing Test HAVE_PR_SET_PTRACER - Success
-- Performing Test HAVE_FULLY_FEATURED_PTHREAD_MUTEXES
-- Performing Test HAVE_FULLY_FEATURED_PTHREAD_MUTEXES - Success
-- WITH_LLDB_LIBS: /home/viewizard/Desktop/runtime/.tools/rootfs/armel//usr/lib/arm-linux-gnueabi
-- WITH_LLDB_INCLUDES: /home/viewizard/Desktop/runtime/.tools/rootfs/armel//usr/lib/llvm-3.6/include
-- LLDB_LIB: 
-- LLDB_H: /home/viewizard/Desktop/runtime/.tools/rootfs/armel/usr/include
-- Configuring incomplete, errors occurred!
See also "/home/viewizard/Desktop/diagnostics/artifacts/obj/Linux.armel.Release/CMakeFiles/CMakeOutput.log".
See also "/home/viewizard/Desktop/diagnostics/artifacts/obj/Linux.armel.Release/CMakeFiles/CMakeError.log".
~/Desktop/diagnostics
Failed to generate build project!
```
Related to cmake changes (starts from 3.14.0-rc3, https://gitlab.kitware.com/cmake/cmake/commit/92d9ec9bfb61d2cd35a82d6906de86c71350b865)
More info: https://gitlab.kitware.com/cmake/cmake/issues/18973

Note, this is the same fix, as we already have in coreclr - https://github.com/dotnet/runtime/blob/master/src/coreclr/tryrun.cmake#L6