### PR TITLE
Add DiagnosticsAgent API

### DIFF
--- a/documentation/design-docs/diagnostics-client-library.md
+++ b/documentation/design-docs/diagnostics-client-library.md
@@ -246,12 +246,12 @@ This sample shows how to use the `DiagnosticsAgent` API to create a simple Agent
 ```cs
 namespace Microsoft.Diagnostics.Tools.Reverse
 {
-    internal static class Program
+    class Program
     {
         static ConcurrentDictionary<int, (Task, EventPipeSession)> sessionDict = new ConcurrentDictionary<int, (Task, EventPipeSession)>();
         static ConcurrentDictionary<int, (int, DiagnosticsClient)> clientDict = new ConcurrentDictionary<int, (int, DiagnosticsClient)>();
 
-        public static void main(string[] args)
+        static void Main(string[] args)
         {
             // get the address for the server (this sample assumes Linux)
             string address = (args.Length >= 1) ? args[0] : "~/myawesome.sock";

--- a/documentation/design-docs/diagnostics-client-library.md
+++ b/documentation/design-docs/diagnostics-client-library.md
@@ -248,8 +248,8 @@ namespace Microsoft.Diagnostics.Tools.Reverse
 {
     class Program
     {
-        static ConcurrentDictionary<int, (Task, EventPipeSession)> sessionDict = new ConcurrentDictionary<int, (Task, EventPipeSession)>();
-        static ConcurrentDictionary<int, (int, DiagnosticsClient)> clientDict = new ConcurrentDictionary<int, (int, DiagnosticsClient)>();
+        static ConcurrentDictionary<Guid, (Task, EventPipeSession)> sessionDict = new ConcurrentDictionary<int, (Task, EventPipeSession)>();
+        static ConcurrentDictionary<Guid, (int, DiagnosticsClient)> clientDict = new ConcurrentDictionary<int, (int, DiagnosticsClient)>();
 
         static void Main(string[] args)
         {
@@ -302,7 +302,7 @@ namespace Microsoft.Diagnostics.Tools.Reverse
         {
             Console.Write("Enter instance cookie to trace: ");
             string input = Console.ReadLine();
-            int cookie = int.Parse(input);
+            var cookie = new Guid(input);
             if (clientDict.TryGetValue(cookie, out var value))
             {
                 var (pid, client) = value;
@@ -327,7 +327,7 @@ namespace Microsoft.Diagnostics.Tools.Reverse
         {
             Console.Write("Enter instance id to stop: ");
             string input = Console.ReadLine();
-            int cookie = int.Parse(input);
+            var cookie = new Guid(input);
             if (sessionDict.TryGetValue(cookie, out var entry))
             {
                 var (task, session) = entry;
@@ -494,12 +494,11 @@ namespace Microsoft.Diagnostics.NETCore.Client
     public sealed class DiagnosticsConnectionEventArgs : EventArgs
     {
         // The process ID of the connected process
-        // This cannot be used to uniquely identify an Application since connected Applications may not be in the same PID-space, e.g., containers
+        // This cannot  always be used to uniquely identify an Application since connected Applications may not be in the same PID-space, e.g., containers
         public int ProcessId { get; set; }
 
-        // This is a random 16-bit number casted to an int.  It is not cryptographically secure, but should be unique across PID-spaces
-        // and should be used to unique identify connection Applications.  This will be the same every time an Application instance connects
-        public int RuntimeInstanceCookie { get; set; }
+        // This is a random Guid.  It should be used to unique identify connection Applications.  This will be the same every time an Application instance connects
+        public Guid RuntimeInstanceCookie { get; set; }
 
         // A Diagnostics Client that can be used to issue commands to the Application whose connection raise the event.
         public DiagnosticsClient Client { get; set; }

--- a/documentation/design-docs/diagnostics-client-library.md
+++ b/documentation/design-docs/diagnostics-client-library.md
@@ -510,8 +510,8 @@ namespace Microsoft.Diagnostics.NETCore.Client
         /// <summary>
         /// Creates a Diagnostics Agent
         /// </summary>
-        /// <parameter name="transportAddress"> The address at which to create the IPC server.  On Windows, this is the path to a named pipe, and on Unix/Linux, it is the path to a Unix Domain Socket. </parameter>
-        public DiagnosticsAgent(string transportAddress);
+        /// <parameter name="ipcEndpointAddress"> The address at which to create the IPC server.  On Windows, this is the path to a named pipe, and on Unix/Linux, it is the path to a Unix Domain Socket. </parameter>
+        public DiagnosticsAgent(string ipcEndpointAddress);
 
         /// <summary>
         /// This event is raised the first time an application connects to the IPC server.

--- a/documentation/design-docs/diagnostics-client-library.md
+++ b/documentation/design-docs/diagnostics-client-library.md
@@ -257,7 +257,6 @@ namespace Microsoft.Diagnostics.Tools.Reverse
             string address = (args.Length >= 1) ? args[0] : "~/myawesome.sock";
             try
             {
-                var clientDict = 
                 using (DiagnosticsAgent agent = new DiagnosticsAgent(address))
                 {
                     agent.OnDiagnosticsConnection += (sender, eventArgs) =>

--- a/documentation/design-docs/diagnostics-client-library.md
+++ b/documentation/design-docs/diagnostics-client-library.md
@@ -334,7 +334,7 @@ namespace Microsoft.Diagnostics.Tools.Reverse
             {
                 var (task, session) = entry;
                 var (pid, client) = clientDict[cookie];
-                client.StopEventPipeSession(session);
+                session.Stop();
                 await task;
             }
             else
@@ -370,12 +370,6 @@ namespace Microsoft.Diagnostics.NETCore.Client
         /// An EventPipeSession object representing the EventPipe session that just started.
         /// </returns> 
         public EventPipeSession StartEventPipeSession(IEnumerable<EventPipeProvider> providers, bool requestRundown=true, int circularBufferMB=256)
-
-        /// <summary>
-        /// Stop tracing the application via CollectTracing2 command.
-        /// </summary>
-        /// <param name="session">The EventPipeSession to stop. This session must have originated from the same application that created this diagnostics client</param>
-        public void StopEventPipeSession(EventPipeSession session);
 
         /// <summary>
         /// Trigger a core dump generation.
@@ -535,11 +529,6 @@ namespace Microsoft.Diagnostics.NETCore.Client
         /// </summary>
         /// <returns> The server loop task.  This can be `awaited` if a user wants to be sure the server has been shut down.  N.B.: don't `await` this task if you are relying on the IDisposable interface </returns>
         public async Task Connect();
-
-        /// <summary>
-        /// Stops the server loop and listening.  Unnecessary if you are using the IDisposable interface.
-        /// </summary>
-        public void Disconnect();
     }
 }
 ```

