### PR TITLE
Update clrmd to fix dotnet-dump module enum perf.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -37,7 +37,7 @@
     <MicrosoftAspNetCoreHttpsPolicyVersion>2.1.1</MicrosoftAspNetCoreHttpsPolicyVersion>
     <MicrosoftAspNetCoreMvcVersion>2.1.3</MicrosoftAspNetCoreMvcVersion>
     <MicrosoftAspNetCoreResponseCompressionVersion>2.1.1</MicrosoftAspNetCoreResponseCompressionVersion>
-    <MicrosoftDiagnosticsRuntimeVersion>1.1.116301</MicrosoftDiagnosticsRuntimeVersion>
+    <MicrosoftDiagnosticsRuntimeVersion>1.1.122004</MicrosoftDiagnosticsRuntimeVersion>
     <MicrosoftDiaSymReaderNativePackageVersion>1.7.0</MicrosoftDiaSymReaderNativePackageVersion>
     <MicrosoftDiagnosticsTracingTraceEventVersion>2.0.51</MicrosoftDiagnosticsTracingTraceEventVersion>
     <MicrosoftExtensionsConfigurationJsonVersion>2.1.1</MicrosoftExtensionsConfigurationJsonVersion>

--- a/src/SOS/SOS.Hosting/dbgeng/DebugAdvanced.cs
+++ b/src/SOS/SOS.Hosting/dbgeng/DebugAdvanced.cs
@@ -21,13 +21,13 @@ namespace SOS
 
         #region IDebugAdvanced Delegates
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetThreadContextDelegate(
             [In] IntPtr self,
             [In] IntPtr context,
             [In] uint contextSize);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int SetThreadContextDelegate(
             [In] IntPtr self,
             [In] IntPtr context,

--- a/src/SOS/SOS.Hosting/dbgeng/DebugClient.cs
+++ b/src/SOS/SOS.Hosting/dbgeng/DebugClient.cs
@@ -106,43 +106,43 @@ namespace SOS
 
         #region IDebugClient Delegates
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int AttachKernelDelegate(
             IntPtr self,
             [In] DEBUG_ATTACH flags,
             [In][MarshalAs(UnmanagedType.LPStr)] string connectOptions);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetKernelConnectionOptionsDelegate(
             IntPtr self,
             [Out][MarshalAs(UnmanagedType.LPStr)] StringBuilder Buffer,
             [In] int BufferSize,
             [Out] uint* OptionsSize);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int SetKernelConnectionOptionsDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPStr)] string Options);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int StartProcessServerDelegate(
             IntPtr self,
             [In] DEBUG_CLASS Flags,
             [In][MarshalAs(UnmanagedType.LPStr)] string Options,
             [In] IntPtr Reserved);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int ConnectProcessServerDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPStr)] string RemoteOptions,
             [Out] ulong* Server);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int DisconnectProcessServerDelegate(
             IntPtr self,
             [In] ulong Server);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetRunningProcessSystemIdsDelegate(
             IntPtr self,
             [In] ulong Server,
@@ -150,7 +150,7 @@ namespace SOS
             [In] uint Count,
             [Out] uint* ActualCount);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetRunningProcessSystemIdByExecutableNameDelegate(
             IntPtr self,
             [In] ulong Server,
@@ -158,7 +158,7 @@ namespace SOS
             [In] DEBUG_GET_PROC Flags,
             [Out] uint* Id);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetRunningProcessDescriptionDelegate(
             IntPtr self,
             [In] ulong Server,
@@ -171,21 +171,21 @@ namespace SOS
             [In] int DescriptionSize,
             [Out] uint* ActualDescriptionSize);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int AttachProcessDelegate(
             IntPtr self,
             [In] ulong Server,
             [In] uint ProcessID,
             [In] DEBUG_ATTACH AttachFlags);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int CreateProcessDelegate(
             IntPtr self,
             [In] ulong Server,
             [In][MarshalAs(UnmanagedType.LPStr)] string CommandLine,
             [In] DEBUG_CREATE_PROCESS Flags);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int CreateProcessAndAttachDelegate(
             IntPtr self,
             [In] ulong Server,
@@ -194,164 +194,164 @@ namespace SOS
             [In] uint ProcessId,
             [In] DEBUG_ATTACH AttachFlags);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetProcessOptionsDelegate(
             IntPtr self,
             [Out] DEBUG_PROCESS* Options);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int AddProcessOptionsDelegate(
             IntPtr self,
             [In] DEBUG_PROCESS Options);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int RemoveProcessOptionsDelegate(
             IntPtr self,
             [In] DEBUG_PROCESS Options);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int SetProcessOptionsDelegate(
             IntPtr self,
             [In] DEBUG_PROCESS Options);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int OpenDumpFileDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPStr)] string DumpFile);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int WriteDumpFileDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPStr)] string DumpFile,
             [In] DEBUG_DUMP Qualifier);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int ConnectSessionDelegate(
             IntPtr self,
             [In] DEBUG_CONNECT_SESSION Flags,
             [In] uint HistoryLimit);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int StartServerDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPStr)] string Options);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int OutputServerDelegate(
             IntPtr self,
             [In] DEBUG_OUTCTL OutputControl,
             [In][MarshalAs(UnmanagedType.LPStr)] string Machine,
             [In] DEBUG_SERVERS Flags);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int TerminateProcessesDelegate(
             IntPtr self);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int DetachProcessesDelegate(
             IntPtr self);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int EndSessionDelegate(
             IntPtr self,
             [In] DEBUG_END Flags);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetExitCodeDelegate(
             IntPtr self,
             [Out] uint* Code);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int DispatchCallbacksDelegate(
             IntPtr self,
             [In] uint Timeout);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int ExitDispatchDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.Interface)] IDebugClient Client);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int CreateClientDelegate(
             IntPtr self,
             [Out][MarshalAs(UnmanagedType.Interface)] IntPtr Client);             // out IDebugClient
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetInputCallbacksDelegate(
             IntPtr self,
             [Out][MarshalAs(UnmanagedType.Interface)] IntPtr Callbacks);          // out IDebugInputCallbacks
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int SetInputCallbacksDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.Interface)] IDebugInputCallbacks Callbacks);
 
         /* GetOutputCallbacks could a conversion thunk from the debugger engine so we can't specify a specific interface */
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetOutputCallbacksDelegate(
             IntPtr self,
             [Out] IntPtr Callbacks);    // out IDebugOutputCallbacks
 
         /* We may have to pass a debugger engine conversion thunk back in so we can't specify a specific interface */
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int SetOutputCallbacksDelegate(
             IntPtr self,
             [In] IDebugOutputCallbacks Callbacks);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetOutputMaskDelegate(
             IntPtr self,
             [Out] DEBUG_OUTPUT* Mask);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int SetOutputMaskDelegate(
             IntPtr self,
             [In] DEBUG_OUTPUT Mask);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetOtherOutputMaskDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.Interface)] IDebugClient Client,
             [Out] DEBUG_OUTPUT* Mask);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int SetOtherOutputMaskDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.Interface)] IDebugClient Client,
             [In] DEBUG_OUTPUT Mask);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetOutputWidthDelegate(
             IntPtr self,
             [Out] uint* Columns);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int SetOutputWidthDelegate(
             IntPtr self,
             [In] uint Columns);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetOutputLinePrefixDelegate(
             IntPtr self,
             [Out][MarshalAs(UnmanagedType.LPStr)] StringBuilder Buffer,
             [In] int BufferSize,
             [Out] uint* PrefixSize);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int SetOutputLinePrefixDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPStr)] string Prefix);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetIdentityDelegate(
             IntPtr self,
             [Out][MarshalAs(UnmanagedType.LPStr)] StringBuilder Buffer,
             [In] int BufferSize,
             [Out] uint* IdentitySize);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int OutputIdentityDelegate(
             IntPtr self,
             [In] DEBUG_OUTCTL OutputControl,
@@ -360,19 +360,19 @@ namespace SOS
 
         /* GetEventCallbacks could a conversion thunk from the debugger engine so we can't specify a specific interface */
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetEventCallbacksDelegate(
             IntPtr self,
             [Out] IntPtr Callbacks);    // out IDebugEventCallbacks
 
         /* We may have to pass a debugger engine conversion thunk back in so we can't specify a specific interface */
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int SetEventCallbacksDelegate(
             IntPtr self,
             [In] IDebugEventCallbacks Callbacks);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int FlushCallbacksDelegate(
             IntPtr self);
 

--- a/src/SOS/SOS.Hosting/dbgeng/DebugControl.cs
+++ b/src/SOS/SOS.Hosting/dbgeng/DebugControl.cs
@@ -134,26 +134,26 @@ namespace SOS
 
         #region IDebugControl Delegates
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetInterruptDelegate(
             IntPtr self);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int SetInterruptDelegate(
             IntPtr self,
             [In] DEBUG_INTERRUPT Flags);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetInterruptTimeoutDelegate(
             IntPtr self,
             [Out] int* Seconds);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int SetInterruptTimeoutDelegate(
             IntPtr self,
             [In] uint Seconds);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetLogFileDelegate(
             IntPtr self,
             [Out][MarshalAs(UnmanagedType.LPStr)] StringBuilder Buffer,
@@ -161,59 +161,59 @@ namespace SOS
             [Out] uint* FileSize,
             [Out][MarshalAs(UnmanagedType.Bool)] bool* Append);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int OpenLogFileDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPStr)] string File,
             [In][MarshalAs(UnmanagedType.Bool)] bool Append);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int CloseLogFileDelegate(
             IntPtr self);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetLogMaskDelegate(
             IntPtr self,
             [Out] DEBUG_OUTPUT* Mask);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int SetLogMaskDelegate(
             IntPtr self,
             [In] DEBUG_OUTPUT Mask);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int InputDelegate(
             IntPtr self,
             [Out][MarshalAs(UnmanagedType.LPStr)] StringBuilder Buffer,
             [In] int BufferSize,
             [Out] uint* InputSize);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int ReturnInputDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPStr)] string Buffer);
 
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        //[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate int OutputDelegate(
             IntPtr self,
             [In] DEBUG_OUTPUT Mask,
             [In][MarshalAs(UnmanagedType.LPStr)] string Format);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int OutputVaListDelegate(
             IntPtr self,
             [In] DEBUG_OUTPUT Mask,
             [In][MarshalAs(UnmanagedType.LPStr)] string Format,
             [In] IntPtr valist);
 
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        //[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate int ControlledOutputDelegate(
             IntPtr self,
             [In] DEBUG_OUTCTL OutputControl,
             [In] DEBUG_OUTPUT Mask,
             [In][MarshalAs(UnmanagedType.LPStr)] string Format);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int ControlledOutputVaListDelegate(
             IntPtr self,
             [In] DEBUG_OUTCTL OutputControl,
@@ -221,55 +221,55 @@ namespace SOS
             [In][MarshalAs(UnmanagedType.LPStr)] string Format,
             [In] IntPtr valist);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        //[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate int OutputPromptDelegate(
             IntPtr self,
             [In] DEBUG_OUTCTL OutputControl,
             [In][MarshalAs(UnmanagedType.LPStr)] string Format);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int OutputPromptVaListDelegate( /* THIS SHOULD NEVER BE CALLED FROM C# */
             IntPtr self,
             [In] DEBUG_OUTCTL OutputControl,
             [In][MarshalAs(UnmanagedType.LPStr)] string Format,
             [In] IntPtr valist);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetPromptTextDelegate(
             IntPtr self,
             [Out][MarshalAs(UnmanagedType.LPStr)] StringBuilder Buffer,
             [In] int BufferSize,
             [Out] uint* TextSize);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int OutputCurrentStateDelegate(
             IntPtr self,
             [In] DEBUG_OUTCTL OutputControl,
             [In] DEBUG_CURRENT Flags);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int OutputVersionInformationDelegate(
             IntPtr self,
             [In] DEBUG_OUTCTL OutputControl);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetNotifyEventHandleDelegate(
             IntPtr self,
             [Out] ulong* Handle);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int SetNotifyEventHandleDelegate(
             IntPtr self,
             [In] ulong Handle);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int AssembleDelegate(
             IntPtr self,
             [In] ulong Offset,
             [In][MarshalAs(UnmanagedType.LPStr)] string Instr,
             [Out] ulong* EndOffset);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int DisassembleDelegate(
             IntPtr self,
             [In] ulong Offset,
@@ -279,12 +279,12 @@ namespace SOS
             [Out] uint* DisassemblySize,
             [Out] ulong* EndOffset);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetDisassembleEffectiveOffsetDelegate(
             IntPtr self,
             [Out] ulong* Offset);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int OutputDisassemblyDelegate(
             IntPtr self,
             [In] DEBUG_OUTCTL OutputControl,
@@ -292,7 +292,7 @@ namespace SOS
             [In] DEBUG_DISASM Flags,
             [Out] ulong* EndOffset);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int OutputDisassemblyLinesDelegate(
             IntPtr self,
             [In] DEBUG_OUTCTL OutputControl,
@@ -305,14 +305,14 @@ namespace SOS
             [Out] ulong* EndOffset,
             [Out] ulong* LineOffsets);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetNearInstructionDelegate(
             IntPtr self,
             [In] ulong Offset,
             [In] int Delta,
             [Out] ulong* NearOffset);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetStackTraceDelegate(
             IntPtr self,
             [In] ulong FrameOffset,
@@ -322,12 +322,12 @@ namespace SOS
             [In] int FrameSize,
             [Out] uint* FramesFilled);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetReturnOffsetDelegate(
             IntPtr self,
             [Out] ulong* Offset);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int OutputStackTraceDelegate(
             IntPtr self,
             [In] DEBUG_OUTCTL OutputControl,
@@ -335,40 +335,40 @@ namespace SOS
             [In] int FramesSize,
             [In] DEBUG_STACK Flags);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetDebuggeeTypeDelegate(
             IntPtr self,
             [Out] DEBUG_CLASS* Class,
             [Out] DEBUG_CLASS_QUALIFIER* Qualifier);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetActualProcessorTypeDelegate(
             IntPtr self,
             [Out] IMAGE_FILE_MACHINE* Type);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetExecutingProcessorTypeDelegate(
             IntPtr self,
             [Out] IMAGE_FILE_MACHINE* Type);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetNumberPossibleExecutingProcessorTypesDelegate(
             IntPtr self,
             [Out] uint* Number);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetPossibleExecutingProcessorTypesDelegate(
             IntPtr self,
             [In] uint Start,
             [In] uint Count,
             [Out] IMAGE_FILE_MACHINE* Types);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetNumberProcessorsDelegate(
             IntPtr self,
             [Out] uint* Number);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetSystemVersionDelegate(
             IntPtr self,
             [Out] uint* PlatformId,
@@ -382,16 +382,16 @@ namespace SOS
             [In] int BuildStringSize,
             [Out] uint* BuildStringUsed);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetPageSizeDelegate(
             IntPtr self,
             [Out] uint* Size);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int IsPointer64BitDelegate(
             IntPtr self);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int ReadBugCheckDataDelegate(
             IntPtr self,
             [Out] uint* Code,
@@ -400,19 +400,19 @@ namespace SOS
             [Out] ulong* Arg3,
             [Out] ulong* Arg4);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetNumberSupportedProcessorTypesDelegate(
             IntPtr self,
             [Out] uint* Number);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetSupportedProcessorTypesDelegate(
             IntPtr self,
             [In] uint Start,
             [In] uint Count,
             [Out] IMAGE_FILE_MACHINE* Types);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetProcessorTypeNamesDelegate(
             IntPtr self,
             [In] IMAGE_FILE_MACHINE Type,
@@ -423,69 +423,69 @@ namespace SOS
             [In] int AbbrevNameBufferSize,
             [Out] uint* AbbrevNameSize);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetEffectiveProcessorTypeDelegate(
             IntPtr self,
             [Out] IMAGE_FILE_MACHINE* Type);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int SetEffectiveProcessorTypeDelegate(
             IntPtr self,
             [In] IMAGE_FILE_MACHINE Type);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetExecutionStatusDelegate(
             IntPtr self,
             [Out] DEBUG_STATUS* Status);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int SetExecutionStatusDelegate(
             IntPtr self,
             [In] DEBUG_STATUS Status);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetCodeLevelDelegate(
             IntPtr self,
             [Out] DEBUG_LEVEL* Level);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int SetCodeLevelDelegate(
             IntPtr self,
             [In] DEBUG_LEVEL Level);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetEngineOptionsDelegate(
             IntPtr self,
             [Out] DEBUG_ENGOPT* Options);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int AddEngineOptionsDelegate(
             IntPtr self,
             [In] DEBUG_ENGOPT Options);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int RemoveEngineOptionsDelegate(
             IntPtr self,
             [In] DEBUG_ENGOPT Options);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int SetEngineOptionsDelegate(
             IntPtr self,
             [In] DEBUG_ENGOPT Options);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetSystemErrorControlDelegate(
             IntPtr self,
             [Out] ERROR_LEVEL* OutputLevel,
             [Out] ERROR_LEVEL* BreakLevel);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int SetSystemErrorControlDelegate(
             IntPtr self,
             [In] ERROR_LEVEL OutputLevel,
             [In] ERROR_LEVEL BreakLevel);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetTextMacroDelegate(
             IntPtr self,
             [In] uint Slot,
@@ -493,23 +493,23 @@ namespace SOS
             [In] int BufferSize,
             [Out] uint* MacroSize);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int SetTextMacroDelegate(
             IntPtr self,
             [In] uint Slot,
             [In][MarshalAs(UnmanagedType.LPStr)] string Macro);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetRadixDelegate(
             IntPtr self,
             [Out] uint* Radix);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int SetRadixDelegate(
             IntPtr self,
             [In] uint Radix);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int EvaluateDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPStr)] string Expression,
