### PR TITLE
Support testing internal service releases

### DIFF
--- a/diagnostics.yml
+++ b/diagnostics.yml
@@ -18,10 +18,12 @@ variables:
   - name: _InternalBuildArgs
     value: ''
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    - name: _SignType
+      value: real
     # DotNet-Diagnostics-SDL-Params provides Tsa* variables for SDL checks.
     - group: DotNet-Diagnostics-SDL-Params
     - name: _InternalBuildArgs
-      value: /p:DotNetSignType=real
+      value: /p:DotNetSignType=$(_SignType)
         /p:TeamName=$(_TeamName)
         /p:DotNetPublishUsingPipelines=true
         /p:OfficialBuildId=$(BUILD.BUILDNUMBER)

--- a/diagnostics.yml
+++ b/diagnostics.yml
@@ -17,14 +17,11 @@ variables:
     value: DotNetCore
   - name: _InternalBuildArgs
     value: ''
-
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - name: _SignType
-      value: real
     # DotNet-Diagnostics-SDL-Params provides Tsa* variables for SDL checks.
     - group: DotNet-Diagnostics-SDL-Params
     - name: _InternalBuildArgs
-      value: /p:DotNetSignType=$(_SignType)
+      value: /p:DotNetSignType=$(SignType)
         /p:TeamName=$(_TeamName)
         /p:DotNetPublishUsingPipelines=$(PublishPackages)
         /p:OfficialBuildId=$(BUILD.BUILDNUMBER)

--- a/diagnostics.yml
+++ b/diagnostics.yml
@@ -21,9 +21,9 @@ variables:
     # DotNet-Diagnostics-SDL-Params provides Tsa* variables for SDL checks.
     - group: DotNet-Diagnostics-SDL-Params
     - name: _InternalBuildArgs
-      value: /p:DotNetSignType=$(SignType)
+      value: /p:DotNetSignType=real
         /p:TeamName=$(_TeamName)
-        /p:DotNetPublishUsingPipelines=$(PublishPackages)
+        /p:DotNetPublishUsingPipelines=true
         /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
 
 stages:

--- a/eng/InstallRuntimes.proj
+++ b/eng/InstallRuntimes.proj
@@ -2,8 +2,13 @@
 <Project>
   <!--
      $(BuildArch) - architecture to test (x64, x86, arm, arm64). Defaults to x64.
-     $(DailyTest) - if true, only install/test the latest (master branch) runtime
      $(PrivateBuildPath) - if non-empty, path to private runtime build to copy/test
+
+     Internal service release testing:
+
+     $(InternalRuntimeSourceVersion) - the service release version i.e. 2.1.17, 3.1.3, etc.
+     $(InternalRuntimeSourceFeed)    - the service release internal feed
+     $(InternalRuntimeSourceFeedKey) - the service release feed PAT
      
      From Versions.props:
 
@@ -20,9 +25,12 @@
   -->
 
   <PropertyGroup>
-    <DailyTest Condition="'$(DailyTest)' == ''">false</DailyTest>
     <BuildArch Condition="'$(BuildArch)' == ''">$(Platform)</BuildArch>
     <BuildArch Condition="'$(BuildArch)' == ''">x64</BuildArch>
+    <PrivateBuildTesting>false</PrivateBuildTesting>
+    <PrivateBuildTesting Condition="'$(PrivateBuildPath)' != ''">true</PrivateBuildTesting>
+    <InternalReleaseTesting>false</InternalReleaseTesting>
+    <InternalReleaseTesting Condition="'$(InternalRuntimeSourceFeed)' != ''">true</InternalReleaseTesting>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(BuildArch)' != 'x86'">
@@ -49,21 +57,34 @@
       <PropertyGroup>
         <PowershellWrapper>powershell -NonInteractive -ExecutionPolicy ByPass -NoProfile -command</PowershellWrapper>
         <DotnetInstallScriptCmd>'$(RepositoryEngineeringDir)common\dotnet-install.ps1'</DotnetInstallScriptCmd>
+        <InternalInstallArgs Condition="$(InternalReleaseTesting)">-RuntimeSourceFeed $(InternalRuntimeSourceFeed) -RuntimeSourceFeedKey $(InternalRuntimeSourceFeedKey)</InternalInstallArgs>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
         <DotnetInstallScriptCmd>$(RepositoryEngineeringDir)common/dotnet-install.sh</DotnetInstallScriptCmd>
+        <InternalInstallArgs Condition="$(InternalReleaseTesting)">-runtimesourcefeed $(InternalRuntimeSourceFeed) -runtimesourcefeedkey $(InternalRuntimeSourceFeedKey)</InternalInstallArgs>
       </PropertyGroup>
     </Otherwise>
   </Choose>
 
-  <ItemGroup>
-    <!-- We always test on latest, so install that one even for scheduled builds -->
-    <TestVersions Include="Latest" RuntimeVersion="$(MicrosoftNETCoreAppVersion)" AspNetVersion="$(MicrosoftAspNetCoreAppRefVersion)" Install="true" />
-    <TestVersions Include="31" RuntimeVersion="$(MicrosoftNETCoreApp31Version)" AspNetVersion="$(MicrosoftAspNetCoreApp31Version)" Install="!$(DailyTest)" />
-    <TestVersions Include="30" RuntimeVersion="$(MicrosoftNETCoreApp30Version)" AspNetVersion="$(MicrosoftAspNetCoreApp30Version)" Install="!$(DailyTest)" />
-    <TestVersions Include="21" RuntimeVersion="$(MicrosoftNETCoreApp21Version)" AspNetVersion="$(MicrosoftAspNetCoreApp21Version)" Install="true" />
+  <ItemGroup Condition="!$(InternalReleaseTesting) and !$(PrivateBuildTesting)">
+    <TestVersions Include="Latest" RuntimeVersion="$(MicrosoftNETCoreAppVersion)" AspNetVersion="$(MicrosoftAspNetCoreAppRefVersion)" />
+    <TestVersions Include="31" RuntimeVersion="$(MicrosoftNETCoreApp31Version)" AspNetVersion="$(MicrosoftAspNetCoreApp31Version)" />
+    <TestVersions Include="30" RuntimeVersion="$(MicrosoftNETCoreApp30Version)" AspNetVersion="$(MicrosoftAspNetCoreApp30Version)" />
+    <TestVersions Include="21" RuntimeVersion="$(MicrosoftNETCoreApp21Version)" AspNetVersion="$(MicrosoftAspNetCoreApp21Version)" />
+  </ItemGroup>
+
+  <!-- Local private build testing -->
+  <ItemGroup Condition="$(PrivateBuildTesting)">
+    <TestVersions Include="Latest" RuntimeVersion="$(MicrosoftNETCoreAppVersion)" AspNetVersion="$(MicrosoftAspNetCoreAppRefVersion)" />
+    <TestVersions Include="21" RuntimeVersion="$(MicrosoftNETCoreApp21Version)" />
+  </ItemGroup>
+
+  <!-- Internal service release testing -->
+  <ItemGroup Condition="$(InternalReleaseTesting)">
+    <TestVersions Include="Internal" RuntimeVersion="$(InternalRuntimeSourceVersion)" ExtraInstallArgs="$(InternalInstallArgs)" />
+    <TestVersions Include="21" RuntimeVersion="$(MicrosoftNETCoreApp21Version)" />
   </ItemGroup>
 
 <!--
@@ -72,7 +93,11 @@
 
   <Target Name="InstallTestRuntimes" 
           BeforeTargets="RunTests"
-          DependsOnTargets="InstallRuntimesWindows;InstallRuntimesUnix;WriteTestVersionManifest;TestPrivateBuild" />
+          DependsOnTargets="InstallRuntimesWindows;InstallRuntimesUnix;WriteTestVersionManifest;TestPrivateBuild">
+
+    <Message Condition="$(InternalReleaseTesting)" Importance="High" Text="InternalRuntimeSource: version '$(InternalRuntimeSourceVersion)' feed '$(InternalRuntimeSourceFeed)'" />
+
+  </Target>
 
 <!--
     Installs the test runtimes on Windows
@@ -82,11 +107,11 @@
           Condition="$([MSBuild]::IsOsPlatform(Windows))"
           Inputs="$(VersionsPropsPath)" Outputs="$(TestConfigFileName)">
 
