### PR TITLE
Unify all nettrace endpoints into single trace endpoint.

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/Controllers/DiagController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/Controllers/DiagController.cs
@@ -5,10 +5,8 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Diagnostics;
 using System.IO;
 using System.Net;
-using System.Net.Http.Headers;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -75,26 +73,14 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
             });
         }
 
-        [HttpGet("cpuprofile/{pid?}")]
-        public Task<ActionResult> CpuProfile(int? pid, [FromQuery][Range(-1, int.MaxValue)]int durationSeconds = 30)
-        {
-            TimeSpan duration = ConvertSecondsToTimeSpan(durationSeconds);
-            return InvokeService(async () =>
-            {
-                int pidValue = _diagnosticServices.ResolveProcess(pid);
-                IStreamWithCleanup result = await _diagnosticServices.StartCpuTrace(pidValue, duration, this.HttpContext.RequestAborted);
-                return new StreamWithCleanupResult(result, "application/octet-stream", FormattableString.Invariant($"{Guid.NewGuid()}.nettrace"));
-            });
-        }
-
         [HttpGet("trace/{pid?}")]
-        public Task<ActionResult> Trace(int? pid, [FromQuery][Range(-1, int.MaxValue)]int durationSeconds = 30)
+        public Task<ActionResult> Trace(int? pid, [FromQuery]TraceProfile profile = TraceProfile.All, [FromQuery][Range(-1, int.MaxValue)]int durationSeconds = 30)
         {
             TimeSpan duration = ConvertSecondsToTimeSpan(durationSeconds);
             return InvokeService(async () =>
             {
                 int pidValue = _diagnosticServices.ResolveProcess(pid);
-                IStreamWithCleanup result = await _diagnosticServices.StartTrace(pidValue, duration, this.HttpContext.RequestAborted);
+                IStreamWithCleanup result = await _diagnosticServices.StartTrace(pidValue, profile, duration, this.HttpContext.RequestAborted);
                 return new StreamWithCleanupResult(result, "application/octet-stream", FormattableString.Invariant($"{Guid.NewGuid()}.nettrace"));
             });
         }

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/Controllers/DiagController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/Controllers/DiagController.cs
@@ -74,13 +74,17 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
         }
 
         [HttpGet("trace/{pid?}")]