@@ -517,14 +517,14 @@ namespace SOS
             [Out] DEBUG_VALUE* Value,
             [Out] uint* RemainderIndex);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int CoerceValueDelegate(
             IntPtr self,
             [In] DEBUG_VALUE In,
             [In] DEBUG_VALUE_TYPE OutType,
             [Out] DEBUG_VALUE* Out);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int CoerceValuesDelegate(
             IntPtr self,
             [In] uint Count,
@@ -532,38 +532,38 @@ namespace SOS
             [In][MarshalAs(UnmanagedType.LPArray)] DEBUG_VALUE_TYPE[] OutType,
             [Out] DEBUG_VALUE* Out);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int ExecuteDelegate(
             IntPtr self,
             [In] DEBUG_OUTCTL OutputControl,
             [In][MarshalAs(UnmanagedType.LPStr)] string Command,
             [In] DEBUG_EXECUTE Flags);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int ExecuteCommandFileDelegate(
             IntPtr self,
             [In] DEBUG_OUTCTL OutputControl,
             [In][MarshalAs(UnmanagedType.LPStr)] string CommandFile,
             [In] DEBUG_EXECUTE Flags);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetNumberBreakpointsDelegate(
             IntPtr self,
             [Out] uint* Number);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetBreakpointByIndexDelegate(
             IntPtr self,
             [In] uint Index,
             [Out][MarshalAs(UnmanagedType.Interface)] IntPtr bp);     // out IDebugBreakpoint
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetBreakpointByIdDelegate(
             IntPtr self,
             [In] uint Id,
             [Out][MarshalAs(UnmanagedType.Interface)] IntPtr bp);     // out IDebugBreakpoint
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetBreakpointParametersDelegate(
             IntPtr self,
             [In] uint Count,
@@ -571,72 +571,72 @@ namespace SOS
             [In] uint Start,
             [Out] DEBUG_BREAKPOINT_PARAMETERS* Params);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int AddBreakpointDelegate(
             IntPtr self,
             [In] DEBUG_BREAKPOINT_TYPE Type,
             [In] uint DesiredId,
             [Out][MarshalAs(UnmanagedType.Interface)] IntPtr bp);     // out IDebugBreakpoint
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int RemoveBreakpointDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.Interface)] IDebugBreakpoint Bp);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int AddExtensionDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPStr)] string Path,
             [In] uint Flags,
             [Out] ulong* Handle);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int RemoveExtensionDelegate(
             IntPtr self,
             [In] ulong Handle);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetExtensionByPathDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPStr)] string Path,
             [Out] ulong* Handle);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int CallExtensionDelegate(
             IntPtr self,
             [In] ulong Handle,
             [In][MarshalAs(UnmanagedType.LPStr)] string Function,
             [In][MarshalAs(UnmanagedType.LPStr)] string Arguments);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetExtensionFunctionDelegate(
             IntPtr self,
             [In] ulong Handle,
             [In][MarshalAs(UnmanagedType.LPStr)] string FuncName,
             [Out] IntPtr* Function);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetWindbgExtensionApis32Delegate(
             IntPtr self,
             [In][Out] WINDBG_EXTENSION_APIS* Api);
 
         /* Must be In and Out as the nSize member has to be initialized */
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetWindbgExtensionApis64Delegate(
             IntPtr self,
             [In][Out] WINDBG_EXTENSION_APIS* Api);
 
         /* Must be In and Out as the nSize member has to be initialized */
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetNumberEventFiltersDelegate(
             IntPtr self,
             [Out] uint* SpecificEvents,
             [Out] uint* SpecificExceptions,
             [Out] uint* ArbitraryExceptions);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetEventFilterTextDelegate(
             IntPtr self,
             [In] uint Index,
@@ -644,7 +644,7 @@ namespace SOS
             [In] int BufferSize,
             [Out] uint* TextSize);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetEventFilterCommandDelegate(
             IntPtr self,
             [In] uint Index,
@@ -652,27 +652,27 @@ namespace SOS
             [In] int BufferSize,
             [Out] uint* CommandSize);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int SetEventFilterCommandDelegate(
             IntPtr self,
             [In] uint Index,
             [In][MarshalAs(UnmanagedType.LPStr)] string Command);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetSpecificFilterParametersDelegate(
             IntPtr self,
             [In] uint Start,
             [In] uint Count,
             [Out] DEBUG_SPECIFIC_FILTER_PARAMETERS* Params);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int SetSpecificFilterParametersDelegate(
             IntPtr self,
             [In] uint Start,
             [In] uint Count,
             [In][MarshalAs(UnmanagedType.LPArray)] DEBUG_SPECIFIC_FILTER_PARAMETERS[] Params);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetSpecificEventFilterArgumentDelegate(
             IntPtr self,
             [In] uint Index,
@@ -680,13 +680,13 @@ namespace SOS
             [In] int BufferSize,
             [Out] uint* ArgumentSize);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int SetSpecificEventFilterArgumentDelegate(
             IntPtr self,
             [In] uint Index,
             [In][MarshalAs(UnmanagedType.LPStr)] string Argument);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetExceptionFilterParametersDelegate(
             IntPtr self,
             [In] uint Count,
@@ -694,13 +694,13 @@ namespace SOS
             [In] uint Start,
             [Out] DEBUG_EXCEPTION_FILTER_PARAMETERS* Params);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int SetExceptionFilterParametersDelegate(
             IntPtr self,
             [In] uint Count,
             [In][MarshalAs(UnmanagedType.LPArray)] DEBUG_EXCEPTION_FILTER_PARAMETERS[] Params);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetExceptionFilterSecondCommandDelegate(
             IntPtr self,
             [In] uint Index,
@@ -708,19 +708,19 @@ namespace SOS
             [In] int BufferSize,
             [Out] uint* CommandSize);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int SetExceptionFilterSecondCommandDelegate(
             IntPtr self,
             [In] uint Index,
             [In][MarshalAs(UnmanagedType.LPStr)] string Command);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int WaitForEventDelegate(
             IntPtr self,
             [In] DEBUG_WAIT Flags,
             [In] uint Timeout);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetLastEventInformationDelegate(
             IntPtr self,
             [Out] DEBUG_EVENT* Type,
@@ -737,27 +737,27 @@ namespace SOS
 
         #region IDebugControl2 Delegates
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetCurrentTimeDateDelegate(
             IntPtr self,
             [Out] uint* TimeDate);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetCurrentSystemUpTimeDelegate(
             IntPtr self,
             [Out] uint* UpTime);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetDumpFormatFlagsDelegate(
             IntPtr self,
             [Out] DEBUG_FORMAT* FormatFlags);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetNumberTextReplacementsDelegate(
             IntPtr self,
             [Out] uint* NumRepl);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetTextReplacementDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPStr)] string SrcText,