-    <Exec Command="$(PowershellWrapper) &quot;&amp; { &amp;$(DotnetInstallScriptCmd) $(CommonInstallArgs) -version %(TestVersions.RuntimeVersion) -runtime dotnet }&quot;"
-          Condition="%(TestVersions.Install)" />
+    <Exec Command="$(PowershellWrapper) &quot;&amp; { &amp;$(DotnetInstallScriptCmd) $(CommonInstallArgs) %(TestVersions.ExtraInstallArgs) -version %(TestVersions.RuntimeVersion) -runtime dotnet }&quot;"
+          Condition="'%(TestVersions.RuntimeVersion)' != ''" />
 
-    <Exec Command="$(PowershellWrapper) &quot;&amp; { &amp;$(DotnetInstallScriptCmd) $(CommonInstallArgs) -version %(TestVersions.AspNetVersion) -runtime aspnetcore }&quot;"
-          Condition="%(TestVersions.Install)" />
+    <Exec Command="$(PowershellWrapper) &quot;&amp; { &amp;$(DotnetInstallScriptCmd) $(CommonInstallArgs) %(TestVersions.ExtraInstallArgs) -version %(TestVersions.AspNetVersion) -runtime aspnetcore }&quot;"
+          Condition="'%(TestVersions.AspNetVersion)' != ''" />
   </Target>
 
 <!--
@@ -97,13 +122,13 @@
           Condition="!$([MSBuild]::IsOsPlatform(Windows))"
           Inputs="$(VersionsPropsPath)" Outputs="$(TestConfigFileName)">
 
-    <Exec Command="$(DotnetInstallScriptCmd) $(CommonInstallArgs) -version %(TestVersions.RuntimeVersion) -runtime dotnet"
+    <Exec Command="$(DotnetInstallScriptCmd) $(CommonInstallArgs) %(TestVersions.ExtraInstallArgs) -version %(TestVersions.RuntimeVersion) -runtime dotnet"
           IgnoreStandardErrorWarningFormat="true"
-          Condition="%(TestVersions.Install)" />
+          Condition="'%(TestVersions.RuntimeVersion)' != ''" />
 
-    <Exec Command="$(DotnetInstallScriptCmd) $(CommonInstallArgs) -version %(TestVersions.AspNetVersion) -runtime aspnetcore"
+    <Exec Command="$(DotnetInstallScriptCmd) $(CommonInstallArgs) %(TestVersions.ExtraInstallArgs) -version %(TestVersions.AspNetVersion) -runtime aspnetcore"
           IgnoreStandardErrorWarningFormat="true"
-          Condition="%(TestVersions.Install)" />
+          Condition="'%(TestVersions.AspNetVersion)' != ''" />
    </Target>
 
 <!--
@@ -115,17 +140,24 @@
           Outputs="$(TestConfigFileName)">
 
     <PropertyGroup>
+      <RuntimeVersionLatest>$(MicrosoftNETCoreAppVersion)</RuntimeVersionLatest>
+      <RuntimeVersionLatest Condition="$(InternalReleaseTesting)">$(InternalRuntimeSourceVersion)</RuntimeVersionLatest>
       <TestConfigFileLines>
 <![CDATA[
 <Configuration>
-  <DailyTest>$(DailyTest)</DailyTest>
+  <PrivateBuildTesting>$(PrivateBuildTesting)</PrivateBuildTesting>
+  <InternalReleaseTesting>$(InternalReleaseTesting)</InternalReleaseTesting>
+
   <RuntimeVersion21>$(MicrosoftNETCoreApp21Version)</RuntimeVersion21>
   <AspNetCoreVersion21>$(MicrosoftAspNetCoreApp21Version)</AspNetCoreVersion21>
+
   <RuntimeVersion30>$(MicrosoftNETCoreApp30Version)</RuntimeVersion30>
   <AspNetCoreVersion30>$(MicrosoftAspNetCoreApp30Version)</AspNetCoreVersion30>
+
   <RuntimeVersion31>$(MicrosoftNETCoreApp31Version)</RuntimeVersion31>
   <AspNetCoreVersion31>$(MicrosoftAspNetCoreApp31Version)</AspNetCoreVersion31>
-  <RuntimeVersionLatest>$(MicrosoftNETCoreAppVersion)</RuntimeVersionLatest>
+
+  <RuntimeVersionLatest>$(RuntimeVersionLatest)</RuntimeVersionLatest>
   <AspNetCoreVersionLatest>$(MicrosoftAspNetCoreAppRefVersion)</AspNetCoreVersionLatest>
 </Configuration>
 ]]>

--- a/eng/InstallRuntimes.proj
+++ b/eng/InstallRuntimes.proj
@@ -6,10 +6,10 @@
 
      Internal service release testing:
 
-     $(InternalRuntimeSourceType) - the type of install/test run: normal, public, msrc
-     $(InternalRuntimeSourceVersion) - the service release version i.e. 2.1.17, 3.1.3, etc.
-     $(InternalRuntimeSourceFeed)    - the service release internal feed
-     $(InternalRuntimeSourceFeedKey) - the service release feed PAT
+     $(DotnetRuntimeVersion)         - the service release version to test against (fx-version option value) i.e. 2.1.17, 3.1.3 or blank
+     $(DotnetRuntimeDownloadVersion) - the service release package version i.e. 2.1.17, 3.1.3-servicing.20128.1 or blank
+     $(RuntimeSourceFeed)            - the service release internal blob storage link
+     $(RuntimeSourceFeedKey)         - the service release blob feed token
      
      From Versions.props:
 
@@ -31,7 +31,9 @@
     <PrivateBuildTesting>false</PrivateBuildTesting>
     <PrivateBuildTesting Condition="'$(PrivateBuildPath)' != ''">true</PrivateBuildTesting>
     <InternalReleaseTesting>false</InternalReleaseTesting>
-    <InternalReleaseTesting Condition="'$(InternalRuntimeSourceType)' == 'public' or '$(InternalRuntimeSourceType)' == 'msrc'">true</InternalReleaseTesting>
+    <InternalReleaseTesting Condition="'$(DotnetRuntimeVersion)' != '' and '$(DotnetRuntimeVersion)' != 'default'">true</InternalReleaseTesting>
+    <DotnetRuntimeDownloadVersion Condition="'$(DotnetRuntimeDownloadVersion)' == '' or '$(DotnetRuntimeDownloadVersion)' == 'default'">$(DotnetRuntimeVersion)</DotnetRuntimeDownloadVersion>
+    <ExtraInstallArgs>-runtimesourcefeed '$(RuntimeSourceFeed)' -runtimesourcefeedkey '$(RuntimeSourceFeedKey)'</ExtraInstallArgs>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(BuildArch)' != 'x86'">
@@ -58,13 +60,11 @@
       <PropertyGroup>
         <PowershellWrapper>powershell -NonInteractive -ExecutionPolicy ByPass -NoProfile -command</PowershellWrapper>
         <DotnetInstallScriptCmd>'$(RepositoryEngineeringDir)common\dotnet-install.ps1'</DotnetInstallScriptCmd>
-        <InternalInstallArgs Condition="'$(InternalRuntimeSourceType)' == 'msrc'">-RuntimeSourceFeed $(InternalRuntimeSourceFeed) -RuntimeSourceFeedKey $(InternalRuntimeSourceFeedKey)</InternalInstallArgs>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
         <DotnetInstallScriptCmd>$(RepositoryEngineeringDir)common/dotnet-install.sh</DotnetInstallScriptCmd>
-        <InternalInstallArgs Condition="'$(InternalRuntimeSourceType)' == 'msrc'">-runtimesourcefeed $(InternalRuntimeSourceFeed) -runtimesourcefeedkey $(InternalRuntimeSourceFeedKey)</InternalInstallArgs>
       </PropertyGroup>
     </Otherwise>
   </Choose>
@@ -84,7 +84,7 @@
 
   <!-- Internal service release testing -->
   <ItemGroup Condition="$(InternalReleaseTesting)">
