### PR TITLE
Single-file exe SOS support

### DIFF
--- a/diagnostics.sln
+++ b/diagnostics.sln
@@ -77,6 +77,96 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Diagnostics.Monit
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Diagnostics.Monitoring.RestServer", "src\Microsoft.Diagnostics.Monitoring.RestServer\Microsoft.Diagnostics.Monitoring.RestServer.csproj", "{B54DE8DD-6591-45C2-B9F7-22C4A23A384C}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "inc", "inc", "{41BDFD6D-D165-4D67-BEF6-4E539040D30A}"
+	ProjectSection(SolutionItems) = preProject
+		src\inc\arrayholder.h = src\inc\arrayholder.h
+		src\inc\bitvector.h = src\inc\bitvector.h
+		src\inc\clrdata.idl = src\inc\clrdata.idl
+		src\inc\clrinternal.idl = src\inc\clrinternal.idl
+		src\inc\clrprivappxhosting.idl = src\inc\clrprivappxhosting.idl
+		src\inc\clrprivbinding.idl = src\inc\clrprivbinding.idl
+		src\inc\clrprivhosting.idl = src\inc\clrprivhosting.idl
+		src\inc\clrprivruntimebinders.idl = src\inc\clrprivruntimebinders.idl
+		src\inc\CMakeLists.txt = src\inc\CMakeLists.txt
+		src\inc\cor.h = src\inc\cor.h
+		src\inc\cordebug.idl = src\inc\cordebug.idl
+		src\inc\coreclrhost.h = src\inc\coreclrhost.h
+		src\inc\corexcep.h = src\inc\corexcep.h
+		src\inc\corhdr.h = src\inc\corhdr.h
+		src\inc\corhlpr.cpp = src\inc\corhlpr.cpp
+		src\inc\corhlpr.h = src\inc\corhlpr.h
+		src\inc\corjitflags.h = src\inc\corjitflags.h
+		src\inc\corprof.idl = src\inc\corprof.idl
+		src\inc\corpub.idl = src\inc\corpub.idl
+		src\inc\corsym.idl = src\inc\corsym.idl
+		src\inc\cortypeinfo.h = src\inc\cortypeinfo.h
+		src\inc\crosscomp.h = src\inc\crosscomp.h
+		src\inc\daccess.h = src\inc\daccess.h
+		src\inc\dacprivate.h = src\inc\dacprivate.h
+		src\inc\dbgportable.h = src\inc\dbgportable.h
+		src\inc\dbgtargetcontext.h = src\inc\dbgtargetcontext.h
+		src\inc\dbgutil.h = src\inc\dbgutil.h
+		src\inc\debugmacros.h = src\inc\debugmacros.h
+		src\inc\debugmacrosext.h = src\inc\debugmacrosext.h
+		src\inc\fusion.idl = src\inc\fusion.idl
+		src\inc\gcdecoder.cpp = src\inc\gcdecoder.cpp
+		src\inc\gcdesc.h = src\inc\gcdesc.h
+		src\inc\gcdump.h = src\inc\gcdump.h
+		src\inc\gcinfo.h = src\inc\gcinfo.h
+		src\inc\gcinfodecoder.h = src\inc\gcinfodecoder.h
+		src\inc\gcinfodumper.h = src\inc\gcinfodumper.h
+		src\inc\gcinfotypes.h = src\inc\gcinfotypes.h
+		src\inc\genericstackprobe.h = src\inc\genericstackprobe.h
+		src\inc\hillclimbing.h = src\inc\hillclimbing.h
+		src\inc\holder.h = src\inc\holder.h
+		src\inc\iallocator.h = src\inc\iallocator.h
+		src\inc\livedatatarget.h = src\inc\livedatatarget.h
+		src\inc\log.h = src\inc\log.h
+		src\inc\loglf.h = src\inc\loglf.h
+		src\inc\longfilepathwrappers.h = src\inc\longfilepathwrappers.h
+		src\inc\metahost.idl = src\inc\metahost.idl
+		src\inc\MSCOREE.IDL = src\inc\MSCOREE.IDL
+		src\inc\mscorsvc.idl = src\inc\mscorsvc.idl
+		src\inc\msodw.h = src\inc\msodw.h
+		src\inc\new.hpp = src\inc\new.hpp
+		src\inc\opcode.def = src\inc\opcode.def
+		src\inc\openum.h = src\inc\openum.h
+		src\inc\palclr.h = src\inc\palclr.h
+		src\inc\palclr_win.h = src\inc\palclr_win.h
+		src\inc\predeftlsslot.h = src\inc\predeftlsslot.h
+		src\inc\random.h = src\inc\random.h
+		src\inc\regdisp.h = src\inc\regdisp.h
+		src\inc\runtimeinfo.h = src\inc\runtimeinfo.h
+		src\inc\safemath.h = src\inc\safemath.h
+		src\inc\sospriv.idl = src\inc\sospriv.idl
+		src\inc\stacktrace.h = src\inc\stacktrace.h
+		src\inc\static_assert.h = src\inc\static_assert.h
+		src\inc\staticcontract.h = src\inc\staticcontract.h
+		src\inc\stresslog.h = src\inc\stresslog.h
+		src\inc\switches.h = src\inc\switches.h
+		src\inc\tls.h = src\inc\tls.h
+		src\inc\volatile.h = src\inc\volatile.h
+		src\inc\warningcontrol.h = src\inc\warningcontrol.h
+		src\inc\xclrdata.idl = src\inc\xclrdata.idl
+		src\inc\xcordebug.idl = src\inc\xcordebug.idl
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "clr_std", "clr_std", "{33239640-6F4B-4DA4-A780-2F5B26D57EAD}"
+	ProjectSection(SolutionItems) = preProject
+		src\inc\clr_std\algorithm = src\inc\clr_std\algorithm
+		src\inc\clr_std\string = src\inc\clr_std\string
+		src\inc\clr_std\type_traits = src\inc\clr_std\type_traits
+		src\inc\clr_std\utility = src\inc\clr_std\utility
+		src\inc\clr_std\vector = src\inc\clr_std\vector
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "llvm", "llvm", "{06730767-421B-465F-BB63-A3A07D72D7A2}"
+	ProjectSection(SolutionItems) = preProject
+		src\inc\llvm\Dwarf.def = src\inc\llvm\Dwarf.def
+		src\inc\llvm\Dwarf.h = src\inc\llvm\Dwarf.h
+		src\inc\llvm\ELF.h = src\inc\llvm\ELF.h
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Checked|Any CPU = Checked|Any CPU
@@ -1188,6 +1278,9 @@ Global
 		{C57F7656-6663-4A3C-BE38-B75C6C57E77D} = {B62728C8-1267-4043-B46F-5537BBAEC692}
 		{CFCF90E5-91CF-44FD-819D-97F530AEF769} = {19FAB78C-3351-4911-8F0C-8C6056401740}
 		{B54DE8DD-6591-45C2-B9F7-22C4A23A384C} = {19FAB78C-3351-4911-8F0C-8C6056401740}
+		{41BDFD6D-D165-4D67-BEF6-4E539040D30A} = {19FAB78C-3351-4911-8F0C-8C6056401740}
+		{33239640-6F4B-4DA4-A780-2F5B26D57EAD} = {41BDFD6D-D165-4D67-BEF6-4E539040D30A}
+		{06730767-421B-465F-BB63-A3A07D72D7A2} = {41BDFD6D-D165-4D67-BEF6-4E539040D30A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {46465737-C938-44FC-BE1A-4CE139EBB5E0}

--- a/src/SOS/CMakeLists.txt
+++ b/src/SOS/CMakeLists.txt
@@ -18,6 +18,7 @@ endif(WIN32)
 
 add_definitions(-D_SECURE_SCL=0)
 
+add_subdirectory(dbgutil)
 add_subdirectory(SOS.NETCore)
 add_subdirectory(Strike)
 
@@ -32,4 +33,3 @@ if(CLR_CMAKE_PLATFORM_UNIX)
 endif(CLR_CMAKE_PLATFORM_UNIX)
 
 add_subdirectory(debugshim)
-add_subdirectory(dbgutil)

--- a/src/SOS/SOS.Hosting/SOSHost.cs
+++ b/src/SOS/SOS.Hosting/SOSHost.cs
@@ -71,10 +71,20 @@ namespace SOS
         private delegate void LoadNativeSymbolsDelegate(
             SymbolReader.SymbolFileCallback callback,
             IntPtr parameter,
+            SymbolReader.RuntimeConfiguration config,
             string moduleFilePath,
             ulong address,
             int size,
             SymbolReader.ReadMemoryDelegate readMemory);
+
+        private delegate void LoadNativeSymbolsFromIndexDelegate(
+            SymbolReader.SymbolFileCallback callback,
+            IntPtr parameter,
+            SymbolReader.RuntimeConfiguration config,
+            string moduleFilePath,
+            bool specialKeys,
+            int moduleIndexSize,
+            IntPtr moduleIndex);
 
         private delegate IntPtr LoadSymbolsForModuleDelegate(
             string assemblyPath,
@@ -130,6 +140,7 @@ namespace SOS
             public DisplaySymbolStoreDelegate DisplaySymbolStoreDelegate;
             public DisableSymbolStoreDelegate DisableSymbolStoreDelegate;
             public LoadNativeSymbolsDelegate LoadNativeSymbolsDelegate;
+            public LoadNativeSymbolsFromIndexDelegate LoadNativeSymbolsFromIndexDelegate;
             public LoadSymbolsForModuleDelegate LoadSymbolsForModuleDelegate;
             public DisposeDelegate DisposeDelegate;
             public ResolveSequencePointDelegate ResolveSequencePointDelegate;
@@ -144,6 +155,7 @@ namespace SOS
             DisplaySymbolStoreDelegate = SymbolReader.DisplaySymbolStore,
             DisableSymbolStoreDelegate = SymbolReader.DisableSymbolStore,
             LoadNativeSymbolsDelegate = SymbolReader.LoadNativeSymbols,
+            LoadNativeSymbolsFromIndexDelegate = SymbolReader.LoadNativeSymbolsFromIndex,
             LoadSymbolsForModuleDelegate = SymbolReader.LoadSymbolsForModule,
             DisposeDelegate = SymbolReader.Dispose,
             ResolveSequencePointDelegate = SymbolReader.ResolveSequencePoint,

--- a/src/SOS/SOS.NETCore/SymbolReader.cs
+++ b/src/SOS/SOS.NETCore/SymbolReader.cs
@@ -50,6 +50,17 @@ namespace SOS
             public int localsSize;
         }
 
+        /// <summary>
+        /// Matches the IRuntime::RuntimeConfiguration in runtime.h
+        /// </summary>
+        public enum RuntimeConfiguration
+        {
+            WindowsDesktop  = 0,
+            WindowsCore     = 1,
+            UnixCore        = 2,
+            OSXCore         = 3
+        }
+
         private sealed class OpenedReader : IDisposable
         {
             public readonly MetadataReaderProvider Provider;
@@ -253,79 +264,62 @@ namespace SOS
         }
 
         /// <summary>
-        /// Load native symbols and modules (i.e. dac, dbi).
+        /// Load native symbols and modules (i.e. DAC, DBI).
         /// </summary>
         /// <param name="callback">called back for each symbol file loaded</param>
         /// <param name="parameter">callback parameter</param>
+        /// <param name="config">Target configuration: Windows, Linux or OSX</param>
         /// <param name="moduleFilePath">module path</param>
         /// <param name="address">module base address</param>
         /// <param name="size">module size</param>
         /// <param name="readMemory">read memory callback delegate</param>
-        public static void LoadNativeSymbols(SymbolFileCallback callback, IntPtr parameter, string moduleFilePath, ulong address, int size, ReadMemoryDelegate readMemory)
+        public static void LoadNativeSymbols(
+            SymbolFileCallback callback,
+            IntPtr parameter,
+            RuntimeConfiguration config,
+            string moduleFilePath,
+            ulong address,
+            int size,
+            ReadMemoryDelegate readMemory)
         {
             if (IsSymbolStoreEnabled())
             {
                 Stream stream = new TargetStream(address, size, readMemory);
-                KeyTypeFlags flags = KeyTypeFlags.SymbolKey | KeyTypeFlags.ClrKeys;
                 KeyGenerator generator = null;
 
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                switch (config)
                 {
-                    var elfFile = new ELFFile(new StreamAddressSpace(stream), 0, true);
-                    generator = new ELFFileKeyGenerator(s_tracer, elfFile, moduleFilePath);
-                }
-                else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-                {
-                    var machOFile = new MachOFile(new StreamAddressSpace(stream), 0, true);
-                    generator = new MachOFileKeyGenerator(s_tracer, machOFile, moduleFilePath);
-                }
-                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                {
-                    var peFile = new PEFile(new StreamAddressSpace(stream), true);
-                    if (peFile.IsValid())
-                    {
-                        generator = new PEFileKeyGenerator(s_tracer, peFile, moduleFilePath);
-                    }
-                    else
-                    {
-                        // Support loading ELF files on Windows for the cross-dac
+                    case RuntimeConfiguration.UnixCore:
                         var elfFile = new ELFFile(new StreamAddressSpace(stream), 0, true);
                         generator = new ELFFileKeyGenerator(s_tracer, elfFile, moduleFilePath);
-                    }
-                }
-                else {
-                    return;
+                        break;
+                    case RuntimeConfiguration.OSXCore:
+                        var machOFile = new MachOFile(new StreamAddressSpace(stream), 0, true);
+                        generator = new MachOFileKeyGenerator(s_tracer, machOFile, moduleFilePath);
+                        break;
+                    case RuntimeConfiguration.WindowsCore:
+                    case RuntimeConfiguration.WindowsDesktop:
+                        var peFile = new PEFile(new StreamAddressSpace(stream), true);
+                        generator = new PEFileKeyGenerator(s_tracer, peFile, moduleFilePath);
+                        break;
+                    default:
+                        s_tracer.Error("Unsupported platform {0}", config);
+                        return;
                 }
 
                 try
                 {
-                    IEnumerable<SymbolStoreKey> keys = generator.GetKeys(flags);
-                    foreach (SymbolStoreKey forKey in keys)
+                    IEnumerable<SymbolStoreKey> keys = generator.GetKeys(KeyTypeFlags.SymbolKey | KeyTypeFlags.DacDbiKeys);
+                    foreach (SymbolStoreKey key in keys)
                     {
-                        SymbolStoreKey key = forKey;
-                        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && key.FullPathName.Equals("libmscordaccore.so"))
-                        {
-                            // We are opening a Linux dump on Windows
-                            // We need to use the Windows index and filename
-                            key = new SymbolStoreKey(key.Index.Replace("libmscordaccore.so", "mscordaccore.dll"),
-                                                     "mscordaccore.dll",
-                                                     key.IsClrSpecialFile,
-                                                     key.PdbChecksums);
-                        }
                         string moduleFileName = Path.GetFileName(key.FullPathName);
                         s_tracer.Verbose("{0} {1}", key.FullPathName, key.Index);
 
-                        // Don't download the sos binaries that come with the runtime
-                        if (!IsPathEqual(moduleFileName, "SOS.NETCore.dll") && 
-                            !IsPathEqual(moduleFileName, "sos.dll") && 
-                            !moduleFileName.StartsWith("libsos."))
+                        string downloadFilePath = GetSymbolFile(key);
+                        if (downloadFilePath != null)
                         {
-                            string downloadFilePath = GetSymbolFile(key);
-                            if (downloadFilePath != null)
-                            {
-                                s_tracer.Information("{0}: {1}", moduleFileName, downloadFilePath);
-                                callback(parameter, moduleFileName, downloadFilePath);
-                            }
+                            s_tracer.Information("{0}: {1}", moduleFileName, downloadFilePath);
+                            callback(parameter, moduleFileName, downloadFilePath);
                         }
                     }
                 }
@@ -334,6 +328,83 @@ namespace SOS
                     s_tracer.Error("{0}/{1:X16}: {2}", moduleFilePath, address, ex.Message);
                 }
             }
+        }
+
+        /// <summary>
+        /// Load native modules (i.e. DAC, DBI) from the runtime build id.
+        /// </summary>
+        /// <param name="callback">called back for each symbol file loaded</param>
+        /// <param name="parameter">callback parameter</param>
+        /// <param name="config">Target configuration: Windows, Linux or OSX</param>
+        /// <param name="moduleFilePath">module path</param>
+        /// <param name="specialKeys">if true, returns the DBI/DAC keys, otherwise the identity key</param>
+        /// <param name="moduleIndexSize">build id size</param>
+        /// <param name="moduleIndex">pointer to build id</param>
+        public static void LoadNativeSymbolsFromIndex(
+            SymbolFileCallback callback,
+            IntPtr parameter,
+            RuntimeConfiguration config,
+            string moduleFilePath,
+            bool specialKeys,
+            int moduleIndexSize,
+            IntPtr moduleIndex)
+        {
+            try
+            {
+                KeyTypeFlags flags = specialKeys ? KeyTypeFlags.DacDbiKeys : KeyTypeFlags.IdentityKey;
+                byte[] id = new byte[moduleIndexSize];
+                Marshal.Copy(moduleIndex, id, 0, moduleIndexSize);
+
+                IEnumerable<SymbolStoreKey> keys = null;
+                switch (config)
+                {
+                    case RuntimeConfiguration.UnixCore:
+                        keys = ELFFileKeyGenerator.GetKeys(flags, moduleFilePath, id, symbolFile: false, symbolFileName: null);
+                        break;
+
+                    case RuntimeConfiguration.OSXCore:
+                        keys = MachOFileKeyGenerator.GetKeys(flags, moduleFilePath, id, symbolFile: false, symbolFileName: null);
+                        break;
+
+                    case RuntimeConfiguration.WindowsCore:
+                    case RuntimeConfiguration.WindowsDesktop:
+                        uint timeStamp = BitConverter.ToUInt32(id, 0);
+                        uint fileSize = BitConverter.ToUInt32(id, 4);
+                        SymbolStoreKey key = PEFileKeyGenerator.GetKey(moduleFilePath, timeStamp, fileSize);
+                        keys = new SymbolStoreKey[] { key };
+                        break;
+
+                    default:
+                        s_tracer.Error("Unsupported platform {0}", config);
+                        return;
+                }
+                foreach (SymbolStoreKey key in keys)
+                {
+                    string moduleFileName = Path.GetFileName(key.FullPathName);
+                    s_tracer.Verbose("{0} {1}", key.FullPathName, key.Index);
+
+                    string downloadFilePath = GetSymbolFile(key);
+                    if (downloadFilePath != null)
+                    {
+                        s_tracer.Information("{0}: {1}", moduleFileName, downloadFilePath);
+                        callback(parameter, moduleFileName, downloadFilePath);
+                    }
+                }
+            }
+            catch (Exception ex) when (ex is BadInputFormatException || ex is InvalidVirtualAddressException || ex is TaskCanceledException)
+            {
+                s_tracer.Error("{0} - {1}", ex.Message, moduleFilePath);
+            }
+        }
+
+        /// <summary>
+        /// Load symbol or module files from the keys
+        /// </summary>
+        /// <param name="callback">called back for each symbol file loaded</param>
+        /// <param name="parameter">callback parameter</param>
+        /// <param name="keys">list of keys to download</param>
+        private static void LoadSymbolFiles(SymbolFileCallback callback, IntPtr parameter, IEnumerable<SymbolStoreKey> keys)
+        {
         }
 
         /// <summary>

--- a/src/SOS/SOS.UnitTests/SOSRunner.cs
+++ b/src/SOS/SOS.UnitTests/SOSRunner.cs
@@ -544,8 +544,6 @@ public class SOSRunner : IDisposable
                     {
                         throw new ArgumentException("No DotNetDumpHost in configuration");
                     }
-                    initialCommands.Add("setsymbolserver -directory %DEBUG_ROOT%");
-
                     // Add the path to runtime so dotnet-dump/SOS can find DAC/DBI for triage dumps
                     if (information.DumpType == DumpType.Triage)
                     {
@@ -555,6 +553,7 @@ public class SOSRunner : IDisposable
                             initialCommands.Add("setclrpath " + runtimeSymbolsPath);
                         }
                     }
+                    initialCommands.Add("setsymbolserver -directory %DEBUG_ROOT%");
                     arguments.Append(debuggerPath);
                     arguments.Append(@" analyze %DUMP_NAME%");
                     debuggerPath = config.DotNetDumpHost();

--- a/src/SOS/Strike/CMakeLists.txt
+++ b/src/SOS/Strike/CMakeLists.txt
@@ -170,13 +170,6 @@ else(WIN32)
 endif(WIN32)
 
 if(CLR_CMAKE_PLATFORM_ARCH_AMD64)
-# if(CLR_CMAKE_PLATFORM_LINUX)
-    #list(APPEND 
-    #  SOS_LIBRARY 
-    #  createdump_lib
-    #)
-    #add_definitions(-DCREATE_DUMP_SUPPORTED)
-# endif(CLR_CMAKE_PLATFORM_LINUX)
   set(SOS_SOURCES_ARCH
     disasmX86.cpp
   )

--- a/src/SOS/Strike/datatarget.cpp
+++ b/src/SOS/Strike/datatarget.cpp
@@ -12,8 +12,9 @@
 
 #define IMAGE_FILE_MACHINE_AMD64             0x8664  // AMD64 (K8)
 
-DataTarget::DataTarget(void) :
-    m_ref(0)
+DataTarget::DataTarget(ULONG64 baseAddress) :
+    m_ref(0),
+    m_baseAddress(baseAddress)
 {
 }
 
@@ -46,6 +47,12 @@ DataTarget::QueryInterface(
     else if (InterfaceId == IID_ICLRMetadataLocator)
     {
         *Interface = (ICLRMetadataLocator*)this;
+        AddRef();
+        return S_OK;
+    }
+    else if (InterfaceId == IID_ICLRRuntimeLocator)
+    {
+        *Interface = (ICLRRuntimeLocator*)this;
         AddRef();
         return S_OK;
     }
@@ -366,4 +373,13 @@ DataTarget::GetMetadata(
     return ::GetMetadataLocator(imagePath, imageTimestamp, imageSize, mvid, mdRva, flags, bufferSize, buffer, dataSize);
 }
 
+// ICLRRuntimeLocator
+
+HRESULT STDMETHODCALLTYPE 
+DataTarget::GetRuntimeBase(
+    /* [out] */ CLRDATA_ADDRESS* baseAddress)
+{
+    *baseAddress = m_baseAddress;
+    return S_OK;
+}
 

--- a/src/SOS/Strike/datatarget.h
+++ b/src/SOS/Strike/datatarget.h
@@ -2,13 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-class DataTarget : public ICLRDataTarget2, ICorDebugDataTarget4, ICLRMetadataLocator
+class DataTarget : public ICLRDataTarget2, ICorDebugDataTarget4, ICLRMetadataLocator, ICLRRuntimeLocator
 {
 private:
     LONG m_ref;                         // Reference count.
+    ULONG64 m_baseAddress;              // Runtime base address
 
 public:
-    DataTarget(void);
+    DataTarget(ULONG64 baseAddress);
     virtual ~DataTarget() {}
     
     // IUnknown.
@@ -115,4 +116,9 @@ public:
         /* [out, size_is(bufferSize), length_is(*dataSize)] */
         BYTE* buffer,
         /* [out] */ ULONG32* dataSize);
+
+    // ICLRRuntimeLocator
+
+    virtual HRESULT STDMETHODCALLTYPE GetRuntimeBase(
+        /* [out] */ CLRDATA_ADDRESS* baseAddress);
 };

--- a/src/SOS/Strike/hostcoreclr.cpp
+++ b/src/SOS/Strike/hostcoreclr.cpp
@@ -621,6 +621,7 @@ HRESULT InitializeHosting()
     IfFailRet(createDelegate(hostHandle, domainId, SOSManagedDllName, SymbolReaderClassName, "DisplaySymbolStore", (void **)&g_SOSNetCoreCallbacks.DisplaySymbolStoreDelegate));
     IfFailRet(createDelegate(hostHandle, domainId, SOSManagedDllName, SymbolReaderClassName, "DisableSymbolStore", (void **)&g_SOSNetCoreCallbacks.DisableSymbolStoreDelegate));
     IfFailRet(createDelegate(hostHandle, domainId, SOSManagedDllName, SymbolReaderClassName, "LoadNativeSymbols", (void **)&g_SOSNetCoreCallbacks.LoadNativeSymbolsDelegate));
+    IfFailRet(createDelegate(hostHandle, domainId, SOSManagedDllName, SymbolReaderClassName, "LoadNativeSymbolsFromIndex", (void **)&g_SOSNetCoreCallbacks.LoadNativeSymbolsFromIndexDelegate));
     IfFailRet(createDelegate(hostHandle, domainId, SOSManagedDllName, SymbolReaderClassName, "LoadSymbolsForModule", (void **)&g_SOSNetCoreCallbacks.LoadSymbolsForModuleDelegate));
     IfFailRet(createDelegate(hostHandle, domainId, SOSManagedDllName, SymbolReaderClassName, "Dispose", (void **)&g_SOSNetCoreCallbacks.DisposeDelegate));
     IfFailRet(createDelegate(hostHandle, domainId, SOSManagedDllName, SymbolReaderClassName, "ResolveSequencePoint", (void **)&g_SOSNetCoreCallbacks.ResolveSequencePointDelegate));
