### PR TITLE
Change the "dotnet-dump collect" default to "full" dumps.

### DIFF
--- a/src/Tools/dotnet-dump/Dumper.Windows.cs
+++ b/src/Tools/dotnet-dump/Dumper.Windows.cs
@@ -24,14 +24,32 @@ namespace Microsoft.Diagnostics.Tools.Dump
                     using (var stream = new FileStream(outputFile, FileMode.Create, FileAccess.ReadWrite, FileShare.None))
                     {
                         var exceptionInfo = new NativeMethods.MINIDUMP_EXCEPTION_INFORMATION();
-                        var dumpType = type == DumpTypeOption.Mini ? NativeMethods.MINIDUMP_TYPE.MiniDumpWithThreadInfo :
-                            NativeMethods.MINIDUMP_TYPE.MiniDumpWithDataSegs |
-                            NativeMethods.MINIDUMP_TYPE.MiniDumpWithPrivateReadWriteMemory |
-                            NativeMethods.MINIDUMP_TYPE.MiniDumpWithHandleData |
-                            NativeMethods.MINIDUMP_TYPE.MiniDumpWithUnloadedModules |
-                            NativeMethods.MINIDUMP_TYPE.MiniDumpWithFullMemoryInfo |
-                            NativeMethods.MINIDUMP_TYPE.MiniDumpWithThreadInfo |
-                            NativeMethods.MINIDUMP_TYPE.MiniDumpWithTokenInformation;
+
+                        NativeMethods.MINIDUMP_TYPE dumpType = NativeMethods.MINIDUMP_TYPE.MiniDumpNormal;
+                        switch (type)
+                        {
+                            case DumpTypeOption.Full:
+                                dumpType = NativeMethods.MINIDUMP_TYPE.MiniDumpWithFullMemory |
+                                           NativeMethods.MINIDUMP_TYPE.MiniDumpWithDataSegs |
+                                           NativeMethods.MINIDUMP_TYPE.MiniDumpWithHandleData |
+                                           NativeMethods.MINIDUMP_TYPE.MiniDumpWithUnloadedModules |
+                                           NativeMethods.MINIDUMP_TYPE.MiniDumpWithFullMemoryInfo |
+                                           NativeMethods.MINIDUMP_TYPE.MiniDumpWithThreadInfo |
+                                           NativeMethods.MINIDUMP_TYPE.MiniDumpWithTokenInformation;
+                                break;
+                            case DumpTypeOption.Heap:
+                                dumpType = NativeMethods.MINIDUMP_TYPE.MiniDumpWithPrivateReadWriteMemory |
+                                           NativeMethods.MINIDUMP_TYPE.MiniDumpWithDataSegs |
+                                           NativeMethods.MINIDUMP_TYPE.MiniDumpWithHandleData |
+                                           NativeMethods.MINIDUMP_TYPE.MiniDumpWithUnloadedModules |
+                                           NativeMethods.MINIDUMP_TYPE.MiniDumpWithFullMemoryInfo |
+                                           NativeMethods.MINIDUMP_TYPE.MiniDumpWithThreadInfo |
+                                           NativeMethods.MINIDUMP_TYPE.MiniDumpWithTokenInformation;
+                                break;
+                            case DumpTypeOption.Mini:
+                                dumpType = NativeMethods.MINIDUMP_TYPE.MiniDumpWithThreadInfo;
+                                break;
+                        }
 
                         // Retry the write dump on ERROR_PARTIAL_COPY
                         for (int i = 0; i < 5; i++)

--- a/src/Tools/dotnet-dump/Dumper.cs
+++ b/src/Tools/dotnet-dump/Dumper.cs
@@ -20,9 +20,12 @@ namespace Microsoft.Diagnostics.Tools.Dump
         /// </summary>
         public enum DumpTypeOption
         {
+            Full,       // The largest dump containing all memory including the module images.
+
             Heap,       // A large and relatively comprehensive dump containing module lists, thread lists, all 
                         // stacks, exception information, handle information, and all memory except for mapped images.
-            Mini        // A small dump containing module lists, thread lists, exception information and all stacks.
+
+            Mini,       // A small dump containing module lists, thread lists, exception information and all stacks.
         }
 
         public Dumper()
@@ -49,7 +52,19 @@ namespace Microsoft.Diagnostics.Tools.Dump
                 output = Path.GetFullPath(output);
 
                 // Display the type of dump and dump path
-                string dumpTypeMessage = type == DumpTypeOption.Mini ? "dump" : "dump with heap";
+                string dumpTypeMessage = null;
+                switch (type)
+                {
+                    case DumpTypeOption.Full:
+                        dumpTypeMessage = "full";
+                        break;
+                    case DumpTypeOption.Heap:
+                        dumpTypeMessage = "dump with heap";
+                        break;
+                    case DumpTypeOption.Mini:
+                        dumpTypeMessage = "dump";
+                        break;
+                }
                 console.Out.WriteLine($"Writing {dumpTypeMessage} to {output}");
 
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -62,7 +77,20 @@ namespace Microsoft.Diagnostics.Tools.Dump
                 else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 {
                     var client = new DiagnosticsClient(processId);
-                    DumpType dumpType = type == DumpTypeOption.Heap ? DumpType.WithHeap : DumpType.Normal;
+
+                    DumpType dumpType = DumpType.Normal;
+                    switch (type)
+                    {
+                        case DumpTypeOption.Full:
+                            dumpType = DumpType.Full;
+                            break;
+                        case DumpTypeOption.Heap:
+                            dumpType = DumpType.WithHeap;
+                            break;
+                        case DumpTypeOption.Mini:
+                            dumpType = DumpType.Normal;
+                            break;
+                    }
 
                     // Send the command to the runtime to initiate the core dump
                     client.WriteDump(dumpType, output, diag);

--- a/src/Tools/dotnet-dump/Program.cs
+++ b/src/Tools/dotnet-dump/Program.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.Diagnostics.NETCore.Client;
 using Microsoft.Internal.Common.Commands;
 using Microsoft.Tools.Common;
 using System.CommandLine;
@@ -64,11 +63,10 @@ on Linux where YYYYMMDD is Year/Month/Day and HHMMSS is Hour/Minute/Second. Othe
         private static Option TypeOption() =>
             new Option(
                 alias: "--type",
-                description: @"The dump type determines the kinds of information that are collected from the process. There are two types: heap - A large and 
-relatively comprehensive dump containing module lists, thread lists, all stacks, exception information, handle information, and all memory except for mapped 
-images. mini - A small dump containing module lists, thread lists, exception information and all stacks. If not specified 'heap' is the default.")
+                description: @"The dump type determines the kinds of information that are collected from the process. There are several types: full - The largest dump containing all memory including the module images. heap - A large and relatively comprehensive dump containing module lists, thread lists, all stacks, exception information, handle information, and all memory except for mapped 
+images. mini - A small dump containing module lists, thread lists, exception information and all stacks. If not specified 'full' is the default.")
             {
-                Argument = new Argument<Dumper.DumpTypeOption>(name: "dump_type", defaultValue: Dumper.DumpTypeOption.Heap)
+                Argument = new Argument<Dumper.DumpTypeOption>(name: "dump_type", defaultValue: Dumper.DumpTypeOption.Full)
             };
 
         private static Command AnalyzeCommand() =>


### PR DESCRIPTION
The new "full" dump collection type includes all the module images
on both Windows and Linux. The old default type "Heap" is still
the same and can be used if the dump is too big.

Full dumps are roughly 1.5 times bigger on Windows and 30%
bigger on Linux for a simple webapp.

Issue: https://github.com/dotnet/diagnostics/issues/808