-    <TestVersions Include="Internal" RuntimeVersion="$(InternalRuntimeSourceVersion)" ExtraInstallArgs="$(InternalInstallArgs)" />
+    <TestVersions Include="Internal" RuntimeVersion="$(DotnetRuntimeDownloadVersion)" ExtraInstallArgs="$(ExtraInstallArgs)" />
     <TestVersions Include="21" RuntimeVersion="$(MicrosoftNETCoreApp21Version)" />
   </ItemGroup>
 
@@ -94,7 +94,7 @@
 
   <Target Name="InstallTestRuntimes" 
           BeforeTargets="RunTests"
-          DependsOnTargets="InstallRuntimesWindows;InstallRuntimesUnix;WriteTestVersionManifest;TestPrivateBuild" />
+          DependsOnTargets="CleanupVersionManifest;InstallRuntimesWindows;InstallRuntimesUnix;CopyPrivateBuild;WriteTestVersionManifest;" />
 
 <!--
     Installs the test runtimes on Windows
@@ -138,7 +138,7 @@
 
     <PropertyGroup>
       <RuntimeVersionLatest>$(MicrosoftNETCoreAppVersion)</RuntimeVersionLatest>
-      <RuntimeVersionLatest Condition="$(InternalReleaseTesting)">$(InternalRuntimeSourceVersion)</RuntimeVersionLatest>
+      <RuntimeVersionLatest Condition="$(InternalReleaseTesting)">$(DotnetRuntimeVersion)</RuntimeVersionLatest>
       <TestConfigFileLines>
 <![CDATA[
 <Configuration>
@@ -171,10 +171,22 @@
   </Target>
 
 <!--
+    Removes the test config file if internal service release or private build testing
+-->
+
+  <Target Name="CleanupVersionManifest"
+          Condition="$(InternalReleaseTesting) or $(PrivateBuildTesting)">
+
+    <!-- Make sure the config file gets regenerated in the WriteTestVersionManifest target -->
+    <Delete Files="$(TestConfigFileName)" />
+
+  </Target>
+
+<!--
     Copies the private runtime build binaries and on Windows adds registry keys
 -->
 
-  <Target Name="TestPrivateBuild"
+  <Target Name="CopyPrivateBuild"
           Condition="'$(PrivateBuildPath)' != ''"
           DependsOnTargets="ModifyRegistry">
 

--- a/eng/InstallRuntimes.proj
+++ b/eng/InstallRuntimes.proj
@@ -6,6 +6,7 @@
 
      Internal service release testing:
 
+     $(InternalRuntimeSourceType) - the type of install/test run: normal, public, msrc
      $(InternalRuntimeSourceVersion) - the service release version i.e. 2.1.17, 3.1.3, etc.
      $(InternalRuntimeSourceFeed)    - the service release internal feed
      $(InternalRuntimeSourceFeedKey) - the service release feed PAT
@@ -30,7 +31,7 @@
     <PrivateBuildTesting>false</PrivateBuildTesting>
     <PrivateBuildTesting Condition="'$(PrivateBuildPath)' != ''">true</PrivateBuildTesting>
     <InternalReleaseTesting>false</InternalReleaseTesting>
-    <InternalReleaseTesting Condition="'$(InternalRuntimeSourceFeed)' != ''">true</InternalReleaseTesting>
+    <InternalReleaseTesting Condition="'$(InternalRuntimeSourceType)' == 'public' or '$(InternalRuntimeSourceType)' == 'msrc'">true</InternalReleaseTesting>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(BuildArch)' != 'x86'">
@@ -57,13 +58,13 @@
       <PropertyGroup>
         <PowershellWrapper>powershell -NonInteractive -ExecutionPolicy ByPass -NoProfile -command</PowershellWrapper>
         <DotnetInstallScriptCmd>'$(RepositoryEngineeringDir)common\dotnet-install.ps1'</DotnetInstallScriptCmd>
-        <InternalInstallArgs Condition="$(InternalReleaseTesting)">-RuntimeSourceFeed $(InternalRuntimeSourceFeed) -RuntimeSourceFeedKey $(InternalRuntimeSourceFeedKey)</InternalInstallArgs>
+        <InternalInstallArgs Condition="'$(InternalRuntimeSourceType)' == 'msrc'">-RuntimeSourceFeed $(InternalRuntimeSourceFeed) -RuntimeSourceFeedKey $(InternalRuntimeSourceFeedKey)</InternalInstallArgs>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
         <DotnetInstallScriptCmd>$(RepositoryEngineeringDir)common/dotnet-install.sh</DotnetInstallScriptCmd>
-        <InternalInstallArgs Condition="$(InternalReleaseTesting)">-runtimesourcefeed $(InternalRuntimeSourceFeed) -runtimesourcefeedkey $(InternalRuntimeSourceFeedKey)</InternalInstallArgs>
+        <InternalInstallArgs Condition="'$(InternalRuntimeSourceType)' == 'msrc'">-runtimesourcefeed $(InternalRuntimeSourceFeed) -runtimesourcefeedkey $(InternalRuntimeSourceFeedKey)</InternalInstallArgs>
       </PropertyGroup>
     </Otherwise>
   </Choose>
@@ -93,11 +94,7 @@
 
   <Target Name="InstallTestRuntimes" 
           BeforeTargets="RunTests"
-          DependsOnTargets="InstallRuntimesWindows;InstallRuntimesUnix;WriteTestVersionManifest;TestPrivateBuild">
-
-    <Message Condition="$(InternalReleaseTesting)" Importance="High" Text="InternalRuntimeSource: version '$(InternalRuntimeSourceVersion)' feed '$(InternalRuntimeSourceFeed)'" />
-
-  </Target>
+          DependsOnTargets="InstallRuntimesWindows;InstallRuntimesUnix;WriteTestVersionManifest;TestPrivateBuild" />
 
 <!--
     Installs the test runtimes on Windows

--- a/eng/InstallRuntimes.proj
+++ b/eng/InstallRuntimes.proj
@@ -6,8 +6,8 @@
 
      Internal service release testing:
 
-     $(DotnetRuntimeVersion)         - the service release version to test against (fx-version option value) i.e. 2.1.17, 3.1.3 or blank
-     $(DotnetRuntimeDownloadVersion) - the service release package version i.e. 2.1.17, 3.1.3-servicing.20128.1 or blank
+     $(DotnetRuntimeVersion)         - the service release version to test against (fx-version option value) i.e. 2.1.17, 3.1.3 or "default"
+     $(DotnetRuntimeDownloadVersion) - the service release package version i.e. 2.1.17, 3.1.3-servicing.20128.1 or "default"
      $(RuntimeSourceFeed)            - the service release internal blob storage link
      $(RuntimeSourceFeedKey)         - the service release blob feed token
      
@@ -31,8 +31,7 @@
     <PrivateBuildTesting>false</PrivateBuildTesting>
     <PrivateBuildTesting Condition="'$(PrivateBuildPath)' != ''">true</PrivateBuildTesting>
     <InternalReleaseTesting>false</InternalReleaseTesting>
-    <InternalReleaseTesting Condition="'$(DotnetRuntimeVersion)' != '' and '$(DotnetRuntimeVersion)' != 'default'">true</InternalReleaseTesting>
-    <DotnetRuntimeDownloadVersion Condition="'$(DotnetRuntimeDownloadVersion)' == '' or '$(DotnetRuntimeDownloadVersion)' == 'default'">$(DotnetRuntimeVersion)</DotnetRuntimeDownloadVersion>
+    <InternalReleaseTesting Condition="'$(DotnetRuntimeVersion)' != 'default'">true</InternalReleaseTesting>
     <ExtraInstallArgs>-runtimesourcefeed '$(RuntimeSourceFeed)' -runtimesourcefeedkey '$(RuntimeSourceFeedKey)'</ExtraInstallArgs>
   </PropertyGroup>
 
@@ -84,7 +83,8 @@
 
   <!-- Internal service release testing -->
   <ItemGroup Condition="$(InternalReleaseTesting)">
-    <TestVersions Include="Internal" RuntimeVersion="$(DotnetRuntimeDownloadVersion)" ExtraInstallArgs="$(ExtraInstallArgs)" />
+    <TestVersions Include="Internal" RuntimeVersion="$(DotnetRuntimeDownloadVersion)" ExtraInstallArgs="$(ExtraInstallArgs)" Condition="'$(DotnetRuntimeDownloadVersion)' != 'default'"/>
+    <TestVersions Include="Internal" RuntimeVersion="$(DotnetRuntimeVersion)" ExtraInstallArgs="$(ExtraInstallArgs)" Condition="'$(DotnetRuntimeDownloadVersion)' == 'default'"/>
     <TestVersions Include="21" RuntimeVersion="$(MicrosoftNETCoreApp21Version)" />
   </ItemGroup>
 

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -9,8 +9,8 @@ Param(
   [switch] $skipnative,
   [string] $privatebuildpath = "",
   [switch] $cleanupprivatebuild,
-  [ValidatePattern("(\d+\.\d+.\d+(-[a-z0-9\.]+)?)?")][string] $dotnetruntimeversion = '',
-  [ValidatePattern("(\d+\.\d+.\d+(-[a-z0-9\.]+)?)?")][string] $dotnetruntimedownloadversion= '',
+  [ValidatePattern("(\d+\.\d+.\d+(-[a-z0-9\.]+)?)?")][string] $dotnetruntimeversion = 'default',
+  [ValidatePattern("(\d+\.\d+.\d+(-[a-z0-9\.]+)?)?")][string] $dotnetruntimedownloadversion= 'default',
   [string] $runtimesourcefeed = '',
   [string] $runtimesourcefeedkey = '',
   [Parameter(ValueFromRemainingArguments=$true)][String[]] $remainingargs

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -9,8 +9,8 @@ Param(
   [switch] $skipnative,
   [string] $privatebuildpath = "",
   [switch] $cleanupprivatebuild,
-  [string] $runtimesourcetype = '',
-  [string] $runtimesourceversion = '',
+  [ValidatePattern("(\d+\.\d+.\d+(-[a-z0-9\.]+)?)?")][string] $dotnetruntimeversion = '',
+  [ValidatePattern("(\d+\.\d+.\d+(-[a-z0-9\.]+)?)?")][string] $dotnetruntimedownloadversion= '',
   [string] $runtimesourcefeed = '',
   [string] $runtimesourcefeedkey = '',
   [Parameter(ValueFromRemainingArguments=$true)][String[]] $remainingargs
@@ -89,10 +89,10 @@ if ($test) {
           /p:BuildArch=$architecture `
           /p:TestArchitectures=$architecture `
           /p:PrivateBuildPath=$privatebuildpath `
-          /p:InternalRuntimeSourceType=$runtimesourcetype `
-          /p:InternalRuntimeSourceVersion=$runtimesourceversion `
-          /p:InternalRuntimeSourceFeed=$runtimesourcefeed `
-          /p:InternalRuntimeSourceFeedKey=$runtimesourcefeedkey
+          /p:DotnetRuntimeVersion=$dotnetruntimeversion `
+          /p:DotnetRuntimeDownloadVersion=$dotnetruntimedownloadversion `
+          /p:RuntimeSourceFeed=$runtimesourcefeed `
+          /p:RuntimeSourceFeedKey=$runtimesourcefeedkey
 
         if ($lastExitCode -ne 0) {
             exit $lastExitCode

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -9,8 +9,8 @@ Param(
   [switch] $skipnative,
   [string] $privatebuildpath = "",
   [switch] $cleanupprivatebuild,
-  [ValidatePattern("(\d+\.\d+.\d+(-[a-z0-9\.]+)?)?")][string] $dotnetruntimeversion = 'default',
-  [ValidatePattern("(\d+\.\d+.\d+(-[a-z0-9\.]+)?)?")][string] $dotnetruntimedownloadversion= 'default',
+  [ValidatePattern("(default|\d+\.\d+.\d+(-[a-z0-9\.]+)?)")][string] $dotnetruntimeversion = 'default',
+  [ValidatePattern("(default|\d+\.\d+.\d+(-[a-z0-9\.]+)?)")][string] $dotnetruntimedownloadversion= 'default',
   [string] $runtimesourcefeed = '',
   [string] $runtimesourcefeedkey = '',
   [Parameter(ValueFromRemainingArguments=$true)][String[]] $remainingargs

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -88,11 +88,11 @@ if ($test) {
           /bl:$logdir\Test.binlog `
           /p:BuildArch=$architecture `
           /p:TestArchitectures=$architecture `
-          /p:PrivateBuildPath=$privatebuildpath `
-          /p:DotnetRuntimeVersion=$dotnetruntimeversion `
-          /p:DotnetRuntimeDownloadVersion=$dotnetruntimedownloadversion `
-          /p:RuntimeSourceFeed=$runtimesourcefeed `
-          /p:RuntimeSourceFeedKey=$runtimesourcefeedkey
+          /p:PrivateBuildPath="$privatebuildpath" `
+          /p:DotnetRuntimeVersion="$dotnetruntimeversion" `
+          /p:DotnetRuntimeDownloadVersion="$dotnetruntimedownloadversion" `
+          /p:RuntimeSourceFeed="$runtimesourcefeed" `
+          /p:RuntimeSourceFeedKey="$runtimesourcefeedkey"
 
         if ($lastExitCode -ne 0) {
             exit $lastExitCode

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -9,6 +9,7 @@ Param(
   [switch] $skipnative,
   [string] $privatebuildpath = "",
   [switch] $cleanupprivatebuild,
+  [string] $runtimesourcetype = '',
   [string] $runtimesourceversion = '',
   [string] $runtimesourcefeed = '',
   [string] $runtimesourcefeedkey = '',
@@ -88,6 +89,7 @@ if ($test) {
           /p:BuildArch=$architecture `
           /p:TestArchitectures=$architecture `
           /p:PrivateBuildPath=$privatebuildpath `
+          /p:InternalRuntimeSourceType=$runtimesourcetype `
           /p:InternalRuntimeSourceVersion=$runtimesourceversion `
           /p:InternalRuntimeSourceFeed=$runtimesourcefeed `
           /p:InternalRuntimeSourceFeedKey=$runtimesourcefeedkey

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -35,8 +35,8 @@ __Verbosity=minimal
 __ManagedBuildArgs=
 __TestArgs=
 __UnprocessedBuildArgs=
-__DotnetRuntimeVersion=''
-__DotnetRuntimeDownloadVersion=''
+__DotnetRuntimeVersion='default'
+__DotnetRuntimeDownloadVersion='default'
 __RuntimeSourceFeed=''
 __RuntimeSourceFeedKey=''
 

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -178,27 +178,27 @@ while :; do
             ;;
 
         -privatebuildpath)
-            __PrivateBuildPath=$2
+            __PrivateBuildPath="$2"
             shift
             ;;
 
         -dotnetruntimeversion)
-            __DotnetRuntimeVersion=$2
+            __DotnetRuntimeVersion="$2"
             shift
             ;;
 
         -dotnetruntimedownloadversion)
-            __DotnetRuntimeDownloadVersion=$2
+            __DotnetRuntimeDownloadVersion="$2"
             shift
             ;;
 
         -runtimesourcefeed)
-            __RuntimeSourceFeed=$2
+            __RuntimeSourceFeed="$2"
             shift
             ;;
 
         -runtimesourcefeedkey)
-            __RuntimeSourceFeedKey=$2
+            __RuntimeSourceFeedKey="$2"
             shift
             ;;
 
@@ -540,12 +540,12 @@ if [ $__Test == true ]; then
         --configuration "$__BuildType" \
         --verbosity "$__Verbosity" \
         /bl:$__LogDir/Test.binlog \
-        /p:BuildArch=$__BuildArch \
-        /p:PrivateBuildPath=$__PrivateBuildPath \
-        /p:DotnetRuntimeVersion=$__DotnetRuntimeVersion \
-        /p:DotnetRuntimeDownloadVersion=$__DotnetRuntimeDownloadVersion \
-        /p:RuntimeSourceFeed=$__RuntimeSourceFeed \
-        /p:RuntimeSourceFeedKey=$__RuntimeSourceFeedKey \
+        /p:BuildArch="$__BuildArch" \
+        /p:PrivateBuildPath="$__PrivateBuildPath" \
+        /p:DotnetRuntimeVersion="$__DotnetRuntimeVersion" \
+        /p:DotnetRuntimeDownloadVersion="$__DotnetRuntimeDownloadVersion" \
+        /p:RuntimeSourceFeed="$__RuntimeSourceFeed" \
+        /p:RuntimeSourceFeedKey="$__RuntimeSourceFeedKey" \
         $__TestArgs
 
       if [ $? != 0 ]; then

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -35,6 +35,7 @@ __Verbosity=minimal
 __ManagedBuildArgs=
 __TestArgs=
 __UnprocessedBuildArgs=
+__RuntimeSourceType=''
 __RuntimeSourceVersion=''
 __RuntimeSourceFeed=''
 __RuntimeSourceFeedKey=''
@@ -178,6 +179,11 @@ while :; do
 
         -privatebuildpath)
             __PrivateBuildPath=$2
+            shift
+            ;;
+
+        -runtimesourcetype)
+            __RuntimeSourceType=$2
             shift
             ;;
 
@@ -536,6 +542,7 @@ if [ $__Test == true ]; then
         /bl:$__LogDir/Test.binlog \
         /p:BuildArch=$__BuildArch \
         /p:PrivateBuildPath=$__PrivateBuildPath \
+        /p:InternalRuntimeSourceType=$__RuntimeSourceType \
         /p:InternalRuntimeSourceVersion=$__RuntimeSourceVersion \
         /p:InternalRuntimeSourceFeed=$__RuntimeSourceFeed \
         /p:InternalRuntimeSourceFeedKey=$__RuntimeSourceFeedKey \

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -35,8 +35,8 @@ __Verbosity=minimal
 __ManagedBuildArgs=
 __TestArgs=
 __UnprocessedBuildArgs=
-__RuntimeSourceType=''
-__RuntimeSourceVersion=''
+__DotnetRuntimeVersion=''
+__DotnetRuntimeDownloadVersion=''
 __RuntimeSourceFeed=''
 __RuntimeSourceFeedKey=''
 
@@ -182,13 +182,13 @@ while :; do
             shift
             ;;
 
-        -runtimesourcetype)
-            __RuntimeSourceType=$2
+        -dotnetruntimeversion)
+            __DotnetRuntimeVersion=$2
             shift
             ;;
 
