### PR TITLE
Add symbol publishing property to disable the special indexing

### DIFF
--- a/diagnostics.yml
+++ b/diagnostics.yml
@@ -387,6 +387,7 @@ stages:
         # as well as NuGet, SourceLink, and signing validation.
         # The variables get imported from group dotnet-diagnostics-sdl-params
         enableSourceLinkValidation: true
+        symbolPublishingAdditionalParameters: '/p:PublishSpecialClrFiles=false'
         SDLValidationParameters:
           enable: true
           continueOnError: false


### PR DESCRIPTION
Fixes the "DUP" errors in the symbol publishing stage.