@@ -763,7 +764,7 @@ static void LoadNativeSymbolsCallback(void* param, const char* moduleFilePath, U
 {
     _ASSERTE(g_hostingInitialized);
     _ASSERTE(g_SOSNetCoreCallbacks.LoadNativeSymbolsDelegate != nullptr);
-    g_SOSNetCoreCallbacks.LoadNativeSymbolsDelegate(SymbolFileCallback, param, moduleFilePath, moduleAddress, moduleSize, ReadMemoryForSymbols);
+    g_SOSNetCoreCallbacks.LoadNativeSymbolsDelegate(SymbolFileCallback, param, IRuntime::Core, moduleFilePath, moduleAddress, moduleSize, ReadMemoryForSymbols);
 }
 
 /**********************************************************************\

--- a/src/SOS/Strike/hostcoreclr.h
+++ b/src/SOS/Strike/hostcoreclr.h
@@ -29,7 +29,8 @@ typedef  BOOL (*InitializeSymbolStoreDelegate)(
 
 typedef  void (*DisplaySymbolStoreDelegate)(WriteLineDelegate);
 typedef  void (*DisableSymbolStoreDelegate)();
-typedef  void (*LoadNativeSymbolsDelegate)(SymbolFileCallbackDelegate, void*, const char*, ULONG64, int, ReadMemoryDelegate);
+typedef  void (*LoadNativeSymbolsDelegate)(SymbolFileCallbackDelegate, void*, int, const char*, ULONG64, int, ReadMemoryDelegate);
+typedef  void (*LoadNativeSymbolsFromIndexDelegate)(SymbolFileCallbackDelegate, void*, int, const char*, BOOL, int, const unsigned char* moduleIndex);
 typedef  PVOID (*LoadSymbolsForModuleDelegate)(const char*, BOOL, ULONG64, int, ULONG64, int, ReadMemoryDelegate);
 typedef  void (*DisposeDelegate)(PVOID);
 typedef  BOOL (*ResolveSequencePointDelegate)(PVOID, const char*, unsigned int, unsigned int*, unsigned int*);
@@ -55,6 +56,7 @@ struct SOSNetCoreCallbacks
     DisplaySymbolStoreDelegate DisplaySymbolStoreDelegate;
     DisableSymbolStoreDelegate DisableSymbolStoreDelegate;
     LoadNativeSymbolsDelegate LoadNativeSymbolsDelegate;
+    LoadNativeSymbolsFromIndexDelegate LoadNativeSymbolsFromIndexDelegate;
     LoadSymbolsForModuleDelegate LoadSymbolsForModuleDelegate;
     DisposeDelegate DisposeDelegate;
     ResolveSequencePointDelegate ResolveSequencePointDelegate;

--- a/src/SOS/Strike/runtime.cpp
+++ b/src/SOS/Strike/runtime.cpp
@@ -20,12 +20,14 @@
 #include "datatarget.h"
 #include "cordebugdatatarget.h"
 #include "cordebuglibraryprovider.h"
+#include "runtimeinfo.h"
 
 #ifdef FEATURE_PAL
 #include <sys/stat.h>
 #include <dlfcn.h>
 #include <unistd.h>
 #endif // !FEATURE_PAL
+
 
 Runtime* Runtime::s_netcore = nullptr;
 #ifndef FEATURE_PAL
@@ -43,6 +45,61 @@ LPCSTR g_runtimeModulePath = nullptr;
 // Current runtime instance
 IRuntime* g_pRuntime = nullptr;
 
+#if !defined(__APPLE__)
+
+extern bool TryGetSymbol(uint64_t baseAddress, const char* symbolName, uint64_t* symbolAddress);
+
+bool ElfReaderReadMemory(void* address, void* buffer, size_t size)
+{
+    ULONG read = 0;
+    return SUCCEEDED(g_ExtData->ReadVirtual((ULONG64)address, buffer, (ULONG)size, &read));
+}
+
+/**********************************************************************\
+ * Search all the modules in the process for the single-file host
+\**********************************************************************/
+static HRESULT GetSingleFileInfo(PULONG pModuleIndex, PULONG64 pModuleAddress, RuntimeInfo** ppRuntimeInfo)
+{
+    _ASSERTE(pModuleIndex != nullptr);
+    _ASSERTE(pModuleAddress != nullptr);
+
+    ULONG loaded, unloaded;
+    HRESULT hr = g_ExtSymbols->GetNumberModules(&loaded, &unloaded);
+    if (FAILED(hr)) {
+        return hr;
+    }
+
+    for (ULONG index = 0; index < loaded; index++)
+    {
+        ULONG64 baseAddress;
+        hr = g_ExtSymbols->GetModuleByIndex(index, &baseAddress);
+        if (FAILED(hr)) {
+            return hr;
+        }
+        ULONG64 symbolAddress;
+        if (TryGetSymbol(baseAddress, "DotNetRuntimeInfo", &symbolAddress))
+        {
+            ULONG read = 0;
+            ArrayHolder<BYTE> buffer = new BYTE[sizeof(RuntimeInfo)];
+            hr = g_ExtData->ReadVirtual(symbolAddress, buffer, sizeof(RuntimeInfo), &read);
+            if (FAILED(hr)) {
+                return hr;
+            }
+            if (strcmp(((RuntimeInfo*)buffer.GetPtr())->Signature, "DotNetRuntimeInfo") != 0) {
+                break;
+            }
+            *pModuleIndex = index;
+            *pModuleAddress = baseAddress;
+            *ppRuntimeInfo = (RuntimeInfo*)buffer.Detach();
+            return S_OK;
+        }
+    }
+
+    return E_FAIL;
+}
+
+#endif // !defined(__APPLE__)
+
 /**********************************************************************\
  * Creates a desktop or .NET Core instance of the runtime class
 \**********************************************************************/
@@ -52,11 +109,25 @@ HRESULT Runtime::CreateInstance(RuntimeConfiguration configuration, Runtime **pp
     ULONG moduleIndex = 0;
     ULONG64 moduleAddress = 0;
     ULONG64 moduleSize = 0;
+    RuntimeInfo* runtimeInfo = nullptr;
     HRESULT hr = S_OK;
 
     if (*ppRuntime == nullptr)
     {
+        // Check if the normal runtime module (coreclr.dll, libcoreclr.so, etc.) is loaded
         hr = g_ExtSymbols->GetModuleByModuleName(runtimeModuleName, 0, &moduleIndex, &moduleAddress);
+#if !defined(__APPLE__)
+        if (FAILED(hr))
+        {
+            // If the standard runtime module isn't loaded, try looking for a single-file program
+            if (configuration == IRuntime::UnixCore)
+            {
+                hr = GetSingleFileInfo(&moduleIndex, &moduleAddress, &runtimeInfo);
+            }
+        }
+#endif // !defined(__APPLE__)
+
+        // If the previous operations were successful, get the size of the runtime module
         if (SUCCEEDED(hr))
         {
 #ifdef FEATURE_PAL
@@ -86,11 +157,13 @@ HRESULT Runtime::CreateInstance(RuntimeConfiguration configuration, Runtime **pp
             }
 #endif
         }
+
+        // If the previous operations were successful, create the Runtime instance
         if (SUCCEEDED(hr))
         {
             if (moduleSize > 0) 
             {
-                *ppRuntime = new Runtime(configuration, moduleIndex, moduleAddress, moduleSize);
+                *ppRuntime = new Runtime(configuration, moduleIndex, moduleAddress, moduleSize, runtimeInfo);
                 OnUnloadTask::Register(CleanupRuntimes);
             }
             else 
@@ -225,51 +298,6 @@ void Runtime::Flush()
 /**********************************************************************\
  * Returns the runtime directory of the target
 \**********************************************************************/
-HRESULT Runtime::GetRuntimeDirectory(std::string& runtimeDirectory)
-{
-#ifdef FEATURE_PAL
-    LPCSTR directory = g_ExtServices->GetCoreClrDirectory();
-    if (directory == NULL)
-    {
-        ExtErr("Error: Runtime module (%s) not loaded yet\n", GetRuntimeDllName());
-        return E_FAIL;
-    }
-    if (!GetAbsolutePath(directory, runtimeDirectory))
-    {
-        ExtDbgOut("Error: Runtime directory %s doesn't exist\n", directory);
-        return E_FAIL;
-    }
-#else
-    ArrayHolder<char> szModuleName = new char[MAX_LONGPATH + 1];
-    HRESULT hr = g_ExtSymbols->GetModuleNames(m_index, 0, szModuleName, MAX_LONGPATH, NULL, NULL, 0, NULL, NULL, 0, NULL);
-    if (FAILED(hr))
-    {
-        ExtErr("Error: Failed to get runtime module name\n");
-        return hr;
-    }
-    if (GetFileAttributesA(szModuleName) == INVALID_FILE_ATTRIBUTES)
-    {
-        hr = HRESULT_FROM_WIN32(GetLastError());
-        ExtDbgOut("Error: Runtime module %s doesn't exist %08x\n", szModuleName, hr);
-        return hr;
-    }
-    runtimeDirectory = szModuleName;
-
-    // Parse off the module name to get just the path
-    size_t lastSlash = runtimeDirectory.rfind(DIRECTORY_SEPARATOR_CHAR_A);
-    if (lastSlash == std::string::npos)
-    {
-        ExtDbgOut("Error: Runtime module %s has no directory separator\n", szModuleName);
-        return E_FAIL;
-    }
-    runtimeDirectory.assign(runtimeDirectory, 0, lastSlash);
-#endif
-    return S_OK;
-}
-
-/**********************************************************************\
- * Returns the runtime directory of the target
-\**********************************************************************/
 LPCSTR Runtime::GetRuntimeDirectory()
 {
     if (m_runtimeDirectory == nullptr)
@@ -280,11 +308,26 @@ LPCSTR Runtime::GetRuntimeDirectory()
         }
         else 
         {
-            std::string runtimeDirectory;
-            if (SUCCEEDED(GetRuntimeDirectory(runtimeDirectory)))
+            ArrayHolder<char> szModuleName = new char[MAX_LONGPATH + 1];
+            HRESULT hr = g_ExtSymbols->GetModuleNames(m_index, 0, szModuleName, MAX_LONGPATH, NULL, NULL, 0, NULL, NULL, 0, NULL);
+            if (FAILED(hr))
             {
-                m_runtimeDirectory = _strdup(runtimeDirectory.c_str());
+                ExtErr("Error: Failed to get runtime module name\n");
+                return nullptr;
             }
+            if (GetFileAttributesA(szModuleName) == INVALID_FILE_ATTRIBUTES)
+            {
+                hr = HRESULT_FROM_WIN32(GetLastError());
+                ExtDbgOut("Error: Runtime module %s doesn't exist %08x\n", szModuleName.GetPtr(), hr);
+                return nullptr;
+            }
+            // Parse off the file name
+            char* lastSlash = strrchr(szModuleName, DIRECTORY_SEPARATOR_CHAR_A);
+            if (lastSlash != nullptr)
+            {
+                *lastSlash = '\0';
+            }
+            m_runtimeDirectory = _strdup(szModuleName.GetPtr());
         }
     }
     return m_runtimeDirectory;
@@ -410,7 +453,7 @@ HRESULT Runtime::GetClrDataProcess(IXCLRDataProcess** ppClrDataProcess)
             FreeLibrary(hdac);
             return CORDBG_E_MISSING_DEBUGGER_EXPORTS;
         }
-        ICLRDataTarget *target = new DataTarget();
+        ICLRDataTarget *target = new DataTarget(GetModuleAddress());
         HRESULT hr = pfnCLRDataCreateInstance(__uuidof(IXCLRDataProcess), target, (void**)&m_clrDataProcess);
         if (FAILED(hr))
         {
@@ -526,6 +569,13 @@ HRESULT Runtime::GetCorDebugInterface(ICorDebugProcess** ppCorDebugProcess)
 void Runtime::DisplayStatus()
 {
     ExtOut("%s runtime at %p size %08llx\n", GetRuntimeConfigurationName(GetRuntimeConfiguration()), m_address, m_size);
+    if (m_runtimeInfo != nullptr) {
+        ArrayHolder<char> szModuleName = new char[MAX_LONGPATH + 1];
+        HRESULT hr = g_ExtSymbols->GetModuleNames(m_index, 0, szModuleName, MAX_LONGPATH, NULL, NULL, 0, NULL, NULL, 0, NULL);
+        if (SUCCEEDED(hr)) {
+            ExtOut("Single-file module path: %s\n", szModuleName.GetPtr());
+        }
+    }
     if (m_runtimeDirectory != nullptr) {
         ExtOut("Runtime directory: %s\n", m_runtimeDirectory);
     }
@@ -546,15 +596,37 @@ extern int ReadMemoryForSymbols(ULONG64 address, uint8_t* buffer, int cb);
 \**********************************************************************/
 void Runtime::LoadRuntimeModules()
 {
-    ArrayHolder<char> moduleFilePath = new char[MAX_LONGPATH + 1];
-    HRESULT hr = g_ExtSymbols->GetModuleNames(m_index, 0, moduleFilePath, MAX_LONGPATH, NULL, NULL, 0, NULL, NULL, 0, NULL);
-    if (SUCCEEDED(hr))
+    HRESULT hr = InitializeSymbolStore();
+    if (SUCCEEDED(hr) && g_symbolStoreInitialized)
     {
-        hr = InitializeSymbolStore();
-        if (SUCCEEDED(hr) && g_symbolStoreInitialized)
+        if (m_runtimeInfo != nullptr)
         {
-            _ASSERTE(g_SOSNetCoreCallbacks.LoadNativeSymbolsDelegate != nullptr);
-            g_SOSNetCoreCallbacks.LoadNativeSymbolsDelegate(SymbolFileCallback, this, moduleFilePath, m_address, (int)m_size, ReadMemoryForSymbols);
+            _ASSERTE(g_SOSNetCoreCallbacks.LoadNativeSymbolsFromIndexDelegate != nullptr);
+            g_SOSNetCoreCallbacks.LoadNativeSymbolsFromIndexDelegate(
+                SymbolFileCallback,
+                this,
+                GetRuntimeConfiguration(),
+                GetRuntimeDllName(),
+                true,                                   // special keys (runtime, DAC and DBI)
+                m_runtimeInfo->RuntimeModuleIndex[0],   // size of module index
+                &m_runtimeInfo->RuntimeModuleIndex[1]); // beginning of index 
+        }
+        else
+        {
+            ArrayHolder<char> moduleFilePath = new char[MAX_LONGPATH + 1];
+            hr = g_ExtSymbols->GetModuleNames(m_index, 0, moduleFilePath, MAX_LONGPATH, NULL, NULL, 0, NULL, NULL, 0, NULL);
+            if (SUCCEEDED(hr))
+            {
+                _ASSERTE(g_SOSNetCoreCallbacks.LoadNativeSymbolsDelegate != nullptr);
+                g_SOSNetCoreCallbacks.LoadNativeSymbolsDelegate(
+                    SymbolFileCallback,
+                    this,
+                    GetRuntimeConfiguration(),
+                    moduleFilePath,
+                    m_address,
+                    (int)m_size,
+                    ReadMemoryForSymbols);
+            }
         }
     }
 }

--- a/src/SOS/Strike/sos_unixexports.src
+++ b/src/SOS/Strike/sos_unixexports.src
@@ -47,6 +47,7 @@ PrintException
 PathTo
 StopOnCatch
 SetHostRuntime
+SetClrPath
 SetSymbolServer
 SOSFlush
 SOSStatus

--- a/src/SOS/Strike/sosdocsunix.txt
+++ b/src/SOS/Strike/sosdocsunix.txt
@@ -1602,16 +1602,16 @@ help.
 COMMAND: gcwhere.
 GCWhere <object address>
 
-!GCWhere displays the location in the GC heap of the argument passed in.
+GCWhere displays the location in the GC heap of the argument passed in.
 
-    0:002> !GCWhere 02800038  
+    0:002> sos GCWhere 02800038  
     Address  Gen Heap segment  begin    allocated size
     02800038 2    0   02800000 02800038 0282b740  12
 
 When the argument lies in the managed heap, but is not a valid *object* address 
 the "size" is displayed as 0:
 
-    0:002> !GCWhere 0280003c
+    0:002> sos GCWhere 0280003c
     Address  Gen Heap segment  begin    allocated size
     0280003c 2    0   02800000 02800038 0282b740  0
 \\
@@ -1791,7 +1791,7 @@ reference the object:
 COMMAND: histroot.
 HistRoot <root>
 
-The root value obtained from !HistObjFind can be used to track the movement of 
+The root value obtained from sos HistObjFind can be used to track the movement of 
 an object through the GCs.
 
 HistRoot provides information related to both promotions and relocations of the 
@@ -1954,7 +1954,7 @@ Display internal SOS status or reset the internal cached state.
 \\
 
 COMMAND: setclrpath.
-!setclrpath <path-to-runtime>
+setclrpath <path-to-runtime>
 
 Sets the path to load the runtime DAC/DBI files. This command may be necessary for dumps that were created
 on another machine or for triage dumps.

--- a/src/SOS/dbgutil/CMakeLists.txt
+++ b/src/SOS/dbgutil/CMakeLists.txt
@@ -1,16 +1,32 @@
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
 if(WIN32)
-  #use static crt
-  add_definitions(-MT)
+    include_directories(${ROOT_DIR}/src/inc/llvm)
+    #use static crt
+    add_definitions(-MT)
 endif(WIN32)
 
-set(CMAKE_INCLUDE_CURRENT_DIR ON)
+add_definitions(-DPAL_STDCPP_COMPAT)
 
 set(DBGUTIL_SOURCES
     dbgutil.cpp
 )
 
+if(NOT DEFINED CLR_CMAKE_PLATFORM_DARWIN)
+    list(APPEND DBGUTIL_SOURCES
+        elfreader.cpp
+    )
+endif(NOT DEFINED CLR_CMAKE_PLATFORM_DARWIN)
+
+if(CLR_CMAKE_PLATFORM_ALPINE_LINUX)
+    add_definitions(-DTARGET_ALPINE_LINUX)
+endif(CLR_CMAKE_PLATFORM_ALPINE_LINUX)
+
 if(CLR_CMAKE_PLATFORM_UNIX)
+    add_definitions(-DHOST_UNIX)
     add_compile_options(-fPIC)
+else(CLR_CMAKE_PLATFORM_UNIX)
+    add_definitions(-DHOST_WINDOWS)
 endif(CLR_CMAKE_PLATFORM_UNIX)
 
 _add_library(dbgutil STATIC ${DBGUTIL_SOURCES})

--- a/src/SOS/dbgutil/dbgutil.cpp
+++ b/src/SOS/dbgutil/dbgutil.cpp
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 //*****************************************************************************
 // dbgutil.cpp
-// 
+//
 
 //
 //*****************************************************************************
@@ -16,6 +16,8 @@
 #include "corerror.h"
 #include <assert.h>
 #include <stdio.h>
+
+#ifdef HOST_WINDOWS
 
 // Returns the RVA of the resource section for the module specified by the given data target and module base.
 // Returns failure if the module doesn't have a resource section.
@@ -142,7 +144,7 @@ HRESULT GetResourceRvaFromResourceSectionRva(ICorDebugDataTarget* pDataTarget,
     // Each entry it points to is another resource directory that indexes all the same type
     // resources by name. And each entry in that table points to another resource directory that indexes
     // all the same type/name resources by language. Entries in the final table give the RVA of the actual
-    // resource. 
+    // resource.
     // Note all RVAs in this section are relative to the beginning of the resource section,
     // not the beginning of the image.
 
@@ -196,7 +198,7 @@ HRESULT GetResourceRvaFromResourceSectionRvaByName(ICorDebugDataTarget* pDataTar
     // Each entry it points to is another resource directory that indexes all the same type
     // resources by name. And each entry in that table points to another resource directory that indexes
     // all the same type/name resources by language. Entries in the final table give the RVA of the actual
-    // resource. 
+    // resource.
     // Note all RVAs in this section are relative to the beginning of the resource section,
     // not the beginning of the image.
     hr = GetNextLevelResourceEntryRVA(pDataTarget, type, moduleBaseAddress, resourceSectionRva, &nameTableRva);
@@ -229,7 +231,7 @@ HRESULT GetResourceRvaFromResourceSectionRvaByName(ICorDebugDataTarget* pDataTar
 }
 
 // Traverses down one level in the PE resource tree structure
-// 
+//
 // Arguments:
 //   pDataTarget - the data target for inspecting this process
 //   id - the id of the next node in the resource tree you want
@@ -295,7 +297,7 @@ HRESULT GetNextLevelResourceEntryRVA(ICorDebugDataTarget* pDataTarget,
 }
 
 // Traverses down one level in the PE resource tree structure
-// 
+//
 // Arguments:
 //   pDataTarget - the data target for inspecting this process
 //   name - the name of the next node in the resource tree you want
@@ -390,6 +392,8 @@ HRESULT GetNextLevelResourceEntryRVAByName(ICorDebugDataTarget* pDataTarget,
 
     return hr;
 }
+
+#endif // HOST_WINDOWS
 
 // A small wrapper that reads from the data target and throws on error
 HRESULT ReadFromDataTarget(ICorDebugDataTarget* pDataTarget,

--- a/src/SOS/dbgutil/dbgutil.vcxproj
+++ b/src/SOS/dbgutil/dbgutil.vcxproj
@@ -23,6 +23,10 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dbgutil.cpp" />
+    <ClCompile Include="elfreader.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="elfreader.h" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{A9A7C879-C320-3327-BB84-16E1322E17AE}</ProjectGuid>

--- a/src/SOS/dbgutil/elfreader.cpp
+++ b/src/SOS/dbgutil/elfreader.cpp
@@ -1,0 +1,568 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include <windows.h>
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
+#include <limits.h>
+#include "elfreader.h"
+
+#define Elf_Ehdr   ElfW(Ehdr)
+#define Elf_Phdr   ElfW(Phdr)
+#define Elf_Shdr   ElfW(Shdr)
+#define Elf_Nhdr   ElfW(Nhdr)
+#define Elf_Dyn    ElfW(Dyn)
+#define Elf_Sym    ElfW(Sym)
+
+#if _TARGET_64BIT_
+#define PRIx PRIx64
+#define PRIu PRIu64
+#define PRId PRId64
+#define PRIA "016"
+#define PRIxA PRIA PRIx
+#else
+#define PRIx PRIx32
+#define PRIu PRIu32
+#define PRId PRId32
+#define PRIA "08"
+#define PRIxA PRIA PRIx
+#endif
+
+#ifdef HOST_UNIX
+#define TRACE(args...) Trace(args)
+#else
+#define TRACE(args, ...)
+#endif
+
+#ifndef HOST_WINDOWS
+static const char ElfMagic[] = { 0x7f, 'E', 'L', 'F', '\0' };
+#endif
+
+extern bool ElfReaderReadMemory(void* address, void* buffer, size_t size);
+
+class ElfReaderExport: public ElfReader
+{
+public:
+    ElfReaderExport()
+    {
+    }
+
+    virtual ~ElfReaderExport()
+    {
+    }
+
+private:
+    virtual bool ReadMemory(void* address, void* buffer, size_t size)
+    {
+        return ElfReaderReadMemory(address, buffer, size);
+    }
+};
+
+//
+// Main entry point to get an export symbol
+//
+bool
+TryGetSymbol(uint64_t baseAddress, const char* symbolName, uint64_t* symbolAddress)
+{
+    ElfReaderExport elfreader;
+    if (elfreader.PopulateForSymbolLookup(baseAddress))
+    {
+        uint64_t symbolOffset;
+        if (elfreader.TryLookupSymbol(symbolName, &symbolOffset))
+        {
+            *symbolAddress = baseAddress + symbolOffset;
+            return true;
+        }
+    }
+    *symbolAddress = 0;
+    return false;
+}
+
+//
+// ELF reader constructor/destructor
+//
+
+ElfReader::ElfReader() :
+    m_gnuHashTableAddr(nullptr),
+    m_stringTableAddr(nullptr),
+    m_stringTableSize(0),
+    m_symbolTableAddr(nullptr),
+    m_buckets(nullptr),
+    m_chainsAddress(nullptr)
+{
+    memset(&m_hashTable, 0, sizeof(m_hashTable));
+}
+
+ElfReader::~ElfReader()
+{
+    if (m_buckets != nullptr) {
+        delete m_buckets;
+    }
+}
+
+//
+// Initialize the ELF reader from a module the base address. This function
+// caches the info neccessary in the ElfReader class look up symbols.
+//
+bool
+ElfReader::PopulateForSymbolLookup(uint64_t baseAddress)
+{
+    TRACE("PopulateForSymbolLookup: base %" PRIA PRIx64 "\n", baseAddress);
+    Elf_Dyn* dynamicAddr = nullptr;
+    uint64_t loadbias = 0;
+
+    // Enumerate program headers searching for the PT_DYNAMIC header, etc.
+    if (!EnumerateProgramHeaders(
+        baseAddress,
+#ifdef TARGET_ALPINE_LINUX
+        // On Alpine, the below dynamic entries for hash, string table, etc. are
+        // RVAs instead of absolute address like on all other Linux distros. Get
+        // the "loadbias" (basically the base address of the module) and add to
+        // these RVAs.
+        &loadbias,
+#else
+        nullptr,
+#endif
+        &dynamicAddr))
+    {
+        return false;
+    }
+
+    if (dynamicAddr == nullptr) {
+        return false;
+    }
+
+    // Search for dynamic entries
+    for (;;)
+    {
+        Elf_Dyn dyn;
+        if (!ReadMemory(dynamicAddr, &dyn, sizeof(dyn))) {
+            TRACE("ERROR: ReadMemory(%p, %" PRIx ") dyn FAILED\n", dynamicAddr, sizeof(dyn));
+            return false;
+        }
+        TRACE("DSO: dyn %p tag %" PRId " (%" PRIx ") d_ptr %" PRIxA "\n", dynamicAddr, dyn.d_tag, dyn.d_tag, dyn.d_un.d_ptr);
+        if (dyn.d_tag == DT_NULL) {
+            break;
+        }
+        else if (dyn.d_tag == DT_GNU_HASH) {
+            m_gnuHashTableAddr = (void*)(dyn.d_un.d_ptr + loadbias);
+        }
+        else if (dyn.d_tag == DT_STRTAB) {
+            m_stringTableAddr = (void*)(dyn.d_un.d_ptr + loadbias);
+        }
+        else if (dyn.d_tag == DT_STRSZ) {
+            m_stringTableSize = (int)dyn.d_un.d_ptr;
+        }
+        else if (dyn.d_tag == DT_SYMTAB) {
+            m_symbolTableAddr = (void*)(dyn.d_un.d_ptr + loadbias);
+        }
+        dynamicAddr++;
+    }
+
+    if (m_gnuHashTableAddr == nullptr || m_stringTableAddr == nullptr || m_symbolTableAddr == nullptr) {
+        TRACE("ERROR: hash, string or symbol table address not found\n");
+        return false;
+    }
+
+    // Initialize the hash table
+    if (!InitializeGnuHashTable()) {
+        return false;
+    }
+
+    return true;
+}
+
+//
+// Symbol table support
+//
+
+bool
+ElfReader::TryLookupSymbol(std::string symbolName, uint64_t* symbolOffset)
+{
+    std::vector<int32_t> symbolIndexes;
+    if (GetPossibleSymbolIndex(symbolName, symbolIndexes)) {
+        Elf_Sym symbol;
+        for (int32_t possibleLocation : symbolIndexes)
+        {
+            if (GetSymbol(possibleLocation, &symbol))
+            {
+                std::string possibleName;
+                if (GetStringAtIndex(symbol.st_name, possibleName))
+                {
+                    if (symbolName.compare(possibleName) == 0)
+                    {
+                        *symbolOffset = symbol.st_value;
+                        TRACE("TryLookupSymbol found '%s' at offset %" PRIxA "\n", symbolName.c_str(), *symbolOffset);
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+    TRACE("TryLookupSymbol '%s' not found\n", symbolName.c_str());
+    *symbolOffset = 0;
+    return false;
+}
+
+bool
+ElfReader::GetSymbol(int32_t index, Elf_Sym* symbol)
+{
+    int symSize = sizeof(Elf_Sym);
+    if (!ReadMemory((char*)m_symbolTableAddr + (index * symSize), symbol, symSize)) {
+        return false;
+    }
+    return true;
+}
+
+//
+// Hash (GNU) hash table support
+//
+
+bool
+ElfReader::InitializeGnuHashTable()
+{
+    if (!ReadMemory(m_gnuHashTableAddr, &m_hashTable, sizeof(m_hashTable))) {
+        TRACE("ERROR: InitializeGnuHashTable hashtable ReadMemory(%p) FAILED\n", m_gnuHashTableAddr);
+        return false;
+    }
+    if (m_hashTable.BucketCount <= 0 || m_hashTable.SymbolOffset == 0) {
+        TRACE("ERROR: InitializeGnuHashTable invalid BucketCount or SymbolOffset\n");
+        return false;
+    }
+    m_buckets = new (std::nothrow) int32_t[m_hashTable.BucketCount];
+    if (m_buckets == nullptr) {
+        return false;
+    }
+    void* bucketsAddress = (char*)m_gnuHashTableAddr + sizeof(GnuHashTable) + (m_hashTable.BloomSize * sizeof(size_t));
+    if (!ReadMemory(bucketsAddress, m_buckets, m_hashTable.BucketCount * sizeof(int32_t))) {
+        TRACE("ERROR: InitializeGnuHashTable buckets ReadMemory(%p) FAILED\n", bucketsAddress);
+        return false;
+    }
+    m_chainsAddress = (char*)bucketsAddress + (m_hashTable.BucketCount * sizeof(int32_t));
+    return true;
+}
+
+bool
+ElfReader::GetPossibleSymbolIndex(const std::string& symbolName, std::vector<int32_t>& symbolIndexes)
+{
+    uint32_t hash = Hash(symbolName);
+    int i = m_buckets[hash % m_hashTable.BucketCount] - m_hashTable.SymbolOffset;
+    TRACE("GetPossibleSymbolIndex hash %08x index: %d BucketCount %d SymbolOffset %08x\n", hash, i, m_hashTable.BucketCount, m_hashTable.SymbolOffset);
+    for (;; i++)
+    {
+        int32_t chainVal;
+        if (!GetChain(i, &chainVal)) {
+            TRACE("ERROR: GetPossibleSymbolIndex GetChain FAILED\n");
+            return false;
+        }
+        if ((chainVal & 0xfffffffe) == (hash & 0xfffffffe))
+        {
+            symbolIndexes.push_back(i + m_hashTable.SymbolOffset);
+        }
+        if ((chainVal & 0x1) == 0x1)
+        {
+            break;
+        }
+    }
+    return true;
+}
+
+uint32_t
+ElfReader::Hash(const std::string& symbolName)
+{
+    uint32_t h = 5381;
+    for (unsigned int i = 0; i < symbolName.length(); i++)
+    {
+        h = (h << 5) + h + symbolName[i];
+    }
+    return h;
+}
+
+bool
+ElfReader::GetChain(int index, int32_t* chain)
+{
+    return ReadMemory((char*)m_chainsAddress + (index * sizeof(int32_t)), chain, sizeof(int32_t));
+}
+
+//
+// String table support
+//
+
+bool
+ElfReader::GetStringAtIndex(int index, std::string& result)
+{
+    while(true)
+    {
+        if (index > m_stringTableSize) {
+            TRACE("ERROR: GetStringAtIndex index %d > string table size\n", index);
+            return false;
+        }
+        char ch;
+        void* address = (char*)m_stringTableAddr + index;
+        if (!ReadMemory(address, &ch, sizeof(ch))) {
+            TRACE("ERROR: GetStringAtIndex ReadMemory(%p) FAILED\n", address);
+            return false;
+        }
+        if (ch == '\0') {
+            break;
+        }
+        result.append(1, ch);
+        index++;
+    }
+    return true;
+}
+
+#ifdef HOST_UNIX
+
+//
+// Enumerate all the ELF info starting from the root program header. This
+// function doesn't cache any state in the ElfReader class.
+//
+bool
+ElfReader::EnumerateElfInfo(Elf_Phdr* phdrAddr, int phnum)
+{
+    TRACE("EnumerateElfInfo: phdr %p phnum %d\n", phdrAddr, phnum);
+
+    if (phdrAddr == nullptr || phnum <= 0) {
+        return false;
+    }
+    uint64_t baseAddress = (uint64_t)phdrAddr - sizeof(Elf_Ehdr);
+    Elf_Dyn* dynamicAddr = nullptr;
+
+    // Enumerate program headers searching for the PT_DYNAMIC header, etc.
+    if (!EnumerateProgramHeaders(phdrAddr, phnum, baseAddress, nullptr, &dynamicAddr)) {
+        return false;
+    }
+    return EnumerateLinkMapEntries(dynamicAddr);
+}
+
+//
+// Enumerate through the dynamic debug link map entries
+//
+bool
+ElfReader::EnumerateLinkMapEntries(Elf_Dyn* dynamicAddr)
+{
+    if (dynamicAddr == nullptr) {
+        return false;
+    }
+
+    // Search dynamic entries for DT_DEBUG (r_debug entry)
+    struct r_debug* rdebugAddr = nullptr;
+    for (;;)
+    {
+        Elf_Dyn dyn;
+        if (!ReadMemory(dynamicAddr, &dyn, sizeof(dyn))) {
+            TRACE("ERROR: ReadMemory(%p, %" PRIx ") dyn FAILED\n", dynamicAddr, sizeof(dyn));
+            return false;
+        }
+        TRACE("DSO: dyn %p tag %" PRId " (%" PRIx ") d_ptr %" PRIxA "\n", dynamicAddr, dyn.d_tag, dyn.d_tag, dyn.d_un.d_ptr);
+        if (dyn.d_tag == DT_NULL) {
+            break;
+        }
+        else if (dyn.d_tag == DT_DEBUG) {
+            rdebugAddr = reinterpret_cast<struct r_debug*>(dyn.d_un.d_ptr);
+        }
+        dynamicAddr++;
+    }
+
+    TRACE("DSO: rdebugAddr %p\n", rdebugAddr);
+    if (rdebugAddr == nullptr) {
+        return false;
+    }
+
+    struct r_debug debugEntry;
+    if (!ReadMemory(rdebugAddr, &debugEntry, sizeof(debugEntry))) {
+        TRACE("ERROR: ReadMemory(%p, %" PRIx ") r_debug FAILED\n", rdebugAddr, sizeof(debugEntry));
+        return false;
+    }
+
+    // Add the DSO link_map entries
+    for (struct link_map* linkMapAddr = debugEntry.r_map; linkMapAddr != nullptr;)
+    {
+        struct link_map map;
+        if (!ReadMemory(linkMapAddr, &map, sizeof(map))) {
+            TRACE("ERROR: ReadMemory(%p, %" PRIx ") link_map FAILED\n", linkMapAddr, sizeof(map));
+            return false;
+        }
+        // Read the module's name and make sure the memory is added to the core dump
+        std::string moduleName;
+        int i = 0;
+        if (map.l_name != nullptr)
+        {
+            for (; i < PATH_MAX; i++)
+            {
+                char ch;
+                if (!ReadMemory(map.l_name + i, &ch, sizeof(ch))) {
+                    TRACE("DSO: ReadMemory link_map name %p + %d FAILED\n", map.l_name, i);
+                    break;
+                }
+                if (ch == '\0') {
+                    break;
+                }
+                moduleName.append(1, ch);
+            }
+        }
+        TRACE("\nDSO: link_map entry %p l_ld %p l_addr (Ehdr) %" PRIx " %s\n", linkMapAddr, map.l_ld, map.l_addr, moduleName.c_str());
+
+        // Call the derived class for each module
+        VisitModule(map.l_addr, moduleName);
+
+        linkMapAddr = map.l_next;
+    }
+
+    return true;
+}
+
+#endif // HOST_UNIX
+
+bool
+ElfReader::EnumerateProgramHeaders(uint64_t baseAddress, uint64_t* ploadbias, Elf_Dyn** pdynamicAddr)
+{
+    Elf_Ehdr ehdr;
+    if (!ReadMemory((void*)baseAddress, &ehdr, sizeof(ehdr))) {
+        TRACE("ERROR: EnumerateProgramHeaders ReadMemory(%p, %" PRIx ") ehdr FAILED\n", (void*)baseAddress, sizeof(ehdr));
+        return false;
+    }
+    if (memcmp(ehdr.e_ident, ElfMagic, strlen(ElfMagic)) != 0) {
+        TRACE("ERROR: EnumerateProgramHeaders Invalid elf header signature\n");
+        return false;
+    }
+    _ASSERTE(ehdr.e_phentsize == sizeof(Elf_Phdr));
+#ifdef _TARGET_64BIT_
+    _ASSERTE(ehdr.e_ident[EI_CLASS] == ELFCLASS64);
+#else
+    _ASSERTE(ehdr.e_ident[EI_CLASS] == ELFCLASS32);
+#endif
+    _ASSERTE(ehdr.e_ident[EI_DATA] == ELFDATA2LSB);
+    int phnum = ehdr.e_phnum;
+#ifdef PN_XNUM
+     _ASSERTE(phnum != PN_XNUM);
+#endif
+    if (ehdr.e_phoff == 0 || phnum <= 0) {
+        return false;
+    }
+    TRACE("ELF: type %d mach 0x%x ver %d flags 0x%x phnum %d phoff %" PRIxA " phentsize 0x%02x shnum %d shoff %" PRIxA " shentsize 0x%02x shstrndx %d\n",
+        ehdr.e_type, ehdr.e_machine, ehdr.e_version, ehdr.e_flags, phnum, ehdr.e_phoff, ehdr.e_phentsize, ehdr.e_shnum, ehdr.e_shoff, ehdr.e_shentsize, ehdr.e_shstrndx);
+
+    Elf_Phdr* phdrAddr = reinterpret_cast<Elf_Phdr*>(baseAddress + ehdr.e_phoff);
+    return EnumerateProgramHeaders(phdrAddr, phnum, baseAddress, ploadbias, pdynamicAddr);
+}
+
+//
+// Enumerate and find the dynamic program header entry
+//
+bool
+ElfReader::EnumerateProgramHeaders(Elf_Phdr* phdrAddr, int phnum, uint64_t baseAddress, uint64_t* ploadbias, Elf_Dyn** pdynamicAddr)
+{
+    uint64_t loadbias = baseAddress;
+
+    // Calculate the load bias from the PT_LOAD program headers
+    for (int i = 0; i < phnum; i++)
+    {
+        Elf_Phdr ph;
+        if (!ReadMemory(phdrAddr + i, &ph, sizeof(ph))) {
+            TRACE("ERROR: ReadMemory(%p, %" PRIx ") phdr FAILED\n", phdrAddr + i, sizeof(ph));
+            return false;
+        }
+        if (ph.p_type == PT_LOAD && ph.p_offset == 0) {
+            loadbias -= ph.p_vaddr;
+            TRACE("PHDR: loadbias %" PRIA PRIx64 "\n", loadbias);
+            break;
+        }
+    }
+
+    if (ploadbias != nullptr) {
+        *ploadbias = loadbias;
+    }
+
+    // Enumerate all the program headers
+    for (int i = 0; i < phnum; i++)
+    {
+        Elf_Phdr ph;
+        if (!ReadMemory(phdrAddr + i, &ph, sizeof(ph))) {
+            TRACE("ERROR: ReadMemory(%p, %" PRIx ") phdr FAILED\n", phdrAddr + i, sizeof(ph));
+            return false;
+        }
+        TRACE("PHDR: %p type %d (%x) vaddr %" PRIxA " memsz %" PRIxA " paddr %" PRIxA " filesz %" PRIxA " offset %" PRIxA " align %" PRIxA "\n",
+            phdrAddr + i, ph.p_type, ph.p_type, ph.p_vaddr, ph.p_memsz, ph.p_paddr, ph.p_filesz, ph.p_offset, ph.p_align);
+
+        switch (ph.p_type)
+        {
+        case PT_DYNAMIC:
+            if (pdynamicAddr != nullptr) {
+                *pdynamicAddr = reinterpret_cast<Elf_Dyn*>(loadbias + ph.p_vaddr);
+            }
+            break;
+        }
+
+        // Give any derived classes a chance at the program header
+        VisitProgramHeader(loadbias, baseAddress, &ph);
+    }
+
+    return true;
+}
+
+#ifdef HOST_WINDOWS
+
+/* ELF 32bit header */
+Elf32_Ehdr::Elf32_Ehdr()
+{
+    e_ident[EI_MAG0] = ElfMagic[0];
+    e_ident[EI_MAG1] = ElfMagic[1];
+    e_ident[EI_MAG2] = ElfMagic[2];
+    e_ident[EI_MAG3] = ElfMagic[3];
+    e_ident[EI_CLASS] = ELFCLASS32;
+    e_ident[EI_DATA] = ELFDATA2LSB;
+    e_ident[EI_VERSION] = EV_CURRENT;
+    e_ident[EI_OSABI] = ELFOSABI_NONE;
+    e_ident[EI_ABIVERSION] = 0;
+    for (int i = EI_PAD; i < EI_NIDENT; ++i) {
+        e_ident[i] = 0;
+    }
+    e_type = ET_REL;
+#if defined(_TARGET_X86_)
+    e_machine = EM_386;
+#elif defined(_TARGET_ARM_)
+    e_machine = EM_ARM;
+#endif
+    e_flags = 0;
+    e_version = 1;
+    e_entry = 0;
+    e_phoff = 0;
+    e_ehsize = sizeof(Elf32_Ehdr);
+    e_phentsize = 0;
+    e_phnum = 0;
+}
+
+/* ELF 64bit header */
+Elf64_Ehdr::Elf64_Ehdr()
+{
+    e_ident[EI_MAG0] = ElfMagic[0];
+    e_ident[EI_MAG1] = ElfMagic[1];
+    e_ident[EI_MAG2] = ElfMagic[2];
+    e_ident[EI_MAG3] = ElfMagic[3];
+    e_ident[EI_CLASS] = ELFCLASS64;
+    e_ident[EI_DATA] = ELFDATA2LSB;
+    e_ident[EI_VERSION] = EV_CURRENT;
+    e_ident[EI_OSABI] = ELFOSABI_NONE;
+    e_ident[EI_ABIVERSION] = 0;
+    for (int i = EI_PAD; i < EI_NIDENT; ++i) {
+        e_ident[i] = 0;
+    }
+    e_type = ET_REL;
+#if defined(_TARGET_AMD64_)
+    e_machine = EM_X86_64;
+#elif defined(TARGET_ARM64_)
+    e_machine = EM_AARCH64;
+#endif
+    e_flags = 0;
+    e_version = 1;
+    e_entry = 0;
+    e_phoff = 0;
+    e_ehsize = sizeof(Elf64_Ehdr);
+    e_phentsize = 0;
+    e_phnum = 0;
+}
+
+#endif // HOST_WINDOWS

--- a/src/SOS/dbgutil/elfreader.h
+++ b/src/SOS/dbgutil/elfreader.h
@@ -1,0 +1,70 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include <elf.h>
+#ifdef HOST_UNIX
+#include <link.h>
+#endif // HOST_UNIX
+#include <string>
+#include <vector>
+
+#if _TARGET_64BIT_
+#define TARGET_WORDSIZE 64
+#else
+#define TARGET_WORDSIZE 32
+#endif
+
+#ifndef ElfW
+/* We use this macro to refer to ELF types independent of the native wordsize.
+   `ElfW(TYPE)' is used in place of `Elf32_TYPE' or `Elf64_TYPE'.  */
+#define ElfW(type)      _ElfW (Elf, TARGET_WORDSIZE, type)
+#define _ElfW(e,w,t)    _ElfW_1 (e, w, _##t)
+#define _ElfW_1(e,w,t)  e##w##t
+#endif
+
+typedef struct {
+    int32_t BucketCount;
+    int32_t SymbolOffset;
+    int32_t BloomSize;
+    int32_t BloomShift;
+} GnuHashTable;
+
+class ElfReader
+{
+private:
+    void* m_gnuHashTableAddr;               // DT_GNU_HASH
+    void* m_stringTableAddr;                // DT_STRTAB
+    int m_stringTableSize;                  // DT_STRSIZ
+    void* m_symbolTableAddr;                // DT_SYMTAB
+
+    GnuHashTable m_hashTable;               // gnu hash table info
+    int32_t* m_buckets;                     // gnu hash table buckets    
+    void* m_chainsAddress;
+
+public:
+    ElfReader();
+    virtual ~ElfReader();
+#ifdef HOST_UNIX
+    bool EnumerateElfInfo(ElfW(Phdr)* phdrAddr, int phnum);
+#endif
+    bool PopulateForSymbolLookup(uint64_t baseAddress);
+    bool TryLookupSymbol(std::string symbolName, uint64_t* symbolOffset);
+    bool EnumerateProgramHeaders(uint64_t baseAddress, uint64_t* ploadbias = nullptr, ElfW(Dyn)** pdynamicAddr = nullptr);
+
+private:
+    bool GetSymbol(int32_t index, ElfW(Sym)* symbol);
+    bool InitializeGnuHashTable();
+    bool GetPossibleSymbolIndex(const std::string& symbolName, std::vector<int32_t>& symbolIndexes);
+    uint32_t Hash(const std::string& symbolName);
+    bool GetChain(int index, int32_t* chain);
+    bool GetStringAtIndex(int index, std::string& result);
+#ifdef HOST_UNIX
+    bool EnumerateLinkMapEntries(ElfW(Dyn)* dynamicAddr);
+#endif
+    bool EnumerateProgramHeaders(ElfW(Phdr)* phdrAddr, int phnum, uint64_t baseAddress, uint64_t* ploadbias, ElfW(Dyn)** pdynamicAddr);
+    virtual void VisitModule(uint64_t baseAddress, std::string& moduleName) { };
+    virtual void VisitProgramHeader(uint64_t loadbias, uint64_t baseAddress, ElfW(Phdr)* phdr) { };
+    virtual bool ReadMemory(void* address, void* buffer, size_t size) = 0;
+    virtual void Trace(const char* format, ...) { };
+};

--- a/src/SOS/lldbplugin/soscommand.cpp
+++ b/src/SOS/lldbplugin/soscommand.cpp
@@ -129,7 +129,7 @@ bool
 sosCommandInitialize(lldb::SBDebugger debugger)
 {
     lldb::SBCommandInterpreter interpreter = debugger.GetCommandInterpreter();
-    interpreter.AddCommand("sos", new sosCommand(nullptr), "Various coreclr debugging commands. See 'soshelp' for more details. sos <command-name> <args>");
+    interpreter.AddCommand("sos", new sosCommand(nullptr), "Various .NET Core debugging commands. See 'soshelp' for more details. sos <command-name> <args>");
     interpreter.AddCommand("bpmd", new sosCommand("bpmd"), "Creates a breakpoint at the specified managed method in the specified module.");
     interpreter.AddCommand("clrstack", new sosCommand("ClrStack"), "Provides a stack trace of managed code only.");
     interpreter.AddCommand("clrthreads", new sosCommand("Threads"), "List the managed threads running.");
@@ -168,6 +168,7 @@ sosCommandInitialize(lldb::SBDebugger debugger)
     interpreter.AddCommand("histobjfind", new sosCommand("HistObjFind"), "Displays all the log entries that reference an object at the specified address.");
     interpreter.AddCommand("histroot", new sosCommand("HistRoot"), "Displays information related to both promotions and relocations of the specified root.");
     interpreter.AddCommand("sethostruntime", new sosCommand("SetHostRuntime"), "Sets or displays the .NET Core runtime directory to use to run managed code in SOS.");
+    interpreter.AddCommand("setclrpath", new sosCommand("SetClrPath"), "Set the path to load the runtime DAC/DBI files.");
     interpreter.AddCommand("setsymbolserver", new sosCommand("SetSymbolServer"), "Enables the symbol server support ");
     interpreter.AddCommand("sympath", new sosCommand("SetSymbolServer", "-sympath"), "Add server, cache and directory paths in the Windows symbol path format.");
     interpreter.AddCommand("soshelp", new sosCommand("Help"), "Displays all available commands when no parameter is specified, or displays detailed help information about the specified command. soshelp <command>");

--- a/src/SOS/lldbplugin/sosplugin.cpp
+++ b/src/SOS/lldbplugin/sosplugin.cpp
@@ -12,7 +12,6 @@ bool
 lldb::PluginInitialize (lldb::SBDebugger debugger)
 {
     sosCommandInitialize(debugger);
-    setclrpathCommandInitialize(debugger);
     setsostidCommandInitialize(debugger);
     return true;
 }

--- a/src/Tools/dotnet-dump/Analyzer.cs
+++ b/src/Tools/dotnet-dump/Analyzer.cs
@@ -251,19 +251,9 @@ namespace Microsoft.Diagnostics.Tools.Dump
                             if (clrInfo.ModuleInfo.BuildId != null)
                             {
                                 IEnumerable<SymbolStoreKey> keys = ELFFileKeyGenerator.GetKeys(
-                                    KeyTypeFlags.ClrKeys, clrInfo.ModuleInfo.FileName, clrInfo.ModuleInfo.BuildId, symbolFile: false, symbolFileName: null);
+                                    KeyTypeFlags.DacDbiKeys, clrInfo.ModuleInfo.FileName, clrInfo.ModuleInfo.BuildId, symbolFile: false, symbolFileName: null);
 
                                 key = keys.SingleOrDefault((k) => Path.GetFileName(k.FullPathName) == dacFileName);
-
-                                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                                {
-                                    // We are opening a Linux dump on Windows
-                                    // We need to use the Windows index and filename
-                                    key = new SymbolStoreKey(key.Index.Replace("libmscordaccore.so", "mscordaccore.dll"),
-                                                             key.FullPathName.Replace("libmscordaccore.so", "mscordaccore.dll"),
-                                                             key.IsClrSpecialFile,
-                                                             key.PdbChecksums);
-                                }
                             }
                             else
                             {

--- a/src/inc/clrdata.idl
+++ b/src/inc/clrdata.idl
@@ -112,7 +112,7 @@ interface ICLRDataTarget : IUnknown
      * implementation this can fail.
      */
     HRESULT GetCurrentThreadID([out] ULONG32* threadID);
-    
+
     /*
      * Thread context.
      */
@@ -137,7 +137,7 @@ interface ICLRDataTarget : IUnknown
 };
 
 /*
- * Interface used by the data access services layer to manipulate 
+ * Interface used by the data access services layer to manipulate
  * virtual memory regions in the target. The target may not support
  * modification.
  */
@@ -197,9 +197,23 @@ interface ICLRDataTarget3 : ICLRDataTarget2
     HRESULT GetExceptionThreadID([out] ULONG32* threadID);
 };
 
+[
+    object,
+    local,
+    uuid(b760bf44-9377-4597-8be7-58083bdc5146),
+    pointer_default(unique)
+]
+interface ICLRRuntimeLocator : IUnknown
+{
+    /*
+     Returns the base address of the module containing the runtime.
+     */
+    HRESULT GetRuntimeBase([out] CLRDATA_ADDRESS* baseAddress);
+};
+
 /*
- * Interface used by the data access services layer to locate metadata 
- * of assemblies in a target. 
+ * Interface used by the data access services layer to locate metadata
+ * of assemblies in a target.
  *
  * The API client must implement this interface as appropriate for the
  * particular target (for example, a live process or a memory dump).
@@ -217,7 +231,7 @@ interface ICLRDataTarget3 : ICLRDataTarget2
 interface ICLRMetadataLocator : IUnknown
 {
     /*
-     * Ask the target to retrieve metadata for an image.  
+     * Ask the target to retrieve metadata for an image.
      */
     HRESULT GetMetadata([in] LPCWSTR imagePath,
                         [in] ULONG32 imageTimestamp,
@@ -265,8 +279,8 @@ interface ICLRDataEnumMemoryRegionsCallback2 : ICLRDataEnumMemoryRegionsCallback
 {
     /*
      * ICLRDataEnumMemoryRegions::EnumMemoryRegions will call this function
-     * for every memory regions it needs to overwrite/poison with the specified 
-     * data buffer passed as input argument. 
+     * for every memory regions it needs to overwrite/poison with the specified
+     * data buffer passed as input argument.
      */
     HRESULT UpdateMemoryRegion(
         [in] CLRDATA_ADDRESS address,
@@ -280,10 +294,10 @@ interface ICLRDataEnumMemoryRegionsCallback2 : ICLRDataEnumMemoryRegionsCallback
 typedef enum CLRDataEnumMemoryFlags
 {
     CLRDATA_ENUM_MEM_DEFAULT = 0x0,
-    CLRDATA_ENUM_MEM_MINI = CLRDATA_ENUM_MEM_DEFAULT,       // generating skinny mini-dump    
+    CLRDATA_ENUM_MEM_MINI = CLRDATA_ENUM_MEM_DEFAULT,       // generating skinny mini-dump
     CLRDATA_ENUM_MEM_HEAP = 0x1,        // generating heap dump
     CLRDATA_ENUM_MEM_TRIAGE = 0x2,      // generating triage mini-dump
-    
+
     /* More bits to be added here later */
 } CLRDataEnumMemoryFlags;
 

--- a/src/inc/llvm/Dwarf.def
+++ b/src/inc/llvm/Dwarf.def
@@ -1,0 +1,393 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// ==============================================================================
+// LLVM Release License
+// ==============================================================================
+// University of Illinois/NCSA
+// Open Source License
+//
+// Copyright (c) 2003-2015 University of Illinois at Urbana-Champaign.
+// All rights reserved.
+//
+// Developed by:
+//
+//     LLVM Team
+//
+//     University of Illinois at Urbana-Champaign
+//
+//     http://llvm.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal with
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is furnished to do
+// so, subject to the following conditions:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimers.
+//
+//     * Redistributions in binary form must reproduce the above copyright notice,
+//       this list of conditions and the following disclaimers in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the names of the LLVM Team, University of Illinois at
+//       Urbana-Champaign, nor the names of its contributors may be used to
+//       endorse or promote products derived from this Software without specific
+//       prior written permission.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
+// SOFTWARE.
+
+//===----------------------------------------------------------------------===//
+//
+// Macros for running through Dwarf enumerators.
+//
+//===----------------------------------------------------------------------===//
+
+// TODO: Add other DW-based macros.
+#if !(defined HANDLE_DW_TAG || defined HANDLE_DW_OP ||                         \
+      defined HANDLE_DW_LANG || defined HANDLE_DW_ATE ||                       \
+      defined HANDLE_DW_VIRTUALITY)
+#error "Missing macro definition of HANDLE_DW*"
+#endif
+
+#ifndef HANDLE_DW_TAG
+#define HANDLE_DW_TAG(ID, NAME)
+#endif
+
+#ifndef HANDLE_DW_OP
+#define HANDLE_DW_OP(ID, NAME)
+#endif
+
+#ifndef HANDLE_DW_LANG
+#define HANDLE_DW_LANG(ID, NAME)
+#endif
+
+#ifndef HANDLE_DW_ATE
+#define HANDLE_DW_ATE(ID, NAME)
+#endif
+
+#ifndef HANDLE_DW_VIRTUALITY
+#define HANDLE_DW_VIRTUALITY(ID, NAME)
+#endif
+
+HANDLE_DW_TAG(0x0001, array_type)
+HANDLE_DW_TAG(0x0002, class_type)
+HANDLE_DW_TAG(0x0003, entry_point)
+HANDLE_DW_TAG(0x0004, enumeration_type)
+HANDLE_DW_TAG(0x0005, formal_parameter)
+HANDLE_DW_TAG(0x0008, imported_declaration)
+HANDLE_DW_TAG(0x000a, label)
+HANDLE_DW_TAG(0x000b, lexical_block)
+HANDLE_DW_TAG(0x000d, member)
+HANDLE_DW_TAG(0x000f, pointer_type)
+HANDLE_DW_TAG(0x0010, reference_type)
+HANDLE_DW_TAG(0x0011, compile_unit)
+HANDLE_DW_TAG(0x0012, string_type)
+HANDLE_DW_TAG(0x0013, structure_type)
+HANDLE_DW_TAG(0x0015, subroutine_type)
+HANDLE_DW_TAG(0x0016, typedef)
+HANDLE_DW_TAG(0x0017, union_type)
+HANDLE_DW_TAG(0x0018, unspecified_parameters)
+HANDLE_DW_TAG(0x0019, variant)
+HANDLE_DW_TAG(0x001a, common_block)
+HANDLE_DW_TAG(0x001b, common_inclusion)
+HANDLE_DW_TAG(0x001c, inheritance)
+HANDLE_DW_TAG(0x001d, inlined_subroutine)
+HANDLE_DW_TAG(0x001e, module)
+HANDLE_DW_TAG(0x001f, ptr_to_member_type)
+HANDLE_DW_TAG(0x0020, set_type)
+HANDLE_DW_TAG(0x0021, subrange_type)
+HANDLE_DW_TAG(0x0022, with_stmt)
+HANDLE_DW_TAG(0x0023, access_declaration)
+HANDLE_DW_TAG(0x0024, base_type)
+HANDLE_DW_TAG(0x0025, catch_block)
+HANDLE_DW_TAG(0x0026, const_type)
+HANDLE_DW_TAG(0x0027, constant)
+HANDLE_DW_TAG(0x0028, enumerator)
+HANDLE_DW_TAG(0x0029, file_type)
+HANDLE_DW_TAG(0x002a, friend)
+HANDLE_DW_TAG(0x002b, namelist)
+HANDLE_DW_TAG(0x002c, namelist_item)
+HANDLE_DW_TAG(0x002d, packed_type)
+HANDLE_DW_TAG(0x002e, subprogram)
+HANDLE_DW_TAG(0x002f, template_type_parameter)
+HANDLE_DW_TAG(0x0030, template_value_parameter)
+HANDLE_DW_TAG(0x0031, thrown_type)
+HANDLE_DW_TAG(0x0032, try_block)
+HANDLE_DW_TAG(0x0033, variant_part)
+HANDLE_DW_TAG(0x0034, variable)
+HANDLE_DW_TAG(0x0035, volatile_type)
+HANDLE_DW_TAG(0x0036, dwarf_procedure)
+HANDLE_DW_TAG(0x0037, restrict_type)
+HANDLE_DW_TAG(0x0038, interface_type)
+HANDLE_DW_TAG(0x0039, namespace)
+HANDLE_DW_TAG(0x003a, imported_module)
+HANDLE_DW_TAG(0x003b, unspecified_type)
+HANDLE_DW_TAG(0x003c, partial_unit)
+HANDLE_DW_TAG(0x003d, imported_unit)
+HANDLE_DW_TAG(0x003f, condition)
+HANDLE_DW_TAG(0x0040, shared_type)
+HANDLE_DW_TAG(0x0041, type_unit)
+HANDLE_DW_TAG(0x0042, rvalue_reference_type)
+HANDLE_DW_TAG(0x0043, template_alias)
+
+// New in DWARF v5.
+HANDLE_DW_TAG(0x0044, coarray_type)
+HANDLE_DW_TAG(0x0045, generic_subrange)
+HANDLE_DW_TAG(0x0046, dynamic_type)
+
+// User-defined tags.
+HANDLE_DW_TAG(0x4081, MIPS_loop)
+HANDLE_DW_TAG(0x4101, format_label)
+HANDLE_DW_TAG(0x4102, function_template)
+HANDLE_DW_TAG(0x4103, class_template)
+HANDLE_DW_TAG(0x4106, GNU_template_template_param)
+HANDLE_DW_TAG(0x4107, GNU_template_parameter_pack)
+HANDLE_DW_TAG(0x4108, GNU_formal_parameter_pack)
+HANDLE_DW_TAG(0x4200, APPLE_property)
+HANDLE_DW_TAG(0xb000, BORLAND_property)
+HANDLE_DW_TAG(0xb001, BORLAND_Delphi_string)
+HANDLE_DW_TAG(0xb002, BORLAND_Delphi_dynamic_array)
+HANDLE_DW_TAG(0xb003, BORLAND_Delphi_set)
+HANDLE_DW_TAG(0xb004, BORLAND_Delphi_variant)
+
+HANDLE_DW_OP(0x03, addr)
+HANDLE_DW_OP(0x06, deref)
+HANDLE_DW_OP(0x08, const1u)
+HANDLE_DW_OP(0x09, const1s)
+HANDLE_DW_OP(0x0a, const2u)
+HANDLE_DW_OP(0x0b, const2s)
+HANDLE_DW_OP(0x0c, const4u)
+HANDLE_DW_OP(0x0d, const4s)
+HANDLE_DW_OP(0x0e, const8u)
+HANDLE_DW_OP(0x0f, const8s)
+HANDLE_DW_OP(0x10, constu)
+HANDLE_DW_OP(0x11, consts)
+HANDLE_DW_OP(0x12, dup)
+HANDLE_DW_OP(0x13, drop)
+HANDLE_DW_OP(0x14, over)
+HANDLE_DW_OP(0x15, pick)
+HANDLE_DW_OP(0x16, swap)
+HANDLE_DW_OP(0x17, rot)
+HANDLE_DW_OP(0x18, xderef)
+HANDLE_DW_OP(0x19, abs)
+HANDLE_DW_OP(0x1a, and)
+HANDLE_DW_OP(0x1b, div)
+HANDLE_DW_OP(0x1c, minus)
+HANDLE_DW_OP(0x1d, mod)
+HANDLE_DW_OP(0x1e, mul)
+HANDLE_DW_OP(0x1f, neg)
+HANDLE_DW_OP(0x20, not)
+HANDLE_DW_OP(0x21, or )
+HANDLE_DW_OP(0x22, plus)
+HANDLE_DW_OP(0x23, plus_uconst)
+HANDLE_DW_OP(0x24, shl)
+HANDLE_DW_OP(0x25, shr)
+HANDLE_DW_OP(0x26, shra)
+HANDLE_DW_OP(0x27, xor)
+HANDLE_DW_OP(0x2f, skip)
+HANDLE_DW_OP(0x28, bra)
+HANDLE_DW_OP(0x29, eq)
+HANDLE_DW_OP(0x2a, ge)
+HANDLE_DW_OP(0x2b, gt)
+HANDLE_DW_OP(0x2c, le)
+HANDLE_DW_OP(0x2d, lt)
+HANDLE_DW_OP(0x2e, ne)
+HANDLE_DW_OP(0x30, lit0)
+HANDLE_DW_OP(0x31, lit1)
+HANDLE_DW_OP(0x32, lit2)
+HANDLE_DW_OP(0x33, lit3)
+HANDLE_DW_OP(0x34, lit4)
+HANDLE_DW_OP(0x35, lit5)
+HANDLE_DW_OP(0x36, lit6)
+HANDLE_DW_OP(0x37, lit7)
+HANDLE_DW_OP(0x38, lit8)
+HANDLE_DW_OP(0x39, lit9)
+HANDLE_DW_OP(0x3a, lit10)
+HANDLE_DW_OP(0x3b, lit11)
+HANDLE_DW_OP(0x3c, lit12)
+HANDLE_DW_OP(0x3d, lit13)
+HANDLE_DW_OP(0x3e, lit14)
+HANDLE_DW_OP(0x3f, lit15)
+HANDLE_DW_OP(0x40, lit16)
+HANDLE_DW_OP(0x41, lit17)
+HANDLE_DW_OP(0x42, lit18)
+HANDLE_DW_OP(0x43, lit19)
+HANDLE_DW_OP(0x44, lit20)
+HANDLE_DW_OP(0x45, lit21)
+HANDLE_DW_OP(0x46, lit22)
+HANDLE_DW_OP(0x47, lit23)
+HANDLE_DW_OP(0x48, lit24)
+HANDLE_DW_OP(0x49, lit25)
+HANDLE_DW_OP(0x4a, lit26)
+HANDLE_DW_OP(0x4b, lit27)
+HANDLE_DW_OP(0x4c, lit28)
+HANDLE_DW_OP(0x4d, lit29)
+HANDLE_DW_OP(0x4e, lit30)
+HANDLE_DW_OP(0x4f, lit31)
+HANDLE_DW_OP(0x50, reg0)
+HANDLE_DW_OP(0x51, reg1)
+HANDLE_DW_OP(0x52, reg2)
+HANDLE_DW_OP(0x53, reg3)
+HANDLE_DW_OP(0x54, reg4)
+HANDLE_DW_OP(0x55, reg5)
+HANDLE_DW_OP(0x56, reg6)
+HANDLE_DW_OP(0x57, reg7)
+HANDLE_DW_OP(0x58, reg8)
+HANDLE_DW_OP(0x59, reg9)
+HANDLE_DW_OP(0x5a, reg10)
+HANDLE_DW_OP(0x5b, reg11)
+HANDLE_DW_OP(0x5c, reg12)
+HANDLE_DW_OP(0x5d, reg13)
+HANDLE_DW_OP(0x5e, reg14)
+HANDLE_DW_OP(0x5f, reg15)
+HANDLE_DW_OP(0x60, reg16)
+HANDLE_DW_OP(0x61, reg17)
+HANDLE_DW_OP(0x62, reg18)
+HANDLE_DW_OP(0x63, reg19)
+HANDLE_DW_OP(0x64, reg20)
+HANDLE_DW_OP(0x65, reg21)
+HANDLE_DW_OP(0x66, reg22)
+HANDLE_DW_OP(0x67, reg23)
+HANDLE_DW_OP(0x68, reg24)
+HANDLE_DW_OP(0x69, reg25)
+HANDLE_DW_OP(0x6a, reg26)
+HANDLE_DW_OP(0x6b, reg27)
+HANDLE_DW_OP(0x6c, reg28)
+HANDLE_DW_OP(0x6d, reg29)
+HANDLE_DW_OP(0x6e, reg30)
+HANDLE_DW_OP(0x6f, reg31)
+HANDLE_DW_OP(0x70, breg0)
+HANDLE_DW_OP(0x71, breg1)
+HANDLE_DW_OP(0x72, breg2)
+HANDLE_DW_OP(0x73, breg3)
+HANDLE_DW_OP(0x74, breg4)
+HANDLE_DW_OP(0x75, breg5)
+HANDLE_DW_OP(0x76, breg6)
+HANDLE_DW_OP(0x77, breg7)
+HANDLE_DW_OP(0x78, breg8)
+HANDLE_DW_OP(0x79, breg9)
+HANDLE_DW_OP(0x7a, breg10)
+HANDLE_DW_OP(0x7b, breg11)
+HANDLE_DW_OP(0x7c, breg12)
+HANDLE_DW_OP(0x7d, breg13)
+HANDLE_DW_OP(0x7e, breg14)
+HANDLE_DW_OP(0x7f, breg15)
+HANDLE_DW_OP(0x80, breg16)
+HANDLE_DW_OP(0x81, breg17)
+HANDLE_DW_OP(0x82, breg18)
+HANDLE_DW_OP(0x83, breg19)
+HANDLE_DW_OP(0x84, breg20)
+HANDLE_DW_OP(0x85, breg21)
+HANDLE_DW_OP(0x86, breg22)
+HANDLE_DW_OP(0x87, breg23)
+HANDLE_DW_OP(0x88, breg24)
+HANDLE_DW_OP(0x89, breg25)
+HANDLE_DW_OP(0x8a, breg26)
+HANDLE_DW_OP(0x8b, breg27)
+HANDLE_DW_OP(0x8c, breg28)
+HANDLE_DW_OP(0x8d, breg29)
+HANDLE_DW_OP(0x8e, breg30)
+HANDLE_DW_OP(0x8f, breg31)
+HANDLE_DW_OP(0x90, regx)
+HANDLE_DW_OP(0x91, fbreg)
+HANDLE_DW_OP(0x92, bregx)
+HANDLE_DW_OP(0x93, piece)
+HANDLE_DW_OP(0x94, deref_size)
+HANDLE_DW_OP(0x95, xderef_size)
+HANDLE_DW_OP(0x96, nop)
+HANDLE_DW_OP(0x97, push_object_address)
+HANDLE_DW_OP(0x98, call2)
+HANDLE_DW_OP(0x99, call4)
+HANDLE_DW_OP(0x9a, call_ref)
+HANDLE_DW_OP(0x9b, form_tls_address)
+HANDLE_DW_OP(0x9c, call_frame_cfa)
+HANDLE_DW_OP(0x9d, bit_piece)
+HANDLE_DW_OP(0x9e, implicit_value)
+HANDLE_DW_OP(0x9f, stack_value)
+
+// Extensions for GNU-style thread-local storage.
+HANDLE_DW_OP(0xe0, GNU_push_tls_address)
+
+// Extensions for Fission proposal.
+HANDLE_DW_OP(0xfb, GNU_addr_index)
+HANDLE_DW_OP(0xfc, GNU_const_index)
+
+// DWARF languages.
+HANDLE_DW_LANG(0x0001, C89)
+HANDLE_DW_LANG(0x0002, C)
+HANDLE_DW_LANG(0x0003, Ada83)
+HANDLE_DW_LANG(0x0004, C_plus_plus)
+HANDLE_DW_LANG(0x0005, Cobol74)
+HANDLE_DW_LANG(0x0006, Cobol85)
+HANDLE_DW_LANG(0x0007, Fortran77)
+HANDLE_DW_LANG(0x0008, Fortran90)
+HANDLE_DW_LANG(0x0009, Pascal83)
+HANDLE_DW_LANG(0x000a, Modula2)
+HANDLE_DW_LANG(0x000b, Java)
+HANDLE_DW_LANG(0x000c, C99)
+HANDLE_DW_LANG(0x000d, Ada95)
+HANDLE_DW_LANG(0x000e, Fortran95)
+HANDLE_DW_LANG(0x000f, PLI)
+HANDLE_DW_LANG(0x0010, ObjC)
+HANDLE_DW_LANG(0x0011, ObjC_plus_plus)
+HANDLE_DW_LANG(0x0012, UPC)
+HANDLE_DW_LANG(0x0013, D)
+
+// New in DWARF 5:
+HANDLE_DW_LANG(0x0014, Python)
+HANDLE_DW_LANG(0x0015, OpenCL)
+HANDLE_DW_LANG(0x0016, Go)
+HANDLE_DW_LANG(0x0017, Modula3)
+HANDLE_DW_LANG(0x0018, Haskell)
+HANDLE_DW_LANG(0x0019, C_plus_plus_03)
+HANDLE_DW_LANG(0x001a, C_plus_plus_11)
+HANDLE_DW_LANG(0x001b, OCaml)
+HANDLE_DW_LANG(0x001c, Rust)
+HANDLE_DW_LANG(0x001d, C11)
+HANDLE_DW_LANG(0x001e, Swift)
+HANDLE_DW_LANG(0x001f, Julia)
+HANDLE_DW_LANG(0x0020, Dylan)
+HANDLE_DW_LANG(0x0021, C_plus_plus_14)
+HANDLE_DW_LANG(0x0022, Fortran03)
+HANDLE_DW_LANG(0x0023, Fortran08)
+HANDLE_DW_LANG(0x8001, Mips_Assembler)
+HANDLE_DW_LANG(0xb000, BORLAND_Delphi)
+
+// DWARF attribute type encodings.
+HANDLE_DW_ATE(0x01, address)
+HANDLE_DW_ATE(0x02, boolean)
+HANDLE_DW_ATE(0x03, complex_float)
+HANDLE_DW_ATE(0x04, float)
+HANDLE_DW_ATE(0x05, signed)
+HANDLE_DW_ATE(0x06, signed_char)
+HANDLE_DW_ATE(0x07, unsigned)
+HANDLE_DW_ATE(0x08, unsigned_char)
+HANDLE_DW_ATE(0x09, imaginary_float)
+HANDLE_DW_ATE(0x0a, packed_decimal)
+HANDLE_DW_ATE(0x0b, numeric_string)
+HANDLE_DW_ATE(0x0c, edited)
+HANDLE_DW_ATE(0x0d, signed_fixed)
+HANDLE_DW_ATE(0x0e, unsigned_fixed)
+HANDLE_DW_ATE(0x0f, decimal_float)
+HANDLE_DW_ATE(0x10, UTF)
+
+// DWARF virtuality codes.
+HANDLE_DW_VIRTUALITY(0x00, none)
+HANDLE_DW_VIRTUALITY(0x01, virtual)
+HANDLE_DW_VIRTUALITY(0x02, pure_virtual)
+
+#undef HANDLE_DW_TAG
+#undef HANDLE_DW_OP
+#undef HANDLE_DW_LANG
+#undef HANDLE_DW_ATE
+#undef HANDLE_DW_VIRTUALITY

--- a/src/inc/llvm/Dwarf.h
+++ b/src/inc/llvm/Dwarf.h
@@ -1,0 +1,711 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// ==============================================================================
+// LLVM Release License
+// ==============================================================================
+// University of Illinois/NCSA
+// Open Source License
+//
+// Copyright (c) 2003-2015 University of Illinois at Urbana-Champaign.
+// All rights reserved.
+//
+// Developed by:
+//
+//     LLVM Team
+//
+//     University of Illinois at Urbana-Champaign
+//
+//     http://llvm.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal with
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is furnished to do
+// so, subject to the following conditions:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimers.
+//
+//     * Redistributions in binary form must reproduce the above copyright notice,
+//       this list of conditions and the following disclaimers in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the names of the LLVM Team, University of Illinois at
+//       Urbana-Champaign, nor the names of its contributors may be used to
+//       endorse or promote products derived from this Software without specific
+//       prior written permission.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
+// SOFTWARE.
+
+//===----------------------------------------------------------------------===//
+//
+// \file
+// \brief This file contains constants used for implementing Dwarf
+// debug support.
+//
+// For details on the Dwarf specfication see the latest DWARF Debugging
+// Information Format standard document on http://www.dwarfstd.org. This
+// file often includes support for non-released standard features.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_SUPPORT_DWARF_H
+#define LLVM_SUPPORT_DWARF_H
+
+//===----------------------------------------------------------------------===//
+// Dwarf constants as gleaned from the DWARF Debugging Information Format V.4
+// reference manual http://www.dwarfstd.org/.
+//
+
+// Do not mix the following two enumerations sets.  DW_TAG_invalid changes the
+// enumeration base type.
+
+enum LLVMConstants : uint32_t {
+  // LLVM mock tags (see also llvm/Support/Dwarf.def).
+  DW_TAG_invalid = ~0U,        // Tag for invalid results.
+  DW_VIRTUALITY_invalid = ~0U, // Virtuality for invalid results.
+  DW_MACINFO_invalid = ~0U,    // Macinfo type for invalid results.
+
+  // Other constants.
+  DWARF_VERSION = 4,       // Default dwarf version we output.
+  DW_PUBTYPES_VERSION = 2, // Section version number for .debug_pubtypes.
+  DW_PUBNAMES_VERSION = 2, // Section version number for .debug_pubnames.
+  DW_ARANGES_VERSION = 2   // Section version number for .debug_aranges.
+};
+
+// Special ID values that distinguish a CIE from a FDE in DWARF CFI.
+// Not inside an enum because a 64-bit value is needed.
+const uint32_t DW_CIE_ID = UINT32_MAX;
+const uint64_t DW64_CIE_ID = UINT64_MAX;
+
+enum Tag : uint16_t {
+#define HANDLE_DW_TAG(ID, NAME) DW_TAG_##NAME = ID,
+#include "Dwarf.def"
+  DW_TAG_lo_user = 0x4080,
+  DW_TAG_hi_user = 0xffff,
+  DW_TAG_user_base = 0x1000 // Recommended base for user tags.
+};
+
+inline bool isType(Tag T) {
+  switch (T) {
+  case DW_TAG_array_type:
+  case DW_TAG_class_type:
+  case DW_TAG_interface_type:
+  case DW_TAG_enumeration_type:
+  case DW_TAG_pointer_type:
+  case DW_TAG_reference_type:
+  case DW_TAG_rvalue_reference_type:
+  case DW_TAG_string_type:
+  case DW_TAG_structure_type:
+  case DW_TAG_subroutine_type:
+  case DW_TAG_union_type:
+  case DW_TAG_ptr_to_member_type:
+  case DW_TAG_set_type:
+  case DW_TAG_subrange_type:
+  case DW_TAG_base_type:
+  case DW_TAG_const_type:
+  case DW_TAG_file_type:
+  case DW_TAG_packed_type:
+  case DW_TAG_volatile_type:
+  case DW_TAG_typedef:
+    return true;
+  default:
+    return false;
+  }
+}
+
+enum Attribute : uint16_t {
+  // Attributes
+  DW_AT_sibling = 0x01,
+  DW_AT_location = 0x02,
+  DW_AT_name = 0x03,
+  DW_AT_ordering = 0x09,
+  DW_AT_byte_size = 0x0b,
+  DW_AT_bit_offset = 0x0c,
+  DW_AT_bit_size = 0x0d,
+  DW_AT_stmt_list = 0x10,
+  DW_AT_low_pc = 0x11,
+  DW_AT_high_pc = 0x12,
+  DW_AT_language = 0x13,
+  DW_AT_discr = 0x15,
+  DW_AT_discr_value = 0x16,
+  DW_AT_visibility = 0x17,
+  DW_AT_import = 0x18,
+  DW_AT_string_length = 0x19,
+  DW_AT_common_reference = 0x1a,
+  DW_AT_comp_dir = 0x1b,
+  DW_AT_const_value = 0x1c,
+  DW_AT_containing_type = 0x1d,
+  DW_AT_default_value = 0x1e,
+  DW_AT_inline = 0x20,
+  DW_AT_is_optional = 0x21,
+  DW_AT_lower_bound = 0x22,
+  DW_AT_producer = 0x25,
+  DW_AT_prototyped = 0x27,
+  DW_AT_return_addr = 0x2a,
+  DW_AT_start_scope = 0x2c,
+  DW_AT_bit_stride = 0x2e,
+  DW_AT_upper_bound = 0x2f,
+  DW_AT_abstract_origin = 0x31,
+  DW_AT_accessibility = 0x32,
+  DW_AT_address_class = 0x33,
+  DW_AT_artificial = 0x34,
+  DW_AT_base_types = 0x35,
+  DW_AT_calling_convention = 0x36,
+  DW_AT_count = 0x37,
+  DW_AT_data_member_location = 0x38,
+  DW_AT_decl_column = 0x39,
+  DW_AT_decl_file = 0x3a,
+  DW_AT_decl_line = 0x3b,
+  DW_AT_declaration = 0x3c,
+  DW_AT_discr_list = 0x3d,
+  DW_AT_encoding = 0x3e,
+  DW_AT_external = 0x3f,
+  DW_AT_frame_base = 0x40,
+  DW_AT_friend = 0x41,
+  DW_AT_identifier_case = 0x42,
+  DW_AT_macro_info = 0x43,
+  DW_AT_namelist_item = 0x44,
+  DW_AT_priority = 0x45,
+  DW_AT_segment = 0x46,
+  DW_AT_specification = 0x47,
+  DW_AT_static_link = 0x48,
+  DW_AT_type = 0x49,
+  DW_AT_use_location = 0x4a,
+  DW_AT_variable_parameter = 0x4b,
+  DW_AT_virtuality = 0x4c,
+  DW_AT_vtable_elem_location = 0x4d,
+  DW_AT_allocated = 0x4e,
+  DW_AT_associated = 0x4f,
+  DW_AT_data_location = 0x50,
+  DW_AT_byte_stride = 0x51,
+  DW_AT_entry_pc = 0x52,
+  DW_AT_use_UTF8 = 0x53,
+  DW_AT_extension = 0x54,
+  DW_AT_ranges = 0x55,
+  DW_AT_trampoline = 0x56,
+  DW_AT_call_column = 0x57,
+  DW_AT_call_file = 0x58,
+  DW_AT_call_line = 0x59,
+  DW_AT_description = 0x5a,
+  DW_AT_binary_scale = 0x5b,
+  DW_AT_decimal_scale = 0x5c,
+  DW_AT_small = 0x5d,
+  DW_AT_decimal_sign = 0x5e,
+  DW_AT_digit_count = 0x5f,
+  DW_AT_picture_string = 0x60,
+  DW_AT_mutable = 0x61,
+  DW_AT_threads_scaled = 0x62,
+  DW_AT_explicit = 0x63,
+  DW_AT_object_pointer = 0x64,
+  DW_AT_endianity = 0x65,
+  DW_AT_elemental = 0x66,
+  DW_AT_pure = 0x67,
+  DW_AT_recursive = 0x68,
+  DW_AT_signature = 0x69,
+  DW_AT_main_subprogram = 0x6a,
+  DW_AT_data_bit_offset = 0x6b,
+  DW_AT_const_expr = 0x6c,
+  DW_AT_enum_class = 0x6d,
+  DW_AT_linkage_name = 0x6e,
+
+  // New in DWARF 5:
+  DW_AT_string_length_bit_size = 0x6f,
+  DW_AT_string_length_byte_size = 0x70,
+  DW_AT_rank = 0x71,
+  DW_AT_str_offsets_base = 0x72,
+  DW_AT_addr_base = 0x73,
+  DW_AT_ranges_base = 0x74,
+  DW_AT_dwo_id = 0x75,
+  DW_AT_dwo_name = 0x76,
+  DW_AT_reference = 0x77,
+  DW_AT_rvalue_reference = 0x78,
+  DW_AT_macros = 0x79,
+
+  DW_AT_lo_user = 0x2000,
+  DW_AT_hi_user = 0x3fff,
+
+  DW_AT_MIPS_loop_begin = 0x2002,
+  DW_AT_MIPS_tail_loop_begin = 0x2003,
+  DW_AT_MIPS_epilog_begin = 0x2004,
+  DW_AT_MIPS_loop_unroll_factor = 0x2005,
+  DW_AT_MIPS_software_pipeline_depth = 0x2006,
+  DW_AT_MIPS_linkage_name = 0x2007,
+  DW_AT_MIPS_stride = 0x2008,
+  DW_AT_MIPS_abstract_name = 0x2009,
+  DW_AT_MIPS_clone_origin = 0x200a,
+  DW_AT_MIPS_has_inlines = 0x200b,
+  DW_AT_MIPS_stride_byte = 0x200c,
+  DW_AT_MIPS_stride_elem = 0x200d,
+  DW_AT_MIPS_ptr_dopetype = 0x200e,
+  DW_AT_MIPS_allocatable_dopetype = 0x200f,
+  DW_AT_MIPS_assumed_shape_dopetype = 0x2010,
+
+  // This one appears to have only been implemented by Open64 for
+  // fortran and may conflict with other extensions.
+  DW_AT_MIPS_assumed_size = 0x2011,
+
+  // GNU extensions
+  DW_AT_sf_names = 0x2101,
+  DW_AT_src_info = 0x2102,
+  DW_AT_mac_info = 0x2103,
+  DW_AT_src_coords = 0x2104,
+  DW_AT_body_begin = 0x2105,
+  DW_AT_body_end = 0x2106,
+  DW_AT_GNU_vector = 0x2107,
+  DW_AT_GNU_template_name = 0x2110,
+
+  DW_AT_GNU_odr_signature = 0x210f,
+  DW_AT_GNU_macros = 0x2119,
+
+  // Extensions for Fission proposal.
+  DW_AT_GNU_dwo_name = 0x2130,
+  DW_AT_GNU_dwo_id = 0x2131,
+  DW_AT_GNU_ranges_base = 0x2132,
+  DW_AT_GNU_addr_base = 0x2133,
+  DW_AT_GNU_pubnames = 0x2134,
+  DW_AT_GNU_pubtypes = 0x2135,
+  DW_AT_GNU_discriminator = 0x2136,
+
+  // Borland extensions.
+  DW_AT_BORLAND_property_read = 0x3b11,
+  DW_AT_BORLAND_property_write = 0x3b12,
+  DW_AT_BORLAND_property_implements = 0x3b13,
+  DW_AT_BORLAND_property_index = 0x3b14,
+  DW_AT_BORLAND_property_default = 0x3b15,
+  DW_AT_BORLAND_Delphi_unit = 0x3b20,
+  DW_AT_BORLAND_Delphi_class = 0x3b21,
+  DW_AT_BORLAND_Delphi_record = 0x3b22,
+  DW_AT_BORLAND_Delphi_metaclass = 0x3b23,
+  DW_AT_BORLAND_Delphi_constructor = 0x3b24,
+  DW_AT_BORLAND_Delphi_destructor = 0x3b25,
+  DW_AT_BORLAND_Delphi_anonymous_method = 0x3b26,
+  DW_AT_BORLAND_Delphi_interface = 0x3b27,
+  DW_AT_BORLAND_Delphi_ABI = 0x3b28,
+  DW_AT_BORLAND_Delphi_return = 0x3b29,
+  DW_AT_BORLAND_Delphi_frameptr = 0x3b30,
+  DW_AT_BORLAND_closure = 0x3b31,
+
+  // LLVM project extensions.
+  DW_AT_LLVM_include_path = 0x3e00,
+  DW_AT_LLVM_config_macros = 0x3e01,
+  DW_AT_LLVM_isysroot = 0x3e02,
+
+  // Apple extensions.
+  DW_AT_APPLE_optimized = 0x3fe1,
+  DW_AT_APPLE_flags = 0x3fe2,
+  DW_AT_APPLE_isa = 0x3fe3,
+  DW_AT_APPLE_block = 0x3fe4,
+  DW_AT_APPLE_major_runtime_vers = 0x3fe5,
+  DW_AT_APPLE_runtime_class = 0x3fe6,
+  DW_AT_APPLE_omit_frame_ptr = 0x3fe7,
+  DW_AT_APPLE_property_name = 0x3fe8,
+  DW_AT_APPLE_property_getter = 0x3fe9,
+  DW_AT_APPLE_property_setter = 0x3fea,
+  DW_AT_APPLE_property_attribute = 0x3feb,
+  DW_AT_APPLE_objc_complete_type = 0x3fec,
+  DW_AT_APPLE_property = 0x3fed
+};
+
+enum Form : uint16_t {
+  // Attribute form encodings
+  DW_FORM_addr = 0x01,
+  DW_FORM_block2 = 0x03,
+  DW_FORM_block4 = 0x04,
+  DW_FORM_data2 = 0x05,
+  DW_FORM_data4 = 0x06,
+  DW_FORM_data8 = 0x07,
+  DW_FORM_string = 0x08,
+  DW_FORM_block = 0x09,
+  DW_FORM_block1 = 0x0a,
+  DW_FORM_data1 = 0x0b,
+  DW_FORM_flag = 0x0c,
+  DW_FORM_sdata = 0x0d,
+  DW_FORM_strp = 0x0e,
+  DW_FORM_udata = 0x0f,
+  DW_FORM_ref_addr = 0x10,
+  DW_FORM_ref1 = 0x11,
+  DW_FORM_ref2 = 0x12,
+  DW_FORM_ref4 = 0x13,
+  DW_FORM_ref8 = 0x14,
+  DW_FORM_ref_udata = 0x15,
+  DW_FORM_indirect = 0x16,
+  DW_FORM_sec_offset = 0x17,
+  DW_FORM_exprloc = 0x18,
+  DW_FORM_flag_present = 0x19,
+  DW_FORM_ref_sig8 = 0x20,
+
+  // Extensions for Fission proposal
+  DW_FORM_GNU_addr_index = 0x1f01,
+  DW_FORM_GNU_str_index = 0x1f02,
+
+  // Alternate debug sections proposal (output of "dwz" tool).
+  DW_FORM_GNU_ref_alt = 0x1f20,
+  DW_FORM_GNU_strp_alt = 0x1f21
+};
+
+enum LocationAtom {
+#define HANDLE_DW_OP(ID, NAME) DW_OP_##NAME = ID,
+#include "Dwarf.def"
+  DW_OP_lo_user = 0xe0,
+  DW_OP_hi_user = 0xff
+};
+
+enum TypeKind {
+#define HANDLE_DW_ATE(ID, NAME) DW_ATE_##NAME = ID,
+#include "Dwarf.def"
+  DW_ATE_lo_user = 0x80,
+  DW_ATE_hi_user = 0xff
+};
+
+enum DecimalSignEncoding {
+  // Decimal sign attribute values
+  DW_DS_unsigned = 0x01,
+  DW_DS_leading_overpunch = 0x02,
+  DW_DS_trailing_overpunch = 0x03,
+  DW_DS_leading_separate = 0x04,
+  DW_DS_trailing_separate = 0x05
+};
+
+enum EndianityEncoding {
+  // Endianity attribute values
+  DW_END_default = 0x00,
+  DW_END_big = 0x01,
+  DW_END_little = 0x02,
+  DW_END_lo_user = 0x40,
+  DW_END_hi_user = 0xff
+};
+
+enum AccessAttribute {
+  // Accessibility codes
+  DW_ACCESS_public = 0x01,
+  DW_ACCESS_protected = 0x02,
+  DW_ACCESS_private = 0x03
+};
+
+enum VisibilityAttribute {
+  // Visibility codes
+  DW_VIS_local = 0x01,
+  DW_VIS_exported = 0x02,
+  DW_VIS_qualified = 0x03
+};
+
+enum VirtualityAttribute {
+#define HANDLE_DW_VIRTUALITY(ID, NAME) DW_VIRTUALITY_##NAME = ID,
+#include "Dwarf.def"
+  DW_VIRTUALITY_max = 0x02
+};
+
+enum SourceLanguage {
+#define HANDLE_DW_LANG(ID, NAME) DW_LANG_##NAME = ID,
+#include "Dwarf.def"
+  DW_LANG_lo_user = 0x8000,
+  DW_LANG_hi_user = 0xffff
+};
+
+enum CaseSensitivity {
+  // Identifier case codes
+  DW_ID_case_sensitive = 0x00,
+  DW_ID_up_case = 0x01,
+  DW_ID_down_case = 0x02,
+  DW_ID_case_insensitive = 0x03
+};
+
+enum CallingConvention {
+  // Calling convention codes
+  DW_CC_normal = 0x01,
+  DW_CC_program = 0x02,
+  DW_CC_nocall = 0x03,
+  DW_CC_lo_user = 0x40,
+  DW_CC_GNU_borland_fastcall_i386 = 0x41,
+  DW_CC_BORLAND_safecall = 0xb0,
+  DW_CC_BORLAND_stdcall = 0xb1,
+  DW_CC_BORLAND_pascal = 0xb2,
+  DW_CC_BORLAND_msfastcall = 0xb3,
+  DW_CC_BORLAND_msreturn = 0xb4,
+  DW_CC_BORLAND_thiscall = 0xb5,
+  DW_CC_BORLAND_fastcall = 0xb6,
+  DW_CC_hi_user = 0xff
+};
+
+enum InlineAttribute {
+  // Inline codes
+  DW_INL_not_inlined = 0x00,
+  DW_INL_inlined = 0x01,
+  DW_INL_declared_not_inlined = 0x02,
+  DW_INL_declared_inlined = 0x03
+};
+
+enum ArrayDimensionOrdering {
+  // Array ordering
+  DW_ORD_row_major = 0x00,
+  DW_ORD_col_major = 0x01
+};
+
+enum DiscriminantList {
+  // Discriminant descriptor values
+  DW_DSC_label = 0x00,
+  DW_DSC_range = 0x01
+};
+
+enum LineNumberOps {
+  // Line Number Standard Opcode Encodings
+  DW_LNS_extended_op = 0x00,
+  DW_LNS_copy = 0x01,
+  DW_LNS_advance_pc = 0x02,
+  DW_LNS_advance_line = 0x03,
+  DW_LNS_set_file = 0x04,
+  DW_LNS_set_column = 0x05,
+  DW_LNS_negate_stmt = 0x06,
+  DW_LNS_set_basic_block = 0x07,
+  DW_LNS_const_add_pc = 0x08,
+  DW_LNS_fixed_advance_pc = 0x09,
+  DW_LNS_set_prologue_end = 0x0a,
+  DW_LNS_set_epilogue_begin = 0x0b,
+  DW_LNS_set_isa = 0x0c
+};
+
+enum LineNumberExtendedOps {
+  // Line Number Extended Opcode Encodings
+  DW_LNE_end_sequence = 0x01,
+  DW_LNE_set_address = 0x02,
+  DW_LNE_define_file = 0x03,
+  DW_LNE_set_discriminator = 0x04,
+  DW_LNE_lo_user = 0x80,
+  DW_LNE_hi_user = 0xff
+};
+
+enum MacinfoRecordType {
+  // Macinfo Type Encodings
+  DW_MACINFO_define = 0x01,
+  DW_MACINFO_undef = 0x02,
+  DW_MACINFO_start_file = 0x03,
+  DW_MACINFO_end_file = 0x04,
+  DW_MACINFO_vendor_ext = 0xff
+};
+
+enum MacroEntryType {
+  // Macro Information Entry Type Encodings
+  DW_MACRO_define = 0x01,
+  DW_MACRO_undef = 0x02,
+  DW_MACRO_start_file = 0x03,
+  DW_MACRO_end_file = 0x04,
+  DW_MACRO_define_indirect = 0x05,
+  DW_MACRO_undef_indirect = 0x06,
+  DW_MACRO_transparent_include = 0x07,
+  DW_MACRO_define_indirect_sup = 0x08,
+  DW_MACRO_undef_indirect_sup = 0x09,
+  DW_MACRO_transparent_include_sup = 0x0a,
+  DW_MACRO_define_indirectx = 0x0b,
+  DW_MACRO_undef_indirectx = 0x0c,
+  DW_MACRO_lo_user = 0xe0,
+  DW_MACRO_hi_user = 0xff
+};
+
+enum CallFrameInfo {
+  // Call frame instruction encodings
+  DW_CFA_extended = 0x00,
+  DW_CFA_nop = 0x00,
+  DW_CFA_advance_loc = 0x40,
+  DW_CFA_offset = 0x80,
+  DW_CFA_restore = 0xc0,
+  DW_CFA_set_loc = 0x01,
+  DW_CFA_advance_loc1 = 0x02,
+  DW_CFA_advance_loc2 = 0x03,
+  DW_CFA_advance_loc4 = 0x04,
+  DW_CFA_offset_extended = 0x05,
+  DW_CFA_restore_extended = 0x06,
+  DW_CFA_undefined = 0x07,
+  DW_CFA_same_value = 0x08,
+  DW_CFA_register = 0x09,
+  DW_CFA_remember_state = 0x0a,
+  DW_CFA_restore_state = 0x0b,
+  DW_CFA_def_cfa = 0x0c,
+  DW_CFA_def_cfa_register = 0x0d,
+  DW_CFA_def_cfa_offset = 0x0e,
+  DW_CFA_def_cfa_expression = 0x0f,
+  DW_CFA_expression = 0x10,
+  DW_CFA_offset_extended_sf = 0x11,
+  DW_CFA_def_cfa_sf = 0x12,
+  DW_CFA_def_cfa_offset_sf = 0x13,
+  DW_CFA_val_offset = 0x14,
+  DW_CFA_val_offset_sf = 0x15,
+  DW_CFA_val_expression = 0x16,
+  DW_CFA_MIPS_advance_loc8 = 0x1d,
+  DW_CFA_GNU_window_save = 0x2d,
+  DW_CFA_GNU_args_size = 0x2e,
+  DW_CFA_lo_user = 0x1c,
+  DW_CFA_hi_user = 0x3f
+};
+
+enum Constants {
+  // Children flag
+  DW_CHILDREN_no = 0x00,
+  DW_CHILDREN_yes = 0x01,
+
+  DW_EH_PE_absptr = 0x00,
+  DW_EH_PE_omit = 0xff,
+  DW_EH_PE_uleb128 = 0x01,
+  DW_EH_PE_udata2 = 0x02,
+  DW_EH_PE_udata4 = 0x03,
+  DW_EH_PE_udata8 = 0x04,
+  DW_EH_PE_sleb128 = 0x09,
+  DW_EH_PE_sdata2 = 0x0A,
+  DW_EH_PE_sdata4 = 0x0B,
+  DW_EH_PE_sdata8 = 0x0C,
+  DW_EH_PE_signed = 0x08,
+  DW_EH_PE_pcrel = 0x10,
+  DW_EH_PE_textrel = 0x20,
+  DW_EH_PE_datarel = 0x30,
+  DW_EH_PE_funcrel = 0x40,
+  DW_EH_PE_aligned = 0x50,
+  DW_EH_PE_indirect = 0x80
+};
+
+// Constants for debug_loc.dwo in the DWARF5 Split Debug Info Proposal
+enum LocationListEntry : unsigned char {
+  DW_LLE_end_of_list_entry,
+  DW_LLE_base_address_selection_entry,
+  DW_LLE_start_end_entry,
+  DW_LLE_start_length_entry,
+  DW_LLE_offset_pair_entry
+};
+
+/// Contstants for the DW_APPLE_PROPERTY_attributes attribute.
+/// Keep this list in sync with clang's DeclSpec.h ObjCPropertyAttributeKind.
+enum ApplePropertyAttributes {
+  // Apple Objective-C Property Attributes
+  DW_APPLE_PROPERTY_readonly = 0x01,
+  DW_APPLE_PROPERTY_getter = 0x02,
+  DW_APPLE_PROPERTY_assign = 0x04,
+  DW_APPLE_PROPERTY_readwrite = 0x08,
+  DW_APPLE_PROPERTY_retain = 0x10,
+  DW_APPLE_PROPERTY_copy = 0x20,
+  DW_APPLE_PROPERTY_nonatomic = 0x40,
+  DW_APPLE_PROPERTY_setter = 0x80,
+  DW_APPLE_PROPERTY_atomic = 0x100,
+  DW_APPLE_PROPERTY_weak =   0x200,
+  DW_APPLE_PROPERTY_strong = 0x400,
+  DW_APPLE_PROPERTY_unsafe_unretained = 0x800
+};
+
+// Constants for the DWARF5 Accelerator Table Proposal
+enum AcceleratorTable {
+  // Data layout descriptors.
+  DW_ATOM_null = 0u,       // Marker as the end of a list of atoms.
+  DW_ATOM_die_offset = 1u, // DIE offset in the debug_info section.
+  DW_ATOM_cu_offset = 2u, // Offset of the compile unit header that contains the
+                          // item in question.
+  DW_ATOM_die_tag = 3u,   // A tag entry.
+  DW_ATOM_type_flags = 4u, // Set of flags for a type.
+
+  // DW_ATOM_type_flags values.
+
+  // Always set for C++, only set for ObjC if this is the @implementation for a
+  // class.
+  DW_FLAG_type_implementation = 2u,
+
+  // Hash functions.
+
+  // Daniel J. Bernstein hash.
+  DW_hash_function_djb = 0u
+};
+
+// Constants for the GNU pubnames/pubtypes extensions supporting gdb index.
+enum GDBIndexEntryKind {
+  GIEK_NONE,
+  GIEK_TYPE,
+  GIEK_VARIABLE,
+  GIEK_FUNCTION,
+  GIEK_OTHER,
+  GIEK_UNUSED5,
+  GIEK_UNUSED6,
+  GIEK_UNUSED7
+};
+
+enum GDBIndexEntryLinkage {
+  GIEL_EXTERNAL,
+  GIEL_STATIC
+};
+
+/// \defgroup DwarfConstantsDumping Dwarf constants dumping functions
+///
+/// All these functions map their argument's value back to the
+/// corresponding enumerator name or return nullptr if the value isn't
+/// known.
+///
+/// @{
+const char *TagString(unsigned Tag);
+const char *ChildrenString(unsigned Children);
+const char *AttributeString(unsigned Attribute);
+const char *FormEncodingString(unsigned Encoding);
+const char *OperationEncodingString(unsigned Encoding);
+const char *AttributeEncodingString(unsigned Encoding);
+const char *DecimalSignString(unsigned Sign);
+const char *EndianityString(unsigned Endian);
+const char *AccessibilityString(unsigned Access);
+const char *VisibilityString(unsigned Visibility);
+const char *VirtualityString(unsigned Virtuality);
+const char *LanguageString(unsigned Language);
+const char *CaseString(unsigned Case);
+const char *ConventionString(unsigned Convention);
+const char *InlineCodeString(unsigned Code);
+const char *ArrayOrderString(unsigned Order);
+const char *DiscriminantString(unsigned Discriminant);
+const char *LNStandardString(unsigned Standard);
+const char *LNExtendedString(unsigned Encoding);
+const char *MacinfoString(unsigned Encoding);
+const char *CallFrameString(unsigned Encoding);
+const char *ApplePropertyString(unsigned);
+const char *AtomTypeString(unsigned Atom);
+const char *GDBIndexEntryKindString(GDBIndexEntryKind Kind);
+const char *GDBIndexEntryLinkageString(GDBIndexEntryLinkage Linkage);
+/// @}
+
+/// \brief Returns the symbolic string representing Val when used as a value
+/// for attribute Attr.
+const char *AttributeValueString(uint16_t Attr, unsigned Val);
+
+/// \brief Decsribes an entry of the various gnu_pub* debug sections.
+///
+/// The gnu_pub* kind looks like:
+///
+/// 0-3  reserved
+/// 4-6  symbol kind
+/// 7    0 == global, 1 == static
+///
+/// A gdb_index descriptor includes the above kind, shifted 24 bits up with the
+/// offset of the cu within the debug_info section stored in those 24 bits.
+struct PubIndexEntryDescriptor {
+  GDBIndexEntryKind Kind;
+  GDBIndexEntryLinkage Linkage;
+  PubIndexEntryDescriptor(GDBIndexEntryKind Kind, GDBIndexEntryLinkage Linkage)
+      : Kind(Kind), Linkage(Linkage) {}
+  /* implicit */ PubIndexEntryDescriptor(GDBIndexEntryKind Kind)
+      : Kind(Kind), Linkage(GIEL_EXTERNAL) {}
+  explicit PubIndexEntryDescriptor(uint8_t Value)
+      : Kind(static_cast<GDBIndexEntryKind>((Value & KIND_MASK) >>
+                                            KIND_OFFSET)),
+        Linkage(static_cast<GDBIndexEntryLinkage>((Value & LINKAGE_MASK) >>
+                                                  LINKAGE_OFFSET)) {}
+  uint8_t toBits() { return Kind << KIND_OFFSET | Linkage << LINKAGE_OFFSET; }
+
+private:
+  enum {
+    KIND_OFFSET = 4,
+    KIND_MASK = 7 << KIND_OFFSET,
+    LINKAGE_OFFSET = 7,
+    LINKAGE_MASK = 1 << LINKAGE_OFFSET
+  };
+};
+
+#endif

--- a/src/inc/llvm/ELF.h
+++ b/src/inc/llvm/ELF.h
@@ -1,0 +1,1273 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// ==============================================================================
+// LLVM Release License
+// ==============================================================================
+// University of Illinois/NCSA
+// Open Source License
+//
+// Copyright (c) 2003-2015 University of Illinois at Urbana-Champaign.
+// All rights reserved.
+//
+// Developed by:
+//
+//     LLVM Team
+//
+//     University of Illinois at Urbana-Champaign
+//
+//     http://llvm.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal with
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is furnished to do
+// so, subject to the following conditions:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimers.
+//
+//     * Redistributions in binary form must reproduce the above copyright notice,
+//       this list of conditions and the following disclaimers in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the names of the LLVM Team, University of Illinois at
+//       Urbana-Champaign, nor the names of its contributors may be used to
+//       endorse or promote products derived from this Software without specific
+//       prior written permission.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
+// SOFTWARE.
+
+//===----------------------------------------------------------------------===//
+// This header contains common, non-processor-specific data structures and
+// constants for the ELF file format.
+//
+// The details of the ELF32 bits in this file are largely based on the Tool
+// Interface Standard (TIS) Executable and Linking Format (ELF) Specification
+// Version 1.2, May 1995. The ELF64 stuff is based on ELF-64 Object File Format
+// Version 1.5, Draft 2, May 1998 as well as OpenBSD header files.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_SUPPORT_ELF_H
+#define LLVM_SUPPORT_ELF_H
+
+typedef uint32_t Elf32_Addr; // Program address
+typedef uint32_t Elf32_Off;  // File offset
+typedef uint16_t Elf32_Half;
+typedef uint32_t Elf32_Word;
+typedef int32_t  Elf32_Sword;
+
+typedef uint64_t Elf64_Addr;
+typedef uint64_t Elf64_Off;
+typedef uint16_t Elf64_Half;
+typedef uint32_t Elf64_Word;
+typedef int32_t  Elf64_Sword;
+typedef uint64_t Elf64_Xword;
+typedef int64_t  Elf64_Sxword;
+
+// Object file magic string.
+static const char ElfMagic[] = { 0x7f, 'E', 'L', 'F', '\0' };
+
+// e_ident size and indices.
+enum {
+  EI_MAG0       = 0,          // File identification index.
+  EI_MAG1       = 1,          // File identification index.
+  EI_MAG2       = 2,          // File identification index.
+  EI_MAG3       = 3,          // File identification index.
+  EI_CLASS      = 4,          // File class.
+  EI_DATA       = 5,          // Data encoding.
+  EI_VERSION    = 6,          // File version.
+  EI_OSABI      = 7,          // OS/ABI identification.
+  EI_ABIVERSION = 8,          // ABI version.
+  EI_PAD        = 9,          // Start of padding bytes.
+  EI_NIDENT     = 16          // Number of bytes in e_ident.
+};
+
+struct Elf32_Ehdr {
+  unsigned char e_ident[EI_NIDENT]; // ELF Identification bytes
+  Elf32_Half    e_type;      // Type of file (see ET_* below)
+  Elf32_Half    e_machine;   // Required architecture for this file (see EM_*)
+  Elf32_Word    e_version;   // Must be equal to 1
+  Elf32_Addr    e_entry;     // Address to jump to in order to start program
+  Elf32_Off     e_phoff;     // Program header table's file offset, in bytes
+  Elf32_Off     e_shoff;     // Section header table's file offset, in bytes
+  Elf32_Word    e_flags;     // Processor-specific flags
+  Elf32_Half    e_ehsize;    // Size of ELF header, in bytes
+  Elf32_Half    e_phentsize; // Size of an entry in the program header table
+  Elf32_Half    e_phnum;     // Number of entries in the program header table
+  Elf32_Half    e_shentsize; // Size of an entry in the section header table
+  Elf32_Half    e_shnum;     // Number of entries in the section header table
+  Elf32_Half    e_shstrndx;  // Sect hdr table index of sect name string table
+  bool checkMagic() const {
+    return (memcmp(e_ident, ElfMagic, strlen(ElfMagic))) == 0;
+  }
+  unsigned char getFileClass() const { return e_ident[EI_CLASS]; }
+  unsigned char getDataEncoding() const { return e_ident[EI_DATA]; }
+  Elf32_Ehdr();
+};
+
+// 64-bit ELF header. Fields are the same as for ELF32, but with different
+// types (see above).
+struct Elf64_Ehdr {
+  unsigned char e_ident[EI_NIDENT];
+  Elf64_Half    e_type;
+  Elf64_Half    e_machine;
+  Elf64_Word    e_version;
+  Elf64_Addr    e_entry;
+  Elf64_Off     e_phoff;
+  Elf64_Off     e_shoff;
+  Elf64_Word    e_flags;
+  Elf64_Half    e_ehsize;
+  Elf64_Half    e_phentsize;
+  Elf64_Half    e_phnum;
+  Elf64_Half    e_shentsize;
+  Elf64_Half    e_shnum;
+  Elf64_Half    e_shstrndx;
+  bool checkMagic() const {
+    return (memcmp(e_ident, ElfMagic, strlen(ElfMagic))) == 0;
+  }
+  unsigned char getFileClass() const { return e_ident[EI_CLASS]; }
+  unsigned char getDataEncoding() const { return e_ident[EI_DATA]; }
+  Elf64_Ehdr();
+};
+
+// File types
+enum {
+  ET_NONE   = 0,      // No file type
+  ET_REL    = 1,      // Relocatable file
+  ET_EXEC   = 2,      // Executable file
+  ET_DYN    = 3,      // Shared object file
+  ET_CORE   = 4,      // Core file
+  ET_LOPROC = 0xff00, // Beginning of processor-specific codes
+  ET_HIPROC = 0xffff  // Processor-specific
+};
+
+// Versioning
+enum {
+  EV_NONE = 0,
+  EV_CURRENT = 1
+};
+
+// Machine architectures
+// See current registered ELF machine architectures at:
+//    http://www.uxsglobal.com/developers/gabi/latest/ch4.eheader.html
+enum {
+  EM_NONE          = 0, // No machine
+  EM_M32           = 1, // AT&T WE 32100
+  EM_SPARC         = 2, // SPARC
+  EM_386           = 3, // Intel 386
+  EM_68K           = 4, // Motorola 68000
+  EM_88K           = 5, // Motorola 88000
+  EM_IAMCU         = 6, // Intel MCU
+  EM_860           = 7, // Intel 80860
+  EM_MIPS          = 8, // MIPS R3000
+  EM_S370          = 9, // IBM System/370
+  EM_MIPS_RS3_LE   = 10, // MIPS RS3000 Little-endian
+  EM_PARISC        = 15, // Hewlett-Packard PA-RISC
+  EM_VPP500        = 17, // Fujitsu VPP500
+  EM_SPARC32PLUS   = 18, // Enhanced instruction set SPARC
+  EM_960           = 19, // Intel 80960
+  EM_PPC           = 20, // PowerPC
+  EM_PPC64         = 21, // PowerPC64
+  EM_S390          = 22, // IBM System/390
+  EM_SPU           = 23, // IBM SPU/SPC
+  EM_V800          = 36, // NEC V800
+  EM_FR20          = 37, // Fujitsu FR20
+  EM_RH32          = 38, // TRW RH-32
+  EM_RCE           = 39, // Motorola RCE
+  EM_ARM           = 40, // ARM
+  EM_ALPHA         = 41, // DEC Alpha
+  EM_SH            = 42, // Hitachi SH
+  EM_SPARCV9       = 43, // SPARC V9
+  EM_TRICORE       = 44, // Siemens TriCore
+  EM_ARC           = 45, // Argonaut RISC Core
+  EM_H8_300        = 46, // Hitachi H8/300
+  EM_H8_300H       = 47, // Hitachi H8/300H
+  EM_H8S           = 48, // Hitachi H8S
+  EM_H8_500        = 49, // Hitachi H8/500
+  EM_IA_64         = 50, // Intel IA-64 processor architecture
+  EM_MIPS_X        = 51, // Stanford MIPS-X
+  EM_COLDFIRE      = 52, // Motorola ColdFire
+  EM_68HC12        = 53, // Motorola M68HC12
+  EM_MMA           = 54, // Fujitsu MMA Multimedia Accelerator
+  EM_PCP           = 55, // Siemens PCP
+  EM_NCPU          = 56, // Sony nCPU embedded RISC processor
+  EM_NDR1          = 57, // Denso NDR1 microprocessor
+  EM_STARCORE      = 58, // Motorola Star*Core processor
+  EM_ME16          = 59, // Toyota ME16 processor
+  EM_ST100         = 60, // STMicroelectronics ST100 processor
+  EM_TINYJ         = 61, // Advanced Logic Corp. TinyJ embedded processor family
+  EM_X86_64        = 62, // AMD x86-64 architecture
+  EM_PDSP          = 63, // Sony DSP Processor
+  EM_PDP10         = 64, // Digital Equipment Corp. PDP-10
+  EM_PDP11         = 65, // Digital Equipment Corp. PDP-11
+  EM_FX66          = 66, // Siemens FX66 microcontroller
+  EM_ST9PLUS       = 67, // STMicroelectronics ST9+ 8/16 bit microcontroller
+  EM_ST7           = 68, // STMicroelectronics ST7 8-bit microcontroller
+  EM_68HC16        = 69, // Motorola MC68HC16 Microcontroller
+  EM_68HC11        = 70, // Motorola MC68HC11 Microcontroller
+  EM_68HC08        = 71, // Motorola MC68HC08 Microcontroller
+  EM_68HC05        = 72, // Motorola MC68HC05 Microcontroller
+  EM_SVX           = 73, // Silicon Graphics SVx
+  EM_ST19          = 74, // STMicroelectronics ST19 8-bit microcontroller
+  EM_VAX           = 75, // Digital VAX
+  EM_CRIS          = 76, // Axis Communications 32-bit embedded processor
+  EM_JAVELIN       = 77, // Infineon Technologies 32-bit embedded processor
+  EM_FIREPATH      = 78, // Element 14 64-bit DSP Processor
+  EM_ZSP           = 79, // LSI Logic 16-bit DSP Processor
+  EM_MMIX          = 80, // Donald Knuth's educational 64-bit processor
+  EM_HUANY         = 81, // Harvard University machine-independent object files
+  EM_PRISM         = 82, // SiTera Prism
+  EM_AVR           = 83, // Atmel AVR 8-bit microcontroller
+  EM_FR30          = 84, // Fujitsu FR30
+  EM_D10V          = 85, // Mitsubishi D10V
+  EM_D30V          = 86, // Mitsubishi D30V
+  EM_V850          = 87, // NEC v850
+  EM_M32R          = 88, // Mitsubishi M32R
+  EM_MN10300       = 89, // Matsushita MN10300
+  EM_MN10200       = 90, // Matsushita MN10200
+  EM_PJ            = 91, // picoJava
+  EM_OPENRISC      = 92, // OpenRISC 32-bit embedded processor
+  EM_ARC_COMPACT   = 93, // ARC International ARCompact processor (old
+                         // spelling/synonym: EM_ARC_A5)
+  EM_XTENSA        = 94, // Tensilica Xtensa Architecture
+  EM_VIDEOCORE     = 95, // Alphamosaic VideoCore processor
+  EM_TMM_GPP       = 96, // Thompson Multimedia General Purpose Processor
+  EM_NS32K         = 97, // National Semiconductor 32000 series
+  EM_TPC           = 98, // Tenor Network TPC processor
+  EM_SNP1K         = 99, // Trebia SNP 1000 processor
+  EM_ST200         = 100, // STMicroelectronics (www.st.com) ST200
+  EM_IP2K          = 101, // Ubicom IP2xxx microcontroller family
+  EM_MAX           = 102, // MAX Processor
+  EM_CR            = 103, // National Semiconductor CompactRISC microprocessor
+  EM_F2MC16        = 104, // Fujitsu F2MC16
+  EM_MSP430        = 105, // Texas Instruments embedded microcontroller msp430
+  EM_BLACKFIN      = 106, // Analog Devices Blackfin (DSP) processor
+  EM_SE_C33        = 107, // S1C33 Family of Seiko Epson processors
+  EM_SEP           = 108, // Sharp embedded microprocessor
+  EM_ARCA          = 109, // Arca RISC Microprocessor
+  EM_UNICORE       = 110, // Microprocessor series from PKU-Unity Ltd. and MPRC
+                          // of Peking University
+  EM_EXCESS        = 111, // eXcess: 16/32/64-bit configurable embedded CPU
+  EM_DXP           = 112, // Icera Semiconductor Inc. Deep Execution Processor
+  EM_ALTERA_NIOS2  = 113, // Altera Nios II soft-core processor
+  EM_CRX           = 114, // National Semiconductor CompactRISC CRX
+  EM_XGATE         = 115, // Motorola XGATE embedded processor
+  EM_C166          = 116, // Infineon C16x/XC16x processor
+  EM_M16C          = 117, // Renesas M16C series microprocessors
+  EM_DSPIC30F      = 118, // Microchip Technology dsPIC30F Digital Signal
+                          // Controller
+  EM_CE            = 119, // Freescale Communication Engine RISC core
+  EM_M32C          = 120, // Renesas M32C series microprocessors
+  EM_TSK3000       = 131, // Altium TSK3000 core
+  EM_RS08          = 132, // Freescale RS08 embedded processor
+  EM_SHARC         = 133, // Analog Devices SHARC family of 32-bit DSP
+                          // processors
+  EM_ECOG2         = 134, // Cyan Technology eCOG2 microprocessor
+  EM_SCORE7        = 135, // Sunplus S+core7 RISC processor
+  EM_DSP24         = 136, // New Japan Radio (NJR) 24-bit DSP Processor
+  EM_VIDEOCORE3    = 137, // Broadcom VideoCore III processor
+  EM_LATTICEMICO32 = 138, // RISC processor for Lattice FPGA architecture
+  EM_SE_C17        = 139, // Seiko Epson C17 family
+  EM_TI_C6000      = 140, // The Texas Instruments TMS320C6000 DSP family
+  EM_TI_C2000      = 141, // The Texas Instruments TMS320C2000 DSP family
+  EM_TI_C5500      = 142, // The Texas Instruments TMS320C55x DSP family
+  EM_MMDSP_PLUS    = 160, // STMicroelectronics 64bit VLIW Data Signal Processor
+  EM_CYPRESS_M8C   = 161, // Cypress M8C microprocessor
+  EM_R32C          = 162, // Renesas R32C series microprocessors
+  EM_TRIMEDIA      = 163, // NXP Semiconductors TriMedia architecture family
+  EM_HEXAGON       = 164, // Qualcomm Hexagon processor
+  EM_8051          = 165, // Intel 8051 and variants
+  EM_STXP7X        = 166, // STMicroelectronics STxP7x family of configurable
+                          // and extensible RISC processors
+  EM_NDS32         = 167, // Andes Technology compact code size embedded RISC
+                          // processor family
+  EM_ECOG1         = 168, // Cyan Technology eCOG1X family
+  EM_ECOG1X        = 168, // Cyan Technology eCOG1X family
+  EM_MAXQ30        = 169, // Dallas Semiconductor MAXQ30 Core Micro-controllers
+  EM_XIMO16        = 170, // New Japan Radio (NJR) 16-bit DSP Processor
+  EM_MANIK         = 171, // M2000 Reconfigurable RISC Microprocessor
+  EM_CRAYNV2       = 172, // Cray Inc. NV2 vector architecture
+  EM_RX            = 173, // Renesas RX family
+  EM_METAG         = 174, // Imagination Technologies META processor
+                          // architecture
+  EM_MCST_ELBRUS   = 175, // MCST Elbrus general purpose hardware architecture
+  EM_ECOG16        = 176, // Cyan Technology eCOG16 family
+  EM_CR16          = 177, // National Semiconductor CompactRISC CR16 16-bit
+                          // microprocessor
+  EM_ETPU          = 178, // Freescale Extended Time Processing Unit
+  EM_SLE9X         = 179, // Infineon Technologies SLE9X core
+  EM_L10M          = 180, // Intel L10M
+  EM_K10M          = 181, // Intel K10M
+  EM_AARCH64       = 183, // ARM AArch64
+  EM_AVR32         = 185, // Atmel Corporation 32-bit microprocessor family
+  EM_STM8          = 186, // STMicroeletronics STM8 8-bit microcontroller
+  EM_TILE64        = 187, // Tilera TILE64 multicore architecture family
+  EM_TILEPRO       = 188, // Tilera TILEPro multicore architecture family
+  EM_CUDA          = 190, // NVIDIA CUDA architecture
+  EM_TILEGX        = 191, // Tilera TILE-Gx multicore architecture family
+  EM_CLOUDSHIELD   = 192, // CloudShield architecture family
+  EM_COREA_1ST     = 193, // KIPO-KAIST Core-A 1st generation processor family
+  EM_COREA_2ND     = 194, // KIPO-KAIST Core-A 2nd generation processor family
+  EM_ARC_COMPACT2  = 195, // Synopsys ARCompact V2
+  EM_OPEN8         = 196, // Open8 8-bit RISC soft processor core
+  EM_RL78          = 197, // Renesas RL78 family
+  EM_VIDEOCORE5    = 198, // Broadcom VideoCore V processor
+  EM_78KOR         = 199, // Renesas 78KOR family
+  EM_56800EX       = 200, // Freescale 56800EX Digital Signal Controller (DSC)
+  EM_BA1           = 201, // Beyond BA1 CPU architecture
+  EM_BA2           = 202, // Beyond BA2 CPU architecture
+  EM_XCORE         = 203, // XMOS xCORE processor family
+  EM_MCHP_PIC      = 204, // Microchip 8-bit PIC(r) family
+  EM_INTEL205      = 205, // Reserved by Intel
+  EM_INTEL206      = 206, // Reserved by Intel
+  EM_INTEL207      = 207, // Reserved by Intel
+  EM_INTEL208      = 208, // Reserved by Intel
+  EM_INTEL209      = 209, // Reserved by Intel
+  EM_KM32          = 210, // KM211 KM32 32-bit processor
+  EM_KMX32         = 211, // KM211 KMX32 32-bit processor
+  EM_KMX16         = 212, // KM211 KMX16 16-bit processor
+  EM_KMX8          = 213, // KM211 KMX8 8-bit processor
+  EM_KVARC         = 214, // KM211 KVARC processor
+  EM_CDP           = 215, // Paneve CDP architecture family
+  EM_COGE          = 216, // Cognitive Smart Memory Processor
+  EM_COOL          = 217, // iCelero CoolEngine
+  EM_NORC          = 218, // Nanoradio Optimized RISC
+  EM_CSR_KALIMBA   = 219, // CSR Kalimba architecture family
+  EM_AMDGPU        = 224, // AMD GPU architecture
+
+  // A request has been made to the maintainer of the official registry for
+  // such numbers for an official value for WebAssembly. As soon as one is
+  // allocated, this enum will be updated to use it.
+  EM_WEBASSEMBLY   = 0x4157, // WebAssembly architecture
+};
+
+// Object file classes.
+enum {
+  ELFCLASSNONE = 0,
+  ELFCLASS32 = 1, // 32-bit object file
+  ELFCLASS64 = 2  // 64-bit object file
+};
+
+// Object file byte orderings.
+enum {
+  ELFDATANONE = 0, // Invalid data encoding.
+  ELFDATA2LSB = 1, // Little-endian object file
+  ELFDATA2MSB = 2  // Big-endian object file
+};
+
+// OS ABI identification.
+enum {
+  ELFOSABI_NONE = 0,          // UNIX System V ABI
+  ELFOSABI_HPUX = 1,          // HP-UX operating system
+  ELFOSABI_NETBSD = 2,        // NetBSD
+  ELFOSABI_GNU = 3,           // GNU/Linux
+  ELFOSABI_LINUX = 3,         // Historical alias for ELFOSABI_GNU.
+  ELFOSABI_HURD = 4,          // GNU/Hurd
+  ELFOSABI_SOLARIS = 6,       // Solaris
+  ELFOSABI_AIX = 7,           // AIX
+  ELFOSABI_IRIX = 8,          // IRIX
+  ELFOSABI_FREEBSD = 9,       // FreeBSD
+  ELFOSABI_TRU64 = 10,        // TRU64 UNIX
+  ELFOSABI_MODESTO = 11,      // Novell Modesto
+  ELFOSABI_OPENBSD = 12,      // OpenBSD
+  ELFOSABI_OPENVMS = 13,      // OpenVMS
+  ELFOSABI_NSK = 14,          // Hewlett-Packard Non-Stop Kernel
+  ELFOSABI_AROS = 15,         // AROS
+  ELFOSABI_FENIXOS = 16,      // FenixOS
+  ELFOSABI_CLOUDABI = 17,     // Nuxi CloudABI
+  ELFOSABI_C6000_ELFABI = 64, // Bare-metal TMS320C6000
+  ELFOSABI_AMDGPU_HSA = 64,   // AMD HSA runtime
+  ELFOSABI_C6000_LINUX = 65,  // Linux TMS320C6000
+  ELFOSABI_ARM = 97,          // ARM
+  ELFOSABI_STANDALONE = 255   // Standalone (embedded) application
+};
+
+#define ELF_RELOC(name, value) name = value,
+
+// Specific e_flags for PPC64
+enum {
+  // e_flags bits specifying ABI:
+  // 1 for original ABI using function descriptors,
+  // 2 for revised ABI without function descriptors,
+  // 0 for unspecified or not using any features affected by the differences.
+  EF_PPC64_ABI = 3
+};
+
+// Special values for the st_other field in the symbol table entry for PPC64.
+enum {
+  STO_PPC64_LOCAL_BIT = 5,
+  STO_PPC64_LOCAL_MASK = (7 << STO_PPC64_LOCAL_BIT)
+};
+static inline int64_t
+decodePPC64LocalEntryOffset(unsigned Other) {
+  unsigned Val = (Other & STO_PPC64_LOCAL_MASK) >> STO_PPC64_LOCAL_BIT;
+  return ((1 << Val) >> 2) << 2;
+}
+static inline unsigned
+encodePPC64LocalEntryOffset(int64_t Offset) {
+  unsigned Val = (Offset >= 4 * 4
+                  ? (Offset >= 8 * 4
+                     ? (Offset >= 16 * 4 ? 6 : 5)
+                     : 4)
+                  : (Offset >= 2 * 4
+                     ? 3
+                     : (Offset >= 1 * 4 ? 2 : 0)));
+  return Val << STO_PPC64_LOCAL_BIT;
+}
+
+// ARM Specific e_flags
+enum : unsigned {
+  EF_ARM_SOFT_FLOAT =     0x00000200U,
+  EF_ARM_VFP_FLOAT =      0x00000400U,
+  EF_ARM_EABI_UNKNOWN =   0x00000000U,
+  EF_ARM_EABI_VER1 =      0x01000000U,
+  EF_ARM_EABI_VER2 =      0x02000000U,
+  EF_ARM_EABI_VER3 =      0x03000000U,
+  EF_ARM_EABI_VER4 =      0x04000000U,
+  EF_ARM_EABI_VER5 =      0x05000000U,
+  EF_ARM_EABIMASK =       0xFF000000U
+};
+
+// AVR specific e_flags
+enum : unsigned {
+  EF_AVR_ARCH_AVR1    = 1,
+  EF_AVR_ARCH_AVR2    = 2,
+  EF_AVR_ARCH_AVR25   = 25,
+  EF_AVR_ARCH_AVR3    = 3,
+  EF_AVR_ARCH_AVR31   = 31,
+  EF_AVR_ARCH_AVR35   = 35,
+  EF_AVR_ARCH_AVR4    = 4,
+  EF_AVR_ARCH_AVR5    = 5,
+  EF_AVR_ARCH_AVR51   = 51,
+  EF_AVR_ARCH_AVR6    = 6,
+  EF_AVR_ARCH_AVRTINY = 100,
+  EF_AVR_ARCH_XMEGA1  = 101,
+  EF_AVR_ARCH_XMEGA2  = 102,
+  EF_AVR_ARCH_XMEGA3  = 103,
+  EF_AVR_ARCH_XMEGA4  = 104,
+  EF_AVR_ARCH_XMEGA5  = 105,
+  EF_AVR_ARCH_XMEGA6  = 106,
+  EF_AVR_ARCH_XMEGA7  = 107
+};
+
+// Mips Specific e_flags
+enum : unsigned {
+  EF_MIPS_NOREORDER = 0x00000001, // Don't reorder instructions
+  EF_MIPS_PIC       = 0x00000002, // Position independent code
+  EF_MIPS_CPIC      = 0x00000004, // Call object with Position independent code
+  EF_MIPS_ABI2      = 0x00000020, // File uses N32 ABI
+  EF_MIPS_32BITMODE = 0x00000100, // Code compiled for a 64-bit machine
+                                  // in 32-bit mode
+  EF_MIPS_FP64      = 0x00000200, // Code compiled for a 32-bit machine
+                                  // but uses 64-bit FP registers
+  EF_MIPS_NAN2008   = 0x00000400, // Uses IEE 754-2008 NaN encoding
+
+  // ABI flags
+  EF_MIPS_ABI_O32    = 0x00001000, // This file follows the first MIPS 32 bit ABI
+  EF_MIPS_ABI_O64    = 0x00002000, // O32 ABI extended for 64-bit architecture.
+  EF_MIPS_ABI_EABI32 = 0x00003000, // EABI in 32 bit mode.
+  EF_MIPS_ABI_EABI64 = 0x00004000, // EABI in 64 bit mode.
+  EF_MIPS_ABI        = 0x0000f000, // Mask for selecting EF_MIPS_ABI_ variant.
+
+  // MIPS machine variant
+  EF_MIPS_MACH_3900    = 0x00810000, // Toshiba R3900
+  EF_MIPS_MACH_4010    = 0x00820000, // LSI R4010
+  EF_MIPS_MACH_4100    = 0x00830000, // NEC VR4100
+  EF_MIPS_MACH_4650    = 0x00850000, // MIPS R4650
+  EF_MIPS_MACH_4120    = 0x00870000, // NEC VR4120
+  EF_MIPS_MACH_4111    = 0x00880000, // NEC VR4111/VR4181
+  EF_MIPS_MACH_SB1     = 0x008a0000, // Broadcom SB-1
+  EF_MIPS_MACH_OCTEON  = 0x008b0000, // Cavium Networks Octeon
+  EF_MIPS_MACH_XLR     = 0x008c0000, // RMI Xlr
+  EF_MIPS_MACH_OCTEON2 = 0x008d0000, // Cavium Networks Octeon2
+  EF_MIPS_MACH_OCTEON3 = 0x008e0000, // Cavium Networks Octeon3
+  EF_MIPS_MACH_5400    = 0x00910000, // NEC VR5400
+  EF_MIPS_MACH_5900    = 0x00920000, // MIPS R5900
+  EF_MIPS_MACH_5500    = 0x00980000, // NEC VR5500
+  EF_MIPS_MACH_9000    = 0x00990000, // Unknown
+  EF_MIPS_MACH_LS2E    = 0x00a00000, // ST Microelectronics Loongson 2E
+  EF_MIPS_MACH_LS2F    = 0x00a10000, // ST Microelectronics Loongson 2F
+  EF_MIPS_MACH_LS3A    = 0x00a20000, // Loongson 3A
+  EF_MIPS_MACH         = 0x00ff0000, // EF_MIPS_MACH_xxx selection mask
+
+  // ARCH_ASE
+  EF_MIPS_MICROMIPS = 0x02000000, // microMIPS
+  EF_MIPS_ARCH_ASE_M16 =
+                      0x04000000, // Has Mips-16 ISA extensions
+  EF_MIPS_ARCH_ASE_MDMX =
+                      0x08000000, // Has MDMX multimedia extensions
+  EF_MIPS_ARCH_ASE  = 0x0f000000, // Mask for EF_MIPS_ARCH_ASE_xxx flags
+
+  // ARCH
+  EF_MIPS_ARCH_1    = 0x00000000, // MIPS1 instruction set
+  EF_MIPS_ARCH_2    = 0x10000000, // MIPS2 instruction set
+  EF_MIPS_ARCH_3    = 0x20000000, // MIPS3 instruction set
+  EF_MIPS_ARCH_4    = 0x30000000, // MIPS4 instruction set
+  EF_MIPS_ARCH_5    = 0x40000000, // MIPS5 instruction set
+  EF_MIPS_ARCH_32   = 0x50000000, // MIPS32 instruction set per linux not elf.h
+  EF_MIPS_ARCH_64   = 0x60000000, // MIPS64 instruction set per linux not elf.h
+  EF_MIPS_ARCH_32R2 = 0x70000000, // mips32r2, mips32r3, mips32r5
+  EF_MIPS_ARCH_64R2 = 0x80000000, // mips64r2, mips64r3, mips64r5
+  EF_MIPS_ARCH_32R6 = 0x90000000, // mips32r6
+  EF_MIPS_ARCH_64R6 = 0xa0000000, // mips64r6
+  EF_MIPS_ARCH      = 0xf0000000  // Mask for applying EF_MIPS_ARCH_ variant
+};
+
+// Special values for the st_other field in the symbol table entry for MIPS.
+enum {
+  STO_MIPS_OPTIONAL        = 0x04,  // Symbol whose definition is optional
+  STO_MIPS_PLT             = 0x08,  // PLT entry related dynamic table record
+  STO_MIPS_PIC             = 0x20,  // PIC func in an object mixes PIC/non-PIC
+  STO_MIPS_MICROMIPS       = 0x80,  // MIPS Specific ISA for MicroMips
+  STO_MIPS_MIPS16          = 0xf0   // MIPS Specific ISA for Mips16
+};
+
+// .MIPS.options section descriptor kinds
+enum {
+  ODK_NULL       = 0,   // Undefined
+  ODK_REGINFO    = 1,   // Register usage information
+  ODK_EXCEPTIONS = 2,   // Exception processing options
+  ODK_PAD        = 3,   // Section padding options
+  ODK_HWPATCH    = 4,   // Hardware patches applied
+  ODK_FILL       = 5,   // Linker fill value
+  ODK_TAGS       = 6,   // Space for tool identification
+  ODK_HWAND      = 7,   // Hardware AND patches applied
+  ODK_HWOR       = 8,   // Hardware OR patches applied
+  ODK_GP_GROUP   = 9,   // GP group to use for text/data sections
+  ODK_IDENT      = 10,  // ID information
+  ODK_PAGESIZE   = 11   // Page size information
+};
+
+// Hexagon-specific e_flags
+enum {
+  // Object processor version flags, bits[11:0]
+  EF_HEXAGON_MACH_V2      = 0x00000001,   // Hexagon V2
+  EF_HEXAGON_MACH_V3      = 0x00000002,   // Hexagon V3
+  EF_HEXAGON_MACH_V4      = 0x00000003,   // Hexagon V4
+  EF_HEXAGON_MACH_V5      = 0x00000004,   // Hexagon V5
+  EF_HEXAGON_MACH_V55     = 0x00000005,   // Hexagon V55
+  EF_HEXAGON_MACH_V60     = 0x00000060,   // Hexagon V60
+
+  // Highest ISA version flags
+  EF_HEXAGON_ISA_MACH     = 0x00000000,   // Same as specified in bits[11:0]
+                                          // of e_flags
+  EF_HEXAGON_ISA_V2       = 0x00000010,   // Hexagon V2 ISA
+  EF_HEXAGON_ISA_V3       = 0x00000020,   // Hexagon V3 ISA
+  EF_HEXAGON_ISA_V4       = 0x00000030,   // Hexagon V4 ISA
+  EF_HEXAGON_ISA_V5       = 0x00000040,   // Hexagon V5 ISA
+  EF_HEXAGON_ISA_V55      = 0x00000050,   // Hexagon V55 ISA
+  EF_HEXAGON_ISA_V60      = 0x00000060,   // Hexagon V60 ISA
+};
+
+// Hexagon-specific section indexes for common small data
+enum {
+  SHN_HEXAGON_SCOMMON     = 0xff00,       // Other access sizes
+  SHN_HEXAGON_SCOMMON_1   = 0xff01,       // Byte-sized access
+  SHN_HEXAGON_SCOMMON_2   = 0xff02,       // Half-word-sized access
+  SHN_HEXAGON_SCOMMON_4   = 0xff03,       // Word-sized access
+  SHN_HEXAGON_SCOMMON_8   = 0xff04        // Double-word-size access
+};
+
+
+#undef ELF_RELOC
+
+// Section header.
+struct Elf32_Shdr {
+  Elf32_Word sh_name;      // Section name (index into string table)
+  Elf32_Word sh_type;      // Section type (SHT_*)
+  Elf32_Word sh_flags;     // Section flags (SHF_*)
+  Elf32_Addr sh_addr;      // Address where section is to be loaded
+  Elf32_Off  sh_offset;    // File offset of section data, in bytes
+  Elf32_Word sh_size;      // Size of section, in bytes
+  Elf32_Word sh_link;      // Section type-specific header table index link
+  Elf32_Word sh_info;      // Section type-specific extra information
+  Elf32_Word sh_addralign; // Section address alignment
+  Elf32_Word sh_entsize;   // Size of records contained within the section
+};
+
+// Section header for ELF64 - same fields as ELF32, different types.
+struct Elf64_Shdr {
+  Elf64_Word  sh_name;
+  Elf64_Word  sh_type;
+  Elf64_Xword sh_flags;
+  Elf64_Addr  sh_addr;
+  Elf64_Off   sh_offset;
+  Elf64_Xword sh_size;
+  Elf64_Word  sh_link;
+  Elf64_Word  sh_info;
+  Elf64_Xword sh_addralign;
+  Elf64_Xword sh_entsize;
+};
+
+// Special section indices.
+enum {
+  SHN_UNDEF     = 0,      // Undefined, missing, irrelevant, or meaningless
+  SHN_LORESERVE = 0xff00, // Lowest reserved index
+  SHN_LOPROC    = 0xff00, // Lowest processor-specific index
+  SHN_HIPROC    = 0xff1f, // Highest processor-specific index
+  SHN_LOOS      = 0xff20, // Lowest operating system-specific index
+  SHN_HIOS      = 0xff3f, // Highest operating system-specific index
+  SHN_ABS       = 0xfff1, // Symbol has absolute value; does not need relocation
+  SHN_COMMON    = 0xfff2, // FORTRAN COMMON or C external global variables
+  SHN_XINDEX    = 0xffff, // Mark that the index is >= SHN_LORESERVE
+  SHN_HIRESERVE = 0xffff  // Highest reserved index
+};
+
+// Section types.
+enum : unsigned {
+  SHT_NULL          = 0,  // No associated section (inactive entry).
+  SHT_PROGBITS      = 1,  // Program-defined contents.
+  SHT_SYMTAB        = 2,  // Symbol table.
+  SHT_STRTAB        = 3,  // String table.
+  SHT_RELA          = 4,  // Relocation entries; explicit addends.
+  SHT_HASH          = 5,  // Symbol hash table.
+  SHT_DYNAMIC       = 6,  // Information for dynamic linking.
+  SHT_NOTE          = 7,  // Information about the file.
+  SHT_NOBITS        = 8,  // Data occupies no space in the file.
+  SHT_REL           = 9,  // Relocation entries; no explicit addends.
+  SHT_SHLIB         = 10, // Reserved.
+  SHT_DYNSYM        = 11, // Symbol table.
+  SHT_INIT_ARRAY    = 14, // Pointers to initialization functions.
+  SHT_FINI_ARRAY    = 15, // Pointers to termination functions.
+  SHT_PREINIT_ARRAY = 16, // Pointers to pre-init functions.
+  SHT_GROUP         = 17, // Section group.
+  SHT_SYMTAB_SHNDX  = 18, // Indices for SHN_XINDEX entries.
+  SHT_LOOS          = 0x60000000, // Lowest operating system-specific type.
+  SHT_GNU_ATTRIBUTES= 0x6ffffff5, // Object attributes.
+  SHT_GNU_HASH      = 0x6ffffff6, // GNU-style hash table.
+  SHT_GNU_verdef    = 0x6ffffffd, // GNU version definitions.
+  SHT_GNU_verneed   = 0x6ffffffe, // GNU version references.
+  SHT_GNU_versym    = 0x6fffffff, // GNU symbol versions table.
+  SHT_HIOS          = 0x6fffffff, // Highest operating system-specific type.
+  SHT_LOPROC        = 0x70000000, // Lowest processor arch-specific type.
+  // Fixme: All this is duplicated in MCSectionELF. Why??
+  // Exception Index table
+  SHT_ARM_EXIDX           = 0x70000001U,
+  // BPABI DLL dynamic linking pre-emption map
+  SHT_ARM_PREEMPTMAP      = 0x70000002U,
+  //  Object file compatibility attributes
+  SHT_ARM_ATTRIBUTES      = 0x70000003U,
+  SHT_ARM_DEBUGOVERLAY    = 0x70000004U,
+  SHT_ARM_OVERLAYSECTION  = 0x70000005U,
+  SHT_HEX_ORDERED         = 0x70000000, // Link editor is to sort the entries in
+                                        // this section based on their sizes
+  SHT_X86_64_UNWIND       = 0x70000001, // Unwind information
+
+  SHT_MIPS_REGINFO        = 0x70000006, // Register usage information
+  SHT_MIPS_OPTIONS        = 0x7000000d, // General options
+  SHT_MIPS_ABIFLAGS       = 0x7000002a, // ABI information.
+
+  SHT_HIPROC        = 0x7fffffff, // Highest processor arch-specific type.
+  SHT_LOUSER        = 0x80000000, // Lowest type reserved for applications.
+  SHT_HIUSER        = 0xffffffff  // Highest type reserved for applications.
+};
+
+// Section flags.
+enum : unsigned {
+  // Section data should be writable during execution.
+  SHF_WRITE = 0x1,
+
+  // Section occupies memory during program execution.
+  SHF_ALLOC = 0x2,
+
+  // Section contains executable machine instructions.
+  SHF_EXECINSTR = 0x4,
+
+  // The data in this section may be merged.
+  SHF_MERGE = 0x10,
+
+  // The data in this section is null-terminated strings.
+  SHF_STRINGS = 0x20,
+
+  // A field in this section holds a section header table index.
+  SHF_INFO_LINK = 0x40U,
+
+  // Adds special ordering requirements for link editors.
+  SHF_LINK_ORDER = 0x80U,
+
+  // This section requires special OS-specific processing to avoid incorrect
+  // behavior.
+  SHF_OS_NONCONFORMING = 0x100U,
+
+  // This section is a member of a section group.
+  SHF_GROUP = 0x200U,
+
+  // This section holds Thread-Local Storage.
+  SHF_TLS = 0x400U,
+
+  // This section is excluded from the final executable or shared library.
+  SHF_EXCLUDE = 0x80000000U,
+
+  // Start of target-specific flags.
+
+  /// XCORE_SHF_CP_SECTION - All sections with the "c" flag are grouped
+  /// together by the linker to form the constant pool and the cp register is
+  /// set to the start of the constant pool by the boot code.
+  XCORE_SHF_CP_SECTION = 0x800U,
+
+  /// XCORE_SHF_DP_SECTION - All sections with the "d" flag are grouped
+  /// together by the linker to form the data section and the dp register is
+  /// set to the start of the section by the boot code.
+  XCORE_SHF_DP_SECTION = 0x1000U,
+
+  SHF_MASKOS   = 0x0ff00000,
+
+  // Bits indicating processor-specific flags.
+  SHF_MASKPROC = 0xf0000000,
+
+  // If an object file section does not have this flag set, then it may not hold
+  // more than 2GB and can be freely referred to in objects using smaller code
+  // models. Otherwise, only objects using larger code models can refer to them.
+  // For example, a medium code model object can refer to data in a section that
+  // sets this flag besides being able to refer to data in a section that does
+  // not set it; likewise, a small code model object can refer only to code in a
+  // section that does not set this flag.
+  SHF_X86_64_LARGE = 0x10000000,
+
+  // All sections with the GPREL flag are grouped into a global data area
+  // for faster accesses
+  SHF_HEX_GPREL = 0x10000000,
+
+  // Section contains text/data which may be replicated in other sections.
+  // Linker must retain only one copy.
+  SHF_MIPS_NODUPES = 0x01000000,
+
+  // Linker must generate implicit hidden weak names.
+  SHF_MIPS_NAMES   = 0x02000000,
+
+  // Section data local to process.
+  SHF_MIPS_LOCAL   = 0x04000000,
+
+  // Do not strip this section.
+  SHF_MIPS_NOSTRIP = 0x08000000,
+
+  // Section must be part of global data area.
+  SHF_MIPS_GPREL   = 0x10000000,
+
+  // This section should be merged.
+  SHF_MIPS_MERGE   = 0x20000000,
+
+  // Address size to be inferred from section entry size.
+  SHF_MIPS_ADDR    = 0x40000000,
+
+  // Section data is string data by default.
+  SHF_MIPS_STRING  = 0x80000000,
+
+  SHF_AMDGPU_HSA_GLOBAL   = 0x00100000,
+  SHF_AMDGPU_HSA_READONLY = 0x00200000,
+  SHF_AMDGPU_HSA_CODE     = 0x00400000,
+  SHF_AMDGPU_HSA_AGENT    = 0x00800000
+};
+
+// Section Group Flags
+enum : unsigned {
+  GRP_COMDAT = 0x1,
+  GRP_MASKOS = 0x0ff00000,
+  GRP_MASKPROC = 0xf0000000
+};
+
+// Symbol table entries for ELF32.
+struct Elf32_Sym {
+  Elf32_Word    st_name;  // Symbol name (index into string table)
+  Elf32_Addr    st_value; // Value or address associated with the symbol
+  Elf32_Word    st_size;  // Size of the symbol
+  unsigned char st_info;  // Symbol's type and binding attributes
+  unsigned char st_other; // Must be zero; reserved
+  Elf32_Half    st_shndx; // Which section (header table index) it's defined in
+
+  // These accessors and mutators correspond to the ELF32_ST_BIND,
+  // ELF32_ST_TYPE, and ELF32_ST_INFO macros defined in the ELF specification:
+  unsigned char getBinding() const { return st_info >> 4; }
+  unsigned char getType() const { return st_info & 0x0f; }
+  void setBinding(unsigned char b) { setBindingAndType(b, getType()); }
+  void setType(unsigned char t) { setBindingAndType(getBinding(), t); }
+  void setBindingAndType(unsigned char b, unsigned char t) {
+    st_info = (b << 4) + (t & 0x0f);
+  }
+};
+
+// Symbol table entries for ELF64.
+struct Elf64_Sym {
+  Elf64_Word      st_name;  // Symbol name (index into string table)
+  unsigned char   st_info;  // Symbol's type and binding attributes
+  unsigned char   st_other; // Must be zero; reserved
+  Elf64_Half      st_shndx; // Which section (header tbl index) it's defined in
+  Elf64_Addr      st_value; // Value or address associated with the symbol
+  Elf64_Xword     st_size;  // Size of the symbol
+
+  // These accessors and mutators are identical to those defined for ELF32
+  // symbol table entries.
+  unsigned char getBinding() const { return st_info >> 4; }
+  unsigned char getType() const { return st_info & 0x0f; }
+  void setBinding(unsigned char b) { setBindingAndType(b, getType()); }
+  void setType(unsigned char t) { setBindingAndType(getBinding(), t); }
+  void setBindingAndType(unsigned char b, unsigned char t) {
+    st_info = (b << 4) + (t & 0x0f);
+  }
+};
+
+// The size (in bytes) of symbol table entries.
+enum {
+  SYMENTRY_SIZE32 = 16, // 32-bit symbol entry size
+  SYMENTRY_SIZE64 = 24  // 64-bit symbol entry size.
+};
+
+// Symbol bindings.
+enum {
+  STB_LOCAL = 0,   // Local symbol, not visible outside obj file containing def
+  STB_GLOBAL = 1,  // Global symbol, visible to all object files being combined
+  STB_WEAK = 2,    // Weak symbol, like global but lower-precedence
+  STB_GNU_UNIQUE = 10,
+  STB_LOOS   = 10, // Lowest operating system-specific binding type
+  STB_HIOS   = 12, // Highest operating system-specific binding type
+  STB_LOPROC = 13, // Lowest processor-specific binding type
+  STB_HIPROC = 15  // Highest processor-specific binding type
+};
+
+// Symbol types.
+enum {
+  STT_NOTYPE  = 0,   // Symbol's type is not specified
+  STT_OBJECT  = 1,   // Symbol is a data object (variable, array, etc.)
+  STT_FUNC    = 2,   // Symbol is executable code (function, etc.)
+  STT_SECTION = 3,   // Symbol refers to a section
+  STT_FILE    = 4,   // Local, absolute symbol that refers to a file
+  STT_COMMON  = 5,   // An uninitialized common block
+  STT_TLS     = 6,   // Thread local data object
+  STT_GNU_IFUNC = 10, // GNU indirect function
+  STT_LOOS    = 10,  // Lowest operating system-specific symbol type
+  STT_HIOS    = 12,  // Highest operating system-specific symbol type
+  STT_LOPROC  = 13,  // Lowest processor-specific symbol type
+  STT_HIPROC  = 15,  // Highest processor-specific symbol type
+
+  // AMDGPU symbol types
+  STT_AMDGPU_HSA_KERNEL            = 10,
+  STT_AMDGPU_HSA_INDIRECT_FUNCTION = 11,
+  STT_AMDGPU_HSA_METADATA          = 12
+};
+
+enum {
+  STV_DEFAULT   = 0,  // Visibility is specified by binding type
+  STV_INTERNAL  = 1,  // Defined by processor supplements
+  STV_HIDDEN    = 2,  // Not visible to other components
+  STV_PROTECTED = 3   // Visible in other components but not preemptable
+};
+
+// Symbol number.
+enum {
+  STN_UNDEF = 0
+};
+
+// Special relocation symbols used in the MIPS64 ELF relocation entries
+enum {
+  RSS_UNDEF = 0, // None
+  RSS_GP = 1,    // Value of gp
+  RSS_GP0 = 2,   // Value of gp used to create object being relocated
+  RSS_LOC = 3    // Address of location being relocated
+};
+
+// Relocation entry, without explicit addend.
+struct Elf32_Rel {
+  Elf32_Addr r_offset; // Location (file byte offset, or program virtual addr)
+  Elf32_Word r_info;   // Symbol table index and type of relocation to apply
+
+  // These accessors and mutators correspond to the ELF32_R_SYM, ELF32_R_TYPE,
+  // and ELF32_R_INFO macros defined in the ELF specification:
+  Elf32_Word getSymbol() const { return (r_info >> 8); }
+  unsigned char getType() const { return (unsigned char) (r_info & 0x0ff); }
+  void setSymbol(Elf32_Word s) { setSymbolAndType(s, getType()); }
+  void setType(unsigned char t) { setSymbolAndType(getSymbol(), t); }
+  void setSymbolAndType(Elf32_Word s, unsigned char t) {
+    r_info = (s << 8) + t;
+  }
+};
+
+// Relocation entry with explicit addend.
+struct Elf32_Rela {
+  Elf32_Addr  r_offset; // Location (file byte offset, or program virtual addr)
+  Elf32_Word  r_info;   // Symbol table index and type of relocation to apply
+  Elf32_Sword r_addend; // Compute value for relocatable field by adding this
+
+  // These accessors and mutators correspond to the ELF32_R_SYM, ELF32_R_TYPE,
+  // and ELF32_R_INFO macros defined in the ELF specification:
+  Elf32_Word getSymbol() const { return (r_info >> 8); }
+  unsigned char getType() const { return (unsigned char) (r_info & 0x0ff); }
+  void setSymbol(Elf32_Word s) { setSymbolAndType(s, getType()); }
+  void setType(unsigned char t) { setSymbolAndType(getSymbol(), t); }
+  void setSymbolAndType(Elf32_Word s, unsigned char t) {
+    r_info = (s << 8) + t;
+  }
+};
+
+// Relocation entry, without explicit addend.
+struct Elf64_Rel {
+  Elf64_Addr r_offset; // Location (file byte offset, or program virtual addr).
+  Elf64_Xword r_info;   // Symbol table index and type of relocation to apply.
+
+  // These accessors and mutators correspond to the ELF64_R_SYM, ELF64_R_TYPE,
+  // and ELF64_R_INFO macros defined in the ELF specification:
+  Elf64_Word getSymbol() const { return (r_info >> 32); }
+  Elf64_Word getType() const {
+    return (Elf64_Word) (r_info & 0xffffffffL);
+  }
+  void setSymbol(Elf64_Word s) { setSymbolAndType(s, getType()); }
+  void setType(Elf64_Word t) { setSymbolAndType(getSymbol(), t); }
+  void setSymbolAndType(Elf64_Word s, Elf64_Word t) {
+    r_info = ((Elf64_Xword)s << 32) + (t&0xffffffffL);
+  }
+};
+
+// Relocation entry with explicit addend.
+struct Elf64_Rela {
+  Elf64_Addr  r_offset; // Location (file byte offset, or program virtual addr).
+  Elf64_Xword  r_info;   // Symbol table index and type of relocation to apply.
+  Elf64_Sxword r_addend; // Compute value for relocatable field by adding this.
+
+  // These accessors and mutators correspond to the ELF64_R_SYM, ELF64_R_TYPE,
+  // and ELF64_R_INFO macros defined in the ELF specification:
+  Elf64_Word getSymbol() const { return (r_info >> 32); }
+  Elf64_Word getType() const {
+    return (Elf64_Word) (r_info & 0xffffffffL);
+  }
+  void setSymbol(Elf64_Word s) { setSymbolAndType(s, getType()); }
+  void setType(Elf64_Word t) { setSymbolAndType(getSymbol(), t); }
+  void setSymbolAndType(Elf64_Word s, Elf64_Word t) {
+    r_info = ((Elf64_Xword)s << 32) + (t&0xffffffffL);
+  }
+};
+
+// Program header for ELF32.
+struct Elf32_Phdr {
+  Elf32_Word p_type;   // Type of segment
+  Elf32_Off  p_offset; // File offset where segment is located, in bytes
+  Elf32_Addr p_vaddr;  // Virtual address of beginning of segment
+  Elf32_Addr p_paddr;  // Physical address of beginning of segment (OS-specific)
+  Elf32_Word p_filesz; // Num. of bytes in file image of segment (may be zero)
+  Elf32_Word p_memsz;  // Num. of bytes in mem image of segment (may be zero)
+  Elf32_Word p_flags;  // Segment flags
+  Elf32_Word p_align;  // Segment alignment constraint
+};
+
+// Program header for ELF64.
+struct Elf64_Phdr {
+  Elf64_Word   p_type;   // Type of segment
+  Elf64_Word   p_flags;  // Segment flags
+  Elf64_Off    p_offset; // File offset where segment is located, in bytes
+  Elf64_Addr   p_vaddr;  // Virtual address of beginning of segment
+  Elf64_Addr   p_paddr;  // Physical addr of beginning of segment (OS-specific)
+  Elf64_Xword  p_filesz; // Num. of bytes in file image of segment (may be zero)
+  Elf64_Xword  p_memsz;  // Num. of bytes in mem image of segment (may be zero)
+  Elf64_Xword  p_align;  // Segment alignment constraint
+};
+
+// Segment types.
+enum {
+  PT_NULL    = 0, // Unused segment.
+  PT_LOAD    = 1, // Loadable segment.
+  PT_DYNAMIC = 2, // Dynamic linking information.
+  PT_INTERP  = 3, // Interpreter pathname.
+  PT_NOTE    = 4, // Auxiliary information.
+  PT_SHLIB   = 5, // Reserved.
+  PT_PHDR    = 6, // The program header table itself.
+  PT_TLS     = 7, // The thread-local storage template.
+  PT_LOOS    = 0x60000000, // Lowest operating system-specific pt entry type.
+  PT_HIOS    = 0x6fffffff, // Highest operating system-specific pt entry type.
+  PT_LOPROC  = 0x70000000, // Lowest processor-specific program hdr entry type.
+  PT_HIPROC  = 0x7fffffff, // Highest processor-specific program hdr entry type.
+
+  // x86-64 program header types.
+  // These all contain stack unwind tables.
+  PT_GNU_EH_FRAME  = 0x6474e550,
+  PT_SUNW_EH_FRAME = 0x6474e550,
+  PT_SUNW_UNWIND   = 0x6464e550,
+
+  PT_GNU_STACK  = 0x6474e551, // Indicates stack executability.
+  PT_GNU_RELRO  = 0x6474e552, // Read-only after relocation.
+
+  // ARM program header types.
+  PT_ARM_ARCHEXT = 0x70000000, // Platform architecture compatibility info
+  // These all contain stack unwind tables.
+  PT_ARM_EXIDX   = 0x70000001,
+  PT_ARM_UNWIND  = 0x70000001,
+
+  // MIPS program header types.
+  PT_MIPS_REGINFO  = 0x70000000,  // Register usage information.
+  PT_MIPS_RTPROC   = 0x70000001,  // Runtime procedure table.
+  PT_MIPS_OPTIONS  = 0x70000002,  // Options segment.
+  PT_MIPS_ABIFLAGS = 0x70000003,  // Abiflags segment.
+
+  // AMDGPU program header types.
+  PT_AMDGPU_HSA_LOAD_GLOBAL_PROGRAM = 0x60000000,
+  PT_AMDGPU_HSA_LOAD_GLOBAL_AGENT   = 0x60000001,
+  PT_AMDGPU_HSA_LOAD_READONLY_AGENT = 0x60000002,
+  PT_AMDGPU_HSA_LOAD_CODE_AGENT     = 0x60000003,
+
+  // WebAssembly program header types.
+  PT_WEBASSEMBLY_FUNCTIONS = PT_LOPROC + 0, // Function definitions.
+};
+
+// Segment flag bits.
+enum : unsigned {
+  PF_X        = 1,         // Execute
+  PF_W        = 2,         // Write
+  PF_R        = 4,         // Read
+  PF_MASKOS   = 0x0ff00000,// Bits for operating system-specific semantics.
+  PF_MASKPROC = 0xf0000000 // Bits for processor-specific semantics.
+};
+
+// Dynamic table entry for ELF32.
+struct Elf32_Dyn
+{
+  Elf32_Sword d_tag;            // Type of dynamic table entry.
+  union
+  {
+      Elf32_Word d_val;         // Integer value of entry.
+      Elf32_Addr d_ptr;         // Pointer value of entry.
+  } d_un;
+};
+
+// Dynamic table entry for ELF64.
+struct Elf64_Dyn
+{
+  Elf64_Sxword d_tag;           // Type of dynamic table entry.
+  union
+  {
+      Elf64_Xword d_val;        // Integer value of entry.
+      Elf64_Addr  d_ptr;        // Pointer value of entry.
+  } d_un;
+};
+
+// Dynamic table entry tags.
+enum {
+  DT_NULL         = 0,        // Marks end of dynamic array.
+  DT_NEEDED       = 1,        // String table offset of needed library.
+  DT_PLTRELSZ     = 2,        // Size of relocation entries in PLT.
+  DT_PLTGOT       = 3,        // Address associated with linkage table.
+  DT_HASH         = 4,        // Address of symbolic hash table.
+  DT_STRTAB       = 5,        // Address of dynamic string table.
+  DT_SYMTAB       = 6,        // Address of dynamic symbol table.
+  DT_RELA         = 7,        // Address of relocation table (Rela entries).
+  DT_RELASZ       = 8,        // Size of Rela relocation table.
+  DT_RELAENT      = 9,        // Size of a Rela relocation entry.
+  DT_STRSZ        = 10,       // Total size of the string table.
+  DT_SYMENT       = 11,       // Size of a symbol table entry.
+  DT_INIT         = 12,       // Address of initialization function.
+  DT_FINI         = 13,       // Address of termination function.
+  DT_SONAME       = 14,       // String table offset of a shared objects name.
+  DT_RPATH        = 15,       // String table offset of library search path.
+  DT_SYMBOLIC     = 16,       // Changes symbol resolution algorithm.
+  DT_REL          = 17,       // Address of relocation table (Rel entries).
+  DT_RELSZ        = 18,       // Size of Rel relocation table.
+  DT_RELENT       = 19,       // Size of a Rel relocation entry.
+  DT_PLTREL       = 20,       // Type of relocation entry used for linking.
+  DT_DEBUG        = 21,       // Reserved for debugger.
+  DT_TEXTREL      = 22,       // Relocations exist for non-writable segments.
+  DT_JMPREL       = 23,       // Address of relocations associated with PLT.
+  DT_BIND_NOW     = 24,       // Process all relocations before execution.
+  DT_INIT_ARRAY   = 25,       // Pointer to array of initialization functions.
+  DT_FINI_ARRAY   = 26,       // Pointer to array of termination functions.
+  DT_INIT_ARRAYSZ = 27,       // Size of DT_INIT_ARRAY.
+  DT_FINI_ARRAYSZ = 28,       // Size of DT_FINI_ARRAY.
+  DT_RUNPATH      = 29,       // String table offset of lib search path.
+  DT_FLAGS        = 30,       // Flags.
+  DT_ENCODING     = 32,       // Values from here to DT_LOOS follow the rules
+                              // for the interpretation of the d_un union.
+
+  DT_PREINIT_ARRAY = 32,      // Pointer to array of preinit functions.
+  DT_PREINIT_ARRAYSZ = 33,    // Size of the DT_PREINIT_ARRAY array.
+
+  DT_LOOS         = 0x60000000, // Start of environment specific tags.
+  DT_HIOS         = 0x6FFFFFFF, // End of environment specific tags.
+  DT_LOPROC       = 0x70000000, // Start of processor specific tags.
+  DT_HIPROC       = 0x7FFFFFFF, // End of processor specific tags.
+
+  DT_GNU_HASH     = 0x6FFFFEF5, // Reference to the GNU hash table.
+  DT_RELACOUNT    = 0x6FFFFFF9, // ELF32_Rela count.
+  DT_RELCOUNT     = 0x6FFFFFFA, // ELF32_Rel count.
+
+  DT_FLAGS_1      = 0X6FFFFFFB, // Flags_1.
+  DT_VERSYM       = 0x6FFFFFF0, // The address of .gnu.version section.
+  DT_VERDEF       = 0X6FFFFFFC, // The address of the version definition table.
+  DT_VERDEFNUM    = 0X6FFFFFFD, // The number of entries in DT_VERDEF.
+  DT_VERNEED      = 0X6FFFFFFE, // The address of the version Dependency table.
+  DT_VERNEEDNUM   = 0X6FFFFFFF, // The number of entries in DT_VERNEED.
+
+  // Mips specific dynamic table entry tags.
+  DT_MIPS_RLD_VERSION   = 0x70000001, // 32 bit version number for runtime
+                                      // linker interface.
+  DT_MIPS_TIME_STAMP    = 0x70000002, // Time stamp.
+  DT_MIPS_ICHECKSUM     = 0x70000003, // Checksum of external strings
+                                      // and common sizes.
+  DT_MIPS_IVERSION      = 0x70000004, // Index of version string
+                                      // in string table.
+  DT_MIPS_FLAGS         = 0x70000005, // 32 bits of flags.
+  DT_MIPS_BASE_ADDRESS  = 0x70000006, // Base address of the segment.
+  DT_MIPS_MSYM          = 0x70000007, // Address of .msym section.
+  DT_MIPS_CONFLICT      = 0x70000008, // Address of .conflict section.
+  DT_MIPS_LIBLIST       = 0x70000009, // Address of .liblist section.
+  DT_MIPS_LOCAL_GOTNO   = 0x7000000a, // Number of local global offset
+                                      // table entries.
+  DT_MIPS_CONFLICTNO    = 0x7000000b, // Number of entries
+                                      // in the .conflict section.
+  DT_MIPS_LIBLISTNO     = 0x70000010, // Number of entries
+                                      // in the .liblist section.
+  DT_MIPS_SYMTABNO      = 0x70000011, // Number of entries
+                                      // in the .dynsym section.
+  DT_MIPS_UNREFEXTNO    = 0x70000012, // Index of first external dynamic symbol
+                                      // not referenced locally.
+  DT_MIPS_GOTSYM        = 0x70000013, // Index of first dynamic symbol
+                                      // in global offset table.
+  DT_MIPS_HIPAGENO      = 0x70000014, // Number of page table entries
+                                      // in global offset table.
+  DT_MIPS_RLD_MAP       = 0x70000016, // Address of run time loader map,
+                                      // used for debugging.
+  DT_MIPS_DELTA_CLASS       = 0x70000017, // Delta C++ class definition.
+  DT_MIPS_DELTA_CLASS_NO    = 0x70000018, // Number of entries
+                                          // in DT_MIPS_DELTA_CLASS.
+  DT_MIPS_DELTA_INSTANCE    = 0x70000019, // Delta C++ class instances.
+  DT_MIPS_DELTA_INSTANCE_NO = 0x7000001A, // Number of entries
+                                          // in DT_MIPS_DELTA_INSTANCE.
+  DT_MIPS_DELTA_RELOC       = 0x7000001B, // Delta relocations.
+  DT_MIPS_DELTA_RELOC_NO    = 0x7000001C, // Number of entries
+                                          // in DT_MIPS_DELTA_RELOC.
+  DT_MIPS_DELTA_SYM         = 0x7000001D, // Delta symbols that Delta
+                                          // relocations refer to.
+  DT_MIPS_DELTA_SYM_NO      = 0x7000001E, // Number of entries
+                                          // in DT_MIPS_DELTA_SYM.
+  DT_MIPS_DELTA_CLASSSYM    = 0x70000020, // Delta symbols that hold
+                                          // class declarations.
+  DT_MIPS_DELTA_CLASSSYM_NO = 0x70000021, // Number of entries
+                                          // in DT_MIPS_DELTA_CLASSSYM.
+  DT_MIPS_CXX_FLAGS         = 0x70000022, // Flags indicating information
+                                          // about C++ flavor.
+  DT_MIPS_PIXIE_INIT        = 0x70000023, // Pixie information.
+  DT_MIPS_SYMBOL_LIB        = 0x70000024, // Address of .MIPS.symlib
+  DT_MIPS_LOCALPAGE_GOTIDX  = 0x70000025, // The GOT index of the first PTE
+                                          // for a segment
+  DT_MIPS_LOCAL_GOTIDX      = 0x70000026, // The GOT index of the first PTE
+                                          // for a local symbol
+  DT_MIPS_HIDDEN_GOTIDX     = 0x70000027, // The GOT index of the first PTE
+                                          // for a hidden symbol
+  DT_MIPS_PROTECTED_GOTIDX  = 0x70000028, // The GOT index of the first PTE
+                                          // for a protected symbol
+  DT_MIPS_OPTIONS           = 0x70000029, // Address of `.MIPS.options'.
+  DT_MIPS_INTERFACE         = 0x7000002A, // Address of `.interface'.
+  DT_MIPS_DYNSTR_ALIGN      = 0x7000002B, // Unknown.
+  DT_MIPS_INTERFACE_SIZE    = 0x7000002C, // Size of the .interface section.
+  DT_MIPS_RLD_TEXT_RESOLVE_ADDR = 0x7000002D, // Size of rld_text_resolve
+                                              // function stored in the GOT.
+  DT_MIPS_PERF_SUFFIX       = 0x7000002E, // Default suffix of DSO to be added
+                                          // by rld on dlopen() calls.
+  DT_MIPS_COMPACT_SIZE      = 0x7000002F, // Size of compact relocation
+                                          // section (O32).
+  DT_MIPS_GP_VALUE          = 0x70000030, // GP value for auxiliary GOTs.
+  DT_MIPS_AUX_DYNAMIC       = 0x70000031, // Address of auxiliary .dynamic.
+  DT_MIPS_PLTGOT            = 0x70000032, // Address of the base of the PLTGOT.
+  DT_MIPS_RWPLT             = 0x70000034, // Points to the base
+                                          // of a writable PLT.
+  DT_MIPS_RLD_MAP_REL       = 0x70000035  // Relative offset of run time loader
+                                          // map, used for debugging.
+};
+
+// DT_FLAGS values.
+enum {
+  DF_ORIGIN     = 0x01, // The object may reference $ORIGIN.
+  DF_SYMBOLIC   = 0x02, // Search the shared lib before searching the exe.
+  DF_TEXTREL    = 0x04, // Relocations may modify a non-writable segment.
+  DF_BIND_NOW   = 0x08, // Process all relocations on load.
+  DF_STATIC_TLS = 0x10  // Reject attempts to load dynamically.
+};
+
+// State flags selectable in the `d_un.d_val' element of the DT_FLAGS_1 entry.
+enum {
+  DF_1_NOW        = 0x00000001, // Set RTLD_NOW for this object.
+  DF_1_GLOBAL     = 0x00000002, // Set RTLD_GLOBAL for this object.
+  DF_1_GROUP      = 0x00000004, // Set RTLD_GROUP for this object.
+  DF_1_NODELETE   = 0x00000008, // Set RTLD_NODELETE for this object.
+  DF_1_LOADFLTR   = 0x00000010, // Trigger filtee loading at runtime.
+  DF_1_INITFIRST  = 0x00000020, // Set RTLD_INITFIRST for this object.
+  DF_1_NOOPEN     = 0x00000040, // Set RTLD_NOOPEN for this object.
+  DF_1_ORIGIN     = 0x00000080, // $ORIGIN must be handled.
+  DF_1_DIRECT     = 0x00000100, // Direct binding enabled.
+  DF_1_TRANS      = 0x00000200,
+  DF_1_INTERPOSE  = 0x00000400, // Object is used to interpose.
+  DF_1_NODEFLIB   = 0x00000800, // Ignore default lib search path.
+  DF_1_NODUMP     = 0x00001000, // Object can't be dldump'ed.
+  DF_1_CONFALT    = 0x00002000, // Configuration alternative created.
+  DF_1_ENDFILTEE  = 0x00004000, // Filtee terminates filters search.
+  DF_1_DISPRELDNE = 0x00008000, // Disp reloc applied at build time.
+  DF_1_DISPRELPND = 0x00010000, // Disp reloc applied at run-time.
+  DF_1_NODIRECT   = 0x00020000, // Object has no-direct binding.
+  DF_1_IGNMULDEF  = 0x00040000,
+  DF_1_NOKSYMS    = 0x00080000,
+  DF_1_NOHDR      = 0x00100000,
+  DF_1_EDITED     = 0x00200000, // Object is modified after built.
+  DF_1_NORELOC    = 0x00400000,
+  DF_1_SYMINTPOSE = 0x00800000, // Object has individual interposers.
+  DF_1_GLOBAUDIT  = 0x01000000, // Global auditing required.
+  DF_1_SINGLETON  = 0x02000000  // Singleton symbols are used.
+};
+
+// DT_MIPS_FLAGS values.
+enum {
+  RHF_NONE                    = 0x00000000, // No flags.
+  RHF_QUICKSTART              = 0x00000001, // Uses shortcut pointers.
+  RHF_NOTPOT                  = 0x00000002, // Hash size is not a power of two.
+  RHS_NO_LIBRARY_REPLACEMENT  = 0x00000004, // Ignore LD_LIBRARY_PATH.
+  RHF_NO_MOVE                 = 0x00000008, // DSO address may not be relocated.
+  RHF_SGI_ONLY                = 0x00000010, // SGI specific features.
+  RHF_GUARANTEE_INIT          = 0x00000020, // Guarantee that .init will finish
+                                            // executing before any non-init
+                                            // code in DSO is called.
+  RHF_DELTA_C_PLUS_PLUS       = 0x00000040, // Contains Delta C++ code.
+  RHF_GUARANTEE_START_INIT    = 0x00000080, // Guarantee that .init will start
+                                            // executing before any non-init
+                                            // code in DSO is called.
+  RHF_PIXIE                   = 0x00000100, // Generated by pixie.
+  RHF_DEFAULT_DELAY_LOAD      = 0x00000200, // Delay-load DSO by default.
+  RHF_REQUICKSTART            = 0x00000400, // Object may be requickstarted
+  RHF_REQUICKSTARTED          = 0x00000800, // Object has been requickstarted
+  RHF_CORD                    = 0x00001000, // Generated by cord.
+  RHF_NO_UNRES_UNDEF          = 0x00002000, // Object contains no unresolved
+                                            // undef symbols.
+  RHF_RLD_ORDER_SAFE          = 0x00004000  // Symbol table is in a safe order.
+};
+
+// ElfXX_VerDef structure version (GNU versioning)
+enum {
+  VER_DEF_NONE    = 0,
+  VER_DEF_CURRENT = 1
+};
+
+// VerDef Flags (ElfXX_VerDef::vd_flags)
+enum {
+  VER_FLG_BASE = 0x1,
+  VER_FLG_WEAK = 0x2,
+  VER_FLG_INFO = 0x4
+};
+
+// Special constants for the version table. (SHT_GNU_versym/.gnu.version)
+enum {
+  VER_NDX_LOCAL  = 0,      // Unversioned local symbol
+  VER_NDX_GLOBAL = 1,      // Unversioned global symbol
+  VERSYM_VERSION = 0x7fff, // Version Index mask
+  VERSYM_HIDDEN  = 0x8000  // Hidden bit (non-default version)
+};
+
+// ElfXX_VerNeed structure version (GNU versioning)
+enum {
+  VER_NEED_NONE = 0,
+  VER_NEED_CURRENT = 1
+};
+
+
+#endif

--- a/src/inc/runtimeinfo.h
+++ b/src/inc/runtimeinfo.h
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#pragma once
+
+// The first byte of the index is the count of bytes
+typedef unsigned char SYMBOL_INDEX;
+
+typedef struct _RuntimeInfo
+{
+    const char Signature[18];
+    int Version;
+    const SYMBOL_INDEX RuntimeModuleIndex[24];
+    const SYMBOL_INDEX DacModuleIndex[24];
+    const SYMBOL_INDEX DbiModuleIndex[24];
+} RuntimeInfo;
+
+extern RuntimeInfo DotNetRuntimeInfo;

--- a/src/pal/prebuilt/idl/clrdata_i.cpp
+++ b/src/pal/prebuilt/idl/clrdata_i.cpp
@@ -1,4 +1,6 @@
-
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 /* this ALWAYS GENERATED file contains the IIDs and CLSIDs */
 

--- a/src/pal/prebuilt/idl/clrdata_i.cpp
+++ b/src/pal/prebuilt/idl/clrdata_i.cpp
@@ -1,7 +1,3 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
 
 
 /* this ALWAYS GENERATED file contains the IIDs and CLSIDs */
@@ -9,7 +5,17 @@
 /* link this file in with the server and any clients */
 
 
- /* File created by MIDL compiler version 8.00.0603 */
+ /* File created by MIDL compiler version 8.01.0622 */
+/* at Mon Jan 18 19:14:07 2038
+ */
+/* Compiler settings for C:/ssd/runtime/src/coreclr/src/inc/clrdata.idl:
+    Oicf, W1, Zp8, env=Win32 (32b run), target_arch=X86 8.01.0622 
+    protocol : dce , ms_ext, c_ext, robust
+    error checks: allocation ref bounds_check enum stub_data 
+    VC __declspec() decoration level: 
+         __declspec(uuid()), __declspec(selectany), __declspec(novtable)
+         DECLSPEC_UUID(), MIDL_INTERFACE()
+*/
 /* @@MIDL_FILE_HEADING(  ) */
 
 #pragma warning( disable: 4049 )  /* more than 64k source lines */
@@ -57,9 +63,9 @@ typedef IID CLSID;
 #endif // CLSID_DEFINED
 
 #define MIDL_DEFINE_GUID(type,name,l,w1,w2,b1,b2,b3,b4,b5,b6,b7,b8) \
-        const type name = {l,w1,w2,{b1,b2,b3,b4,b5,b6,b7,b8}}
+        EXTERN_C __declspec(selectany) const type name = {l,w1,w2,{b1,b2,b3,b4,b5,b6,b7,b8}}
 
-#endif !_MIDL_USE_GUIDDEF_
+#endif // !_MIDL_USE_GUIDDEF_
 
 MIDL_DEFINE_GUID(IID, IID_ICLRDataTarget,0x3E11CCEE,0xD08B,0x43e5,0xAF,0x01,0x32,0x71,0x7A,0x64,0xDA,0x03);
 
@@ -68,6 +74,9 @@ MIDL_DEFINE_GUID(IID, IID_ICLRDataTarget2,0x6d05fae3,0x189c,0x4630,0xa6,0xdc,0x1
 
 
 MIDL_DEFINE_GUID(IID, IID_ICLRDataTarget3,0xa5664f95,0x0af4,0x4a1b,0x96,0x0e,0x2f,0x33,0x46,0xb4,0x21,0x4c);
+
+
+MIDL_DEFINE_GUID(IID, IID_ICLRRuntimeLocator,0xb760bf44,0x9377,0x4597,0x8b,0xe7,0x58,0x08,0x3b,0xdc,0x51,0x46);
 
 
 MIDL_DEFINE_GUID(IID, IID_ICLRMetadataLocator,0xaa8fa804,0xbc05,0x4642,0xb2,0xc5,0xc3,0x53,0xed,0x22,0xfc,0x63);

--- a/src/pal/prebuilt/inc/clrdata.h
+++ b/src/pal/prebuilt/inc/clrdata.h
@@ -1,4 +1,6 @@
-
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 /* this ALWAYS GENERATED file contains the definitions for the interfaces */
 

--- a/src/pal/prebuilt/inc/clrdata.h
+++ b/src/pal/prebuilt/inc/clrdata.h
@@ -1,13 +1,19 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
 
 
 /* this ALWAYS GENERATED file contains the definitions for the interfaces */
 
 
- /* File created by MIDL compiler version 8.00.0603 */
+ /* File created by MIDL compiler version 8.01.0622 */
+/* at Mon Jan 18 19:14:07 2038
+ */
+/* Compiler settings for C:/ssd/runtime/src/coreclr/src/inc/clrdata.idl:
+    Oicf, W1, Zp8, env=Win32 (32b run), target_arch=X86 8.01.0622 
+    protocol : dce , ms_ext, c_ext, robust
+    error checks: allocation ref bounds_check enum stub_data 
+    VC __declspec() decoration level: 
+         __declspec(uuid()), __declspec(selectany), __declspec(novtable)
+         DECLSPEC_UUID(), MIDL_INTERFACE()
+*/
 /* @@MIDL_FILE_HEADING(  ) */
 
 #pragma warning( disable: 4049 )  /* more than 64k source lines */
@@ -23,7 +29,7 @@
 
 #ifndef __RPCNDR_H_VERSION__
 #error this stub requires an updated version of <rpcndr.h>
-#endif // __RPCNDR_H_VERSION__
+#endif /* __RPCNDR_H_VERSION__ */
 
 #ifndef COM_NO_WINDOWS_H
 #include "windows.h"
@@ -58,6 +64,13 @@ typedef interface ICLRDataTarget2 ICLRDataTarget2;
 typedef interface ICLRDataTarget3 ICLRDataTarget3;
 
 #endif 	/* __ICLRDataTarget3_FWD_DEFINED__ */
+
+
+#ifndef __ICLRRuntimeLocator_FWD_DEFINED__
+#define __ICLRRuntimeLocator_FWD_DEFINED__
+typedef interface ICLRRuntimeLocator ICLRRuntimeLocator;
+
+#endif 	/* __ICLRRuntimeLocator_FWD_DEFINED__ */
 
 
 #ifndef __ICLRMetadataLocator_FWD_DEFINED__
@@ -761,6 +774,86 @@ EXTERN_C const IID IID_ICLRDataTarget3;
 #endif 	/* __ICLRDataTarget3_INTERFACE_DEFINED__ */
 
 
+#ifndef __ICLRRuntimeLocator_INTERFACE_DEFINED__
+#define __ICLRRuntimeLocator_INTERFACE_DEFINED__
+
+/* interface ICLRRuntimeLocator */
+/* [unique][uuid][local][object] */ 
+
+
+EXTERN_C const IID IID_ICLRRuntimeLocator;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("b760bf44-9377-4597-8be7-58083bdc5146")
+    ICLRRuntimeLocator : public IUnknown
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE GetRuntimeBase( 
+            /* [out] */ CLRDATA_ADDRESS *baseAddress) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct ICLRRuntimeLocatorVtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            ICLRRuntimeLocator * This,
+            /* [in] */ REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            ICLRRuntimeLocator * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            ICLRRuntimeLocator * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetRuntimeBase )( 
+            ICLRRuntimeLocator * This,
+            /* [out] */ CLRDATA_ADDRESS *baseAddress);
+        
+        END_INTERFACE
+    } ICLRRuntimeLocatorVtbl;
+
+    interface ICLRRuntimeLocator
+    {
+        CONST_VTBL struct ICLRRuntimeLocatorVtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define ICLRRuntimeLocator_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define ICLRRuntimeLocator_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define ICLRRuntimeLocator_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define ICLRRuntimeLocator_GetRuntimeBase(This,baseAddress)	\
+    ( (This)->lpVtbl -> GetRuntimeBase(This,baseAddress) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __ICLRRuntimeLocator_INTERFACE_DEFINED__ */
+
+
 #ifndef __ICLRMetadataLocator_INTERFACE_DEFINED__
 #define __ICLRMetadataLocator_INTERFACE_DEFINED__
 
@@ -1032,7 +1125,7 @@ EXTERN_C const IID IID_ICLRDataEnumMemoryRegionsCallback2;
 #endif 	/* __ICLRDataEnumMemoryRegionsCallback2_INTERFACE_DEFINED__ */
 
 
-/* interface __MIDL_itf_clrdata_0000_0006 */
+/* interface __MIDL_itf_clrdata_0000_0007 */
 /* [local] */ 
 
 typedef 
@@ -1046,8 +1139,8 @@ enum CLRDataEnumMemoryFlags
 
 
 
-extern RPC_IF_HANDLE __MIDL_itf_clrdata_0000_0006_v0_0_c_ifspec;
-extern RPC_IF_HANDLE __MIDL_itf_clrdata_0000_0006_v0_0_s_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_clrdata_0000_0007_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_clrdata_0000_0007_v0_0_s_ifspec;
 
 #ifndef __ICLRDataEnumMemoryRegions_INTERFACE_DEFINED__
 #define __ICLRDataEnumMemoryRegions_INTERFACE_DEFINED__


### PR DESCRIPTION
Adds the elfreader from the runtime repo to use to find the "DotNetRuntimeInfo" export when search for the runtime module. 

Plumbs through the build ids from this runtime info to download the DAC and DBI modules.

Add ICLRRuntimeLocator DAC interface (that returns the runtime module base address) to datatarget provided to the DAC.

Cleaned up the DAC/DBI  download code using new Microsoft.SymbolStore support. 