### PR TITLE
Refactor DiagController to better match the OpenAPI description.

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/Controllers/DiagController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/Controllers/DiagController.cs
@@ -1,17 +1,23 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Diagnostics.Monitoring.RestServer.Models;
 using Microsoft.Diagnostics.NETCore.Client;
 using Microsoft.Extensions.Logging;
+using static System.FormattableString;
 
 namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
 {
-    [Route("api/v1/[controller]")]
+    [Route("")] // Root
     [ApiController]
     public class DiagController : ControllerBase
     {
+        private static readonly string DumpFileExtension = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".dmp" : string.Empty;
+
         private readonly ILogger<DiagController> _logger;
         private readonly IDiagnosticServices _diagnosticServices;
 
@@ -21,38 +27,88 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
             _diagnosticServices = diagnosticServices;
         }
 
-        [HttpGet("getpids")]
-        public ActionResult<IEnumerable<string>> GetPids()
+        [HttpGet("processes")]
+        public ActionResult<IEnumerable<ProcessModel>> GetProcesses()
         {
-            return new JsonResult(_diagnosticServices.GetProcesses());
+            return InvokeService(() =>
+            {
+                IList<ProcessModel> processes = new List<ProcessModel>();
+                foreach (int pid in _diagnosticServices.GetProcesses())
+                {
+                    processes.Add(new ProcessModel() { Pid = pid });
+                }
+                return new ActionResult<IEnumerable<ProcessModel>>(processes);
+            });
         }
 
-        [HttpGet(@"{pid}/dump")]
-        public Task<ActionResult> GetDump(int pid, [FromQuery]int? dumpType = 1)
+        [HttpGet("dump")]
+        public Task<ActionResult> GetDump([FromQuery] DumpType type = DumpType.WithHeap)
         {
-            if (!Enum.IsDefined(typeof(DumpType), dumpType))
-            {
-                return Task.FromResult<ActionResult>(BadRequest(new ProblemDetails { Detail = "Invalid dump type", Status = 400 }));
-            }
+            return GetDumpImpl(pid: null, type);
+        }
 
+        [HttpGet("dump/{pid}")]
+        public Task<ActionResult> GetDump(int pid, [FromQuery]DumpType type = DumpType.WithHeap)
+        {
+            return GetDumpImpl(pid, type);
+        }
+
+        public Task<ActionResult> GetDumpImpl(int? pid, DumpType type)
+        {
             return InvokeService(async () =>
             {
-                Stream dump = await _diagnosticServices.GetDump(pid, (DumpType)dumpType);
+                OperationResult<Stream> result = await _diagnosticServices.GetDump(pid, type);
 
                 //Compression is done automatically by the response
                 //Chunking is done because the result has no content-length
-                return File(dump, "application/octet-stream", fileDownloadName: FormattableString.Invariant($"coredump_{pid}"));
+                return CreateFileStreamResult(result, $"coredump_{result.Pid}{DumpFileExtension}");
             });
         }
 
-        [HttpGet("{pid}/cpuprofile")]
-        public Task<ActionResult> CpuProfile(int pid, [FromQuery]int durationSeconds = 30) 
+        [HttpGet("cpuprofile")]
+        public Task<ActionResult> CpuProfile([FromQuery] int duration = 30)
+        {
+            return CpuProfileImpl(pid: null, duration);
+        }
+
+        [HttpGet("cpuprofile/{pid}")]
+        public Task<ActionResult> CpuProfile(int pid, [FromQuery]int duration = 30)
+        {
+            return CpuProfileImpl(pid, duration);
+        }
+
+        private Task<ActionResult> CpuProfileImpl(int? pid, int duration)
         {
             return InvokeService(async () =>
             {
-                Stream stream = await _diagnosticServices.StartCpuTrace(pid, durationSeconds, this.HttpContext.RequestAborted);
-                return File(stream, "application/octet-stream", fileDownloadName: FormattableString.Invariant($"{Guid.NewGuid()}.nettrace"));
+                OperationResult<Stream> result = await _diagnosticServices.StartCpuTrace(pid, duration, this.HttpContext.RequestAborted);
+                return CreateFileStreamResult(result, $"{Guid.NewGuid()}.nettrace");
             });
+        }
+
+        private FileStreamResult CreateFileStreamResult(OperationResult<Stream> result, FormattableString downloadName)
+        {
+            return File(result.Value, "application/octet-stream", Invariant(downloadName));
+        }
+
+        private ActionResult<T> InvokeService<T>(Func<ActionResult<T>> serviceCall)
+        {
+            try
+            {
+                return serviceCall();
+            }
+            catch (ArgumentException e)
+            {
+                return BadRequest(FromException(e));
+            }
+            catch (DiagnosticsClientException e)
+            {
+                return BadRequest(FromException(e));
+            }
+            catch (InvalidOperationException e)
+            {
+                return BadRequest(FromException(e));
+            }
         }
 
         private async Task<ActionResult> InvokeService(Func<Task<ActionResult>> serviceCall)
@@ -60,6 +116,10 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
             try
             {
                 return await serviceCall();
+            }
+            catch (ArgumentException e)
+            {
+                return BadRequest(FromException(e));
             }
             catch (DiagnosticsClientException e)
             {
@@ -73,7 +133,11 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
 
         private static ProblemDetails FromException(Exception e)
         {
-            return new ProblemDetails { Detail = e.Message, Status = 400 };
+            return new ProblemDetails
+            {
+                Detail = e.Message,
+                Status = (int)HttpStatusCode.BadRequest
+            };
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/Controllers/DiagController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/Controllers/DiagController.cs
@@ -41,19 +41,8 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
             });
         }
 