@@ -769,17 +769,17 @@ namespace SOS
             [In] int DstBufferSize,
             [Out] uint* DstSize);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int SetTextReplacementDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPStr)] string SrcText,
             [In][MarshalAs(UnmanagedType.LPStr)] string DstText);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int RemoveTextReplacementsDelegate(
             IntPtr self);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int OutputTextReplacementsDelegate(
             IntPtr self,
             [In] DEBUG_OUTCTL OutputControl,

--- a/src/SOS/SOS.Hosting/dbgeng/DebugDataSpaces.cs
+++ b/src/SOS/SOS.Hosting/dbgeng/DebugDataSpaces.cs
@@ -59,7 +59,7 @@ namespace SOS
 
         #region IDebugDataSpaces Delegates
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private unsafe delegate int ReadVirtualDelegate(
             IntPtr self,
             [In] ulong address,
@@ -67,7 +67,7 @@ namespace SOS
             [In] uint bufferSize,
             [Out] uint* bytesRead);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int WriteVirtualDelegate(
             IntPtr self,
             [In] ulong address,
@@ -75,7 +75,7 @@ namespace SOS
             [In] uint bufferSize,
             [Out] uint* bytesWritten);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int SearchVirtualDelegate(
             IntPtr self,
             [In] ulong Offset,
@@ -85,7 +85,7 @@ namespace SOS
             [In] uint PatternGranularity,
             [Out] ulong* MatchOffset);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int ReadVirtualUncachedDelegate(
             IntPtr self,
             [In] ulong Offset,
@@ -93,7 +93,7 @@ namespace SOS
             [In] uint BufferSize,
             [Out] uint* BytesRead);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int WriteVirtualUncachedDelegate(
             IntPtr self,
             [In] ulong Offset,
@@ -101,21 +101,21 @@ namespace SOS
             [In] uint BufferSize,
             [Out] uint* BytesWritten);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int ReadPointersVirtualDelegate(
             IntPtr self,
             [In] uint Count,
             [In] ulong Offset,
             [Out] ulong* Ptrs);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int WritePointersVirtualDelegate(
             IntPtr self,
             [In] uint Count,
             [In] ulong Offset,
             [In] ulong[] Ptrs);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int ReadPhysicalDelegate(
             IntPtr self,
             [In] ulong Offset,
@@ -123,7 +123,7 @@ namespace SOS
             [In] uint BufferSize,
             [Out] uint* BytesRead);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int WritePhysicalDelegate(
             IntPtr self,
             [In] ulong Offset,
@@ -131,7 +131,7 @@ namespace SOS
             [In] uint BufferSize,
             [Out] uint* BytesWritten);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int ReadControlDelegate(
             IntPtr self,
             [In] uint Processor,
@@ -140,7 +140,7 @@ namespace SOS
             [In] int BufferSize,
             [Out] uint* BytesRead);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int WriteControlDelegate(
             IntPtr self,
             [In] uint Processor,
@@ -149,7 +149,7 @@ namespace SOS
             [In] int BufferSize,
             [Out] uint* BytesWritten);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int ReadIoDelegate(
             IntPtr self,
             [In] INTERFACE_TYPE InterfaceType,
@@ -160,7 +160,7 @@ namespace SOS
             [In] uint BufferSize,
             [Out] uint* BytesRead);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int WriteIoDelegate(
             IntPtr self,
             [In] INTERFACE_TYPE InterfaceType,
@@ -171,19 +171,19 @@ namespace SOS
             [In] uint BufferSize,
             [Out] uint* BytesWritten);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int ReadMsrDelegate(
             IntPtr self,
             [In] uint Msr,
             [Out] ulong* MsrValue);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int WriteMsrDelegate(
             IntPtr self,
             [In] uint Msr,
             [In] ulong MsrValue);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int ReadBusDataDelegate(
             IntPtr self,
             [In] BUS_DATA_TYPE BusDataType,
@@ -194,7 +194,7 @@ namespace SOS
             [In] uint BufferSize,
             [Out] uint* BytesRead);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int WriteBusDataDelegate(
             IntPtr self,
             [In] BUS_DATA_TYPE BusDataType,
@@ -205,11 +205,11 @@ namespace SOS
             [In] uint BufferSize,
             [Out] uint* BytesWritten);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int CheckLowMemoryDelegate(
             IntPtr self);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int ReadDebuggerDataDelegate(
             IntPtr self,
             [In] uint Index,
@@ -217,7 +217,7 @@ namespace SOS
             [In] uint BufferSize,
             [Out] uint* DataSize);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int ReadProcessorSystemDataDelegate(
             IntPtr self,
             [In] uint Processor,
@@ -230,13 +230,13 @@ namespace SOS
 
         #region IDebugDataSpaces2 Delegates
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int VirtualToPhysicalDelegate(
             IntPtr self,
             [In] ulong Virtual,
             [Out] ulong* Physical);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetVirtualTranslationPhysicalOffsetsDelegate(
             IntPtr self,
             [In] ulong Virtual,
@@ -244,7 +244,7 @@ namespace SOS
             [In] uint OffsetsSize,
             [Out] uint* Levels);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int ReadHandleDataDelegate(
             IntPtr self,
             [In] ulong Handle,
@@ -253,7 +253,7 @@ namespace SOS
             [In] uint BufferSize,
             [Out] uint* DataSize);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int FillVirtualDelegate(
             IntPtr self,
             [In] ulong Start,
@@ -262,7 +262,7 @@ namespace SOS
             [In] uint PatternSize,
             [Out] uint* Filled);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int FillPhysicalDelegate(
             IntPtr self,
             [In] ulong Start,
@@ -271,7 +271,7 @@ namespace SOS
             [In] uint PatternSize,
             [Out] uint* Filled);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int QueryVirtualDelegate(
             IntPtr self,
             [In] ulong Offset,

--- a/src/SOS/SOS.Hosting/dbgeng/DebugRegisters.cs
+++ b/src/SOS/SOS.Hosting/dbgeng/DebugRegisters.cs
@@ -36,12 +36,12 @@ namespace SOS
 
         #region IDebugRegisters Delegates
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetNumberRegistersDelegate(
             IntPtr self,
             [Out] uint* Number);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetDescriptionDelegate(
             IntPtr self,
             [In] uint Register,
@@ -50,25 +50,25 @@ namespace SOS
             [Out] uint* NameSize,
             [Out] DEBUG_REGISTER_DESCRIPTION* Desc);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetIndexByNameDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPStr)] string Name,
             [Out] out uint Index);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetValueDelegate(
             IntPtr self,
             [In] uint Register,
             [Out] out DEBUG_VALUE Value);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int SetValueDelegate(
             IntPtr self,
             [In] uint Register,
             [In] DEBUG_VALUE* Value);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetValuesDelegate( //FIX ME!!! This needs to be tested
             IntPtr self,
             [In] uint Count,
@@ -76,7 +76,7 @@ namespace SOS
             [In] uint Start,
             [Out] DEBUG_VALUE* Values);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int SetValuesDelegate(
             IntPtr self,
             [In] uint Count,
@@ -84,23 +84,23 @@ namespace SOS
             [In] uint Start,
             [In] DEBUG_VALUE* Values);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int OutputRegistersDelegate(
             IntPtr self,
             [In] DEBUG_OUTCTL OutputControl,
             [In] DEBUG_REGISTERS Flags);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetInstructionOffsetDelegate(
             IntPtr self,
             [Out] out ulong Offset);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetStackOffsetDelegate(
             IntPtr self,
             [Out] out ulong Offset);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetFrameOffsetDelegate(
             IntPtr self,
             [Out] out ulong Offset);

