### PR TITLE
Add overload of DiagnosticServices.StartLogs to support different logger

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring/Contracts/IDiagnosticServices.cs
+++ b/src/Microsoft.Diagnostics.Monitoring/Contracts/IDiagnosticServices.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft.Extensions.Logging;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
@@ -24,6 +25,8 @@ namespace Microsoft.Diagnostics.Monitoring
         Task<IStreamWithCleanup> StartTrace(int pid, TimeSpan duration, CancellationToken token);
 
         Task StartLogs(Stream outputStream, int pid, TimeSpan duration, CancellationToken token);
+
+        Task StartLogs(ILoggerFactory loggerFactory, int pid, TimeSpan duration, CancellationToken token);
     }
 
     public interface IStreamWithCleanup : IAsyncDisposable

--- a/src/Microsoft.Diagnostics.Monitoring/DiagnosticServices.cs
+++ b/src/Microsoft.Diagnostics.Monitoring/DiagnosticServices.cs
@@ -88,6 +88,11 @@ namespace Microsoft.Diagnostics.Monitoring
             var loggerFactory = new LoggerFactory();
             loggerFactory.AddProvider(new StreamingLoggerProvider(outputStream));
 
+            await StartLogs(loggerFactory, pid, duration, token);
+        }
+
+        public async Task StartLogs(ILoggerFactory loggerFactory, int pid, TimeSpan duration, CancellationToken token)
+        {
             var processor = new DiagnosticsEventPipeProcessor(_contextConfiguration,
                 PipeMode.Logs,
                 loggerFactory,


### PR DESCRIPTION
This is very useful if you want to make a console for showing log stream in real time.