-        -runtimesourceversion)
-            __RuntimeSourceVersion=$2
+        -dotnetruntimedownloadversion)
+            __DotnetRuntimeDownloadVersion=$2
             shift
             ;;
 
@@ -542,10 +542,10 @@ if [ $__Test == true ]; then
         /bl:$__LogDir/Test.binlog \
         /p:BuildArch=$__BuildArch \
         /p:PrivateBuildPath=$__PrivateBuildPath \
-        /p:InternalRuntimeSourceType=$__RuntimeSourceType \
-        /p:InternalRuntimeSourceVersion=$__RuntimeSourceVersion \
-        /p:InternalRuntimeSourceFeed=$__RuntimeSourceFeed \
-        /p:InternalRuntimeSourceFeedKey=$__RuntimeSourceFeedKey \
+        /p:DotnetRuntimeVersion=$__DotnetRuntimeVersion \
+        /p:DotnetRuntimeDownloadVersion=$__DotnetRuntimeDownloadVersion \
+        /p:RuntimeSourceFeed=$__RuntimeSourceFeed \
+        /p:RuntimeSourceFeedKey=$__RuntimeSourceFeedKey \
         $__TestArgs
 
       if [ $? != 0 ]; then

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -85,6 +85,7 @@ jobs:
     - _HelixType: build/product
     - _HelixBuildConfig: $(_BuildConfig)
     - _Pipeline_StreamDumpDir: $(Build.SourcesDirectory)/artifacts/tmp/$(_BuildConfig)/streams