--- a/src/SOS/SOS.Hosting/dbgeng/DebugSymbols.cs
+++ b/src/SOS/SOS.Hosting/dbgeng/DebugSymbols.cs
@@ -166,27 +166,27 @@ namespace SOS
 
         #region IDebugSymbols Delegates
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetSymbolOptionsDelegate(
             IntPtr self,
             [Out] out SYMOPT Options);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int AddSymbolOptionsDelegate(
             IntPtr self,
             [In] SYMOPT Options);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int RemoveSymbolOptionsDelegate(
             IntPtr self,
             [In] SYMOPT Options);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int SetSymbolOptionsDelegate(
             IntPtr self,
             [In] SYMOPT Options);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private unsafe delegate int GetNameByOffsetDelegate(
             IntPtr self,
             [In] ulong Offset,
@@ -195,13 +195,13 @@ namespace SOS
             [Out] uint* NameSize,
             [Out] ulong* Displacement);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetOffsetByNameDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPStr)] string Symbol,
             [Out] ulong* Offset);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetNearNameByOffsetDelegate(
             IntPtr self,
             [In] ulong Offset,
@@ -211,7 +211,7 @@ namespace SOS
             [Out] uint* NameSize,
             [Out] ulong* Displacement);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetLineByOffsetDelegate(
             IntPtr self,
             [In] ulong Offset,
@@ -221,26 +221,26 @@ namespace SOS
             [Out] uint* FileSize,
             [Out] ulong* Displacement);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetOffsetByLineDelegate(
             IntPtr self,
             [In] uint Line,
             [In][MarshalAs(UnmanagedType.LPStr)] string File,
             [Out] ulong* Offset);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetNumberModulesDelegate(
             IntPtr self,
             [Out] out uint Loaded,
             [Out] out uint Unloaded);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetModuleByIndexDelegate(
             IntPtr self,
             [In] uint Index,
             [Out] out ulong Base);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetModuleByModuleNameDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPStr)] string Name,
