### PR TITLE
Servicing testing fixes

### DIFF
--- a/diagnostics.yml
+++ b/diagnostics.yml
@@ -1,3 +1,23 @@
+parameters:
+- name: runtimeFeed
+  displayName: Feed for runtime installation
+  type: string
+  default: default
+  values:
+  - default
+  - custom
+  - msrc-feed
+  - dotnetclimsrc-feed
+- name: runtimeFeedToken
+  displayName: Base 64 SAS Token for runtime installation
+  type: string
+  default: default
+  values:
+  - default
+  - custom
+  - msrc-feed-sas-token-base64
+  - dotnetclimsrc-sas-token-base64
+
 trigger: none
 
 pr:
@@ -27,6 +47,28 @@ variables:
         /p:TeamName=$(_TeamName)
         /p:DotNetPublishUsingPipelines=true
         /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+    - group: DotNet-MSRC-Storage
+    # Custom feed and token
+    - ${{ if eq(parameters.runtimeFeed, 'custom') }}:
+      - name: RuntimeFeedUrl
+        value: $(DotnetRuntimeDownloadFeed)
+    - ${{ if eq(parameters.runtimeFeedToken, 'custom') }}:
+      - name: RuntimeFeedBase64SasToken
+        value: $(DotnetRuntimeDownloadBase64SasToken)
+    # MSRC dotnet feed. Usually on orchestrated 2.1 releases.
+    - ${{ if eq(parameters.runtimeFeed, 'msrc-feed') }}:
+      - name: RuntimeFeedUrl
+        value: https://dotnetfeedmsrc.blob.core.windows.net
+    - ${{ if eq(parameters.runtimeFeedToken, 'msrc-feed-sas-token-base64') }}:
+      - name: RuntimeFeedBase64SasToken
+        value: $(dotnetfeedmsrc-read-sas-token-base64)
+    # dotnetclimsrc contains 3.1+
+    - ${{ if eq(parameters.runtimeFeed, 'dotnetclimsrc-feed') }}:
+      - name: RuntimeFeedUrl
+        value: https://dotnetclimsrc.blob.core.windows.net/dotnet
+    - ${{ if eq(parameters.runtimeFeedToken, 'dotnetclimsrc-sas-token-base64') }}:
+      - name: RuntimeFeedBase64SasToken
+        value: $(dotnetclimsrc-read-sas-token-base64)
 
 stages:
   - stage: build

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -26,10 +26,6 @@ parameters:
   # Depends on 
   dependsOn: ''
 
-  runtimeFeedParams:
-    runtimeFeedToken: ''
-    runtimeFeedUrl: ''
-
 jobs:
 - template: /eng/common/templates/job/job.yml
   parameters:

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -26,6 +26,10 @@ parameters:
   # Depends on 
   dependsOn: ''
 
+  runtimeFeedParams:
+    runtimeFeedToken: ''
+    runtimeFeedUrl: ''
+
 jobs:
 - template: /eng/common/templates/job/job.yml
   parameters:
@@ -89,12 +93,11 @@ jobs:
  
     # For testing msrc's and service releases. The RuntimeSourceVersion is either "default" or the service release version to test
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-      - group: DotNet-MSRC-Storage
       - _InternalInstallArgs:
           -dotnetruntimeversion '$(DotnetRuntimeVersion)'
           -dotnetruntimedownloadversion '$(DotnetRuntimeDownloadVersion)'
-          -runtimesourcefeed '$(dotnetfeedmsrc-private-feed-url)'
-          -runtimesourcefeedkey '$(dotnetclimsrc-read-sas-token-base64)'
+          -runtimesourcefeed '$(RuntimeFeedUrl)'
+          -runtimesourcefeedkey '$(RuntimeFeedBase64SasToken)'
 
     # Only enable publishing in non-public, non PR scenarios.
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:


### PR DESCRIPTION
Uses new runtime parameters yml feature for URL/Token resolution in the installation of testing runtimes. See https://docs.microsoft.com/en-us/azure/devops/pipelines/process/runtime-parameters?view=azure-devops&tabs=script

Adds 3 alternate sources to choose when kicking off the pipeline that look like this:

![image](https://user-images.githubusercontent.com/19413848/80084632-fd5bae80-850b-11ea-85e9-23da0d89f410.png)

- **Custom**: Can specify a special feed/blob container to try to fetch packages from picked from the `DotnetRuntimeDownloadFeed` pipeline variable.
- **msrc-feed**: Points to the MSRC feed
- **dotnetclimsrc-feed** This contains for example our testing bits for 3.1 and 2.1

There's the same 3 options to select the tokens for the SAS base 64 read token to use in authenticated feeds, with the custom variable being `DotnetRuntimeDownloadBase64SasToken`.

3.1 build: https://dev.azure.com/dnceng/internal/_build/results?buildId=613354&view=results
2.1 build: https://dev.azure.com/dnceng/internal/_build/results?buildId=613355&view=results