### PR TITLE
Remove extrapolation from dotnet-counters

### DIFF
--- a/src/Tools/dotnet-counters/CounterPayload.cs
+++ b/src/Tools/dotnet-counters/CounterPayload.cs
@@ -62,11 +62,10 @@ namespace Microsoft.Diagnostics.Tools.Counters
 
     class IncrementingCounterPayload : ICounterPayload
     {
-        private int timescaleInSec;
         public string m_Name;
         public double m_Value;
         public string m_DisplayName;
-        public string m_DisplayRateTimeScale;
+        public string m_Interval;
         public string m_DisplayUnits;
 
         public IncrementingCounterPayload(IDictionary<string, object> payloadFields, int interval)
@@ -74,14 +73,11 @@ namespace Microsoft.Diagnostics.Tools.Counters
             m_Name = payloadFields["Name"].ToString();
             m_Value = (double)payloadFields["Increment"];
             m_DisplayName = payloadFields["DisplayName"].ToString();
-            m_DisplayRateTimeScale = payloadFields["DisplayRateTimeScale"].ToString();
             m_DisplayUnits = payloadFields["DisplayUnits"].ToString();
-            timescaleInSec = m_DisplayRateTimeScale.Length == 0 ? 1 : (int)TimeSpan.Parse(m_DisplayRateTimeScale).TotalSeconds;
-            m_Value *= timescaleInSec;
+            m_Interval = interval.ToString() + " sec";
 
             // In case these properties are not provided, set them to appropriate values.
             m_DisplayName = m_DisplayName.Length == 0 ? m_Name : m_DisplayName;
-            m_DisplayRateTimeScale = m_DisplayRateTimeScale.Length == 0 ? $"{interval} sec" : $"{timescaleInSec} sec";
         }
 
         public string GetName()
@@ -97,9 +93,9 @@ namespace Microsoft.Diagnostics.Tools.Counters
         public string GetDisplay()
         {
             if (m_DisplayUnits.Length > 0)
-                return $"{m_DisplayName} / {m_DisplayRateTimeScale} ({m_DisplayUnits})";
+                return $"{m_DisplayName} / {m_Interval} ({m_DisplayUnits})";
 
-            return $"{m_DisplayName} / {m_DisplayRateTimeScale}";
+            return $"{m_DisplayName} / {m_Interval}";
         }
 
         public string GetCounterType()

--- a/src/tests/dotnet-counters/CSVExporterTests.cs
+++ b/src/tests/dotnet-counters/CSVExporterTests.cs
@@ -131,9 +131,9 @@ namespace DotnetCounters.UnitTests
                     string[] tokens = lines[i].Split(',');
 
                     Assert.Equal("myProvider", tokens[1]);
-                    Assert.Equal($"Incrementing Counter One: {i-1} / 60 sec", tokens[2]);
+                    Assert.Equal($"Incrementing Counter One: {i-1} / 1 sec", tokens[2]);
                     Assert.Equal("Rate", tokens[3]);
-                    Assert.Equal(((i - 1) * 60).ToString(), tokens[4]);
+                    Assert.Equal((i-1).ToString(), tokens[4]);
                 }
             }
             finally
@@ -172,9 +172,9 @@ namespace DotnetCounters.UnitTests
                     string[] tokens = lines[i].Split(',');
 
                     Assert.Equal("myProvider", tokens[1]);
-                    Assert.Equal($"Allocation Rate Gen: {i-1} / 60 sec (MB)", tokens[2]);
+                    Assert.Equal($"Allocation Rate Gen: {i-1} / 1 sec (MB)", tokens[2]);
                     Assert.Equal("Rate", tokens[3]);
-                    Assert.Equal(((i - 1) * 60).ToString(), tokens[4]);
+                    Assert.Equal((i-1).ToString(), tokens[4]);
                 }
             }
             finally

--- a/src/tests/dotnet-counters/JSONExporterTests.cs
+++ b/src/tests/dotnet-counters/JSONExporterTests.cs
@@ -77,36 +77,6 @@ namespace DotnetCounters.UnitTests
         }
 
         [Fact]
-        public void DifferentDisplayRateTest()
-        {
-            string fileName = "displayRateTest.json";
-            JSONExporter exporter = new JSONExporter(fileName, "myProcess.exe");
-            exporter.Initialize();
-            for (int i = 0; i < 10; i++)
-            {
-                exporter.CounterPayloadReceived("myProvider", TestHelpers.GenerateCounterPayload(true, "incrementingCounterOne", 1.0, 60, "Incrementing Counter One"), false);
-            }
-            exporter.Stop();
-
-            Assert.True(File.Exists(fileName));
-            using (StreamReader r = new StreamReader(fileName))
-            {
-                string json = r.ReadToEnd();
-                JSONCounterTrace counterTrace = JsonConvert.DeserializeObject<JSONCounterTrace>(json);
-
-                Assert.Equal("myProcess.exe", counterTrace.targetProcess);
-                Assert.Equal(10, counterTrace.events.Length);
-                foreach (JSONCounterPayload payload in counterTrace.events)
-                {
-                    Assert.Equal("myProvider", payload.provider);
-                    Assert.Equal("Incrementing Counter One / 60 sec", payload.name);
-                    Assert.Equal("Rate", payload.counterType);
-                    Assert.Equal(60.0, payload.value);
-                }
-            }
-        }
-
-        [Fact]
         public void DisplayUnitsTest()
         {
             string fileName = "displayUnitsTest.json";


### PR DESCRIPTION
This changes dotnet-counters behavior when the payload has DisplayRateTimeScale property. Specifically, we heard many feedback that it is confusing for them to see the values extrapolated to a seemingly random value. For instance, "Gen 2 GC / min" would always show up as multiples of 60 if user requested 1 second as `--refresh-interval`. It is easy for users to confuse that as "60 Gen 2 GCs has happened in the past minute", which is not what happened. What really happens here is that if there has been 1 Gen 2 GC happened in the interval at which the user requested, it gets extrapolated to a "/ min" value, so it gets multiplied by 60 and shows up as 60 Gen 2 GCs / min. 

This PR removes that behavior by simply ignoring the DisplayRateTimeScale property and only showing the value that it received from the target runtime itself, and displaying the rate as "X / t sec" where X is the raw value received and Y is the interval requested by the user.

cc @wiktork 