@@ -248,7 +248,7 @@ namespace SOS
             [Out] uint* Index,
             [Out] ulong* Base);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetModuleByOffsetDelegate(
             IntPtr self,
             [In] ulong Offset,
@@ -256,7 +256,7 @@ namespace SOS
             [Out] uint* Index,
             [Out] ulong* Base);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetModuleNamesDelegate(
             IntPtr self,
             [In] uint Index,
@@ -271,7 +271,7 @@ namespace SOS
             [In] uint LoadedImageNameBufferSize,
             [Out] uint* LoadedImageNameSize); 
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetModuleParametersDelegate(
             IntPtr self,
             [In] uint Count,
@@ -279,13 +279,13 @@ namespace SOS
             [In] uint Start,
             [Out] DEBUG_MODULE_PARAMETERS* Params);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetSymbolModuleDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPStr)] string Symbol,
             [Out] ulong* Base);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetTypeNameDelegate(
             IntPtr self,
             [In] ulong Module,
@@ -294,21 +294,21 @@ namespace SOS
             [In] int NameBufferSize,
             [Out] uint* NameSize);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetTypeIdDelegate(
             IntPtr self,
             [In] ulong Module,
             [In][MarshalAs(UnmanagedType.LPStr)] string Name,
             [Out] uint* TypeId);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetTypeSizeDelegate(
             IntPtr self,
             [In] ulong Module,
             [In] uint TypeId,
             [Out] uint* Size);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetFieldOffsetDelegate(
             IntPtr self,
             [In] ulong Module,
@@ -316,21 +316,21 @@ namespace SOS
             [In][MarshalAs(UnmanagedType.LPStr)] string Field,
             [Out] uint* Offset);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetSymbolTypeIdDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPStr)] string Symbol,
             [Out] uint* TypeId,
             [Out] ulong* Module);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetOffsetTypeIdDelegate(
             IntPtr self,
             [In] ulong Offset,
             [Out] uint* TypeId,
             [Out] ulong* Module);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int ReadTypedDataVirtualDelegate(
             IntPtr self,
             [In] ulong Offset,
@@ -340,7 +340,7 @@ namespace SOS
             [In] uint BufferSize,
             [Out] uint* BytesRead);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int WriteTypedDataVirtualDelegate(
             IntPtr self,
             [In] ulong Offset,
@@ -350,7 +350,7 @@ namespace SOS
             [In] uint BufferSize,
             [Out] uint* BytesWritten);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int OutputTypedDataVirtualDelegate(
             IntPtr self,
             [In] DEBUG_OUTCTL OutputControl,
@@ -359,7 +359,7 @@ namespace SOS
             [In] uint TypeId,
             [In] DEBUG_TYPEOPTS Flags);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int ReadTypedDataPhysicalDelegate(
             IntPtr self,
             [In] ulong Offset,
@@ -369,7 +369,7 @@ namespace SOS
             [In] uint BufferSize,
             [Out] uint* BytesRead);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int WriteTypedDataPhysicalDelegate(
             IntPtr self,
             [In] ulong Offset,
@@ -379,7 +379,7 @@ namespace SOS
             [In] uint BufferSize,
             [Out] uint* BytesWritten);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int OutputTypedDataPhysicalDelegate(
             IntPtr self,
             [In] DEBUG_OUTCTL OutputControl,
@@ -388,7 +388,7 @@ namespace SOS
             [In] uint TypeId,
             [In] DEBUG_TYPEOPTS Flags);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetScopeDelegate(
             IntPtr self,
             [Out] ulong* InstructionOffset,
@@ -396,7 +396,7 @@ namespace SOS
             [In] IntPtr ScopeContext,
             [In] uint ScopeContextSize);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int SetScopeDelegate(
             IntPtr self,
             [In] ulong InstructionOffset,
@@ -404,29 +404,29 @@ namespace SOS
             [In] IntPtr ScopeContext,
             [In] uint ScopeContextSize);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int ResetScopeDelegate(
             IntPtr self);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetScopeSymbolGroupDelegate(
             IntPtr self,
             [In] DEBUG_SCOPE_GROUP Flags,
             [In][MarshalAs(UnmanagedType.Interface)] IDebugSymbolGroup Update,
             [Out][MarshalAs(UnmanagedType.Interface)] IntPtr Symbols);            // out IDebugSymbolGroup
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int CreateSymbolGroupDelegate(
             IntPtr self,
             [Out][MarshalAs(UnmanagedType.Interface)] IntPtr Group);              // out IDebugSymbolGroup
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int StartSymbolMatchDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPStr)] string Pattern,
             [Out] ulong* Handle); 
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetNextSymbolMatchDelegate(
             IntPtr self,
             [In] ulong Handle,
@@ -435,58 +435,58 @@ namespace SOS
             [Out] uint* MatchSize,
             [Out] ulong* Offset);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int EndSymbolMatchDelegate(
             IntPtr self,
             [In] ulong Handle);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int ReloadDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPStr)] string Module);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetSymbolPathDelegate(
             IntPtr self,
             [Out][MarshalAs(UnmanagedType.LPStr)] StringBuilder Buffer,
             [In] int BufferSize,
             [Out] uint* PathSize);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int SetSymbolPathDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPStr)] string Path);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int AppendSymbolPathDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPStr)] string Addition);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetImagePathDelegate(
             IntPtr self,
             [Out][MarshalAs(UnmanagedType.LPStr)] StringBuilder Buffer,
             [In] int BufferSize,
             [Out] uint* PathSize);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int SetImagePathDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPStr)] string Path);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int AppendImagePathDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPStr)] string Addition);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetSourcePathDelegate(
             IntPtr self,
             [Out][MarshalAs(UnmanagedType.LPStr)] StringBuilder Buffer,
             [In] int BufferSize,
             [Out] uint* PathSize);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetSourcePathElementDelegate(
             IntPtr self,
             [In] uint Index,
@@ -494,17 +494,17 @@ namespace SOS
             [In] int BufferSize,
             [Out] uint* ElementSize);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int SetSourcePathDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPStr)] string Path);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int AppendSourcePathDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPStr)] string Addition);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int FindSourceFileDelegate(
             IntPtr self,
             [In] uint StartElement,
@@ -515,7 +515,7 @@ namespace SOS
             [In] uint BufferSize,
             [Out] uint* FoundSize);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetSourceFileLineOffsetsDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPStr)] string File,
