### PR TITLE
Fix dotnet-dump analyze <dump-path> -c exit

### DIFF
--- a/src/Microsoft.Diagnostics.Repl/Console/ConsoleProvider.cs
+++ b/src/Microsoft.Diagnostics.Repl/Console/ConsoleProvider.cs
@@ -50,6 +50,7 @@ namespace Microsoft.Diagnostics.Repl
         {
             m_history = new List<StringBuilder>();
             m_activeLine = new StringBuilder();
+            m_shutdown = false;
 
             m_consoleConverter = new CharToLineConverter(text => {
                 NewOutput(text);
@@ -77,7 +78,6 @@ namespace Microsoft.Diagnostics.Repl
         public async Task Start(Func<string, CancellationToken, Task> dispatchCommand)
         {
             m_lastCommandLine = null;
-            m_shutdown = false;
             m_interactiveConsole = !Console.IsInputRedirected;
             RefreshLine();
 
@@ -114,6 +114,8 @@ namespace Microsoft.Diagnostics.Repl
                 }
             }
         }
+
+        public bool Shutdown { get { return m_shutdown; } }
 
         /// <summary>
         /// Stop input processing/dispatching

--- a/src/Tools/dotnet-dump/Analyzer.cs
+++ b/src/Tools/dotnet-dump/Analyzer.cs
@@ -89,20 +89,17 @@ namespace Microsoft.Diagnostics.Tools.Dump
                         {
                             await _commandProcessor.Parse(cmd);
 
-                            if (ExitCommand.Exited)
+                            if (_consoleProvider.Shutdown)
                                 break;
                         }
                     }
 
-                    if (!ExitCommand.Exited)
-                    {
-                        // Start interactive command line processing
-                        var analyzeContext = _serviceProvider.GetService<AnalyzeContext>();
-                        await _consoleProvider.Start(async (string commandLine, CancellationToken cancellation) => {
-                            analyzeContext.CancellationToken = cancellation;
-                            await _commandProcessor.Parse(commandLine);
-                        });
-                    }
+                    // Start interactive command line processing
+                    var analyzeContext = _serviceProvider.GetService<AnalyzeContext>();
+                    await _consoleProvider.Start(async (string commandLine, CancellationToken cancellation) => {
+                        analyzeContext.CancellationToken = cancellation;
+                        await _commandProcessor.Parse(commandLine);
+                    });
                 }
             }
             catch (Exception ex) when 

--- a/src/Tools/dotnet-dump/Analyzer.cs
+++ b/src/Tools/dotnet-dump/Analyzer.cs
@@ -88,15 +88,21 @@ namespace Microsoft.Diagnostics.Tools.Dump
                         foreach (string cmd in command)
                         {
                             await _commandProcessor.Parse(cmd);
+
+                            if (ExitCommand.Exited)
+                                break;
                         }
                     }
 
-                    // Start interactive command line processing
-                    var analyzeContext = _serviceProvider.GetService<AnalyzeContext>();
-                    await _consoleProvider.Start(async (string commandLine, CancellationToken cancellation) => {
-                        analyzeContext.CancellationToken = cancellation;
-                        await _commandProcessor.Parse(commandLine);
-                    });
+                    if (!ExitCommand.Exited)
+                    {
+                        // Start interactive command line processing
+                        var analyzeContext = _serviceProvider.GetService<AnalyzeContext>();
+                        await _consoleProvider.Start(async (string commandLine, CancellationToken cancellation) => {
+                            analyzeContext.CancellationToken = cancellation;
+                            await _commandProcessor.Parse(commandLine);
+                        });
+                    }
                 }
             }
             catch (Exception ex) when 

--- a/src/Tools/dotnet-dump/Commands/ExitCommand.cs
+++ b/src/Tools/dotnet-dump/Commands/ExitCommand.cs
@@ -12,11 +12,8 @@ namespace Microsoft.Diagnostics.Tools.Dump
     [CommandAlias(Name = "quit")]
     public class ExitCommand : CommandBase
     {
-        static ExitCommand() { Exited = false; }
-        static public bool Exited { get; set; }
         public override void Invoke()
         {
-            Exited = true;
             Console.Exit();
         }
     }

--- a/src/Tools/dotnet-dump/Commands/ExitCommand.cs
+++ b/src/Tools/dotnet-dump/Commands/ExitCommand.cs
@@ -12,8 +12,11 @@ namespace Microsoft.Diagnostics.Tools.Dump
     [CommandAlias(Name = "quit")]
     public class ExitCommand : CommandBase
     {
+        static ExitCommand() { Exited = false; }
+        static public bool Exited { get; set; }
         public override void Invoke()
         {
+            Exited = true;
             Console.Exit();
         }
     }


### PR DESCRIPTION
The exit command would fail to exit the analyze process when
executed from the command line.