### PR TITLE
Fix eeheap output on 32-bit targets

### DIFF
--- a/src/SOS/Strike/eeheap.cpp
+++ b/src/SOS/Strike/eeheap.cpp
@@ -527,7 +527,7 @@ void GCPrintLargeHeapSegmentInfo(const DacpGcHeapDetails &heap, DWORD_PTR &total
         ExtOut("%p  %p  %p  0x%" POINTERSIZE_TYPE "x(%" POINTERSIZE_TYPE "d)\n", SOS_PTR(dwAddrSeg),
                  SOS_PTR(segment.mem), SOS_PTR(segment.allocated),
                  (ULONG_PTR)(segment.allocated - segment.mem),
-                 segment.allocated - segment.mem);
+                 (ULONG_PTR)(segment.allocated - segment.mem));
         total_size += (DWORD_PTR) (segment.allocated - segment.mem);
         dwAddrSeg = (DWORD_PTR)segment.next;
     }


### PR DESCRIPTION
Testing arm dump analyze on Linux showed:

```
Large object heap starts at 0x72500000
 segment     begin  allocated      size
724FF000  72500000  72502250  0x2250(1812174861)
4A62D000  4A62E000  5A62E020  0x10000020(1812174861)
2962C000  2962D000  2962D000  0x0(1812174861)
Total Size:              Size: 0x1000dab4 (268491444) bytes.
```

On Windows it showed:
```
Large object heap starts at 0x72500000
 segment     begin  allocated      size
724FF000  72500000  72502250  0x2250(8784)
4A62D000  4A62E000  5A62E020  0x10000020(268435488)
2962C000  2962D000  2962D000  0x0(0)
Total Size:              Size: 0x1000dab4 (268491444) bytes.
```

Windows version is correct.