@@ -527,7 +527,7 @@ namespace SOS
 
         #region IDebugSymbols2 Delegates
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetModuleVersionInformationDelegate(
             IntPtr self,
             [In] uint Index,
@@ -537,7 +537,7 @@ namespace SOS
             [In] uint BufferSize,
             [Out] uint* VerInfoSize);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetModuleNameStringDelegate(
             IntPtr self,
             [In] DEBUG_MODNAME Which,
@@ -547,7 +547,7 @@ namespace SOS
             [In] uint BufferSize,
             [Out] uint* NameSize);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetConstantNameDelegate(
             IntPtr self,
             [In] ulong Module,
@@ -557,7 +557,7 @@ namespace SOS
             [In] int BufferSize,
             [Out] uint* NameSize);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetFieldNameDelegate(
             IntPtr self,
             [In] ulong Module,
@@ -567,22 +567,22 @@ namespace SOS
             [In] int BufferSize,
             [Out] uint* NameSize);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetTypeOptionsDelegate(
             IntPtr self,
             [Out] DEBUG_TYPEOPTS* Options);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int AddTypeOptionsDelegate(
             IntPtr self,
             [In] DEBUG_TYPEOPTS Options);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int RemoveTypeOptionsDelegate(
             IntPtr self,
             [In] DEBUG_TYPEOPTS Options);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int SetTypeOptionsDelegate(
             IntPtr self,
             [In] DEBUG_TYPEOPTS Options);
@@ -591,7 +591,7 @@ namespace SOS
 
         #region IDebugSymbols3 Delegates
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetNameByOffsetWideDelegate(
             IntPtr self,
             [In] ulong Offset,
@@ -600,13 +600,13 @@ namespace SOS
             [Out] uint* NameSize,
             [Out] ulong* Displacement);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetOffsetByNameWideDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPWStr)] string Symbol,
             [Out] ulong* Offset);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetNearNameByOffsetWideDelegate(
             IntPtr self,
             [In] ulong Offset,
@@ -616,7 +616,7 @@ namespace SOS
             [Out] uint* NameSize, 
             [Out] ulong* Displacement);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetLineByOffsetWideDelegate(
             IntPtr self,
             [In] ulong Offset,
@@ -626,14 +626,14 @@ namespace SOS
             [Out] uint* FileSize,
             [Out] ulong* Displacement);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetOffsetByLineWideDelegate(
             IntPtr self,
             [In] uint Line,
             [In][MarshalAs(UnmanagedType.LPWStr)] string File,
             [Out] ulong* Offset);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetModuleByModuleNameWideDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPWStr)] string Name,
@@ -641,13 +641,13 @@ namespace SOS
             [Out] uint* Index,
             [Out] ulong* Base);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetSymbolModuleWideDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPWStr)] string Symbol,
             [Out] ulong* Base);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetTypeNameWideDelegate(
             IntPtr self,
             [In] ulong Module,
@@ -656,14 +656,14 @@ namespace SOS
             [In] int NameBufferSize,
             [Out] uint* NameSize);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetTypeIdWideDelegate(
             IntPtr self,
             [In] ulong Module,
             [In][MarshalAs(UnmanagedType.LPWStr)] string Name,
             [Out] uint* TypeId);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetFieldOffsetWideDelegate(
             IntPtr self,
             [In] ulong Module,
@@ -671,32 +671,32 @@ namespace SOS
             [In][MarshalAs(UnmanagedType.LPWStr)] string Field,
             [Out] uint* Offset);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetSymbolTypeIdWideDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPWStr)] string Symbol,
             [Out] uint* TypeId,
             [Out] ulong* Module);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetScopeSymbolGroup2Delegate(
             IntPtr self,
             [In] DEBUG_SCOPE_GROUP Flags,
             [In][MarshalAs(UnmanagedType.Interface)] IDebugSymbolGroup2 Update,
             [Out][MarshalAs(UnmanagedType.Interface)] IntPtr Symbols);            // out IDebugSymbolGroup2
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int CreateSymbolGroup2Delegate(
             IntPtr self,
             [Out][MarshalAs(UnmanagedType.Interface)] IntPtr Group);              // out IDebugSymbolGroup2
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int StartSymbolMatchWideDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPWStr)] string Pattern,
             [Out] ulong* Handle);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetNextSymbolMatchWideDelegate(
             IntPtr self,
             [In] ulong Handle,
@@ -705,53 +705,53 @@ namespace SOS
             [Out] uint* MatchSize,
             [Out] ulong* Offset);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int ReloadWideDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPWStr)] string Module);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetSymbolPathWideDelegate(
             IntPtr self,
             [Out][MarshalAs(UnmanagedType.LPWStr)] StringBuilder Buffer,
             [In] int BufferSize,
             [Out] uint* PathSize);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int SetSymbolPathWideDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPWStr)] string Path);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int AppendSymbolPathWideDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPWStr)] string Addition);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetImagePathWideDelegate(
             IntPtr self,
             [Out][MarshalAs(UnmanagedType.LPWStr)] StringBuilder Buffer,
             [In] int BufferSize,
             [Out] uint* PathSize);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int SetImagePathWideDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPWStr)] string Path);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int AppendImagePathWideDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPWStr)] string Addition);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetSourcePathWideDelegate(
             IntPtr self,
             [Out][MarshalAs(UnmanagedType.LPWStr)] StringBuilder Buffer,
             [In] int BufferSize,
             [Out] uint* PathSize);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetSourcePathElementWideDelegate(
             IntPtr self,
             [In] uint Index,
@@ -759,17 +759,17 @@ namespace SOS
             [In] int BufferSize,
             [Out] uint* ElementSize);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int SetSourcePathWideDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPWStr)] string Path);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int AppendSourcePathWideDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPWStr)] string Addition);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int FindSourceFileWideDelegate(
             IntPtr self,
             [In] uint StartElement,
@@ -780,7 +780,7 @@ namespace SOS
             [In] uint BufferSize,
             [Out] uint* FoundSize);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetSourceFileLineOffsetsWideDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPWStr)] string File,
