### PR TITLE
Fix description list command

### DIFF
--- a/src/Tools/dotnet-counters/CounterProvider.cs
+++ b/src/Tools/dotnet-counters/CounterProvider.cs
@@ -29,13 +29,6 @@ namespace Microsoft.Diagnostics.Tools.Counters
             }
         }
 
-        public string TryGetDisplayName(string counterName)
-        {
-            if (Counters.ContainsKey(counterName))
-                return Counters[counterName].DisplayName;
-            return null;
-        }
-
         public string ToProviderString(int interval)
         {
             return $"{Name}:{Keywords}:{Level}:EventCounterIntervalSec={interval}";

--- a/src/Tools/dotnet-counters/CounterProvider.cs
+++ b/src/Tools/dotnet-counters/CounterProvider.cs
@@ -53,7 +53,6 @@ namespace Microsoft.Diagnostics.Tools.Counters
     public class CounterProfile
     {
         public string Name { get; set; }
-        public string DisplayName { get; set; }
         public string Description { get; set; }
     }
 }

--- a/src/Tools/dotnet-counters/Exporters/ConsoleWriter.cs
+++ b/src/Tools/dotnet-counters/Exporters/ConsoleWriter.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Diagnostics.Tools.Counters.Exporters
 
             if (!provider.Counters.TryGetValue(name, out ObservedCounter counter))
             {
-                string displayName = provider.KnownProvider?.TryGetDisplayName(name) ?? (string.IsNullOrWhiteSpace(payload.GetDisplay()) ? name : payload.GetDisplay());
+                string displayName = payload.GetDisplay();
                 provider.Counters[name] = counter = new ObservedCounter(displayName);
                 maxNameLength = Math.Max(maxNameLength, displayName.Length);
                 redraw = true;

--- a/src/Tools/dotnet-counters/KnownData.cs
+++ b/src/Tools/dotnet-counters/KnownData.cs
@@ -23,25 +23,25 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 "0xffffffff", // Keywords
                 "5", // Level 
                 new[] { // Counters
-                    new CounterProfile{ Name="cpu-usage", Description="Amount of time the process has utilized the CPU (ms)", DisplayName="CPU Usage (%)" },
-                    new CounterProfile{ Name="working-set", Description="Amount of working set used by the process (MB)", DisplayName="Working Set (MB)" },
-                    new CounterProfile{ Name="gc-heap-size", Description="Total heap size reported by the GC (MB)", DisplayName="GC Heap Size (MB)" },
-                    new CounterProfile{ Name="gen-0-gc-count", Description="Number of Gen 0 GCs / sec", DisplayName="Gen 0 GC / sec" },
-                    new CounterProfile{ Name="gen-1-gc-count", Description="Number of Gen 1 GCs / sec", DisplayName="Gen 1 GC / sec" },
-                    new CounterProfile{ Name="gen-2-gc-count", Description="Number of Gen 2 GCs / sec", DisplayName="Gen 2 GC / sec" },
-                    new CounterProfile{ Name="time-in-gc", Description="% time in GC since the last GC", DisplayName="% Time in GC (since last GC)" },
-                    new CounterProfile{ Name="gen-0-size", Description="Gen 0 Heap Size", DisplayName="Gen 0 Size (B)" },
-                    new CounterProfile{ Name="gen-1-size", Description="Gen 1 Heap Size", DisplayName="Gen 1 Size (B)" },
-                    new CounterProfile{ Name="gen-2-size", Description="Gen 2 Heap Size", DisplayName="Gen 2 Size (B)" },
-                    new CounterProfile{ Name="loh-size", Description="LOH Heap Size", DisplayName="LOH Size (B)" },
-                    new CounterProfile{ Name="alloc-rate", Description="Allocation Rate", DisplayName="Allocation Rate (Bytes / sec)" },
-                    new CounterProfile{ Name="assembly-count", Description="Number of Assemblies Loaded", DisplayName="# of Assemblies Loaded" },
-                    new CounterProfile{ Name="exception-count", Description="Number of Exceptions / sec", DisplayName="Exceptions / sec" },
-                    new CounterProfile{ Name="threadpool-thread-count", Description="Number of ThreadPool Threads", DisplayName="ThreadPool Threads Count" },
-                    new CounterProfile{ Name="monitor-lock-contention-count", Description="Monitor Lock Contention Count", DisplayName="Monitor Lock Contention Count / sec" },
-                    new CounterProfile{ Name="threadpool-queue-length", Description="ThreadPool Work Items Queue Length", DisplayName="ThreadPool Queue Length" },
-                    new CounterProfile{ Name="threadpool-completed-items-count", Description="ThreadPool Completed Work Items Count", DisplayName="ThreadPool Completed Work Items / sec" },
-                    new CounterProfile{ Name="active-timer-count", Description="Active Timers Count", DisplayName="Number of Active Timers" },
+                    new CounterProfile{ Name="cpu-usage", Description="Amount of time the process has utilized the CPU (ms)" },
+                    new CounterProfile{ Name="working-set", Description="Amount of working set used by the process (MB)" },
+                    new CounterProfile{ Name="gc-heap-size", Description="Total heap size reported by the GC (MB)" },
+                    new CounterProfile{ Name="gen-0-gc-count", Description="Number of Gen 0 GCs / min" },
+                    new CounterProfile{ Name="gen-1-gc-count", Description="Number of Gen 1 GCs / min" },
+                    new CounterProfile{ Name="gen-2-gc-count", Description="Number of Gen 2 GCs / min" },
+                    new CounterProfile{ Name="time-in-gc", Description="% time in GC since the last GC" },
+                    new CounterProfile{ Name="gen-0-size", Description="Gen 0 Heap Size" },
+                    new CounterProfile{ Name="gen-1-size", Description="Gen 1 Heap Size" },
+                    new CounterProfile{ Name="gen-2-size", Description="Gen 2 Heap Size" },
+                    new CounterProfile{ Name="loh-size", Description="LOH Heap Size" },
+                    new CounterProfile{ Name="alloc-rate", Description="Allocation Rate" },
+                    new CounterProfile{ Name="assembly-count", Description="Number of Assemblies Loaded" },
+                    new CounterProfile{ Name="exception-count", Description="Number of Exceptions / sec" },
+                    new CounterProfile{ Name="threadpool-thread-count", Description="Number of ThreadPool Threads" },
+                    new CounterProfile{ Name="monitor-lock-contention-count", Description="Monitor Lock Contention Count" },
+                    new CounterProfile{ Name="threadpool-queue-length", Description="ThreadPool Work Items Queue Length" },
+                    new CounterProfile{ Name="threadpool-completed-items-count", Description="ThreadPool Completed Work Items Count" },
+                    new CounterProfile{ Name="active-timer-count", Description="Active Timers Count" },
                 });
             yield return new CounterProvider(
                 "Microsoft.AspNetCore.Hosting", // Name
@@ -49,10 +49,10 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 "0x0", // Keywords
                 "4", // Level 
                 new[] { // Counters
-                    new CounterProfile{ Name="requests-per-second", Description="Request rate", DisplayName="Request / sec" },
-                    new CounterProfile{ Name="total-requests", Description="Total number of requests", DisplayName="Total Requests" },
-                    new CounterProfile{ Name="current-requests", Description="Current number of requests", DisplayName="Current Requests" },
-                    new CounterProfile{ Name="failed-requests", Description="Failed number of requests", DisplayName="Failed Requests" },
+                    new CounterProfile{ Name="requests-per-second", Description="Request rate" },
+                    new CounterProfile{ Name="total-requests", Description="Total number of requests" },
+                    new CounterProfile{ Name="current-requests", Description="Current number of requests" },
+                    new CounterProfile{ Name="failed-requests", Description="Failed number of requests" },
                 });
         }
 


### PR DESCRIPTION
- Cleanup unused field DisplayName as dotnet-counters now knows how to parse DisplayName field from the counter payloads.
- Fix description of GC collection counts in list command