+    - _InternalInstallArgs: -runtimesourceversion $(InternalRuntimeSourceVersion) -runtimesourcefeed $(InternalRuntimeSourceFeed) -runtimesourcefeedkey $(InternalRuntimeSourceFeedKey)
 
     # Only enable publishing in non-public, non PR scenarios.
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
@@ -110,6 +111,7 @@ jobs:
           -architecture $(_BuildArch)
           -prepareMachine 
           /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+          $(_InternalInstallArgs)
         displayName: Build / Test
         condition: succeeded()
 
@@ -132,6 +134,7 @@ jobs:
           --prepareMachine 
           /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
           /p:BUILD_BUILDNUMBER=$(BUILD.BUILDNUMBER)
+          $(_InternalInstallArgs)
         displayName: Docker Build / Test
         condition: succeeded()
 
@@ -143,6 +146,7 @@ jobs:
           --architecture $(_BuildArch)
           --prepareMachine
           /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+          $(_InternalInstallArgs)
         displayName: Build / Test
         condition: succeeded()
  

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -85,7 +85,16 @@ jobs:
     - _HelixType: build/product
     - _HelixBuildConfig: $(_BuildConfig)
     - _Pipeline_StreamDumpDir: $(Build.SourcesDirectory)/artifacts/tmp/$(_BuildConfig)/streams
-    - _InternalInstallArgs: -runtimesourceversion $(InternalRuntimeSourceVersion) -runtimesourcefeed $(InternalRuntimeSourceFeed) -runtimesourcefeedkey $(InternalRuntimeSourceFeedKey)
+    - _InternalBuildArgs: ''
+ 
+    # For testing msrc's and service releases
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      - group: DotNet-MSRC-Storage
+      - _InternalInstallArgs:
+          -runtimesourcetype $(RuntimeSourceType)
+          -runtimesourceversion $(RuntimeSourceVersion)
+          -runtimesourcefeed $(dotnetfeedmsrc-private-feed-url)
+          -runtimesourcefeedkey $(dotnetclimsrc-read-sas-token-base64)
 
     # Only enable publishing in non-public, non PR scenarios.
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -85,16 +85,16 @@ jobs:
     - _HelixType: build/product
     - _HelixBuildConfig: $(_BuildConfig)
     - _Pipeline_StreamDumpDir: $(Build.SourcesDirectory)/artifacts/tmp/$(_BuildConfig)/streams
-    - _InternalBuildArgs: ''
+    - _InternalInstallArgs: ''
  
-    # For testing msrc's and service releases
+    # For testing msrc's and service releases. The RuntimeSourceVersion is either "default" or the service release version to test
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       - group: DotNet-MSRC-Storage
       - _InternalInstallArgs:
-          -runtimesourcetype $(RuntimeSourceType)
-          -runtimesourceversion $(RuntimeSourceVersion)
-          -runtimesourcefeed $(dotnetfeedmsrc-private-feed-url)
-          -runtimesourcefeedkey $(dotnetclimsrc-read-sas-token-base64)
+          -dotnetruntimeversion '$(DotnetRuntimeVersion)'
+          -dotnetruntimedownloadversion '$(DotnetRuntimeDownloadVersion)'
+          -runtimesourcefeed '$(dotnetfeedmsrc-private-feed-url)'
+          -runtimesourcefeedkey '$(dotnetclimsrc-read-sas-token-base64)'
 
     # Only enable publishing in non-public, non PR scenarios.
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:

--- a/src/SOS/SOS.UnitTests/ConfigFiles/Unix/Debugger.Tests.Config.txt
+++ b/src/SOS/SOS.UnitTests/ConfigFiles/Unix/Debugger.Tests.Config.txt
@@ -21,6 +21,22 @@
   <LogDir>$(RootBinDir)/TestResults/$(TargetConfiguration)/sos.unittests_$(Timestamp)</LogDir>
   <DumpDir>$(RootBinDir)/tmp/$(TargetConfiguration)\dumps</DumpDir>
   