-        public Task<ActionResult> Trace(int? pid, [FromQuery]TraceProfile profile = TraceProfile.All, [FromQuery][Range(-1, int.MaxValue)]int durationSeconds = 30)
+        public Task<ActionResult> Trace(
+            int? pid,
+            [FromQuery]TraceProfile profile = TraceProfile.All,
+            [FromQuery][Range(-1, int.MaxValue)]int durationSeconds = 30,
+            [FromQuery][Range(1, int.MaxValue)] int metricsIntervalSeconds = 1)
         {
             TimeSpan duration = ConvertSecondsToTimeSpan(durationSeconds);
             return InvokeService(async () =>
             {
                 int pidValue = _diagnosticServices.ResolveProcess(pid);
-                IStreamWithCleanup result = await _diagnosticServices.StartTrace(pidValue, profile, duration, this.HttpContext.RequestAborted);
+                IStreamWithCleanup result = await _diagnosticServices.StartTrace(pidValue, profile, duration, metricsIntervalSeconds, this.HttpContext.RequestAborted);
                 return new StreamWithCleanupResult(result, "application/octet-stream", FormattableString.Invariant($"{Guid.NewGuid()}.nettrace"));
             });
         }

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/Controllers/DiagController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/Controllers/DiagController.cs
@@ -21,6 +21,8 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
     [ApiController]
     public class DiagController : ControllerBase
     {
+        private const TraceProfile DefaultTraceProfiles = TraceProfile.Cpu | TraceProfile.Http | TraceProfile.Metrics;
+
         private readonly ILogger<DiagController> _logger;
         private readonly IDiagnosticServices _diagnosticServices;
 
@@ -76,7 +78,7 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
         [HttpGet("trace/{pid?}")]
         public Task<ActionResult> Trace(
             int? pid,
-            [FromQuery]TraceProfile profile = TraceProfile.All,
+            [FromQuery]TraceProfile profile = DefaultTraceProfiles,
             [FromQuery][Range(-1, int.MaxValue)]int durationSeconds = 30,
             [FromQuery][Range(1, int.MaxValue)] int metricsIntervalSeconds = 1)
         {

--- a/src/Microsoft.Diagnostics.Monitoring/Configuration/AggregateSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring/Configuration/AggregateSourceConfiguration.cs
@@ -12,6 +12,11 @@ namespace Microsoft.Diagnostics.Monitoring
     {
         private IList<MonitoringSourceConfiguration> _configurations;
 
+        public AggregateSourceConfiguration(IEnumerable<MonitoringSourceConfiguration> configurations)
+        {
+            _configurations = configurations.ToList();
+        }
+
         public AggregateSourceConfiguration(params MonitoringSourceConfiguration[] configurations)
         {
             _configurations = configurations;

--- a/src/Microsoft.Diagnostics.Monitoring/Configuration/AggregateSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring/Configuration/AggregateSourceConfiguration.cs
@@ -12,11 +12,6 @@ namespace Microsoft.Diagnostics.Monitoring
     {
         private IList<MonitoringSourceConfiguration> _configurations;
 
-        public AggregateSourceConfiguration(IEnumerable<MonitoringSourceConfiguration> configurations)
-        {
-            _configurations = configurations.ToList();
-        }
-
         public AggregateSourceConfiguration(params MonitoringSourceConfiguration[] configurations)
         {
             _configurations = configurations;

--- a/src/Microsoft.Diagnostics.Monitoring/Contracts/IDiagnosticServices.cs
+++ b/src/Microsoft.Diagnostics.Monitoring/Contracts/IDiagnosticServices.cs
@@ -21,9 +21,7 @@ namespace Microsoft.Diagnostics.Monitoring
         Task<Stream> GetGcDump(int pid, CancellationToken token);
 
         //TODO We can most likely unify trace, cpu, and logs/metrics around one call with the appropriate config
-        Task<IStreamWithCleanup> StartCpuTrace(int pid, TimeSpan duration, CancellationToken token);
-
-        Task<IStreamWithCleanup> StartTrace(int pid, TimeSpan duration, CancellationToken token);
+        Task<IStreamWithCleanup> StartTrace(int pid, TraceProfile profile, TimeSpan duration, CancellationToken token);
 
         Task StartLogs(Stream outputStream, int pid, TimeSpan duration, CancellationToken token);
     }
@@ -41,8 +39,13 @@ namespace Microsoft.Diagnostics.Monitoring
         Triage
     }
 
-    public sealed class TraceRequest
+    [Flags]
+    public enum TraceProfile
     {
-        public string Configuraton { get; set; }
+        Cpu =     0x1,
+        Http =    0x2,
+        Logs =    0x4,
+        Metrics = 0x8,
+        All = Cpu | Http | Logs | Metrics
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring/Contracts/IDiagnosticServices.cs
+++ b/src/Microsoft.Diagnostics.Monitoring/Contracts/IDiagnosticServices.cs
@@ -44,7 +44,6 @@ namespace Microsoft.Diagnostics.Monitoring
         Cpu =     0x1,
         Http =    0x2,
         Logs =    0x4,
-        Metrics = 0x8,
-        All = Cpu | Http | Logs | Metrics
+        Metrics = 0x8
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring/Contracts/IDiagnosticServices.cs
+++ b/src/Microsoft.Diagnostics.Monitoring/Contracts/IDiagnosticServices.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Diagnostics.Monitoring
 
         Task<Stream> GetGcDump(int pid, CancellationToken token);
 
-        Task<IStreamWithCleanup> StartTrace(int pid, TraceProfile profile, TimeSpan duration, CancellationToken token);
+        Task<IStreamWithCleanup> StartTrace(int pid, TraceProfile profile, TimeSpan duration, int metricsIntervalSeconds, CancellationToken token);
 
         Task StartLogs(Stream outputStream, int pid, TimeSpan duration, CancellationToken token);
     }

--- a/src/Microsoft.Diagnostics.Monitoring/Contracts/IDiagnosticServices.cs
+++ b/src/Microsoft.Diagnostics.Monitoring/Contracts/IDiagnosticServices.cs
@@ -20,7 +20,6 @@ namespace Microsoft.Diagnostics.Monitoring
 
         Task<Stream> GetGcDump(int pid, CancellationToken token);
 
-        //TODO We can most likely unify trace, cpu, and logs/metrics around one call with the appropriate config
         Task<IStreamWithCleanup> StartTrace(int pid, TraceProfile profile, TimeSpan duration, CancellationToken token);
 
         Task StartLogs(Stream outputStream, int pid, TimeSpan duration, CancellationToken token);

--- a/src/Microsoft.Diagnostics.Monitoring/DiagnosticServices.cs
+++ b/src/Microsoft.Diagnostics.Monitoring/DiagnosticServices.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Diagnostics.Monitoring
             return stream;
         }
 
-        public async Task<IStreamWithCleanup> StartTrace(int pid, TraceProfile profile, TimeSpan duration, CancellationToken token)
+        public async Task<IStreamWithCleanup> StartTrace(int pid, TraceProfile profile, TimeSpan duration, int metricsIntervalSeconds, CancellationToken token)
         {
             IList<MonitoringSourceConfiguration> configurations = new List<MonitoringSourceConfiguration>();
             if (profile.HasFlag(TraceProfile.Cpu))
@@ -103,7 +103,7 @@ namespace Microsoft.Diagnostics.Monitoring
             }
             if (profile.HasFlag(TraceProfile.Metrics))
             {
-                configurations.Add(new MetricSourceConfiguration(5));
+                configurations.Add(new MetricSourceConfiguration(metricsIntervalSeconds));
             }
 
             AggregateSourceConfiguration aggregateConfiguration = new AggregateSourceConfiguration(configurations.ToArray());

--- a/src/Microsoft.Diagnostics.Monitoring/DiagnosticServices.cs
+++ b/src/Microsoft.Diagnostics.Monitoring/DiagnosticServices.cs
@@ -103,10 +103,10 @@ namespace Microsoft.Diagnostics.Monitoring
             }
             if (profile.HasFlag(TraceProfile.Metrics))
             {
-                configurations.Add(new MetricSourceConfiguration());
+                configurations.Add(new MetricSourceConfiguration(5));
             }
 
-            AggregateSourceConfiguration aggregateConfiguration = new AggregateSourceConfiguration(configurations);
+            AggregateSourceConfiguration aggregateConfiguration = new AggregateSourceConfiguration(configurations.ToArray());
 
             DiagnosticsMonitor monitor = new DiagnosticsMonitor(aggregateConfiguration);
             Stream stream = await monitor.ProcessEvents(pid, duration, token);


### PR DESCRIPTION
Combine all nettrace-producing endpoints into the trace endpoint.
Client can specify which event profiles they want using the profile query parameter.