### PR TITLE
Use DateTime.Now instead of Stopwatch.GetTimestamp()

### DIFF
--- a/src/Tools/dotnet-gcdump/DotNetHeapDump/EventPipeDotNetHeapDumper.cs
+++ b/src/Tools/dotnet-gcdump/DotNetHeapDump/EventPipeDotNetHeapDumper.cs
@@ -35,8 +35,8 @@ namespace Microsoft.Diagnostics.Tools.GCDump
         /// <returns></returns>
         public static bool DumpFromEventPipe(CancellationToken ct, int processID, MemoryGraph memoryGraph, TextWriter log, int timeout, DotNetHeapInfo dotNetInfo = null)
         {
-            var startTicks = Stopwatch.GetTimestamp();
-            Func<TimeSpan> getElapsed = () => TimeSpan.FromTicks(Stopwatch.GetTimestamp() - startTicks);
+            DateTime start = DateTime.Now;
+            Func<TimeSpan> getElapsed = () => DateTime.Now - start;
 
             var dumper = new DotNetHeapDumpGraphReader(log)
             {


### PR DESCRIPTION
Fixes issue where the log messages had erroneous times in them.  The "ticks" returned by `Stopwatch.GetTimestamp()` are potentially a different "tick" than the ticks expected by `TimeSpan.FromTicks` depending on the resolution of the system's internal clock.