### PR TITLE
Add --name option to CLI tools

### DIFF
--- a/documentation/dotnet-counters-instructions.md
+++ b/documentation/dotnet-counters-instructions.md
@@ -150,6 +150,7 @@ dotnet tool install --global dotnet-counters
 
     dotnet-counters collect [-h||--help]
                             [-p|--process-id <pid>]
+                            [-n|--name <name>]
                             [-o|--output <name>]
                             [--format <csv|json>]
                             [--refreshInterval <sec>]
@@ -162,6 +163,9 @@ dotnet tool install --global dotnet-counters
     
     -p,--process-id
         The ID of the process that will be monitored
+
+    -n,--name
+        The name of the process that will be monitored. This can be specified in place of process-id.
 
     -o, --output
         The name of the output file

--- a/documentation/dotnet-gcdump-instructions.md
+++ b/documentation/dotnet-gcdump-instructions.md
@@ -63,13 +63,14 @@ Prior to .NET Core 3.1-preview2, there was an issue where static and COM types w
 
 ```cmd
 collect:
-  Collects a diagnostic trace from a currently running process
+  Collects a gcdump from a currently running process
 
 Usage:
   dotnet-gcdump collect [options]
 
 Options:
-  -p, --process-id <pid>             The process to collect the trace from
+  -p, --process-id <pid>             The process to collect the gcdump from
+  -n, --name <name>                  The name of the process to collect the gcdump from.
   -o, --output <gcdump-file-path>    The path where collected gcdumps should be written. Defaults to '.\YYYYMMDD_HHMMSS_<pid>.gcdump'
                                      where YYYYMMDD is Year/Month/Day and HHMMSS is Hour/Minute/Second. Otherwise, it is the full path
                                      and file name of the dump.

--- a/documentation/dotnet-trace-instructions.md
+++ b/documentation/dotnet-trace-instructions.md
@@ -144,6 +144,9 @@ Options:
   -p, --process-id <pid>
     The process to collect the trace from
 
+  -n, --name <name>
+    The name of the process to collect the trace from.
+
   -o, --output <trace-file-path>
     The output path for the collected trace data. If not specified it defaults to 'trace.nettrace'
 

--- a/src/Tools/Common/Commands/Utils.cs
+++ b/src/Tools/Common/Commands/Utils.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Microsoft.Diagnostics.NETCore.Client;
+
+namespace Microsoft.Internal.Common.Utils
+{
+    internal class CommandUtils
+    {
+        // Returns processId that matches the given name.
+        // It also checks whether the process has a diagnostics server port.
+        // If there are more than 1 process with the given name or there isn't any active process
+        // with the given name, then this returns -1
+        public static int FindProcessIdWithName(string name)
+        {
+            var publishedProcessesPids = new List<int>(DiagnosticsClient.GetPublishedProcesses());
+            var processesWithMatchingName = Process.GetProcessesByName(name);
+            var commonId = -1;
+
+            for (int i = 0; i < processesWithMatchingName.Length; i++)
+            {
+                if (publishedProcessesPids.Contains(processesWithMatchingName[i].Id))
+                {
+                    if (commonId != -1)
+                    {
+                        Console.WriteLine("There are more than one active processes with the given name: {0}", name);
+                        return -1;
+                    }
+                    commonId = processesWithMatchingName[i].Id;
+                }
+            }
+            if (commonId == -1)
+            {
+                Console.WriteLine("There is no active process with the given name: {0}", name);
+            }
+            return commonId;
+        }
+    }
+}

--- a/src/Tools/dotnet-counters/CounterMonitor.cs
+++ b/src/Tools/dotnet-counters/CounterMonitor.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
 
         public async Task<int> Monitor(CancellationToken ct, List<string> counter_list, IConsole console, int processId, int refreshInterval, string name)
         {
-            if (name != "")
+            if (name != null)
             {
                 if (processId != 0)
                 {
@@ -127,7 +127,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
 
         public async Task<int> Collect(CancellationToken ct, List<string> counter_list, IConsole console, int processId, int refreshInterval, CountersExportFormat format, string output, string name)
         {
-            if (name != "")
+            if (name != null)
             {
                 if (processId != 0)
                 {

--- a/src/Tools/dotnet-counters/CounterMonitor.cs
+++ b/src/Tools/dotnet-counters/CounterMonitor.cs
@@ -94,11 +94,15 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 {
                     if (commonId != -1)
                     {
-                        Console.WriteLine($"There are more than one active processes with the given name: {name}");
+                        Console.WriteLine("There are more than one active processes with the given name: {0}", name);
                         return -1;
                     }
                     commonId = processesWithMatchingName[i].Id;
                 }
+            }
+            if (commonId == -1)
+            {
+                Console.WriteLine("There is no active process with the given name: {0}", name);
             }
             return commonId;
         }
@@ -115,7 +119,6 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 processId = FindProcessIdWithName(name);
                 if (processId < 0)
                 {
-                    Console.WriteLine("There is no active process with the given name: {name}");
                     return 0;
                 }
             }

--- a/src/Tools/dotnet-counters/CounterMonitor.cs
+++ b/src/Tools/dotnet-counters/CounterMonitor.cs
@@ -125,8 +125,22 @@ namespace Microsoft.Diagnostics.Tools.Counters
             }
         }
 
-        public async Task<int> Collect(CancellationToken ct, List<string> counter_list, IConsole console, int processId, int refreshInterval, CountersExportFormat format, string output)
+        public async Task<int> Collect(CancellationToken ct, List<string> counter_list, IConsole console, int processId, int refreshInterval, CountersExportFormat format, string output, string name)
         {
+            if (name != "")
+            {
+                if (processId != 0)
+                {
+                    Console.WriteLine("Can only specify either --name or --process-id option.");
+                    return 0;
+                }
+                processId = CommandUtils.FindProcessIdWithName(name);
+                if (processId < 0)
+                {
+                    return 0;
+                }
+            }
+
             try
             {
                 _ct = ct;

--- a/src/Tools/dotnet-counters/CounterMonitor.cs
+++ b/src/Tools/dotnet-counters/CounterMonitor.cs
@@ -14,6 +14,7 @@ using System.Threading.Tasks;
 
 using Microsoft.Diagnostics.Tracing;
 using Microsoft.Diagnostics.Tools.Counters.Exporters;
+using Microsoft.Internal.Common.Utils;
 
 namespace Microsoft.Diagnostics.Tools.Counters
 {
@@ -82,31 +83,6 @@ namespace Microsoft.Diagnostics.Tools.Counters
             _renderer.Stop();
         }
 
-        private int FindProcessIdWithName(string name)
-        {
-            var publishedProcessesPids = new List<int>(DiagnosticsClient.GetPublishedProcesses());
-            var processesWithMatchingName = Process.GetProcessesByName(name);
-            var commonId = -1;
-
-            for (int i = 0; i < processesWithMatchingName.Length; i++)
-            {
-                if (publishedProcessesPids.Contains(processesWithMatchingName[i].Id))
-                {
-                    if (commonId != -1)
-                    {
-                        Console.WriteLine("There are more than one active processes with the given name: {0}", name);
-                        return -1;
-                    }
-                    commonId = processesWithMatchingName[i].Id;
-                }
-            }
-            if (commonId == -1)
-            {
-                Console.WriteLine("There is no active process with the given name: {0}", name);
-            }
-            return commonId;
-        }
-
         public async Task<int> Monitor(CancellationToken ct, List<string> counter_list, IConsole console, int processId, int refreshInterval, string name)
         {
             if (name != "")
@@ -116,7 +92,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
                     Console.WriteLine("Can only specify either --name or --process-id option.");
                     return 0;
                 }
-                processId = FindProcessIdWithName(name);
+                processId = CommandUtils.FindProcessIdWithName(name);
                 if (processId < 0)
                 {
                     return 0;

--- a/src/Tools/dotnet-counters/Program.cs
+++ b/src/Tools/dotnet-counters/Program.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
 
     internal class Program
     {
-        delegate Task<int> ExportDelegate(CancellationToken ct, List<string> counter_list, IConsole console, int processId, int refreshInterval, CountersExportFormat format, string output);
+        delegate Task<int> ExportDelegate(CancellationToken ct, List<string> counter_list, IConsole console, int processId, int refreshInterval, CountersExportFormat format, string output, string processName);
 
         private static Command MonitorCommand() =>
             new Command(

--- a/src/Tools/dotnet-counters/Program.cs
+++ b/src/Tools/dotnet-counters/Program.cs
@@ -29,9 +29,9 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 description: "Start monitoring a .NET application")
             {
                 // Handler
-                CommandHandler.Create<CancellationToken, List<string>, IConsole, int, int>(new CounterMonitor().Monitor),
+                CommandHandler.Create<CancellationToken, List<string>, IConsole, int, int, string>(new CounterMonitor().Monitor),
                 // Arguments and Options
-                CounterList(), ProcessIdOption(), RefreshIntervalOption()
+                CounterList(), ProcessIdOption(), RefreshIntervalOption(), NameOption()
             };
 
         private static Command CollectCommand() =>
@@ -42,7 +42,15 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 // Handler
                 HandlerDescriptor.FromDelegate((ExportDelegate)new CounterMonitor().Collect).GetCommandHandler(),
                 // Arguments and Options
-                CounterList(), ProcessIdOption(), RefreshIntervalOption(), ExportFormatOption(), ExportFileNameOption()
+                CounterList(), ProcessIdOption(), RefreshIntervalOption(), ExportFormatOption(), ExportFileNameOption(), NameOption()
+            };
+
+        private static Option NameOption() =>
+            new Option(
+                aliases: new[] { "-n", "--name" },
+                description: "The name of the process that will be monitored.")
+            {
+                Argument = new Argument<string>(name: "name")
             };
 
         private static Option ProcessIdOption() =>

--- a/src/Tools/dotnet-counters/dotnet-counters.csproj
+++ b/src/Tools/dotnet-counters/dotnet-counters.csproj
@@ -14,6 +14,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)..\dotnet-trace\Extensions.cs" Link="Extensions.cs" />
     <Compile Include="..\Common\CommandExtensions.cs" Link="CommandExtensions.cs" />
     <Compile Include="..\Common\Commands\ProcessStatus.cs" Link="ProcessStatus.cs" />
+    <Compile Include="..\Common\Commands\Utils.cs" Link="Utils.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tools/dotnet-dump/Dumper.cs
+++ b/src/Tools/dotnet-dump/Dumper.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Diagnostics.Tools.Dump
         public int Collect(IConsole console, int processId, string output, bool diag, DumpTypeOption type, string name)
         {
             Console.WriteLine(name);
-            if (name != "")
+            if (name != null)
             {
                 if (processId != 0)
                 {

--- a/src/Tools/dotnet-dump/Dumper.cs
+++ b/src/Tools/dotnet-dump/Dumper.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.NETCore.Client;
+using Microsoft.Internal.Common.Utils;
 using System;
 using System.CommandLine;
 using System.Diagnostics;
@@ -32,8 +33,23 @@ namespace Microsoft.Diagnostics.Tools.Dump
         {
         }
 
-        public int Collect(IConsole console, int processId, string output, bool diag, DumpTypeOption type)
+        public int Collect(IConsole console, int processId, string output, bool diag, DumpTypeOption type, string name)
         {
+            Console.WriteLine(name);
+            if (name != "")
+            {
+                if (processId != 0)
+                {
+                    Console.WriteLine("Can only specify either --name or --process-id option.");
+                    return 0;
+                }
+                processId = CommandUtils.FindProcessIdWithName(name);
+                if (processId < 0)
+                {
+                    return 0;
+                }
+            }
+
             if (processId == 0) {
                 console.Error.WriteLine("ProcessId is required.");
                 return 1;

--- a/src/Tools/dotnet-dump/Program.cs
+++ b/src/Tools/dotnet-dump/Program.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Diagnostics.Tools.Dump
         private static Option ProcessNameOption() =>
             new Option(
                 aliases: new[] { "-n", "--name" },
-                description: "The name of the process that will be monitored.")
+                description: "The name of the process to collect a memory dump.")
             {
                 Argument = new Argument<string>(name: "name")
             };

--- a/src/Tools/dotnet-dump/Program.cs
+++ b/src/Tools/dotnet-dump/Program.cs
@@ -30,9 +30,9 @@ namespace Microsoft.Diagnostics.Tools.Dump
             new Command( name: "collect", description: "Capture dumps from a process")
             {
                 // Handler
-                CommandHandler.Create<IConsole, int, string, bool, Dumper.DumpTypeOption>(new Dumper().Collect),
+                CommandHandler.Create<IConsole, int, string, bool, Dumper.DumpTypeOption, string>(new Dumper().Collect),
                 // Options
-                ProcessIdOption(), OutputOption(), DiagnosticLoggingOption(), TypeOption()
+                ProcessIdOption(), OutputOption(), DiagnosticLoggingOption(), TypeOption(), ProcessNameOption()
             };
 
         private static Option ProcessIdOption() =>
@@ -41,6 +41,14 @@ namespace Microsoft.Diagnostics.Tools.Dump
                 description: "The process id to collect a memory dump.")
             {
                 Argument = new Argument<int>(name: "pid")
+            };
+
+        private static Option ProcessNameOption() =>
+            new Option(
+                aliases: new[] { "-n", "--name" },
+                description: "The name of the process that will be monitored.")
+            {
+                Argument = new Argument<string>(name: "name")
             };
 
         private static Option OutputOption() =>

--- a/src/Tools/dotnet-dump/dotnet-dump.csproj
+++ b/src/Tools/dotnet-dump/dotnet-dump.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <Compile Include="..\Common\CommandExtensions.cs" Link="CommandExtensions.cs" />
     <Compile Include="..\Common\Commands\ProcessStatus.cs" Link="ProcessStatus.cs" />
+    <Compile Include="..\Common\Commands\Utils.cs" Link="Utils.cs" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Tools/dotnet-gcdump/CommandLine/CollectCommandHandler.cs
+++ b/src/Tools/dotnet-gcdump/CommandLine/CollectCommandHandler.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Tools.Common;
+using Microsoft.Internal.Common.Utils;
 using System;
 using System.CommandLine;
 using System.CommandLine.Binding;
@@ -15,7 +16,7 @@ namespace Microsoft.Diagnostics.Tools.GCDump
 {
     internal static class CollectCommandHandler
     {
-        delegate Task<int> CollectDelegate(CancellationToken ct, IConsole console, int processId, string output, int timeout, bool verbose);
+        delegate Task<int> CollectDelegate(CancellationToken ct, IConsole console, int processId, string output, int timeout, bool verbose, string name);
 
         /// <summary>
         /// Collects a gcdump from a currently running process.
@@ -25,8 +26,22 @@ namespace Microsoft.Diagnostics.Tools.GCDump
         /// <param name="processId">The process to collect the gcdump from.</param>
         /// <param name="output">The output path for the collected gcdump.</param>
         /// <returns></returns>
-        private static async Task<int> Collect(CancellationToken ct, IConsole console, int processId, string output, int timeout, bool verbose)
+        private static async Task<int> Collect(CancellationToken ct, IConsole console, int processId, string output, int timeout, bool verbose, string name)
         {
+            if (name != "")
+            {
+                if (processId != 0)
+                {
+                    Console.WriteLine("Can only specify either --name or --process-id option.");
+                    return -1;
+                }
+                processId = CommandUtils.FindProcessIdWithName(name);
+                if (processId < 0)
+                {
+                    return -1;
+                }
+            }
+
             try
             {
                 if (processId < 0)
@@ -121,7 +136,7 @@ namespace Microsoft.Diagnostics.Tools.GCDump
                 // Handler
                 HandlerDescriptor.FromDelegate((CollectDelegate) Collect).GetCommandHandler(),
                 // Options
-                ProcessIdOption(), OutputPathOption(), VerboseOption(), TimeoutOption()
+                ProcessIdOption(), OutputPathOption(), VerboseOption(), TimeoutOption(), NameOption()
             };
 
         private static Option ProcessIdOption() =>
@@ -130,6 +145,14 @@ namespace Microsoft.Diagnostics.Tools.GCDump
                 description: "The process id to collect the trace.")
             {
                 Argument = new Argument<int>(name: "pid", defaultValue: 0),
+            };
+
+        private static Option NameOption() =>
+            new Option(
+                aliases: new[] { "-n", "--name" },
+                description: "The name of the process that will be monitored.")
+            {
+                Argument = new Argument<string>(name: "name")
             };
 
         private static Option OutputPathOption() =>

--- a/src/Tools/dotnet-gcdump/CommandLine/CollectCommandHandler.cs
+++ b/src/Tools/dotnet-gcdump/CommandLine/CollectCommandHandler.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Diagnostics.Tools.GCDump
         /// <returns></returns>
         private static async Task<int> Collect(CancellationToken ct, IConsole console, int processId, string output, int timeout, bool verbose, string name)
         {
-            if (name != "")
+            if (name != null)
             {
                 if (processId != 0)
                 {

--- a/src/Tools/dotnet-gcdump/CommandLine/CollectCommandHandler.cs
+++ b/src/Tools/dotnet-gcdump/CommandLine/CollectCommandHandler.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Diagnostics.Tools.GCDump
         private static Option ProcessIdOption() =>
             new Option(
                 aliases: new[] { "-p", "--process-id" },
-                description: "The process id to collect the trace.")
+                description: "The process id to collect the gcdump.")
             {
                 Argument = new Argument<int>(name: "pid", defaultValue: 0),
             };
@@ -150,7 +150,7 @@ namespace Microsoft.Diagnostics.Tools.GCDump
         private static Option NameOption() =>
             new Option(
                 aliases: new[] { "-n", "--name" },
-                description: "The name of the process that will be monitored.")
+                description: "The name of the process to collect the gcdump.")
             {
                 Argument = new Argument<string>(name: "name")
             };

--- a/src/Tools/dotnet-gcdump/dotnet-gcdump.csproj
+++ b/src/Tools/dotnet-gcdump/dotnet-gcdump.csproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <Compile Include="..\Common\CommandExtensions.cs" Link="CommandExtensions.cs" />
     <Compile Include="..\Common\Commands\ProcessStatus.cs" Link="ProcessStatus.cs" />
+    <Compile Include="..\Common\Commands\Utils.cs" Link="Utils.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 Debug.Assert(profile != null);
 
                 // Either processName or processId has to be specified.
-                if (name!= "")
+                if (name != null)
                 {
                     if (processId != 0)
                     {

--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
@@ -3,7 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.NETCore.Client;
-using Microsoft.Internal.Common.Utils; using Microsoft.Tools.Common;
+using Microsoft.Internal.Common.Utils;
+using Microsoft.Tools.Common;
 using System;
 using System.Collections.Generic;
 using System.CommandLine;

--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.NETCore.Client;
-using Microsoft.Tools.Common;
+using Microsoft.Internal.Common.Utils; using Microsoft.Tools.Common;
 using System;
 using System.Collections.Generic;
 using System.CommandLine;
@@ -19,7 +19,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
 {
     internal static class CollectCommandHandler
     {
-        delegate Task<int> CollectDelegate(CancellationToken ct, IConsole console, int processId, FileInfo output, uint buffersize, string providers, string profile, TraceFileFormat format, TimeSpan duration, string clrevents, string clreventlevel);
+        delegate Task<int> CollectDelegate(CancellationToken ct, IConsole console, int processId, FileInfo output, uint buffersize, string providers, string profile, TraceFileFormat format, TimeSpan duration, string clrevents, string clreventlevel, string name);
 
         /// <summary>
         /// Collects a diagnostic trace from a currently running process.
@@ -27,6 +27,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
         /// <param name="ct">The cancellation token</param>
         /// <param name="console"></param>
         /// <param name="processId">The process to collect the trace from.</param>
+        /// <param name="name">The name of process to collect the trace from.</param>
         /// <param name="output">The output path for the collected trace data.</param>
         /// <param name="buffersize">Sets the size of the in-memory circular buffer in megabytes.</param>
         /// <param name="providers">A list of EventPipe providers to be enabled. This is in the form 'Provider[,Provider]', where Provider is in the form: 'KnownProviderName[:Flags[:Level][:KeyValueArgs]]', and KeyValueArgs is in the form: '[key1=value1][;key2=value2]'</param>
@@ -36,12 +37,27 @@ namespace Microsoft.Diagnostics.Tools.Trace
         /// <param name="clrevents">A list of CLR events to be emitted.</param>
         /// <param name="clreventlevel">The verbosity level of CLR events</param>
         /// <returns></returns>
-        private static async Task<int> Collect(CancellationToken ct, IConsole console, int processId, FileInfo output, uint buffersize, string providers, string profile, TraceFileFormat format, TimeSpan duration, string clrevents, string clreventlevel)
+        private static async Task<int> Collect(CancellationToken ct, IConsole console, int processId, FileInfo output, uint buffersize, string providers, string profile, TraceFileFormat format, TimeSpan duration, string clrevents, string clreventlevel, string name)
         {
             try
             {
                 Debug.Assert(output != null);
                 Debug.Assert(profile != null);
+
+                // Either processName or processId has to be specified.
+                if (name!= "")
+                {
+                    if (processId != 0)
+                    {
+                        Console.WriteLine("Can only specify either --name or --process-id option.");
+                        return ErrorCodes.ArgumentError;
+                    }
+                    processId = CommandUtils.FindProcessIdWithName(name);
+                    if (processId < 0)
+                    {
+                        return ErrorCodes.ArgumentError;
+                    }
+                }
 
                 if (processId < 0)
                 {
@@ -305,7 +321,8 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 CommonOptions.FormatOption(),
                 DurationOption(),
                 CLREventsOption(),
-                CLREventLevelOption()
+                CLREventLevelOption(),
+                CommonOptions.NameOption()
             };
 
         private static uint DefaultCircularBufferSizeInMB => 256;

--- a/src/Tools/dotnet-trace/CommandLine/Options/CommonOptions.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Options/CommonOptions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
         public static Option NameOption() =>
             new Option(
                 aliases: new[] { "-n", "--name" },
-                description: "The name of the process that will be monitored.")
+                description: "The name of the process to collect the trace.")
             {
                 Argument = new Argument<string>(name: "name")
             };

--- a/src/Tools/dotnet-trace/CommandLine/Options/CommonOptions.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Options/CommonOptions.cs
@@ -16,6 +16,14 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 Argument = new Argument<int>(name: "pid")
             };
 
+        public static Option NameOption() =>
+            new Option(
+                aliases: new[] { "-n", "--name" },
+                description: "The name of the process that will be monitored.")
+            {
+                Argument = new Argument<string>(name: "name")
+            };
+
         public static TraceFileFormat DefaultTraceFileFormat => TraceFileFormat.NetTrace;
 
         public static Option FormatOption() =>

--- a/src/Tools/dotnet-trace/dotnet-trace.csproj
+++ b/src/Tools/dotnet-trace/dotnet-trace.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <Compile Include="..\Common\CommandExtensions.cs" Link="CommandExtensions.cs" />
     <Compile Include="..\Common\Commands\ProcessStatus.cs" Link="ProcessStatus.cs" />
+    <Compile Include="..\Common\Commands\Utils.cs" Link="Utils.cs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Address #296.

This adds the `--name` option support to dotnet-counters (collect, monitor), dotnet-trace (collect), dotnet-dump (collect), and dotnet-gcdump (collect). 

Also fixed a few typos in dotnet-gcdump along the way.