-        [HttpGet("dump")]
-        public Task<ActionResult> GetDump([FromQuery] DumpType type = DumpType.WithHeap)
-        {
-            return GetDumpImpl(pid: null, type);
-        }
-
-        [HttpGet("dump/{pid}")]
-        public Task<ActionResult> GetDump(int pid, [FromQuery]DumpType type = DumpType.WithHeap)
-        {
-            return GetDumpImpl(pid, type);
-        }
-
-        public Task<ActionResult> GetDumpImpl(int? pid, DumpType type)
+        [HttpGet("dump/{pid?}")]
+        public Task<ActionResult> GetDump(int? pid, [FromQuery]DumpType type = DumpType.WithHeap)
         {
             return InvokeService(async () =>
             {
@@ -65,19 +54,8 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
             });
         }
 
-        [HttpGet("cpuprofile")]
-        public Task<ActionResult> CpuProfile([FromQuery] int duration = 30)
-        {
-            return CpuProfileImpl(pid: null, duration);
-        }
-
-        [HttpGet("cpuprofile/{pid}")]
-        public Task<ActionResult> CpuProfile(int pid, [FromQuery]int duration = 30)
-        {
-            return CpuProfileImpl(pid, duration);
-        }
-
-        private Task<ActionResult> CpuProfileImpl(int? pid, int duration)
+        [HttpGet("cpuprofile/{pid?}")]
+        public Task<ActionResult> CpuProfile(int? pid, [FromQuery]int duration = 30)
         {
             return InvokeService(async () =>
             {

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/Models/ProcessModel.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/Models/ProcessModel.cs
@@ -1,0 +1,11 @@
+﻿using System.Runtime.Serialization;
+
+namespace Microsoft.Diagnostics.Monitoring.RestServer.Models
+{
+    [DataContract(Name = "Process")]
+    public class ProcessModel
+    {
+        [DataMember(Name = "pid")]
+        public int Pid { get; set; }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring/Contracts/IDiagnosticServices.cs
+++ b/src/Microsoft.Diagnostics.Monitoring/Contracts/IDiagnosticServices.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -15,17 +14,17 @@ namespace Microsoft.Diagnostics.Monitoring
     {
         IEnumerable<int> GetProcesses();
 
-        Task<Stream> GetDump(int pid, DumpType mode);
+        Task<OperationResult<Stream>> GetDump(int? pid, DumpType mode);
 
         //TODO We can most likely unify trace, cpu, and logs/metrics around one call with the appropriate config
-        Task<Stream> StartCpuTrace(int pid, int duration, CancellationToken token);
+        Task<OperationResult<Stream>> StartCpuTrace(int? pid, int duration, CancellationToken token);
     }
 
     public enum DumpType
     {
         Full = 1,
-        Normal,
-        MiniWithHeap,
+        Mini,
+        WithHeap,
         Triage
     }
 
@@ -38,5 +37,12 @@ namespace Microsoft.Diagnostics.Monitoring
     public sealed class TraceRequest
     {
         public string Configuraton { get; set; }
+    }
+
+    public sealed class OperationResult<T>
+    {
+        public int Pid { get; set; }
+
+        public T Value { get; set; }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring/DiagnosticServices.cs
+++ b/src/Microsoft.Diagnostics.Monitoring/DiagnosticServices.cs
@@ -1,15 +1,13 @@
-﻿using Microsoft.Diagnostics.NETCore.Client;
-using Microsoft.Extensions.Logging;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.IO.Compression;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Diagnostics.NETCore.Client;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Diagnostics.Monitoring
 {
@@ -27,43 +25,60 @@ namespace Microsoft.Diagnostics.Monitoring
 
         public IEnumerable<int> GetProcesses()
         {
-            //TODO This won't work properly with multi-container scenarios that don't share the process space.
-            //TODO We will need to use DiagnosticsAgent if we are the server.
-            return DiagnosticsClient.GetPublishedProcesses();
+            try
+            {
+                //TODO This won't work properly with multi-container scenarios that don't share the process space.
+                //TODO We will need to use DiagnosticsAgent if we are the server.
+                return DiagnosticsClient.GetPublishedProcesses();
+            }
+            catch (UnauthorizedAccessException)
+            {
+                throw new InvalidOperationException("Unable to enumerate processes.");
+            }
         }
 
-        public async Task<Stream> GetDump(int pid, DumpType mode)
+        public async Task<OperationResult<Stream>> GetDump(int? pid, DumpType mode)
         {
-            string dumpFilePath = FormattableString.Invariant($@"{Path.GetTempPath()}{Path.DirectorySeparatorChar}{Guid.NewGuid()}_{pid}");
+            if (!pid.HasValue)
+            {
+                pid = GetSingleProcessId();
+            }
+
+            string dumpFilePath = FormattableString.Invariant($@"{Path.GetTempPath()}{Path.DirectorySeparatorChar}{Guid.NewGuid()}_{pid.Value}");
             NETCore.Client.DumpType dumpType = MapDumpType(mode);
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 // Get the process
-                Process process = Process.GetProcessById(pid);
+                Process process = Process.GetProcessById(pid.Value);
                 await Dumper.CollectDumpAsync(process, dumpFilePath, dumpType);
             }
             else
             {
                 await Task.Run(() =>
                 {
-                    var client = new DiagnosticsClient(pid);
+                    var client = new DiagnosticsClient(pid.Value);
                     client.WriteDump(dumpType, dumpFilePath);
                 });
             }
 
-            return new AutoDeleteFileStream(dumpFilePath);
+            return CreateResult(pid.Value, new AutoDeleteFileStream(dumpFilePath));
         }
 
-        public Task<Stream> StartCpuTrace(int pid, int durationSeconds, CancellationToken cancellationToken)
+        public Task<OperationResult<Stream>> StartCpuTrace(int? pid, int durationSeconds, CancellationToken cancellationToken)
         {
             if ((durationSeconds < 1) || (durationSeconds > MaxTraceSeconds))
             {
                 throw new InvalidOperationException("Invalid duration");
             }
 
+            if (!pid.HasValue)
+            {
+                pid = GetSingleProcessId();
+            }
+
             //TODO Should we limit only 1 trace per file?
-            var client = new DiagnosticsClient(pid);
+            var client = new DiagnosticsClient(pid.Value);
 
             //TODO Pull event providers from the configuration.
             var cpuProviders = new EventPipeProvider[] {
@@ -88,7 +103,7 @@ namespace Microsoft.Diagnostics.Monitoring
                 }
             }, CancellationToken.None);
 
-            return Task.FromResult(session.EventStream);
+            return Task.FromResult(CreateResult(pid.Value, session.EventStream));
         }
 
         private static NETCore.Client.DumpType MapDumpType(DumpType dumpType)
@@ -97,15 +112,46 @@ namespace Microsoft.Diagnostics.Monitoring
             {
                 case DumpType.Full:
                     return NETCore.Client.DumpType.Full;
-                case DumpType.MiniWithHeap:
+                case DumpType.WithHeap:
                     return NETCore.Client.DumpType.WithHeap;
                 case DumpType.Triage:
                     return NETCore.Client.DumpType.Triage;
-                case DumpType.Normal:
+                case DumpType.Mini:
                     return NETCore.Client.DumpType.Normal;
                 default:
                     throw new ArgumentException("Unexpected dumpType", nameof(dumpType));
             }
+        }
+
+        private int GetSingleProcessId()
+        {
+            // Short-circuit for when running in a container on Kubernetes where the entrypoint
+            // of the container is a dotnet application.
+            if (RuntimeInfo.IsKubernetes && null != Process.GetProcessById(1))
+            {
+                return 1;
+            }
+
+            // Only return a process ID if there is exactly one discoverable process.
+            int[] pids = GetProcesses().ToArray();
+            switch (pids.Length)
+            {
+                case 0:
+                    throw new ArgumentException("Unable to discover a target process.");
+                case 1:
+                    return pids[0];
+                default:
+                    throw new ArgumentException("Unable to select a single target process because multiple target processes have been discovered.");
+            }
+        }
+
+        private static OperationResult<Stream> CreateResult(int pid, Stream stream)
+        {
+            return new OperationResult<Stream>()
+            {
+                Pid = pid,
+                Value = stream
+            };
         }
 
         public void Dispose()

--- a/src/Microsoft.Diagnostics.Monitoring/DiagnosticServices.cs
+++ b/src/Microsoft.Diagnostics.Monitoring/DiagnosticServices.cs
@@ -125,9 +125,9 @@ namespace Microsoft.Diagnostics.Monitoring
 
         private int GetSingleProcessId()
         {
-            // Short-circuit for when running in a container on Kubernetes where the entrypoint
+            // Short-circuit for when running in a Docker container, assuming the entrypoint
             // of the container is a dotnet application.
-            if (RuntimeInfo.IsKubernetes && null != Process.GetProcessById(1))
+            if (RuntimeInfo.IsInDockerContainer && null != Process.GetProcessById(1))
             {
                 return 1;
             }

--- a/src/Microsoft.Diagnostics.Monitoring/RuntimeInfo.cs
+++ b/src/Microsoft.Diagnostics.Monitoring/RuntimeInfo.cs
@@ -1,11 +1,30 @@
 ﻿using System.IO;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.Diagnostics.Monitoring
 {
     internal static class RuntimeInfo
     {
-        private static readonly string KubernetesServiceAccountPath = "/var/run/secrets/kubernetes.io/serviceaccount";
+        public static bool IsInDockerContainer
+        {
+            get
+            {
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                {
+                    // Check if one of the control groups of this process is owned by docker
+                    if (File.ReadAllText("/proc/self/cgroup").Contains("/docker/"))
+                    {
+                        return true;
+                    }
 
-        public static bool IsKubernetes => Directory.Exists(KubernetesServiceAccountPath);
+                    // Most of the control groups are owned by "kubepods" when running in kubernetes;
+                    // Check for docker environment file
+                    return File.Exists("/.dockerenv");
+                }
+
+                // TODO: Add detection for other platforms
+                return false;
+            }
+        }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring/RuntimeInfo.cs
+++ b/src/Microsoft.Diagnostics.Monitoring/RuntimeInfo.cs
@@ -1,0 +1,11 @@
+﻿using System.IO;
+
+namespace Microsoft.Diagnostics.Monitoring
+{
+    internal static class RuntimeInfo
+    {
+        private static readonly string KubernetesServiceAccountPath = "/var/run/secrets/kubernetes.io/serviceaccount";
+
+        public static bool IsKubernetes => Directory.Exists(KubernetesServiceAccountPath);
+    }
+}

--- a/src/Tools/dotnet-monitor/Startup.cs
+++ b/src/Tools/dotnet-monitor/Startup.cs
@@ -30,6 +30,8 @@ namespace Microsoft.Diagnostics.Monitoring
         {
             services.AddMvc((MvcOptions options) =>
             {
+                options.Filters.Add(new ProducesAttribute("application/json"));
+
                 // HACK We need to disable EndpointRouting in order to run properly in 3.1
                 System.Reflection.PropertyInfo prop = options.GetType().GetProperty("EnableEndpointRouting");
                 prop?.SetValue(options, false);


### PR DESCRIPTION
These changes update the existing api controller methods of the dotnet-monitor tool to match the changes in #1014 and the comments that were provided. Some of the highlights are:
- The api root is now at / e.g. http//:localhost:52323/ is the root of the api.
- The dump and cpuprofile verbs now allow implicit process selection if a process ID is not specified. There is a specialization for docker where it will go directly to process 1 if it exists.
- The processes verb returns process objects with pids (object to be filled out once reverse api server is available to use).
- Changed the defaults of some of the parameters to match the OpenAPI definition and its suggested changes.