--- a/documentation/design-docs/diagnostics-client-library.md
+++ b/documentation/design-docs/diagnostics-client-library.md
@@ -504,7 +504,6 @@ namespace Microsoft.Diagnostics.NETCore.Client
         public int RuntimeInstanceCookie { get; set; }
 
         // A Diagnostics Client that can be used to issue commands to the Application whose connection raise the event.
-        // N.B.: You cannot re-use after issuing a command.
         public DiagnosticsClient Client { get; set; }
     }
 
@@ -517,18 +516,16 @@ namespace Microsoft.Diagnostics.NETCore.Client
         public DiagnosticsAgent(string transportAddress);
 
         /// <summary>
-        /// This event is raised whenever an application connects to the IPC server.
-        /// That should happen:
-        /// - after every command issued to an application via this connection
-        /// - when an application starts
+        /// This event is raised the first time an application connects to the IPC server.
+        /// The provided DiagnosticsClient is valid as long as the DiagnosticsAgent is still alive
         /// </summary>
         public event EventHandler<DiagnosticsConnectionEventArgs> OnDiagnosticsConnection;
 
         /// <summary>
         /// Starts the server loop in the background and begins listening for connections.
         /// </summary>
-        /// <returns> The server loop task.  This can be `awaited` if a user wants to be sure the server has been shut down.  N.B.: don't `await` this task if you are relying on the IDisposable interface </returns>
-        public async Task Connect();
+        /// <returns> The server loop task.  This can be `awaited` if a user wants to be sure the server has been shut down. </returns>
+        public void Connect();
     }
 }
 ```

--- a/documentation/design-docs/diagnostics-client-library.md
+++ b/documentation/design-docs/diagnostics-client-library.md
@@ -264,7 +264,6 @@ namespace Microsoft.Diagnostics.Tools.Reverse
                         clientDict[eventArgs.RuntimeInstanceCookie] = (eventArgs.ProcessId, eventArgs.Client);
                         Console.Write($"== New Connection: instanceCookie: {eventArgs.RuntimeInstanceCookie}, ProcessId: {eventArgs.ProcessId}\n> ");
                     };
-                    var serverTask = agent.Connect();
 
                     bool shouldExit = false;
                     while (!shouldExit)
@@ -516,15 +515,10 @@ namespace Microsoft.Diagnostics.NETCore.Client
 
         /// <summary>
         /// This event is raised the first time an application connects to the IPC server.
-        /// The provided DiagnosticsClient is valid as long as the DiagnosticsAgent is still alive
+        /// The provided DiagnosticsClient is valid as long as the DiagnosticsAgent is still alive.
+        /// Registering for this event will cause the handler to be notified of all currently active connections.
         /// </summary>
         public event EventHandler<DiagnosticsConnectionEventArgs> OnDiagnosticsConnection;
-
-        /// <summary>
-        /// Starts the server loop in the background and begins listening for connections.
-        /// </summary>
-        /// <returns> The server loop task.  This can be `awaited` if a user wants to be sure the server has been shut down. </returns>
-        public void Connect();
     }
 }
 ```

