### PR TITLE
dotnet-counters ps -u or --user to filter process that is displayed

### DIFF
--- a/src/Tools/Common/Commands/ProcessStatus.cs
+++ b/src/Tools/Common/Commands/ProcessStatus.cs
@@ -71,12 +71,12 @@ namespace Microsoft.Internal.Common.Commands
                         {
                             if(uid == GetProcessUser(process.Id))
                             {
-                                sb.Append($"{process.Id,10} {process.ProcessName,-10} {process.MainModule.FileName}\n");
+                                sb.Append($"{process.Id, 10} {process.ProcessName, -10} {process.MainModule.FileName}\n");
                             }
                         }
                         else
                         {
-                            sb.Append($"{process.Id,10} {process.ProcessName,-10} {process.MainModule.FileName}\n");
+                            sb.Append($"{process.Id, 10} {process.ProcessName, -10} {process.MainModule.FileName}\n");
                         }
                     }
                     catch (InvalidOperationException)

--- a/src/Tools/Common/Commands/ProcessStatus.cs
+++ b/src/Tools/Common/Commands/ProcessStatus.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Internal.Common.Commands
         /// </summary>
         public static void PrintProcessStatus(IConsole console, string userName = "")
         {
-            int uid = -1;
+            int uid;
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && (userName != "all" || userName != ""))
             {

--- a/src/Tools/Common/Commands/ProcessStatus.cs
+++ b/src/Tools/Common/Commands/ProcessStatus.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Internal.Common.Commands
         {
             Command cmd = new Command(description);
             cmd.Handler = CommandHandler.Create<IConsole, string>(PrintProcessStatus);
-
+            cmd.AddOption(FilterUserOption());
             return cmd;
         }
 

--- a/src/Tools/Common/Commands/ProcessStatus.cs
+++ b/src/Tools/Common/Commands/ProcessStatus.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Internal.Common.Commands
     {
         public static Command ProcessStatusCommand(string description)
         {
-            Command cmd = new Command(description);
+            Command cmd = new Command(name: "ps", description);
             cmd.Handler = CommandHandler.Create<IConsole, string>(PrintProcessStatus);
             cmd.AddOption(FilterUserOption());
             return cmd;

--- a/src/Tools/Common/Commands/ProcessStatus.cs
+++ b/src/Tools/Common/Commands/ProcessStatus.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.NETCore.Client;
-using Microsoft.Diagnostics.Tracing.Parsers.Kernel;
 using System;
 using System.Collections.Generic;
 using System.CommandLine;

--- a/src/Tools/Common/Commands/ProcessStatus.cs
+++ b/src/Tools/Common/Commands/ProcessStatus.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Internal.Common.Commands
         {
             int uid;
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && (user != "all" || user != ""))
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && (user != "all" && user != ""))
             {
                 uid = MapUserNameToId(user.Trim());
                 if (uid == -1)

--- a/src/Tools/Common/Commands/ProcessStatus.cs
+++ b/src/Tools/Common/Commands/ProcessStatus.cs
@@ -36,13 +36,13 @@ namespace Microsoft.Internal.Common.Commands
         /// <summary>
         /// Print the current list of available .NET core processes for diagnosis and their statuses
         /// </summary>
-        public static void PrintProcessStatus(IConsole console, string userName = "")
+        public static void PrintProcessStatus(IConsole console, string user = "")
         {
             int uid;
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && (userName != "all" || userName != ""))
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && (user != "all" || user != ""))
             {
-                uid = MapUserNameToId(userName);
+                uid = MapUserNameToId(user.Trim());
                 if (uid == -1)
                 {
                     console.Error.WriteLine("User name not found. Cannot filter. Showing all dotnet processes");
@@ -114,7 +114,7 @@ namespace Microsoft.Internal.Common.Commands
                 {
                     if (field.Contains("Uid"))
                     {
-                        return int.Parse(field.Split(" ")[1]);
+                        return int.Parse(field.Split("\t")[1]);
                     }
                 }
 

--- a/src/Tools/Common/Commands/ProcessStatus.cs
+++ b/src/Tools/Common/Commands/ProcessStatus.cs
@@ -3,10 +3,14 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.NETCore.Client;
+using Microsoft.Diagnostics.Tracing.Parsers.Kernel;
 using System;
+using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Invocation;
+using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using Process = System.Diagnostics.Process;
 
@@ -14,17 +18,43 @@ namespace Microsoft.Internal.Common.Commands
 {
     public class ProcessStatusCommandHandler
     {
-        public static Command ProcessStatusCommand(string description) =>
-            new Command(name: "ps", description)
+        public static Command ProcessStatusCommand(string description)
+        {
+            Command cmd = new Command(description);
+            cmd.Handler = CommandHandler.Create<IConsole, string>(PrintProcessStatus);
+
+            return cmd;
+        }
+
+        private static Option FilterUserOption() =>
+            new Option(
+                aliases: new[] { "-u", "--user" },
+                description: "Shows only process owned by a specific user")
             {
-                Handler = CommandHandler.Create<IConsole>(PrintProcessStatus)
+                Argument = new Argument<string>(name: "userName", defaultValue: "all")
             };
 
         /// <summary>
         /// Print the current list of available .NET core processes for diagnosis and their statuses
         /// </summary>
-        public static void PrintProcessStatus(IConsole console)
+        public static void PrintProcessStatus(IConsole console, string userName = "")
         {
+            int uid = -1;
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && (userName != "all" || userName != ""))
+            {
+                uid = MapUserNameToId(userName);
+                if (uid == -1)
+                {
+                    console.Error.WriteLine("User name not found. Cannot filter. Showing all dotnet processes");
+                }
+            }
+
+            else 
+            {
+                uid = -1;
+            }
+
             try
             {
                 StringBuilder sb = new StringBuilder();
@@ -38,7 +68,17 @@ namespace Microsoft.Internal.Common.Commands
                 {
                     try
                     {
-                        sb.Append($"{process.Id, 10} {process.ProcessName, -10} {process.MainModule.FileName}\n");
+                        if(uid!=-1)
+                        {
+                            if(uid == GetProcessUser(process.Id))
+                            {
+                                sb.Append($"{process.Id,10} {process.ProcessName,-10} {process.MainModule.FileName}\n");
+                            }
+                        }
+                        else
+                        {
+                            sb.Append($"{process.Id,10} {process.ProcessName,-10} {process.MainModule.FileName}\n");
+                        }
                     }
                     catch (InvalidOperationException)
                     {
@@ -62,6 +102,52 @@ namespace Microsoft.Internal.Common.Commands
             catch (ArgumentException)
             {
                 return null;
+            }
+        }
+
+        private static int GetProcessUser(int processId)
+        {
+            try
+            {
+                IEnumerable<string> fields = File.ReadLines($"/proc/{processId}/status");
+
+                foreach(string field in fields)
+                {
+                    if (field.Contains("Uid"))
+                    {
+                        return int.Parse(field.Split(" ")[1]);
+                    }
+                }
+
+                return -1;
+            }
+
+            catch (IOException)
+            {
+                return -1;
+            }
+        }
+
+        private static int MapUserNameToId(string userName)
+        {
+            try
+            {
+                IEnumerable<string> users = File.ReadLines("/etc/passwd");
+                foreach (string user in users)
+                {
+                    string[] fields = user.Split(":");
+                    if (fields[0] == userName)
+                    {
+                        return int.Parse(fields[2]);
+                    }
+                }
+
+                return -1;
+            }
+
+            catch (IOException)
+            {
+                return -1;
             }
         }
     }


### PR DESCRIPTION
#314
By default, all users' processes are displayed. If a user wants to filter for a specific username, -u <username> or --user<username> can be used to do that on a Linux machine.