### PR TITLE
Support to non english cultures in the terminal display

### DIFF
--- a/src/Tools/dotnet-counters/Exporters/ConsoleWriter.cs
+++ b/src/Tools/dotnet-counters/Exporters/ConsoleWriter.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 
 namespace Microsoft.Diagnostics.Tools.Counters.Exporters
@@ -125,8 +126,8 @@ namespace Microsoft.Diagnostics.Tools.Counters.Exporters
             }
 
             const string DecimalPlaces = "###";
-            string payloadVal = payload.GetValue().ToString("#,0." + DecimalPlaces);
-            int decimalIndex = payloadVal.IndexOf('.');
+            string payloadVal = payload.GetValue().ToString("#,0." + DecimalPlaces, CultureInfo.CurrentCulture);
+            int decimalIndex = payloadVal.IndexOf(CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator, StringComparison.CurrentCulture);
             if (decimalIndex == -1)
             {
                 decimalIndex = payloadVal.Length;


### PR DESCRIPTION
When you use dotnet-counters monitor in a pc that has any culture with diferent decimal separator than english's separator the process crashes.
Not any error is displayed but the terminal doesn't update and doesn't respond to inputs
![image](https://user-images.githubusercontent.com/36899226/79693449-f7936e00-826a-11ea-9131-c3780aba72d0.png)

This PR fix the problem related with the use of literals for decimal separator adding support for other culures.
![image](https://user-images.githubusercontent.com/36899226/79693472-227dc200-826b-11ea-911c-9d3c9cc971e9.png)