--- a/documentation/design-docs/ipc-protocol.md
+++ b/documentation/design-docs/ipc-protocol.md
@@ -766,16 +766,26 @@ App -> Agent: [Advertise]
 
 There is only one message type in the Advertise IPC Protocol, the Advertise message.  It is a fixed size message of 3 fields (all values are **little-endian**):
 
-* Magic: 6 little-endian bytes that contain the ASCII bytes for the version of advertise protocol being spoken.
-* Instance Cookie: a 16 bit, little-endian number used to disambiguate across PID-spaces
+* Magic: 8 little-endian bytes that contain the ASCII bytes for the version of advertise protocol being spoken.
+* Instance Cookie: a 128 bit, little-endian Guid used to disambiguate across PID-spaces
 * Process ID: a 64 bit, little-endian number containing the pid of the process in its own PID-space
 
 ```c++
 struct AdvertisePayload
 {
-   uint8_t  magic[6]; // contains the ASCII bytes for "AD_V1\0"
-   uint16_t instance_cookie; // a random 16 bit number meant to disambiguate runtimes across PID-spaces
+   uint8_t  magic[8]; // contains the ASCII bytes for "ADVR_V1\0"
+   GUID instance_cookie; // a random 128 bit Guid meant to disambiguate runtimes across PID-spaces
    uint64_t pid; // the process id of the runtime in its own PID-space
+};
+```
+where `GUID` is
+```c++
+struct GUID
+{
+  uint32_t data1;
+  uint16_t data2;
+  uint16_t data3;
+  uint8_t  data4[8];
 };
 ```
 
@@ -798,15 +808,31 @@ Sample encoded message:
     <th>14</th>
     <th>15</th>
     <th>16</th>