@@ -788,7 +788,7 @@ namespace SOS
             [In] int BufferLines,
             [Out] uint* FileLines);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetModuleVersionInformationWideDelegate(
             IntPtr self,
             [In] uint Index,
@@ -798,7 +798,7 @@ namespace SOS
             [In] int BufferSize,
             [Out] uint* VerInfoSize);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetModuleNameStringWideDelegate(
             IntPtr self,
             [In] DEBUG_MODNAME Which,
@@ -808,7 +808,7 @@ namespace SOS
             [In] int BufferSize,
             [Out] uint* NameSize);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetConstantNameWideDelegate(
             IntPtr self,
             [In] ulong Module,
@@ -818,7 +818,7 @@ namespace SOS
             [In] int BufferSize,
             [Out] uint* NameSize);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetFieldNameWideDelegate(
             IntPtr self,
             [In] ulong Module,
@@ -828,14 +828,14 @@ namespace SOS
             [In] int BufferSize,
             [Out] uint* NameSize);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int IsManagedModuleDelegate(
             IntPtr self,
             [In] uint Index,
             [In] ulong Base
         );
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetModuleByModuleName2Delegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPStr)] string Name,
@@ -845,7 +845,7 @@ namespace SOS
             [Out] ulong* Base
         );
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetModuleByModuleName2WideDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPWStr)] string Name,
@@ -855,7 +855,7 @@ namespace SOS
             [Out] ulong* Base
         );
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetModuleByOffset2Delegate(
             IntPtr self,
             [In] ulong Offset,
@@ -865,7 +865,7 @@ namespace SOS
             [Out] ulong* Base
         );
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int AddSyntheticModuleDelegate(
             IntPtr self,
             [In] ulong Base,
@@ -875,7 +875,7 @@ namespace SOS
             [In] DEBUG_ADDSYNTHMOD Flags
         );
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int AddSyntheticModuleWideDelegate(
             IntPtr self,
             [In] ulong Base,
@@ -885,37 +885,37 @@ namespace SOS
             [In] DEBUG_ADDSYNTHMOD Flags
         );
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int RemoveSyntheticModuleDelegate(
             IntPtr self,
             [In] ulong Base
         );
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetCurrentScopeFrameIndexDelegate(
             IntPtr self,
             [Out] uint* Index
         );
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int SetScopeFrameByIndexDelegate(
             IntPtr self,
             [In] uint Index
         );
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int SetScopeFromJitDebugInfoDelegate(
             IntPtr self,
             [In] uint OutputControl,
             [In] ulong InfoOffset
         );
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int SetScopeFromStoredEventDelegate(
             IntPtr self
         );
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int OutputSymbolByOffsetDelegate(
             IntPtr self,
             [In] uint OutputControl,
@@ -923,7 +923,7 @@ namespace SOS
             [In] ulong Offset
         );
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetFunctionEntryByOffsetDelegate(
             IntPtr self,
             [In] ulong Offset,
@@ -933,7 +933,7 @@ namespace SOS
             [Out] uint* BufferNeeded
         );
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetFieldTypeAndOffsetDelegate(
             IntPtr self,
             [In] ulong Module,
@@ -943,7 +943,7 @@ namespace SOS
             [Out] uint* Offset
         );
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetFieldTypeAndOffsetWideDelegate(
             IntPtr self,
             [In] ulong Module,
@@ -953,7 +953,7 @@ namespace SOS
             [Out] uint* Offset
         );
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int AddSyntheticSymbolDelegate(
             IntPtr self,
             [In] ulong Offset,
@@ -963,7 +963,7 @@ namespace SOS
             [Out] DEBUG_MODULE_AND_ID* Id
         );
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int AddSyntheticSymbolWideDelegate(
             IntPtr self,
             [In] ulong Offset,
@@ -973,13 +973,13 @@ namespace SOS
             [Out] DEBUG_MODULE_AND_ID* Id
         );
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int RemoveSyntheticSymbolDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPStruct)] DEBUG_MODULE_AND_ID Id
         );
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetSymbolEntriesByOffsetDelegate(
             IntPtr self,
             [In] ulong Offset,
@@ -990,7 +990,7 @@ namespace SOS
             [Out] uint* Entries
         );
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetSymbolEntriesByNameDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPStr)] string Symbol,
@@ -1000,7 +1000,7 @@ namespace SOS
             [Out] uint* Entries
         );
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetSymbolEntriesByNameWideDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPWStr)] string Symbol,
@@ -1010,7 +1010,7 @@ namespace SOS
             [Out] uint* Entries
         );
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetSymbolEntryByTokenDelegate(
             IntPtr self,
             [In] ulong ModuleBase,
@@ -1018,14 +1018,14 @@ namespace SOS
             [Out] DEBUG_MODULE_AND_ID* Id
         );
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetSymbolEntryInformationDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPStruct)] DEBUG_MODULE_AND_ID Id,
             [Out] DEBUG_SYMBOL_ENTRY* Info
         );
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetSymbolEntryStringDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPStruct)] DEBUG_MODULE_AND_ID Id,
@@ -1035,7 +1035,7 @@ namespace SOS
             [Out] uint* StringSize
         );
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetSymbolEntryStringWideDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPStruct)] DEBUG_MODULE_AND_ID Id,
@@ -1045,7 +1045,7 @@ namespace SOS
             [Out] uint* StringSize
         );
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetSymbolEntryOffsetRegionsDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPStruct)] DEBUG_MODULE_AND_ID Id,
@@ -1055,7 +1055,7 @@ namespace SOS
             [Out] uint* RegionsAvail
         );
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetSymbolEntryBySymbolEntryDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPStruct)] DEBUG_MODULE_AND_ID FromId,
@@ -1063,7 +1063,7 @@ namespace SOS
             [Out] DEBUG_MODULE_AND_ID* ToId
         );
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetSourceEntriesByOffsetDelegate(
             IntPtr self,
             [In] ulong Offset,
@@ -1073,7 +1073,7 @@ namespace SOS
             [Out] uint* EntriesAvail
         );
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetSourceEntriesByLineDelegate(
             IntPtr self,
             [In] uint Line,
@@ -1084,7 +1084,7 @@ namespace SOS
             [Out] uint* EntriesAvail
         );
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetSourceEntriesByLineWideDelegate(
             IntPtr self,
             [In] uint Line,
@@ -1095,7 +1095,7 @@ namespace SOS
             [Out] uint* EntriesAvail
         );
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetSourceEntryStringDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPStruct)] DEBUG_SYMBOL_SOURCE_ENTRY Entry,
@@ -1105,7 +1105,7 @@ namespace SOS
             [Out] uint* StringSize
         );
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetSourceEntryStringWideDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPStruct)] DEBUG_SYMBOL_SOURCE_ENTRY Entry,
@@ -1115,7 +1115,7 @@ namespace SOS
             [Out] uint* StringSize
         );
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetSourceEntryOffsetRegionsDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPStruct)] DEBUG_SYMBOL_SOURCE_ENTRY Entry,
@@ -1125,7 +1125,7 @@ namespace SOS
             [Out] uint* RegionsAvail
         );
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetSourceEntryBySourceEntryDelegate(
             IntPtr self,
             [In][MarshalAs(UnmanagedType.LPStruct)] DEBUG_SYMBOL_SOURCE_ENTRY FromEntry,

--- a/src/SOS/SOS.Hosting/dbgeng/DebugSystemObjects.cs
+++ b/src/SOS/SOS.Hosting/dbgeng/DebugSystemObjects.cs
@@ -54,48 +54,48 @@ namespace SOS
 
         #region IDebugSystemObjects Delegates
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetEventThreadDelegate(
             IntPtr self,
             [Out] uint* Id);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetEventProcessDelegate(
             IntPtr self,
             [Out] uint* Id);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetCurrentThreadIdDelegate(
             IntPtr self,
             [Out] out uint Id);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int SetCurrentThreadIdDelegate(
             IntPtr self,
             [In] uint Id);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetCurrentProcessIdDelegate(
             IntPtr self,
             [Out] out uint Id);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int SetCurrentProcessIdDelegate(
             IntPtr self,
             [In] uint Id);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetNumberThreadsDelegate(
             IntPtr self,
             [Out] out uint Number);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetTotalNumberThreadsDelegate(
             IntPtr self,
             [Out] out uint Total,
             [Out] out uint LargestProcess);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetThreadIdsByIndexDelegate(
             IntPtr self,
             [In] uint Start,
@@ -103,62 +103,62 @@ namespace SOS
             [Out] uint* Ids,
             [Out] uint* SysIds);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetThreadIdByProcessorDelegate(
             IntPtr self,
             [In] uint Processor,
             [Out] uint* Id);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetCurrentThreadDataOffsetDelegate(
             IntPtr self,
             [Out] ulong* Offset);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetThreadIdByDataOffsetDelegate(
             IntPtr self,
             [In] ulong Offset,
             [Out] uint* Id);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetCurrentThreadTebDelegate(
             IntPtr self,
             [Out] ulong* Offset);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetThreadIdByTebDelegate(
             IntPtr self,
             [In] ulong Offset,
             [Out] uint* Id);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetCurrentThreadSystemIdDelegate(
             IntPtr self,
             [Out] out uint SysId);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetThreadIdBySystemIdDelegate(
             IntPtr self,
             [In] uint SysId,
             [Out] out uint Id);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetCurrentThreadHandleDelegate(
             IntPtr self,
             [Out] ulong* Handle);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetThreadIdByHandleDelegate(
             IntPtr self,
             [In] ulong Handle,
             [Out] uint* Id);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetNumberProcessesDelegate(
             IntPtr self,
             [Out] uint* Number);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetProcessIdsByIndexDelegate(
             IntPtr self,
             [In] uint Start,
@@ -166,51 +166,51 @@ namespace SOS
             [Out] uint* Ids,
             [Out] uint* SysIds);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetCurrentProcessDataOffsetDelegate(
             IntPtr self,
             [Out] ulong* Offset);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetProcessIdByDataOffsetDelegate(
             IntPtr self,
             [In] ulong Offset,
             [Out] uint* Id);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetCurrentProcessPebDelegate(
             IntPtr self,
             [Out] ulong* Offset);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetProcessIdByPebDelegate(
             IntPtr self,
             [In] ulong Offset,
             [Out] uint* Id);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetCurrentProcessSystemIdDelegate(
             IntPtr self,
             [Out] uint* SysId);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetProcessIdBySystemIdDelegate(
             IntPtr self,
             [In] uint SysId,
             [Out] uint* Id);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetCurrentProcessHandleDelegate(
             IntPtr self,
             [Out] ulong* Handle);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetProcessIdByHandleDelegate(
             IntPtr self,
             [In] ulong Handle,
             [Out] uint* Id);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate int GetCurrentProcessExecutableNameDelegate(
             IntPtr self,
             [Out][MarshalAs(UnmanagedType.LPStr)] StringBuilder Buffer,

--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -6090,22 +6090,39 @@ DECLARE_API(DumpModule)
         ExtOut("Fail to fill Module %p\n", SOS_PTR(p_ModuleAddr));
         return Status;
     }
+
     
     WCHAR FileName[MAX_LONGPATH];
     FileNameForModule (&module, FileName);
-    ExtOut("Name:       %S\n", FileName[0] ? FileName : W("Unknown Module"));
+    ExtOut("Name: %S\n", FileName[0] ? FileName : W("Unknown Module"));
 
-    ExtOut("Attributes: ");
+    ExtOut("Attributes:              ");
     if (module.bIsPEFile)
         ExtOut("PEFile ");
     if (module.bIsReflection)
         ExtOut("Reflection ");
     if (module.dwTransientFlags & SUPPORTS_UPDATEABLE_METHODS)
-        ExtOut("SupportsUpdateableMethods");
-    ExtOut("\n");
-    
-    DMLOut("Assembly:   %s\n", DMLAssembly(module.Assembly));
+        ExtOut("SupportsUpdateableMethods ");
 
+    ToRelease<IXCLRDataModule> dataModule;
+    if (SUCCEEDED(g_sos->GetModule(TO_CDADDR(p_ModuleAddr), &dataModule)))
+    {
+        DacpGetModuleData moduleData;
+        if (SUCCEEDED(moduleData.Request(dataModule)))
+        {
+            if (moduleData.IsDynamic)
+                ExtOut("IsDynamic ");
+            if (moduleData.IsInMemory)
+                ExtOut("IsInMemory ");
+            if (moduleData.IsFileLayout)
+                ExtOut("IsFileLayout ");
+        }
+    }
+    ExtOut("\n");
+
+    DMLOut("Assembly:                %s\n", DMLAssembly(module.Assembly));
+
+    ExtOut("BaseAddress:             %p\n", SOS_PTR(module.ilBase));
     ExtOut("PEFile:                  %p\n", SOS_PTR(module.File));
     ExtOut("ModuleId:                %p\n", SOS_PTR(module.dwModuleID));
     ExtOut("ModuleIndex:             %p\n", SOS_PTR(module.dwModuleIndex));
@@ -6117,6 +6134,7 @@ DECLARE_API(DumpModule)
     ExtOut("MemberRefToDescMap:      %p\n", SOS_PTR(module.MemberRefToDescMap));
     ExtOut("FileReferencesMap:       %p\n", SOS_PTR(module.FileReferencesMap));
     ExtOut("AssemblyReferencesMap:   %p\n", SOS_PTR(module.ManifestModuleReferencesMap));
+
 
     if (module.ilBase && module.metadataStart)
         ExtOut("MetaData start address:  %p (%d bytes)\n", SOS_PTR(module.metadataStart), module.metadataSize);
@@ -6193,10 +6211,6 @@ DECLARE_API(DumpModule)
         {
             ExtOut("\nThis runtime version does not support listing the profiler modified functions.\n");
         }
-
-
-
-    HRESULT GetMethodsWithProfilerModifiedIL(CLRDATA_ADDRESS module, CLRDATA_ADDRESS *methodDescs, int cMethodDescs, int *pcMethodDescs);
     }
 
     return Status;

