### PR TITLE
Fix Runtime::GetRuntime*Name() for cross-dac

### DIFF
--- a/src/SOS/SOS.UnitTests/Scripts/DualRuntimes.script
+++ b/src/SOS/SOS.UnitTests/Scripts/DualRuntimes.script
@@ -69,7 +69,7 @@ VERIFY:\s*Total\s+<DECVAL>\s+objects\s+
 #
 
 SOSCOMMAND:SOSStatus
-VERIFY:.*\.NET Core runtime at.*\s+
+VERIFY:.*\.NET Core .*runtime at.*\s+
 
 IFDEF:TRIAGE_DUMP
 SOSCOMMAND:setclrpath %DESKTOP_RUNTIME_PATH%

--- a/src/SOS/Strike/EventCallbacks.cpp
+++ b/src/SOS/Strike/EventCallbacks.cpp
@@ -135,12 +135,19 @@ HRESULT __stdcall EventCallbacks::LoadModule(ULONG64 ImageFileHandle,
 {
     HRESULT handleEventStatus = DEBUG_STATUS_NO_CHANGE;
 
-    if (ModuleName != NULL) 
+    if (ModuleName != NULL)
     {
-        bool isNetCore = _stricmp(ModuleName, NETCORE_RUNTIME_MODULE_NAME_A) == 0;
-        bool isDesktop = _stricmp(ModuleName, DESKTOP_RUNTIME_MODULE_NAME_A) == 0;
+        bool isRuntimeModule = false;
+        for (int runtime = 0; runtime < IRuntime::ConfigurationEnd; ++runtime)
+        {
+            if (_stricmp(ModuleName, GetRuntimeModuleName((IRuntime::RuntimeConfiguration)runtime)) == 0)
+            {
+                isRuntimeModule = true;
+                break;
+            }
+        }
 
-        if (isNetCore || isDesktop)
+        if (isRuntimeModule)
         {
             if (g_breakOnRuntimeModuleLoad)
             {

--- a/src/SOS/Strike/exts.h
+++ b/src/SOS/Strike/exts.h
@@ -197,9 +197,9 @@ public:
 inline void EENotLoadedMessage(HRESULT Status)
 {
 #ifdef FEATURE_PAL
-    ExtOut("Failed to find runtime module (%s), 0x%08x\n", NETCORE_RUNTIME_DLL_NAME_A, Status);
+    ExtOut("Failed to find runtime module (%s), 0x%08x\n", GetRuntimeDllName(IRuntime::Core), Status);
 #else
-    ExtOut("Failed to find runtime module (%s or %s), 0x%08x\n", NETCORE_RUNTIME_DLL_NAME_A, DESKTOP_RUNTIME_DLL_NAME_A, Status);
+    ExtOut("Failed to find runtime module (%s or %s or %s), 0x%08x\n", GetRuntimeDllName(IRuntime::Core), GetRuntimeDllName(IRuntime::WindowsDesktop), GetRuntimeDllName(IRuntime::UnixCore), Status);
 #endif
     ExtOut("Extension commands need it in order to have something to do.\n");
 }

--- a/src/SOS/Strike/hostcoreclr.cpp
+++ b/src/SOS/Strike/hostcoreclr.cpp
@@ -732,7 +732,7 @@ void InitializeSymbolStoreFromSymPath()
 //
 static void SymbolFileCallback(void* param, const char* moduleFileName, const char* symbolFilePath)
 {
-    if (strcmp(moduleFileName, NETCORE_RUNTIME_DLL_NAME_A) == 0) {
+    if (strcmp(moduleFileName, GetRuntimeDllName(IRuntime::Core)) == 0) {
         return;
     }
     if (strcmp(moduleFileName, NETCORE_DAC_DLL_NAME_A) == 0) {

--- a/src/SOS/Strike/hostcoreclr.cpp
+++ b/src/SOS/Strike/hostcoreclr.cpp
@@ -368,7 +368,7 @@ static HRESULT GetHostRuntime(std::string& coreClrPath, std::string& hostRuntime
                                 return hr;
                             }
                             // Don't use the desktop runtime to host
-                            if (g_pRuntime->IsDesktop())
+                            if (g_pRuntime->GetRuntimeConfiguration() == IRuntime::WindowsDesktop)
                             {
                                 return E_FAIL;
                             }
@@ -391,7 +391,7 @@ static HRESULT GetHostRuntime(std::string& coreClrPath, std::string& hostRuntime
     hostRuntimeDirectory.assign(g_hostRuntimeDirectory);
     coreClrPath.assign(g_hostRuntimeDirectory);
     coreClrPath.append(DIRECTORY_SEPARATOR_STR_A);
-    coreClrPath.append(NETCORE_RUNTIME_DLL_NAME_A);
+    coreClrPath.append(GetRuntimeDllName(IRuntime::Core));
     return S_OK;
 }
 

--- a/src/SOS/Strike/runtime.cpp
+++ b/src/SOS/Strike/runtime.cpp
@@ -53,6 +53,7 @@ HRESULT Runtime::CreateInstance(bool isDesktop, Runtime **ppRuntime)
     ULONG64 moduleAddress = 0;
     ULONG64 moduleSize = 0;
     HRESULT hr = S_OK;
+    bool isCrossOS = false;
 
     if (*ppRuntime == nullptr)
     {
@@ -64,6 +65,8 @@ HRESULT Runtime::CreateInstance(bool isDesktop, Runtime **ppRuntime)
             runtimeModuleName = NETCORE_RUNTIME_MODULE_NAME_UNIX_A;
 
             hr = g_ExtSymbols->GetModuleByModuleName(runtimeModuleName, 0, &moduleIndex, &moduleAddress);
+
+            isCrossOS = true;
         }
 #endif // !FEATURE_PAL
         if (SUCCEEDED(hr))
@@ -99,7 +102,7 @@ HRESULT Runtime::CreateInstance(bool isDesktop, Runtime **ppRuntime)
         {
             if (moduleSize > 0) 
             {
-                *ppRuntime = new Runtime(isDesktop, moduleIndex, moduleAddress, moduleSize);
+                *ppRuntime = new Runtime(isDesktop, isCrossOS, moduleIndex, moduleAddress, moduleSize);
                 OnUnloadTask::Register(CleanupRuntimes);
             }
             else 

--- a/src/SOS/Strike/runtime.cpp
+++ b/src/SOS/Strike/runtime.cpp
@@ -33,7 +33,7 @@ Runtime* Runtime::s_desktop = nullptr;
 #endif
 
 // Used to initialize the runtime instance with values from the host when under dotnet-dump
-bool Runtime::s_isDesktop = false;
+IRuntime::RuntimeConfiguration Runtime::s_configuration = IRuntime::Core;
 LPCSTR Runtime::s_dacFilePath = nullptr;
 LPCSTR Runtime::s_dbiFilePath = nullptr;
 
@@ -46,29 +46,17 @@ IRuntime* g_pRuntime = nullptr;
 /**********************************************************************\
  * Creates a desktop or .NET Core instance of the runtime class
 \**********************************************************************/
-HRESULT Runtime::CreateInstance(bool isDesktop, Runtime **ppRuntime)
+HRESULT Runtime::CreateInstance(RuntimeConfiguration configuration, Runtime **ppRuntime)
 {
-    PCSTR runtimeModuleName = isDesktop ? DESKTOP_RUNTIME_MODULE_NAME_A : NETCORE_RUNTIME_MODULE_NAME_A;
+    PCSTR runtimeModuleName = GetRuntimeModuleName(configuration);
     ULONG moduleIndex = 0;
     ULONG64 moduleAddress = 0;
     ULONG64 moduleSize = 0;
     HRESULT hr = S_OK;
-    bool isCrossOS = false;
 
     if (*ppRuntime == nullptr)
     {
         hr = g_ExtSymbols->GetModuleByModuleName(runtimeModuleName, 0, &moduleIndex, &moduleAddress);
-#ifndef FEATURE_PAL
-        // On Windows, support loading a Linux core dump by checking for NETCORE_RUNTIME_MODULE_NAME_UNIX_A too
-        if (!SUCCEEDED(hr) && !isDesktop)
-        {
-            runtimeModuleName = NETCORE_RUNTIME_MODULE_NAME_UNIX_A;
-
-            hr = g_ExtSymbols->GetModuleByModuleName(runtimeModuleName, 0, &moduleIndex, &moduleAddress);
-
-            isCrossOS = true;
-        }
-#endif // !FEATURE_PAL
         if (SUCCEEDED(hr))
         {
 #ifdef FEATURE_PAL
@@ -102,7 +90,7 @@ HRESULT Runtime::CreateInstance(bool isDesktop, Runtime **ppRuntime)
         {
             if (moduleSize > 0) 
             {
-                *ppRuntime = new Runtime(isDesktop, isCrossOS, moduleIndex, moduleAddress, moduleSize);
+                *ppRuntime = new Runtime(configuration, moduleIndex, moduleAddress, moduleSize);
                 OnUnloadTask::Register(CleanupRuntimes);
             }
             else 
@@ -127,13 +115,17 @@ HRESULT Runtime::CreateInstance()
     HRESULT hr = S_OK;
     if (g_pRuntime == nullptr)
     {
-        hr = CreateInstance(false, &s_netcore);
+        hr = CreateInstance(IRuntime::Core, &s_netcore);
 #ifdef FEATURE_PAL
         g_pRuntime = s_netcore;
 #else
         if (FAILED(hr))
         {
-            hr = CreateInstance(true, &s_desktop);
+            hr = CreateInstance(IRuntime::UnixCore, &s_netcore);
+        }
+        if (FAILED(hr))
+        {
+            hr = CreateInstance(IRuntime::WindowsDesktop, &s_desktop);
         }
         g_pRuntime = s_netcore != nullptr ? s_netcore : s_desktop;
 #endif
@@ -149,7 +141,7 @@ HRESULT Runtime::CreateInstance()
 bool Runtime::SwitchRuntime(bool desktop)
 {
     if (desktop) {
-        CreateInstance(true, &s_desktop);
+        CreateInstance(IRuntime::WindowsDesktop, &s_desktop);
     }
     IRuntime* runtime = desktop ? s_desktop : s_netcore;
     if (runtime == nullptr) {
@@ -480,7 +472,7 @@ HRESULT Runtime::GetCorDebugInterface(ICorDebugProcess** ppCorDebugProcess)
     GUID skuId = CLR_ID_CORECLR;
 #endif
 #ifndef FEATURE_PAL
-    if (IsDesktop())
+    if (GetRuntimeConfiguration() == IRuntime::WindowsDesktop)
     {
         skuId = CLR_ID_V4_DESKTOP;
     }
@@ -533,7 +525,7 @@ HRESULT Runtime::GetCorDebugInterface(ICorDebugProcess** ppCorDebugProcess)
 \**********************************************************************/
 void Runtime::DisplayStatus()
 {
-    ExtOut("%s runtime at %p (%08x)\n", m_isDesktop ? "Desktop" : ".NET Core", m_address, m_size);
+    ExtOut("%s runtime at %p (%08x)\n", GetRuntimeConfigurationName(GetRuntimeConfiguration()), m_address, m_size);
     if (m_runtimeDirectory != nullptr) {
         ExtOut("Runtime directory: %s\n", m_runtimeDirectory);
     }

--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -7624,7 +7624,7 @@ public:
 
         // This is only needed for desktop runtime because OnCodeGenerated2
         // isn't supported by the desktop DAC.
-        if (g_pRuntime->IsDesktop())
+        if (g_pRuntime->GetRuntimeConfiguration() == IRuntime::WindowsDesktop)
         {
             // Some method has been generated, make a breakpoint and remove it.
             ULONG32 len = mdNameLen;
@@ -9872,7 +9872,7 @@ DECLARE_API(DumpLog)
     _ASSERTE(g_pRuntime != nullptr);
 
     // Not supported on desktop runtime
-    if (g_pRuntime->IsDesktop())
+    if (g_pRuntime->GetRuntimeConfiguration() == IRuntime::WindowsDesktop)
     {
         ExtErr("DumpLog not supported on desktop runtime\n");
         return E_FAIL;


### PR DESCRIPTION
Feels a bit messy/clumsy, but it is good enough to at least start a conversation...

Fixes #908 & #909