+  <TestLatestOnly>false</TestLatestOnly>
+  <TestLatestOnly Condition="'$(PrivateBuildTesting)' == 'true'">true</TestLatestOnly>
+  <TestLatestOnly Condition="'$(InternalReleaseTesting)' == 'true'">true</TestLatestOnly>
+
+  <TestWebApp3>true</TestWebApp3>
+  <TestWebApp3 Condition="'$(InternalReleaseTesting)' == 'true'">false</TestWebApp3>
+
+  <!-- Build the debuggee for this framework version but run it on latest -->
+  <BuildProjectFrameworkLatest Condition="StartsWith('$(RuntimeVersionLatest)', '5')">netcoreapp3.0</BuildProjectFrameworkLatest>
+  <BuildProjectFrameworkLatest Condition="StartsWith('$(RuntimeVersionLatest)', '3.1')">netcoreapp3.0</BuildProjectFrameworkLatest>
+  <BuildProjectFrameworkLatest Condition="StartsWith('$(RuntimeVersionLatest)', '2.1')">netcoreapp2.1</BuildProjectFrameworkLatest>
+
+  <BuildProjectMicrosoftNetCoreAppVersionLatest Condition="StartsWith('$(RuntimeVersionLatest)', '5')">$(RuntimeVersion30)</BuildProjectMicrosoftNetCoreAppVersionLatest>
+  <BuildProjectMicrosoftNetCoreAppVersionLatest Condition="StartsWith('$(RuntimeVersionLatest)', '3.1')">$(RuntimeVersion30)</BuildProjectMicrosoftNetCoreAppVersionLatest>
+  <BuildProjectMicrosoftNetCoreAppVersionLatest Condition="StartsWith('$(RuntimeVersionLatest)', '2.1')">$(RuntimeVersion21)</BuildProjectMicrosoftNetCoreAppVersionLatest>
+
   <DebuggeeSourceRoot>$(RepoRootDir)/src/SOS/SOS.UnitTests/Debuggees</DebuggeeSourceRoot>
   <DebuggeeBuildProcess>sdk.prebuilt</DebuggeeBuildProcess>
   <DebuggeeBuildRoot>$(RootBinDir)</DebuggeeBuildRoot>
@@ -36,20 +52,19 @@
         Default (prebuilt)
       -->
     <Option>
-      <!-- The debuggee built for 3.0 but run it on latest -->
-      <BuildProjectFramework>netcoreapp3.0</BuildProjectFramework>
+      <BuildProjectFramework>$(BuildProjectFrameworkLatest)</BuildProjectFramework>
       <RuntimeFrameworkVersion>$(RuntimeVersionLatest)</RuntimeFrameworkVersion>
     </Option>
-    <Option Condition="'$(DailyTest)' != 'true'">
+    <Option Condition="'$(TestLatestOnly)' != 'true'">
       <!-- The debuggee built for 3.0 but run it on 3.1 -->
       <BuildProjectFramework>netcoreapp3.0</BuildProjectFramework>
       <RuntimeFrameworkVersion>$(RuntimeVersion31)</RuntimeFrameworkVersion>
     </Option>
-    <Option Condition="'$(DailyTest)' != 'true'">
+    <Option Condition="'$(TestLatestOnly)' != 'true'">
       <BuildProjectFramework>netcoreapp3.0</BuildProjectFramework>
       <RuntimeFrameworkVersion>$(RuntimeVersion30)</RuntimeFrameworkVersion>
     </Option>
-    <Option Condition="'$(DailyTest)' != 'true'">
+    <Option Condition="'$(TestLatestOnly)' != 'true'">
       <BuildProjectFramework>netcoreapp2.1</BuildProjectFramework>
       <RuntimeFrameworkVersion>$(RuntimeVersion21)</RuntimeFrameworkVersion>
     </Option>
@@ -62,23 +77,22 @@
       <TestName>SOS.StackAndOtherTests</TestName>
       <Options>
         <Option>
-          <!-- Build the debuggee for 3.0 but run it on latest -->
-          <BuildProjectFramework>netcoreapp3.0</BuildProjectFramework>
-          <BuildProjectMicrosoftNetCoreAppVersion>$(RuntimeVersion30)</BuildProjectMicrosoftNetCoreAppVersion>
+          <BuildProjectFramework>$(BuildProjectFrameworkLatest)</BuildProjectFramework>
+          <BuildProjectMicrosoftNetCoreAppVersion>$(BuildProjectMicrosoftNetCoreAppVersionLatest)</BuildProjectMicrosoftNetCoreAppVersion>
           <RuntimeFrameworkVersion>$(RuntimeVersionLatest)</RuntimeFrameworkVersion>
         </Option>
-        <Option Condition="'$(DailyTest)' != 'true'">
+        <Option Condition="'$(TestLatestOnly)' != 'true'">
           <!-- Build the debuggee for 3.0 but run it on 3.1 -->
           <BuildProjectFramework>netcoreapp3.0</BuildProjectFramework>
           <BuildProjectMicrosoftNetCoreAppVersion>$(RuntimeVersion30)</BuildProjectMicrosoftNetCoreAppVersion>
           <RuntimeFrameworkVersion>$(RuntimeVersion31)</RuntimeFrameworkVersion>
         </Option>
-        <Option Condition="'$(DailyTest)' != 'true'">
+        <Option Condition="'$(TestLatestOnly)' != 'true'">
           <BuildProjectFramework>netcoreapp3.0</BuildProjectFramework>
           <BuildProjectMicrosoftNetCoreAppVersion>$(RuntimeVersion30)</BuildProjectMicrosoftNetCoreAppVersion>
           <RuntimeFrameworkVersion>$(RuntimeVersion30)</RuntimeFrameworkVersion>
         </Option>
-        <Option Condition="'$(DailyTest)' != 'true'">
+        <Option Condition="'$(TestLatestOnly)' != 'true'">
           <BuildProjectFramework>netcoreapp2.1</BuildProjectFramework>
           <BuildProjectMicrosoftNetCoreAppVersion>$(RuntimeVersion21)</BuildProjectMicrosoftNetCoreAppVersion>
           <RuntimeFrameworkVersion>$(RuntimeVersion21)</RuntimeFrameworkVersion>
@@ -88,22 +102,21 @@
     <!--
         SOS.WebApp3 (runs on 3.0, 3.1 and latest aspnetcore)
       -->
-    <Option>
+    <Option Condition="'$(TestWebApp3)' == 'true'">
       <TestName>SOS.WebApp3</TestName>
       <Options>
         <Option>
-          <!-- Build the debuggee for 3.0 but run it on latest -->
-          <BuildProjectFramework>netcoreapp3.0</BuildProjectFramework>
+          <BuildProjectFramework>$(BuildProjectFrameworkLatest)</BuildProjectFramework>
           <RuntimeFrameworkVersion>$(RuntimeVersionLatest)</RuntimeFrameworkVersion>
           <FrameworkVersion>$(AspNetCoreVersionLatest)</FrameworkVersion>
         </Option>
-        <Option Condition="'$(DailyTest)' != 'true'">
+        <Option Condition="'$(TestLatestOnly)' != 'true'">
           <!-- Build the debuggee for 3.0 but run it on 3.1 -->
           <BuildProjectFramework>netcoreapp3.0</BuildProjectFramework>
           <RuntimeFrameworkVersion>$(RuntimeVersion31)</RuntimeFrameworkVersion>
           <FrameworkVersion>$(AspNetCoreVersion31)</FrameworkVersion>
         </Option>
-        <Option Condition="'$(DailyTest)' != 'true'">
+        <Option Condition="'$(TestLatestOnly)' != 'true'">
           <BuildProjectFramework>netcoreapp3.0</BuildProjectFramework>
           <RuntimeFrameworkVersion>$(RuntimeVersion30)</RuntimeFrameworkVersion>
           <FrameworkVersion>$(AspNetCoreVersion30)</FrameworkVersion>

--- a/src/SOS/SOS.UnitTests/ConfigFiles/Unix/Debugger.Tests.Config.txt
+++ b/src/SOS/SOS.UnitTests/ConfigFiles/Unix/Debugger.Tests.Config.txt
@@ -33,10 +33,6 @@
   <BuildProjectFrameworkLatest Condition="StartsWith('$(RuntimeVersionLatest)', '3.1')">netcoreapp3.0</BuildProjectFrameworkLatest>
   <BuildProjectFrameworkLatest Condition="StartsWith('$(RuntimeVersionLatest)', '2.1')">netcoreapp2.1</BuildProjectFrameworkLatest>
 
