### PR TITLE
Disable Microsoft.Diagnostics.NETCore.Client.WriteAllDumpTypesTest

### DIFF
--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/WriteDumpTests.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/WriteDumpTests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
         /// <summary>
         /// A test that writes all the different types of dump file
         /// </summary>
-        [Fact]
+        [Fact(Skip = "Test often times out in official builds/PRs. See https://github.com/dotnet/diagnostics/issues/913")]
         public void WriteAllDumpTypesTest()
         {
             var normalDumpPath = "./myDump-normal.dmp";


### PR DESCRIPTION
Given #913 I'm disabling this test until it can get investigated.

This path is exerted in https://github.com/dotnet/diagnostics/blob/d366deb72b8dc114e2c74075134bf300224fa1ff/src/Tools/dotnet-dump/Dumper.cs#L77 

dotnet-dump has several tests for collecting dump types, so even if we disable the test, we still get some coverage.