--- a/src/Tools/dotnet-dump/Commands/ClrModulesCommand.cs
+++ b/src/Tools/dotnet-dump/Commands/ClrModulesCommand.cs
@@ -14,6 +14,8 @@ namespace Microsoft.Diagnostics.Tools.Dump
     {
         public ClrRuntime Runtime { get; set; }
 
+        public DataTarget DataTarget { get; set; }
+
         [Option(Name = "--verbose", Help = "Displays detailed information about the modules.")]
         [OptionAlias(Name = "-v")]
         public bool Verbose { get; set; }
@@ -34,6 +36,9 @@ namespace Microsoft.Diagnostics.Tools.Dump
                     WriteLine("    MetadataAddress: {0:X16}", module.MetadataAddress);
                     WriteLine("    MetadataSize:    {0:X16}", module.MetadataLength);
                     WriteLine("    PdbInfo:         {0}", module.Pdb?.ToString() ?? "<none>");
+
+                    DataTarget.DataReader.GetVersionInfo(module.ImageBase, out VersionInfo version);
+                    WriteLine("    Version:         {0}", version);
                 }
                 else
                 {


### PR DESCRIPTION
Add assembly version to clrmodules -v command.

Add more info to dumpmodule.

Update clrmd to version 1.1.122004. See PR https://github.com/microsoft/clrmd/pull/609 for details.