### PR TITLE
Make EventPipe and DiagnosticsClient tests run on 3.1 and 5.0

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
   "tools": {
-    "dotnet": {
+    "dotnet": [
       "$(MicrosoftNETCoreApp31Version)",
       "$(MicrosoftNETCoreAppVersion)"
-    }
+    ]
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20151.1"

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "3.1.101"
+    "dotnet": "5.0.100-preview.2.20155.14"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20151.1"

--- a/global.json
+++ b/global.json
@@ -1,6 +1,9 @@
 {
   "tools": {
-    "dotnet": "5.0.100-preview.2.20155.14"
+    "dotnet": {
+      "$(MicrosoftNETCoreApp31Version)",
+      "$(MicrosoftNETCoreAppVersion)"
+    }
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20151.1"

--- a/global.json
+++ b/global.json
@@ -1,9 +1,16 @@
 {
   "tools": {
-    "dotnet": [
-      "$(MicrosoftNETCoreApp31Version)",
-      "$(MicrosoftNETCoreAppVersion)"
-    ]
+    "dotnet": "5.0.100-preview.2.20155.14",
+    "runtimes": {
+      "dotnet/x64": [
+        "$(MicrosoftNETCoreApp31Version)",
+        "$(MicrosoftNETCoreAppVersion)"
+      ],
+      "dotnet/x86": [
+        "$(MicrosoftNETCoreApp31Version)",
+        "$(MicrosoftNETCoreAppVersion)"
+      ]
+    }
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20151.1"

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.UnitTests.csproj
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1;netcoreapp5.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.UnitTests.csproj
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1;netcoreapp5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/eventpipe/EventPipe.UnitTests.csproj
+++ b/src/tests/eventpipe/EventPipe.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1;netcoreapp5.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/eventpipe/EventPipe.UnitTests.csproj
+++ b/src/tests/eventpipe/EventPipe.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1;netcoreapp5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This is part of #883. 