-  <BuildProjectMicrosoftNetCoreAppVersionLatest Condition="StartsWith('$(RuntimeVersionLatest)', '5')">$(RuntimeVersion30)</BuildProjectMicrosoftNetCoreAppVersionLatest>
-  <BuildProjectMicrosoftNetCoreAppVersionLatest Condition="StartsWith('$(RuntimeVersionLatest)', '3.1')">$(RuntimeVersion30)</BuildProjectMicrosoftNetCoreAppVersionLatest>
-  <BuildProjectMicrosoftNetCoreAppVersionLatest Condition="StartsWith('$(RuntimeVersionLatest)', '2.1')">$(RuntimeVersion21)</BuildProjectMicrosoftNetCoreAppVersionLatest>
-
   <DebuggeeSourceRoot>$(RepoRootDir)/src/SOS/SOS.UnitTests/Debuggees</DebuggeeSourceRoot>
   <DebuggeeBuildProcess>sdk.prebuilt</DebuggeeBuildProcess>
   <DebuggeeBuildRoot>$(RootBinDir)</DebuggeeBuildRoot>
@@ -78,23 +74,19 @@
       <Options>
         <Option>
           <BuildProjectFramework>$(BuildProjectFrameworkLatest)</BuildProjectFramework>
-          <BuildProjectMicrosoftNetCoreAppVersion>$(BuildProjectMicrosoftNetCoreAppVersionLatest)</BuildProjectMicrosoftNetCoreAppVersion>
           <RuntimeFrameworkVersion>$(RuntimeVersionLatest)</RuntimeFrameworkVersion>
         </Option>
         <Option Condition="'$(TestLatestOnly)' != 'true'">
           <!-- Build the debuggee for 3.0 but run it on 3.1 -->
           <BuildProjectFramework>netcoreapp3.0</BuildProjectFramework>
-          <BuildProjectMicrosoftNetCoreAppVersion>$(RuntimeVersion30)</BuildProjectMicrosoftNetCoreAppVersion>
           <RuntimeFrameworkVersion>$(RuntimeVersion31)</RuntimeFrameworkVersion>
         </Option>
         <Option Condition="'$(TestLatestOnly)' != 'true'">
           <BuildProjectFramework>netcoreapp3.0</BuildProjectFramework>
-          <BuildProjectMicrosoftNetCoreAppVersion>$(RuntimeVersion30)</BuildProjectMicrosoftNetCoreAppVersion>
           <RuntimeFrameworkVersion>$(RuntimeVersion30)</RuntimeFrameworkVersion>
         </Option>
         <Option Condition="'$(TestLatestOnly)' != 'true'">
           <BuildProjectFramework>netcoreapp2.1</BuildProjectFramework>
-          <BuildProjectMicrosoftNetCoreAppVersion>$(RuntimeVersion21)</BuildProjectMicrosoftNetCoreAppVersion>
           <RuntimeFrameworkVersion>$(RuntimeVersion21)</RuntimeFrameworkVersion>
         </Option>
       </Options>

--- a/src/SOS/SOS.UnitTests/ConfigFiles/Windows/Debugger.Tests.Config.txt
+++ b/src/SOS/SOS.UnitTests/ConfigFiles/Windows/Debugger.Tests.Config.txt
@@ -42,10 +42,6 @@
   <BuildProjectFrameworkLatest Condition="StartsWith('$(RuntimeVersionLatest)', '3.1')">netcoreapp3.0</BuildProjectFrameworkLatest>
   <BuildProjectFrameworkLatest Condition="StartsWith('$(RuntimeVersionLatest)', '2.1')">netcoreapp2.1</BuildProjectFrameworkLatest>
 
-  <BuildProjectMicrosoftNetCoreAppVersionLatest Condition="StartsWith('$(RuntimeVersionLatest)', '5')">$(RuntimeVersion30)</BuildProjectMicrosoftNetCoreAppVersionLatest>
-  <BuildProjectMicrosoftNetCoreAppVersionLatest Condition="StartsWith('$(RuntimeVersionLatest)', '3.1')">$(RuntimeVersion30)</BuildProjectMicrosoftNetCoreAppVersionLatest>
-  <BuildProjectMicrosoftNetCoreAppVersionLatest Condition="StartsWith('$(RuntimeVersionLatest)', '2.1')">$(RuntimeVersion21)</BuildProjectMicrosoftNetCoreAppVersionLatest>
-
   <DesktopFrameworkPath Condition="$(TargetArchitecture) == x64">$(WinDir)\Microsoft.Net\Framework64\v4.0.30319\</DesktopFrameworkPath>
   <DesktopFrameworkPath Condition="$(TargetArchitecture) != x64">$(WinDir)\Microsoft.Net\Framework\v4.0.30319\</DesktopFrameworkPath>
   <DesktopFramework>net462</DesktopFramework>
@@ -98,23 +94,19 @@
           <Options>
             <Option>
               <BuildProjectFramework>$(BuildProjectFrameworkLatest)</BuildProjectFramework>
-              <BuildProjectMicrosoftNetCoreAppVersion>$(BuildProjectMicrosoftNetCoreAppVersionLatest)</BuildProjectMicrosoftNetCoreAppVersion>
               <RuntimeFrameworkVersion>$(RuntimeVersionLatest)</RuntimeFrameworkVersion>
             </Option>
             <Option Condition="'$(TestLatestOnly)' != 'true'">
               <!-- Build the debuggee for 3.0 but run it on 3.1 -->
               <BuildProjectFramework>netcoreapp3.0</BuildProjectFramework>
-              <BuildProjectMicrosoftNetCoreAppVersion>$(RuntimeVersion30)</BuildProjectMicrosoftNetCoreAppVersion>
               <RuntimeFrameworkVersion>$(RuntimeVersion31)</RuntimeFrameworkVersion>
             </Option>
             <Option Condition="'$(TestLatestOnly)' != 'true'">
               <BuildProjectFramework>netcoreapp3.0</BuildProjectFramework>
-              <BuildProjectMicrosoftNetCoreAppVersion>$(RuntimeVersion30)</BuildProjectMicrosoftNetCoreAppVersion>
               <RuntimeFrameworkVersion>$(RuntimeVersion30)</RuntimeFrameworkVersion>
             </Option>
             <Option Condition="'$(TestLatestOnly)' != 'true'">
               <BuildProjectFramework>netcoreapp2.1</BuildProjectFramework>
-              <BuildProjectMicrosoftNetCoreAppVersion>$(RuntimeVersion21)</BuildProjectMicrosoftNetCoreAppVersion>
               <RuntimeFrameworkVersion>$(RuntimeVersion21)</RuntimeFrameworkVersion>
             </Option>
           </Options>

--- a/src/SOS/SOS.UnitTests/ConfigFiles/Windows/Debugger.Tests.Config.txt
+++ b/src/SOS/SOS.UnitTests/ConfigFiles/Windows/Debugger.Tests.Config.txt
@@ -23,6 +23,29 @@
   <CDBPath>$(RootBinDir)\bin\SOS.UnitTests\$(TargetConfiguration)\netcoreapp2.0\publish\runtimes\win-$(TargetArchitecture)\native\cdb.exe</CDBPath>
   <CDBHelperExtension>$(InstallDir)\runcommand.dll</CDBHelperExtension>
 
+  <TestLatestOnly>false</TestLatestOnly>
+  <TestLatestOnly Condition="'$(PrivateBuildTesting)' == 'true'">true</TestLatestOnly>
+  <TestLatestOnly Condition="'$(InternalReleaseTesting)' == 'true'">true</TestLatestOnly>
+
+  <TestWebApp>true</TestWebApp>
+  <TestWebApp Condition="'$(TestLatestOnly)' == 'true'">false</TestWebApp>
+
+  <TestWebApp3>true</TestWebApp3>
+  <TestWebApp3 Condition="'$(InternalReleaseTesting)' == 'true'">false</TestWebApp3>
+
+  <TestDesktop>true</TestDesktop>
+  <TestDesktop Condition="'$(TestLatestOnly)' == 'true'">false</TestDesktop>
+  <TestDesktop Condition="'$(TargetArchitecture)' == 'arm64'">false</TestDesktop>
+
+  <!-- Build the debuggee for this framework version but run it on latest -->
+  <BuildProjectFrameworkLatest Condition="StartsWith('$(RuntimeVersionLatest)', '5')">netcoreapp3.0</BuildProjectFrameworkLatest>
+  <BuildProjectFrameworkLatest Condition="StartsWith('$(RuntimeVersionLatest)', '3.1')">netcoreapp3.0</BuildProjectFrameworkLatest>
+  <BuildProjectFrameworkLatest Condition="StartsWith('$(RuntimeVersionLatest)', '2.1')">netcoreapp2.1</BuildProjectFrameworkLatest>
+
+  <BuildProjectMicrosoftNetCoreAppVersionLatest Condition="StartsWith('$(RuntimeVersionLatest)', '5')">$(RuntimeVersion30)</BuildProjectMicrosoftNetCoreAppVersionLatest>
+  <BuildProjectMicrosoftNetCoreAppVersionLatest Condition="StartsWith('$(RuntimeVersionLatest)', '3.1')">$(RuntimeVersion30)</BuildProjectMicrosoftNetCoreAppVersionLatest>
+  <BuildProjectMicrosoftNetCoreAppVersionLatest Condition="StartsWith('$(RuntimeVersionLatest)', '2.1')">$(RuntimeVersion21)</BuildProjectMicrosoftNetCoreAppVersionLatest>
+
   <DesktopFrameworkPath Condition="$(TargetArchitecture) == x64">$(WinDir)\Microsoft.Net\Framework64\v4.0.30319\</DesktopFrameworkPath>
   <DesktopFrameworkPath Condition="$(TargetArchitecture) != x64">$(WinDir)\Microsoft.Net\Framework\v4.0.30319\</DesktopFrameworkPath>
   <DesktopFramework>net462</DesktopFramework>
