### PR TITLE
Split HTTP request configuration from logging configuration.

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring/Configuration/AggregateSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring/Configuration/AggregateSourceConfiguration.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Diagnostics.Monitoring
 
         public override IList<EventPipeProvider> GetProviders()
         {
+            // CONSIDER: Might have to deduplicate providers and merge them together.
             return _configurations.SelectMany(c => c.GetProviders()).ToList();
         }
     }

--- a/src/Microsoft.Diagnostics.Monitoring/Configuration/AggregateSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring/Configuration/AggregateSourceConfiguration.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Diagnostics.NETCore.Client;
+
+namespace Microsoft.Diagnostics.Monitoring.Configuration
+{
+    public sealed class AggregateSourceConfiguration : MonitoringSourceConfiguration
+    {
+        private IList<MonitoringSourceConfiguration> _configurations = new List<MonitoringSourceConfiguration>();
+
+        public void AddConfiguration(MonitoringSourceConfiguration configuration)
+        {
+            _configurations.Add(configuration);
+        }
+
+        public override IList<EventPipeProvider> GetProviders()
+        {
+            return _configurations.SelectMany(c => c.GetProviders()).ToList();
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring/Configuration/AggregateSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring/Configuration/AggregateSourceConfiguration.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Diagnostics.NETCore.Client;
 
-namespace Microsoft.Diagnostics.Monitoring.Configuration
+namespace Microsoft.Diagnostics.Monitoring
 {
     public sealed class AggregateSourceConfiguration : MonitoringSourceConfiguration
     {

--- a/src/Microsoft.Diagnostics.Monitoring/Configuration/AggregateSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring/Configuration/AggregateSourceConfiguration.cs
@@ -10,11 +10,11 @@ namespace Microsoft.Diagnostics.Monitoring
 {
     public sealed class AggregateSourceConfiguration : MonitoringSourceConfiguration
     {
-        private IList<MonitoringSourceConfiguration> _configurations = new List<MonitoringSourceConfiguration>();
+        private IList<MonitoringSourceConfiguration> _configurations;
 
-        public void AddConfiguration(MonitoringSourceConfiguration configuration)
+        public AggregateSourceConfiguration(params MonitoringSourceConfiguration[] configurations)
         {
-            _configurations.Add(configuration);
+            _configurations = configurations;
         }
 
         public override IList<EventPipeProvider> GetProviders()

--- a/src/Microsoft.Diagnostics.Monitoring/Configuration/HttpRequestSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring/Configuration/HttpRequestSourceConfiguration.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics.Tracing;
 using Microsoft.Diagnostics.NETCore.Client;
 
-namespace Microsoft.Diagnostics.Monitoring.Configuration
+namespace Microsoft.Diagnostics.Monitoring
 {
     public sealed class HttpRequestSourceConfiguration : MonitoringSourceConfiguration
     {

--- a/src/Microsoft.Diagnostics.Monitoring/Configuration/HttpRequestSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring/Configuration/HttpRequestSourceConfiguration.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Diagnostics.Monitoring
 {
     public sealed class HttpRequestSourceConfiguration : MonitoringSourceConfiguration
     {
-        private const string DiagnosticFilterString = "\"" +
+        private const string DiagnosticFilterString =
                 "Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.HttpRequestIn.Start@Activity1Start:-" +
                     "Request.Scheme" +
                     ";Request.Host" +
@@ -49,8 +49,7 @@ namespace Microsoft.Diagnostics.Monitoring
                 "HttpHandlerDiagnosticListener/System.Net.Http.HttpRequestOut.Stop@Activity2Stop:-" +
                     ";ActivityDuration=*Activity.Duration.Ticks" +
                     ";ActivityId=*Activity.Id" +
-                "\r\n" +
-                "\"";
+                "\r\n";
 
         public override IList<EventPipeProvider> GetProviders()
         {

--- a/src/Microsoft.Diagnostics.Monitoring/Configuration/HttpRequestSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring/Configuration/HttpRequestSourceConfiguration.cs
@@ -1,0 +1,72 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using Microsoft.Diagnostics.NETCore.Client;
+
+namespace Microsoft.Diagnostics.Monitoring.Configuration
+{
+    public sealed class HttpRequestSourceConfiguration : MonitoringSourceConfiguration
+    {
+        private const string DiagnosticFilterString = "\"" +
+                "Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.HttpRequestIn.Start@Activity1Start:-" +
+                    "Request.Scheme" +
+                    ";Request.Host" +
+                    ";Request.PathBase" +
+                    ";Request.QueryString" +
+                    ";Request.Path" +
+                    ";Request.Method" +
+                    ";ActivityStartTime=*Activity.StartTimeUtc.Ticks" +
+                    ";ActivityParentId=*Activity.ParentId" +
+                    ";ActivityId=*Activity.Id" +
+                    ";ActivitySpanId=*Activity.SpanId" +
+                    ";ActivityTraceId=*Activity.TraceId" +
+                    ";ActivityParentSpanId=*Activity.ParentSpanId" +
+                    ";ActivityIdFormat=*Activity.IdFormat" +
+                "\r\n" +
+                "Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.HttpRequestIn.Stop@Activity1Stop:-" +
+                    "Response.StatusCode" +
+                    ";ActivityDuration=*Activity.Duration.Ticks" +
+                    ";ActivityId=*Activity.Id" +
+                "\r\n" +
+                "HttpHandlerDiagnosticListener/System.Net.Http.HttpRequestOut@Event:-" +
+                "\r\n" +
+                "HttpHandlerDiagnosticListener/System.Net.Http.HttpRequestOut.Start@Activity2Start:-" +
+                    "Request.RequestUri" +
+                    ";Request.Method" +
+                    ";Request.RequestUri.Host" +
+                    ";Request.RequestUri.Port" +
+                    ";ActivityStartTime=*Activity.StartTimeUtc.Ticks" +
+                    ";ActivityId=*Activity.Id" +
+                    ";ActivitySpanId=*Activity.SpanId" +
+                    ";ActivityTraceId=*Activity.TraceId" +
+                    ";ActivityParentSpanId=*Activity.ParentSpanId" +
+                    ";ActivityIdFormat=*Activity.IdFormat" +
+                    ";ActivityId=*Activity.Id" +
+                    "\r\n" +
+                "HttpHandlerDiagnosticListener/System.Net.Http.HttpRequestOut.Stop@Activity2Stop:-" +
+                    ";ActivityDuration=*Activity.Duration.Ticks" +
+                    ";ActivityId=*Activity.Id" +
+                "\r\n" +
+                "\"";
+
+        public override IList<EventPipeProvider> GetProviders()
+        {
+            var providers = new List<EventPipeProvider>()
+            {
+                // Diagnostic source events
+                new EventPipeProvider(DiagnosticSourceEventSource,
+                        keywords: 0x1 | 0x2,
+                        eventLevel: EventLevel.Verbose,
+                        arguments: new Dictionary<string,string>
+                        {
+                            { "FilterAndPayloadSpecs", DiagnosticFilterString }
+                        })
+            };
+
+            return providers;
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring/Configuration/LoggingSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring/Configuration/LoggingSourceConfiguration.cs
@@ -2,60 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.Diagnostics.NETCore.Client;
-using System;
 using System.Collections.Generic;
 using System.Diagnostics.Tracing;
-using System.Globalization;
-using System.Text;
+using Microsoft.Diagnostics.NETCore.Client;
 
 namespace Microsoft.Diagnostics.Monitoring
 {
     public class LoggingSourceConfiguration : MonitoringSourceConfiguration
     {
-        private const string DiagnosticFilterString = "\"" +
-                    "Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.HttpRequestIn.Start@Activity1Start:-" +
-                    "Request.Scheme" +
-                    ";Request.Host" +
-                    ";Request.PathBase" +
-                    ";Request.QueryString" +
-                    ";Request.Path" +
-                    ";Request.Method" +
-                    ";ActivityStartTime=*Activity.StartTimeUtc.Ticks" +
-                    ";ActivityParentId=*Activity.ParentId" +
-                    ";ActivityId=*Activity.Id" +
-                    ";ActivitySpanId=*Activity.SpanId" +
-                    ";ActivityTraceId=*Activity.TraceId" +
-                    ";ActivityParentSpanId=*Activity.ParentSpanId" +
-                    ";ActivityIdFormat=*Activity.IdFormat" +
-                    "\r\n" +
-                "Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.HttpRequestIn.Stop@Activity1Stop:-" +
-                    "Response.StatusCode" +
-                    ";ActivityDuration=*Activity.Duration.Ticks" +
-                    ";ActivityId=*Activity.Id" +
-                "\r\n" +
-                "HttpHandlerDiagnosticListener/System.Net.Http.HttpRequestOut@Event:-" +
-                "\r\n" +
-                "HttpHandlerDiagnosticListener/System.Net.Http.HttpRequestOut.Start@Activity2Start:-" +
-                    "Request.RequestUri" +
-                    ";Request.Method" +
-                    ";Request.RequestUri.Host" +
-                    ";Request.RequestUri.Port" +
-                    ";ActivityStartTime=*Activity.StartTimeUtc.Ticks" +
-                    ";ActivityId=*Activity.Id" +
-                    ";ActivitySpanId=*Activity.SpanId" +
-                    ";ActivityTraceId=*Activity.TraceId" +
-                    ";ActivityParentSpanId=*Activity.ParentSpanId" +
-                    ";ActivityIdFormat=*Activity.IdFormat" +
-                    ";ActivityId=*Activity.Id" +
-                    "\r\n" +
-                "HttpHandlerDiagnosticListener/System.Net.Http.HttpRequestOut.Stop@Activity2Stop:-" +
-                    ";ActivityDuration=*Activity.Duration.Ticks" +
-                    ";ActivityId=*Activity.Id" +
-                "\r\n" +
-
-                "\"";
-
         public override IList<EventPipeProvider> GetProviders()
         {
             var providers = new List<EventPipeProvider>()
@@ -65,21 +19,7 @@ namespace Microsoft.Diagnostics.Monitoring
                     MicrosoftExtensionsLoggingProviderName,
                     EventLevel.LogAlways,
                     (long)(LoggingEventSource.Keywords.JsonMessage | LoggingEventSource.Keywords.FormattedMessage)
-                ),
-
-                // Activity correlation
-                //new EventPipeProvider(TplEventSource,
-                //        keywords: 0x80,
-                //        eventLevel: EventLevel.LogAlways),
-
-                // Diagnostic source events
-                new EventPipeProvider(DiagnosticSourceEventSource,
-                        keywords: 0x1 | 0x2,
-                        eventLevel: EventLevel.Verbose,
-                        arguments: new Dictionary<string,string>
-                        {
-                            { "FilterAndPayloadSpecs", DiagnosticFilterString }
-                        })
+                )
             };
 
             return providers;

--- a/src/Microsoft.Diagnostics.Monitoring/DiagnosticServices.cs
+++ b/src/Microsoft.Diagnostics.Monitoring/DiagnosticServices.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using FastSerialization;
 using Graphs;
+using Microsoft.Diagnostics.Monitoring.Configuration;
 using Microsoft.Diagnostics.Monitoring.Logging;
 using Microsoft.Diagnostics.NETCore.Client;
 using Microsoft.Extensions.Logging;
@@ -96,7 +97,11 @@ namespace Microsoft.Diagnostics.Monitoring
 
         public async Task<IStreamWithCleanup> StartTrace(int pid, TimeSpan duration, CancellationToken token)
         {
-            DiagnosticsMonitor monitor = new DiagnosticsMonitor(new LoggingSourceConfiguration());
+            AggregateSourceConfiguration configuration = new AggregateSourceConfiguration();
+            configuration.AddConfiguration(new HttpRequestSourceConfiguration());
+            configuration.AddConfiguration(new LoggingSourceConfiguration());
+
+            DiagnosticsMonitor monitor = new DiagnosticsMonitor(configuration);
             Stream stream = await monitor.ProcessEvents(pid, duration, token);
             return new StreamWithCleanup(monitor, stream);
         }

--- a/src/Microsoft.Diagnostics.Monitoring/DiagnosticServices.cs
+++ b/src/Microsoft.Diagnostics.Monitoring/DiagnosticServices.cs
@@ -96,11 +96,12 @@ namespace Microsoft.Diagnostics.Monitoring
 
         public async Task<IStreamWithCleanup> StartTrace(int pid, TimeSpan duration, CancellationToken token)
         {
-            AggregateSourceConfiguration configuration = new AggregateSourceConfiguration();
-            configuration.AddConfiguration(new HttpRequestSourceConfiguration());
-            configuration.AddConfiguration(new LoggingSourceConfiguration());
+            AggregateSourceConfiguration aggregateConfiguration = new AggregateSourceConfiguration(
+                new HttpRequestSourceConfiguration(),
+                new LoggingSourceConfiguration()
+            );
 
-            DiagnosticsMonitor monitor = new DiagnosticsMonitor(configuration);
+            DiagnosticsMonitor monitor = new DiagnosticsMonitor(aggregateConfiguration);
             Stream stream = await monitor.ProcessEvents(pid, duration, token);
             return new StreamWithCleanup(monitor, stream);
         }

--- a/src/Microsoft.Diagnostics.Monitoring/DiagnosticServices.cs
+++ b/src/Microsoft.Diagnostics.Monitoring/DiagnosticServices.cs
@@ -12,7 +12,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using FastSerialization;
 using Graphs;
-using Microsoft.Diagnostics.Monitoring.Configuration;
 using Microsoft.Diagnostics.Monitoring.Logging;
 using Microsoft.Diagnostics.NETCore.Client;
 using Microsoft.Extensions.Logging;


### PR DESCRIPTION
The logs endpoint does not need the HTTP request configuration information since it is not capturing that information from the event pipe event source. This refactors the HTTP request configuration separate from logging configuration and then aggregates the two for the trace endpoint.