+    <th>17</th>
+    <th>18</th>
+    <th>19</th>
+    <th>20</th>
+    <th>21</th>
+    <th>22</th>
+    <th>23</th>
+    <th>24</th>
+    <th>25</th>
+    <th>26</th>
+    <th>27</th>
+    <th>28</th>
+    <th>29</th>
+    <th>30</th>
+    <th>31</th>
+    <th>32</th>
   </tr>
   <tr>
-    <td colspan="6">magic</td>
-    <td colspan="2">instance_cookie</td>
+    <td colspan="8">magic</td>
+    <td colspan="16">instance_cookie</td>
     <td colspan="8">pid</td>
   </tr>
   <tr>
-    <td colspan="6">"AD_V1\0"</td>
-    <td colspan="2">42131</td>
+    <td colspan="8">"ADVR_V1\0"</td>
+    <td colspan="16">123e4567-e89b-12d3-a456-426655440000</td>
     <td colspan="8">20535</td>
   </tr>
 </table>

--- a/documentation/design-docs/ipc-protocol.md
+++ b/documentation/design-docs/ipc-protocol.md
@@ -764,11 +764,12 @@ App -> Agent: [Advertise]
 
 ## Advertise Message
 
-There is only one message type in the Advertise IPC Protocol, the Advertise message.  It is a fixed size message of 3 fields (all values are **little-endian**):
+There is only one message type in the Advertise IPC Protocol, the Advertise message.  It is a fixed size message of 4 fields (all values are **little-endian**):
 
 * Magic: 8 little-endian bytes that contain the ASCII bytes for the version of advertise protocol being spoken.
 * Instance Cookie: a 128 bit, little-endian Guid used to disambiguate across PID-spaces
 * Process ID: a 64 bit, little-endian number containing the pid of the process in its own PID-space
+* Future: a 16 bit, little-endian number for future use.  It is unused in "ADVR_V1".
 
 ```c++
 struct AdvertisePayload
@@ -776,6 +777,7 @@ struct AdvertisePayload
    uint8_t  magic[8]; // contains the ASCII bytes for "ADVR_V1\0"
    GUID instance_cookie; // a random 128 bit Guid meant to disambiguate runtimes across PID-spaces
    uint64_t pid; // the process id of the runtime in its own PID-space
+   uint16_t future; // an unused 2 byte field for future use
 };
 ```
 where `GUID` is
@@ -788,6 +790,7 @@ struct GUID
   uint8_t  data4[8];
 };
 ```
+and `sizoef(AdvertisePayload)==34`
 
 Sample encoded message:
 <table>
@@ -824,15 +827,19 @@ Sample encoded message:
     <th>30</th>
     <th>31</th>
     <th>32</th>
+    <th>33</th>
+    <th>34</th>
   </tr>
   <tr>
     <td colspan="8">magic</td>
     <td colspan="16">instance_cookie</td>
     <td colspan="8">pid</td>
+    <td colspan="2">future</td>
   </tr>
   <tr>
     <td colspan="8">"ADVR_V1\0"</td>
     <td colspan="16">123e4567-e89b-12d3-a456-426655440000</td>
     <td colspan="8">20535</td>
+    <td colspan="2">0x0000</td>
   </tr>
 </table>


### PR DESCRIPTION
The `DiagnosticsAgent` API can be used to create a Diagnostics IPC Protocol server.  A working sample is provided in the updated documentation.  New connections trigger an event that provides users with a `DiagnosticsClient` object that can be used the same as the current implementation.

> N.B.: the implementation of this API will leverage dotnet/runtime#33307.  I have done local testing with a version of this API and things worked well.  Check out the dotnet-reverse tool in my [hack branch](https://github.com/josalem/diagnostics/tree/hack/josalem/diagnostics-agent).  Note that the other tools will be broken in that branch and only dotnet-reverse builds.

CC - @tommcdon @davidfowl 