@@ -49,20 +72,19 @@
             Default (prebuilt)
           -->
         <Option>
-          <!-- The debuggee built for 3.0 but run it on latest -->
-          <BuildProjectFramework>netcoreapp3.0</BuildProjectFramework>
+          <BuildProjectFramework>$(BuildProjectFrameworkLatest)</BuildProjectFramework>
           <RuntimeFrameworkVersion>$(RuntimeVersionLatest)</RuntimeFrameworkVersion>
         </Option>
-        <Option Condition="'$(DailyTest)' != 'true'">
+        <Option Condition="'$(TestLatestOnly)' != 'true'">
           <!-- The debuggee built for 3.0 but run it on 3.1 -->
           <BuildProjectFramework>netcoreapp3.0</BuildProjectFramework>
           <RuntimeFrameworkVersion>$(RuntimeVersion31)</RuntimeFrameworkVersion>
         </Option>
-        <Option Condition="'$(DailyTest)' != 'true'">
+        <Option Condition="'$(TestLatestOnly)' != 'true'">
           <BuildProjectFramework>netcoreapp3.0</BuildProjectFramework>
           <RuntimeFrameworkVersion>$(RuntimeVersion30)</RuntimeFrameworkVersion>
         </Option>
-        <Option Condition="'$(DailyTest)' != 'true'">
+        <Option Condition="'$(TestLatestOnly)' != 'true'">
           <BuildProjectFramework>netcoreapp2.1</BuildProjectFramework>
           <RuntimeFrameworkVersion>$(RuntimeVersion21)</RuntimeFrameworkVersion>
         </Option>
@@ -75,23 +97,22 @@
           <TestName>SOS.StackAndOtherTests</TestName>
           <Options>
             <Option>
-              <!-- Build the debuggee for 3.0 but run it on latest -->
-              <BuildProjectFramework>netcoreapp3.0</BuildProjectFramework>
-              <BuildProjectMicrosoftNetCoreAppVersion>$(RuntimeVersion30)</BuildProjectMicrosoftNetCoreAppVersion>
+              <BuildProjectFramework>$(BuildProjectFrameworkLatest)</BuildProjectFramework>
+              <BuildProjectMicrosoftNetCoreAppVersion>$(BuildProjectMicrosoftNetCoreAppVersionLatest)</BuildProjectMicrosoftNetCoreAppVersion>
               <RuntimeFrameworkVersion>$(RuntimeVersionLatest)</RuntimeFrameworkVersion>
             </Option>
-            <Option Condition="'$(DailyTest)' != 'true'">
+            <Option Condition="'$(TestLatestOnly)' != 'true'">
               <!-- Build the debuggee for 3.0 but run it on 3.1 -->
               <BuildProjectFramework>netcoreapp3.0</BuildProjectFramework>
               <BuildProjectMicrosoftNetCoreAppVersion>$(RuntimeVersion30)</BuildProjectMicrosoftNetCoreAppVersion>
               <RuntimeFrameworkVersion>$(RuntimeVersion31)</RuntimeFrameworkVersion>
             </Option>
-            <Option Condition="'$(DailyTest)' != 'true'">
+            <Option Condition="'$(TestLatestOnly)' != 'true'">
               <BuildProjectFramework>netcoreapp3.0</BuildProjectFramework>
               <BuildProjectMicrosoftNetCoreAppVersion>$(RuntimeVersion30)</BuildProjectMicrosoftNetCoreAppVersion>
               <RuntimeFrameworkVersion>$(RuntimeVersion30)</RuntimeFrameworkVersion>
             </Option>
-            <Option Condition="'$(DailyTest)' != 'true'">
+            <Option Condition="'$(TestLatestOnly)' != 'true'">
               <BuildProjectFramework>netcoreapp2.1</BuildProjectFramework>
               <BuildProjectMicrosoftNetCoreAppVersion>$(RuntimeVersion21)</BuildProjectMicrosoftNetCoreAppVersion>
               <RuntimeFrameworkVersion>$(RuntimeVersion21)</RuntimeFrameworkVersion>
@@ -101,7 +122,7 @@
         <!--
             SOS.WebApp (runs only on Windows 2.x aspnetcore)
           -->
-        <Option Condition="'$(DailyTest)' != 'true'">
+        <Option Condition="'$(TestWebApp)' == 'true'">
           <TestName>SOS.WebApp</TestName>
           <BuildProjectFramework>netcoreapp2.1</BuildProjectFramework>
           <RuntimeFrameworkVersion>$(RuntimeVersion21)</RuntimeFrameworkVersion>
@@ -110,7 +131,7 @@
         <!--
             SOS.WebApp3 and SOS.DualRuntimes (runs on 3.0, 3.1 and latest aspnetcore)
           -->
-        <Option>
+        <Option Condition="'$(TestWebApp3)' == 'true'">
           <Options>
             <Option>
               <TestName>SOS.WebApp3</TestName>
@@ -123,18 +144,17 @@
           </Options>
           <Options>
             <Option>
-              <!-- Build the debuggee for 3.0 but run it on latest -->
-              <BuildProjectFramework>netcoreapp3.0</BuildProjectFramework>
+              <BuildProjectFramework>$(BuildProjectFrameworkLatest)</BuildProjectFramework>
               <RuntimeFrameworkVersion>$(RuntimeVersionLatest)</RuntimeFrameworkVersion>
               <FrameworkVersion>$(AspNetCoreVersionLatest)</FrameworkVersion>
             </Option>
-            <Option Condition="'$(DailyTest)' != 'true'">
+            <Option Condition="'$(TestLatestOnly)' != 'true'">
               <!-- Build the debuggee for 3.0 but run it on 3.1 -->
               <BuildProjectFramework>netcoreapp3.0</BuildProjectFramework>
               <RuntimeFrameworkVersion>$(RuntimeVersion31)</RuntimeFrameworkVersion>
               <FrameworkVersion>$(AspNetCoreVersion31)</FrameworkVersion>
             </Option>
-            <Option Condition="'$(DailyTest)' != 'true'">
+            <Option Condition="'$(TestLatestOnly)' != 'true'">
               <BuildProjectFramework>netcoreapp3.0</BuildProjectFramework>
               <RuntimeFrameworkVersion>$(RuntimeVersion30)</RuntimeFrameworkVersion>
               <FrameworkVersion>$(AspNetCoreVersion30)</FrameworkVersion>
@@ -152,7 +172,7 @@
     <!--
         Desktop Runtime (debuggees cli built)
      -->
-    <Option Condition="$(TargetArchitecture) != arm64">
+    <Option Condition="'$(TestDesktop)' == 'true'">
       <Options>
         <Option>
         </Option>


### PR DESCRIPTION
Adds 2 pipeline variables that need to be set testing an internal service release:

DotNetRuntimeVersion - the service release version to test i.e. 2.1.17, 3.1.3, etc,.
DotNetRuntimeDownloadVerison - the service release version to download i.e. 3.1.3-servicing.20128.1,

No longer runs the tests on desktop framework if private build or internal service release.

Remove dailytest option