### PR TITLE
Validate Docker entrypoint is dotnet process with diagnostics transport.

### DIFF
--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
@@ -25,6 +25,17 @@ namespace Microsoft.Diagnostics.NETCore.Client
         }
 
         /// <summary>
+        /// Checks that the client is able to communicate with target process over diagnostic transport.
+        /// </summary>
+        /// <returns>
+        /// True if client is able to communicate with target process; otherwise, false.
+        /// </returns>
+        public bool CheckTransport()
+        {
+            return IpcClient.CheckTransport(_processId);
+        }
+
+        /// <summary>
         /// Start tracing the application and return an EventPipeSession object
         /// </summary>
         /// <param name="providers">An IEnumerable containing the list of Providers to turn on.</param>

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcClient.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcClient.cs
@@ -9,7 +9,6 @@ using System.IO.Pipes;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
-using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Security.Principal;
 
@@ -73,6 +72,25 @@ namespace Microsoft.Diagnostics.NETCore.Client
                 var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
                 socket.Connect(remoteEP);
                 return new NetworkStream(socket);
+            }
+        }
+
+        /// <summary>
+        /// Checks that the client is able to communicate with target process over diagnostic transport.
+        /// </summary>
+        /// <returns>
+        /// True if client is able to communicate with target process; otherwise, false.
+        /// </returns>
+        public static bool CheckTransport(int processId)
+        {
+            try
+            {
+                using var stream = GetTransport(processId);
+                return null != stream;
+            }
+            catch (Exception)
+            {
+                return false;
             }
         }
 

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/GetPublishedProcessesTests.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/GetPublishedProcessesTests.cs
@@ -77,5 +77,21 @@ namespace Microsoft.Diagnostics.NETCore.Client
                 runner[i].Stop();
             }
         }
+
+        [Fact]
+        public void CheckSpecificProcessTest()
+        {
+            TestRunner runner = new TestRunner(CommonHelper.GetTraceePath(), output);
+            runner.Start(3000);
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Thread.Sleep(5000);
+            }
+
+            var client = new DiagnosticsClient(runner.Pid);
+            Assert.True(client.CheckTransport(), $"Unable to verify diagnostics transport for test process {runner.Pid}.");
+
+            runner.Stop();
+        }
     }
 }


### PR DESCRIPTION
Have dotnet-monitor check that the Docker entrypoint process is dotnet with diagnostics transport before assuming that it's a viable process when using the REST APIs without specifying a process.