### PR TITLE
Fix and apply the arcade update

### DIFF
--- a/eng/InstallRuntimes.proj
+++ b/eng/InstallRuntimes.proj
@@ -76,14 +76,12 @@
   <!-- Local private build testing -->
   <ItemGroup Condition="$(PrivateBuildTesting)">
     <TestVersions Include="Latest" RuntimeVersion="$(MicrosoftNETCoreAppVersion)" AspNetVersion="$(MicrosoftAspNetCoreAppRefVersion)" />
-    <TestVersions Include="21" RuntimeVersion="$(MicrosoftNETCoreApp21Version)" />
   </ItemGroup>
 
   <!-- Internal service release testing -->
   <ItemGroup Condition="$(InternalReleaseTesting)">
     <TestVersions Include="Internal" RuntimeVersion="$(DotnetRuntimeDownloadVersion)" ExtraInstallArgs="$(ExtraInstallArgs)" Condition="'$(DotnetRuntimeDownloadVersion)' != 'default'"/>
     <TestVersions Include="Internal" RuntimeVersion="$(DotnetRuntimeVersion)" ExtraInstallArgs="$(ExtraInstallArgs)" Condition="'$(DotnetRuntimeDownloadVersion)' == 'default'"/>
-    <TestVersions Include="21" RuntimeVersion="$(MicrosoftNETCoreApp21Version)" />
   </ItemGroup>
 
 <!--

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -4,9 +4,9 @@
       <Uri>https://github.com/dotnet/command-line-api</Uri>
       <Sha>166610c56ff732093f0145a2911d4f6c40b786da</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="5.0.0-beta.20228.4">
+    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="5.0.0-beta.20280.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>590a102630c7efc7ca6f652f7c6c47dee4c4086c</Sha>
+      <Sha>fef373440d604c428950236fbc2b99ce0df368a9</Sha>
     </Dependency>
     <Dependency Name="Microsoft.SymbolStore" Version="1.0.130101">
       <Uri>https://github.com/dotnet/symstore</Uri>
@@ -14,9 +14,9 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="5.0.0-beta.20228.4">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="5.0.0-beta.20280.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>590a102630c7efc7ca6f652f7c6c47dee4c4086c</Sha>
+      <Sha>fef373440d604c428950236fbc2b99ce0df368a9</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NETCore.App" Version="5.0.0-preview.7.20302.1">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -53,7 +53,7 @@
     <SystemThreadingChannelsVersion>4.7.0</SystemThreadingChannelsVersion>
     <XUnitVersion>2.4.1</XUnitVersion>
     <XUnitAbstractionsVersion>2.0.3</XUnitAbstractionsVersion>
-    <MicrosoftDotNetRemoteExecutorVersion>5.0.0-beta.20228.4</MicrosoftDotNetRemoteExecutorVersion>
+    <MicrosoftDotNetRemoteExecutorVersion>5.0.0-beta.20280.1</MicrosoftDotNetRemoteExecutorVersion>
     <cdbsosversion>10.0.18362</cdbsosversion>
   </PropertyGroup>
   <PropertyGroup>

--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -20,6 +20,7 @@ Param(
   [switch] $publish,
   [switch] $clean,
   [switch][Alias('bl')]$binaryLog,
+  [switch][Alias('nobl')]$excludeCIBinarylog,
   [switch] $ci,
   [switch] $prepareMachine,
   [switch] $help,
@@ -58,6 +59,7 @@ function Print-Usage() {
   Write-Host "Advanced settings:"
   Write-Host "  -projects <value>       Semi-colon delimited list of sln/proj's to build. Globbing is supported (*.sln)"
   Write-Host "  -ci                     Set when running on CI server"
+  Write-Host "  -excludeCIBinarylog     Don't output binary log (short: -nobl)"
   Write-Host "  -prepareMachine         Prepare machine for CI run, clean up processes after build"
   Write-Host "  -warnAsError <value>    Sets warnaserror msbuild parameter ('true' or 'false')"
   Write-Host "  -msbuildEngine <value>  Msbuild engine to use to run build ('dotnet', 'vs', or unspecified)."
@@ -134,7 +136,9 @@ try {
   }
 
   if ($ci) {
-    $binaryLog = $true
+    if (-not $excludeCIBinarylog) {
+      $binaryLog = $true
+    }
     $nodeReuse = $false
   }
 

--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -32,6 +32,7 @@ usage()
   echo "Advanced settings:"
   echo "  --projects <value>       Project or solution file(s) to build"
   echo "  --ci                     Set when running on CI server"
+  echo "  --excludeCIBinarylog     Don't output binary log (short: -nobl)"
   echo "  --prepareMachine         Prepare machine for CI run, clean up processes after build"
   echo "  --nodeReuse <value>      Sets nodereuse msbuild parameter ('true' or 'false')"
   echo "  --warnAsError <value>    Sets warnaserror msbuild parameter ('true' or 'false')"
@@ -68,6 +69,7 @@ clean=false
 warn_as_error=true
 node_reuse=true
 binary_log=false
+exclude_ci_binary_log=false
 pipelines_log=false
 
 projects=''
@@ -97,6 +99,9 @@ while [[ $# > 0 ]]; do
       ;;
     -binarylog|-bl)
       binary_log=true
+      ;;
+    -excludeCIBinarylog|-nobl)
+      exclude_ci_binary_log=true
       ;;
     -pipelineslog|-pl)
       pipelines_log=true
@@ -156,8 +161,10 @@ done
 
 if [[ "$ci" == true ]]; then
   pipelines_log=true
-  binary_log=true
   node_reuse=false
+  if [[ "$exclude_ci_binary_log" == false ]]; then
+    binary_log=true
+  fi
 fi
 
 . "$scriptroot/tools.sh"

--- a/eng/common/internal/Tools.csproj
+++ b/eng/common/internal/Tools.csproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
     <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
+    <AutomaticallyUseReferenceAssemblyPackages>false</AutomaticallyUseReferenceAssemblyPackages>
   </PropertyGroup>
   <ItemGroup>
     <!-- Clear references, the SDK may add some depending on UsuingToolXxx settings, but we only want to restore the following -->

--- a/eng/common/performance/perfhelixpublish.proj
+++ b/eng/common/performance/perfhelixpublish.proj
@@ -6,6 +6,7 @@
     <Python>py -3</Python>
     <CoreRun>%HELIX_CORRELATION_PAYLOAD%\Core_Root\CoreRun.exe</CoreRun>
     <BaselineCoreRun>%HELIX_CORRELATION_PAYLOAD%\Baseline_Core_Root\CoreRun.exe</BaselineCoreRun>
+    
     <HelixPreCommands>$(HelixPreCommands);call %HELIX_CORRELATION_PAYLOAD%\performance\tools\machine-setup.cmd;set PYTHONPATH=%HELIX_WORKITEM_PAYLOAD%\scripts%3B%HELIX_WORKITEM_PAYLOAD%</HelixPreCommands>
     <ArtifactsDirectory>%HELIX_CORRELATION_PAYLOAD%\artifacts\BenchmarkDotNet.Artifacts</ArtifactsDirectory>
     <BaselineArtifactsDirectory>%HELIX_CORRELATION_PAYLOAD%\artifacts\BenchmarkDotNet.Artifacts_Baseline</BaselineArtifactsDirectory>
@@ -38,6 +39,13 @@
     <DotnetExe>$(PerformanceDirectory)/tools/dotnet/$(Architecture)/dotnet</DotnetExe>
     <Percent>%25</Percent>
     <XMLResults>$HELIX_WORKITEM_ROOT/testResults.xml</XMLResults>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(MonoDotnet)' == 'true' and '$(AGENT_OS)' == 'Windows_NT'">
+    <CoreRunArgument>--corerun %HELIX_CORRELATION_PAYLOAD%\dotnet-mono\shared\Microsoft.NETCore.App\5.0.0\corerun.exe</CoreRunArgument>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(MonoDotnet)' == 'true' and '$(AGENT_OS)' != 'Windows_NT'">
+    <CoreRunArgument>--corerun $(BaseDirectory)/dotnet-mono/shared/Microsoft.NETCore.App/5.0.0/corerun</CoreRunArgument>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(UseCoreRun)' == 'true'">

--- a/eng/common/performance/performance-setup.ps1
+++ b/eng/common/performance/performance-setup.ps1
@@ -3,7 +3,7 @@ Param(
     [string] $CoreRootDirectory,
     [string] $BaselineCoreRootDirectory,
     [string] $Architecture="x64",
-    [string] $Framework="netcoreapp5.0",
+    [string] $Framework="net5.0",
     [string] $CompilationMode="Tiered",
     [string] $Repository=$env:BUILD_REPOSITORY_NAME,
     [string] $Branch=$env:BUILD_SOURCEBRANCH,
@@ -12,8 +12,12 @@ Param(
     [string] $RunCategories="Libraries Runtime",
     [string] $Csproj="src\benchmarks\micro\MicroBenchmarks.csproj",
     [string] $Kind="micro",
+    [switch] $LLVM,
+    [switch] $MonoInterpreter,
+    [switch] $MonoAOT, 
     [switch] $Internal,
     [switch] $Compare,
+    [string] $MonoDotnet="",
     [string] $Configurations="CompilationMode=$CompilationMode RunKind=$Kind"
 )
 
@@ -31,7 +35,8 @@ $HelixSourcePrefix = "pr"
 
 $Queue = "Windows.10.Amd64.ClientRS4.DevEx.15.8.Open"
 
-if ($Framework.StartsWith("netcoreapp")) {
+# TODO: Implement a better logic to determine if Framework is .NET Core or >= .NET 5.
+if ($Framework.StartsWith("netcoreapp") -or ($Framework -eq "net5.0")) {
     $Queue = "Windows.10.Amd64.ClientRS5.Open"
 }
 
@@ -47,6 +52,21 @@ if ($Internal) {
     $ExtraBenchmarkDotNetArguments = ""
     $Creator = ""
     $HelixSourcePrefix = "official"
+}
+
+if($MonoDotnet -ne "")
+{
+    $Configurations += " LLVM=$LLVM MonoInterpreter=$MonoInterpreter MonoAOT=$MonoAOT"
+    if($ExtraBenchmarkDotNetArguments -eq "")
+    {
+        #FIX ME: We need to block these tests as they don't run on mono for now
+        $ExtraBenchmarkDotNetArguments = "--exclusion-filter *Perf_Image* *Perf_NamedPipeStream*"
+    }
+    else
+    {
+        #FIX ME: We need to block these tests as they don't run on mono for now
+        $ExtraBenchmarkDotNetArguments += " --exclusion-filter *Perf_Image* *Perf_NamedPipeStream*"
+    }
 }
 
 # FIX ME: This is a workaround until we get this from the actual pipeline
@@ -67,6 +87,13 @@ if ($RunFromPerformanceRepo) {
 }
 else {
     git clone --branch master --depth 1 --quiet https://github.com/dotnet/performance $PerformanceDirectory
+}
+
+if($MonoDotnet -ne "")
+{
+    $UsingMono = "true"
+    $MonoDotnetPath = (Join-Path $PayloadDirectory "dotnet-mono")
+    Move-Item -Path $MonoDotnet -Destination $MonoDotnetPath
 }
 
 if ($UseCoreRun) {
@@ -104,6 +131,7 @@ Write-PipelineSetVariable -Name 'UseCoreRun' -Value "$UseCoreRun" -IsMultiJobVar
 Write-PipelineSetVariable -Name 'UseBaselineCoreRun' -Value "$UseBaselineCoreRun" -IsMultiJobVariable $false
 Write-PipelineSetVariable -Name 'RunFromPerfRepo' -Value "$RunFromPerformanceRepo" -IsMultiJobVariable $false
 Write-PipelineSetVariable -Name 'Compare' -Value "$Compare" -IsMultiJobVariable $false
+Write-PipelineSetVariable -Name 'MonoDotnet' -Value "$UsingMono" -IsMultiJobVariable $false
 
 # Helix Arguments
 Write-PipelineSetVariable -Name 'Creator' -Value "$Creator" -IsMultiJobVariable $false

--- a/eng/common/performance/performance-setup.sh
+++ b/eng/common/performance/performance-setup.sh
@@ -4,7 +4,7 @@ source_directory=$BUILD_SOURCESDIRECTORY
 core_root_directory=
 baseline_core_root_directory=
 architecture=x64
-framework=netcoreapp5.0
+framework=net5.0
 compilation_mode=tiered
 repository=$BUILD_REPOSITORY_NAME
 branch=$BUILD_SOURCEBRANCH
@@ -12,13 +12,18 @@ commit_sha=$BUILD_SOURCEVERSION
 build_number=$BUILD_BUILDNUMBER
 internal=false
 compare=false
+mono_dotnet=
 kind="micro"
+llvm=false
+monointerpreter=false
+monoaot=false
 run_categories="Libraries Runtime"
 csproj="src\benchmarks\micro\MicroBenchmarks.csproj"
 configurations="CompliationMode=$compilation_mode RunKind=$kind"
 run_from_perf_repo=false
 use_core_run=true
 use_baseline_core_run=true
+using_mono=false
 
 while (($# > 0)); do
   lowerI="$(echo $1 | awk '{print tolower($0)}')"
@@ -65,6 +70,7 @@ while (($# > 0)); do
       ;;
     --kind)
       kind=$2
+      configurations="CompliationMode=$compilation_mode RunKind=$kind"
       shift 2
       ;;
     --runcategories)
@@ -78,6 +84,22 @@ while (($# > 0)); do
     --internal)
       internal=true
       shift 1
+      ;;
+    --llvm)
+      llvm=true
+      shift 1
+      ;;
+    --monointerpreter)
+      monointerpreter=true
+      shift 1
+      ;;
+    --monoaot)
+      monoaot=true
+      shift 1
+      ;;
+    --monodotnet)
+      mono_dotnet=$2
+      shift 2
       ;;
     --compare)
       compare=true
@@ -107,6 +129,7 @@ while (($# > 0)); do
       echo "  --kind <value>                 Related to csproj. The kind of benchmarks that should be run. Defaults to micro"
       echo "  --runcategories <value>        Related to csproj. Categories of benchmarks to run. Defaults to \"coreclr corefx\""
       echo "  --internal                     If the benchmarks are running as an official job."
+      echo "  --monodotnet                   Pass the path to the mono dotnet for mono performance testing."
       echo ""
       exit 0
       ;;
@@ -164,6 +187,10 @@ if [[ "$internal" == true ]]; then
     fi
 fi
 
+if [[ "$mono_dotnet" != "" ]]; then
+    configurations="$configurations LLVM=$llvm MonoInterpreter=$monointerpreter MonoAOT=$monoaot"
+fi
+
 common_setup_arguments="--channel master --queue $queue --build-number $build_number --build-configs $configurations --architecture $architecture"
 setup_arguments="--repository https://github.com/$repository --branch $branch --get-perf-hash --commit-sha $commit_sha $common_setup_arguments"
 
@@ -184,6 +211,12 @@ else
     
     docs_directory=$performance_directory/docs
     mv $docs_directory $workitem_directory
+fi
+
+if [[ "$mono_dotnet" != "" ]]; then
+    using_mono=true
+    mono_dotnet_path=$payload_directory/dotnet-mono
+    mv $mono_dotnet $mono_dotnet_path
 fi
 
 if [[ "$use_core_run" = true ]]; then
@@ -221,3 +254,4 @@ Write-PipelineSetVariable -name "HelixSourcePrefix" -value "$helix_source_prefix
 Write-PipelineSetVariable -name "Kind" -value "$kind" -is_multi_job_variable false
 Write-PipelineSetVariable -name "_BuildConfig" -value "$architecture.$kind.$framework" -is_multi_job_variable false
 Write-PipelineSetVariable -name "Compare" -value "$compare" -is_multi_job_variable false
+Write-PipelineSetVariable -name "MonoDotnet" -value "$using_mono" -is_multi_job_variable false

--- a/eng/common/pipeline-logging-functions.sh
+++ b/eng/common/pipeline-logging-functions.sh
@@ -31,26 +31,21 @@ function Write-PipelineTelemetryError {
     return
   fi
 
-  message="(NETCORE_ENGINEERING_TELEMETRY=$telemetry_category) $message"
-  function_args+=("$message")
   if [[ $force == true ]]; then
     function_args+=("-force")
   fi
-
-  Write-PipelineTaskError $function_args
+  message="(NETCORE_ENGINEERING_TELEMETRY=$telemetry_category) $message"
+  function_args+=("$message")
+  Write-PipelineTaskError ${function_args[@]}
 }
 
 function Write-PipelineTaskError {
-  if [[ $force != true ]] && [[ "$ci" != true ]]; then
-    echo "$@" >&2
-    return
-  fi
-
   local message_type="error"
   local sourcepath=''
   local linenumber=''
   local columnnumber=''
   local error_code=''
+  local force=false
 
   while [[ $# -gt 0 ]]; do
     opt="$(echo "${1/#--/-}" | awk '{print tolower($0)}')"
@@ -75,6 +70,9 @@ function Write-PipelineTaskError {
         error_code=$2
         shift
         ;;
+      -force|-f)
+        force=true
+        ;;
       *)
         break
         ;;
@@ -82,6 +80,11 @@ function Write-PipelineTaskError {
 
     shift
   done
+
+  if [[ $force != true ]] && [[ "$ci" != true ]]; then
+    echo "$@" >&2
+    return
+  fi
 
   local message="##vso[task.logissue"
 

--- a/eng/common/post-build/publish-using-darc.ps1
+++ b/eng/common/post-build/publish-using-darc.ps1
@@ -1,0 +1,71 @@
+param(
+  [Parameter(Mandatory=$true)][int] $BuildId,
+  [Parameter(Mandatory=$true)][string] $AzdoToken,
+  [Parameter(Mandatory=$true)][string] $MaestroToken,
+  [Parameter(Mandatory=$false)][string] $MaestroApiEndPoint = 'https://maestro-prod.westus2.cloudapp.azure.com',
+  [Parameter(Mandatory=$true)][string] $WaitPublishingFinish,
+  [Parameter(Mandatory=$true)][string] $EnableSourceLinkValidation,
+  [Parameter(Mandatory=$true)][string] $EnableSigningValidation,
+  [Parameter(Mandatory=$true)][string] $EnableNugetValidation,
+  [Parameter(Mandatory=$true)][string] $PublishInstallersAndChecksums,
+  [Parameter(Mandatory=$false)][string] $ArtifactsPublishingAdditionalParameters,
+  [Parameter(Mandatory=$false)][string] $SigningValidationAdditionalParameters
+)
+
+try {
+  . $PSScriptRoot\post-build-utils.ps1
+  . $PSScriptRoot\..\darc-init.ps1
+
+  $optionalParams = [System.Collections.ArrayList]::new()
+
+  if ("" -ne $ArtifactsPublishingAdditionalParameters) {
+    $optionalParams.Add("artifact-publishing-parameters") | Out-Null
+    $optionalParams.Add($ArtifactsPublishingAdditionalParameters) | Out-Null
+  }
+
+  if ("false" -eq $WaitPublishingFinish) {
+    $optionalParams.Add("--no-wait") | Out-Null
+  }
+
+  if ("true" -eq $PublishInstallersAndChecksums) {
+    $optionalParams.Add("--publish-installers-and-checksums") | Out-Null
+  }
+
+  if ("true" -eq $EnableNugetValidation) {
+    $optionalParams.Add("--validate-nuget") | Out-Null
+  }
+
+  if ("true" -eq $EnableSourceLinkValidation) {
+    $optionalParams.Add("--validate-sourcelinkchecksums") | Out-Null
+  }
+
+  if ("true" -eq $EnableSigningValidation) {
+    $optionalParams.Add("--validate-signingchecksums") | Out-Null
+
+    if ("" -ne $SigningValidationAdditionalParameters) {
+      $optionalParams.Add("--signing-validation-parameters") | Out-Null
+      $optionalParams.Add($SigningValidationAdditionalParameters) | Out-Null
+    }
+  }
+
+  & darc add-build-to-channel `
+	--id $buildId `
+	--default-channels `
+	--source-branch master `
+	--azdev-pat $AzdoToken `
+	--bar-uri $MaestroApiEndPoint `
+	--password $MaestroToken `
+	@optionalParams
+
+  if ($LastExitCode -ne 0) {
+    Write-Host "Problems using Darc to promote build ${buildId} to default channels. Stopping execution..."
+    exit 1
+  }
+
+  Write-Host 'done.'
+} 
+catch {
+  Write-Host $_
+  Write-PipelineTelemetryError -Category 'PromoteBuild' -Message "There was an error while trying to publish build '$BuildId' to default channels."
+  ExitWithExitCode 1
+}

--- a/eng/common/post-build/symbols-validation.ps1
+++ b/eng/common/post-build/symbols-validation.ps1
@@ -2,72 +2,29 @@ param(
   [Parameter(Mandatory=$true)][string] $InputPath,              # Full path to directory where NuGet packages to be checked are stored
   [Parameter(Mandatory=$true)][string] $ExtractPath,            # Full path to directory where the packages will be extracted during validation
   [Parameter(Mandatory=$true)][string] $DotnetSymbolVersion,    # Version of dotnet symbol to use
-  [Parameter(Mandatory=$false)][switch] $ContinueOnError        # If we should keep checking symbols after an error
+  [Parameter(Mandatory=$false)][switch] $ContinueOnError,       # If we should keep checking symbols after an error
+  [Parameter(Mandatory=$false)][switch] $Clean                  # Clean extracted symbols directory after checking symbols
 )
 
-function FirstMatchingSymbolDescriptionOrDefault {
-  param( 
-    [string] $FullPath,                  # Full path to the module that has to be checked
-    [string] $TargetServerParam,         # Parameter to pass to `Symbol Tool` indicating the server to lookup for symbols
-    [string] $SymbolsPath
-  )
+# Maximum number of jobs to run in parallel
+$MaxParallelJobs = 6
 
-  $FileName = [System.IO.Path]::GetFileName($FullPath)
-  $Extension = [System.IO.Path]::GetExtension($FullPath)
+# Wait time between check for system load
+$SecondsBetweenLoadChecks = 10
 
-  # Those below are potential symbol files that the `dotnet symbol` might
-  # return. Which one will be returned depend on the type of file we are
-  # checking and which type of file was uploaded.
-
-  # The file itself is returned
-  $SymbolPath = $SymbolsPath + '\' + $FileName
-
-  # PDB file for the module
-  $PdbPath = $SymbolPath.Replace($Extension, '.pdb')
-
-  # PDB file for R2R module (created by crossgen)
-  $NGenPdb = $SymbolPath.Replace($Extension, '.ni.pdb')
-
-  # DBG file for a .so library
-  $SODbg = $SymbolPath.Replace($Extension, '.so.dbg')
-
-  # DWARF file for a .dylib
-  $DylibDwarf = $SymbolPath.Replace($Extension, '.dylib.dwarf')
- 
-  $dotnetSymbolExe = "$env:USERPROFILE\.dotnet\tools"
-  $dotnetSymbolExe = Resolve-Path "$dotnetSymbolExe\dotnet-symbol.exe"
-
-  & $dotnetSymbolExe --symbols --modules --windows-pdbs $TargetServerParam $FullPath -o $SymbolsPath | Out-Null
-
-  if (Test-Path $PdbPath) {
-    return 'PDB'
-  }
-  elseif (Test-Path $NGenPdb) {
-    return 'NGen PDB'
-  }
-  elseif (Test-Path $SODbg) {
-    return 'DBG for SO'
-  }  
-  elseif (Test-Path $DylibDwarf) {
-    return 'Dwarf for Dylib'
-  }  
-  elseif (Test-Path $SymbolPath) {
-    return 'Module'
-  }
-  else {
-    return $null
-  }
-}
-
-function CountMissingSymbols {
+$CountMissingSymbols = {
   param( 
     [string] $PackagePath          # Path to a NuGet package
   )
 
+  . $using:PSScriptRoot\..\tools.ps1
+
+  Add-Type -AssemblyName System.IO.Compression.FileSystem
+
   # Ensure input file exist
   if (!(Test-Path $PackagePath)) {
     Write-PipelineTaskError "Input file does not exist: $PackagePath"
-    ExitWithExitCode 1
+    return 1
   }
   
   # Extensions for which we'll look for symbols
@@ -78,23 +35,85 @@ function CountMissingSymbols {
 
   $PackageId = [System.IO.Path]::GetFileNameWithoutExtension($PackagePath)
   $PackageGuid = New-Guid
-  $ExtractPath = Join-Path -Path $ExtractPath -ChildPath $PackageGuid
+  $ExtractPath = Join-Path -Path $using:ExtractPath -ChildPath $PackageGuid
   $SymbolsPath = Join-Path -Path $ExtractPath -ChildPath 'Symbols'
   
-  [System.IO.Compression.ZipFile]::ExtractToDirectory($PackagePath, $ExtractPath)
+  try {
+    [System.IO.Compression.ZipFile]::ExtractToDirectory($PackagePath, $ExtractPath)
+  }
+  catch {
+    Write-Host "Something went wrong extracting $PackagePath"
+    Write-Host $_
+    return -1
+  }
 
   Get-ChildItem -Recurse $ExtractPath |
     Where-Object {$RelevantExtensions -contains $_.Extension} |
     ForEach-Object {
-      if ($_.FullName -Match '\\ref\\') {
-        Write-Host "`t Ignoring reference assembly file " $_.FullName
+      $FileName = $_.FullName
+      if ($FileName -Match '\\ref\\') {
+        Write-Host "`t Ignoring reference assembly file " $FileName
         return
       }
 
-      $SymbolsOnMSDL = FirstMatchingSymbolDescriptionOrDefault $_.FullName '--microsoft-symbol-server' $SymbolsPath
-      $SymbolsOnSymWeb = FirstMatchingSymbolDescriptionOrDefault $_.FullName '--internal-server' $SymbolsPath
+      $FirstMatchingSymbolDescriptionOrDefault = {
+      param( 
+        [string] $FullPath,                  # Full path to the module that has to be checked
+        [string] $TargetServerParam,         # Parameter to pass to `Symbol Tool` indicating the server to lookup for symbols
+        [string] $SymbolsPath
+      )
 
-      Write-Host -NoNewLine "`t Checking file " $_.FullName "... "
+      $FileName = [System.IO.Path]::GetFileName($FullPath)
+      $Extension = [System.IO.Path]::GetExtension($FullPath)
+
+      # Those below are potential symbol files that the `dotnet symbol` might
+      # return. Which one will be returned depend on the type of file we are
+      # checking and which type of file was uploaded.
+
+      # The file itself is returned
+      $SymbolPath = $SymbolsPath + '\' + $FileName
+
+      # PDB file for the module
+      $PdbPath = $SymbolPath.Replace($Extension, '.pdb')
+
+      # PDB file for R2R module (created by crossgen)
+      $NGenPdb = $SymbolPath.Replace($Extension, '.ni.pdb')
+
+      # DBG file for a .so library
+      $SODbg = $SymbolPath.Replace($Extension, '.so.dbg')
+
+      # DWARF file for a .dylib
+      $DylibDwarf = $SymbolPath.Replace($Extension, '.dylib.dwarf')
+    
+      $dotnetSymbolExe = "$env:USERPROFILE\.dotnet\tools"
+      $dotnetSymbolExe = Resolve-Path "$dotnetSymbolExe\dotnet-symbol.exe"
+
+      & $dotnetSymbolExe --symbols --modules --windows-pdbs $TargetServerParam $FullPath -o $SymbolsPath | Out-Null
+
+      if (Test-Path $PdbPath) {
+        return 'PDB'
+      }
+      elseif (Test-Path $NGenPdb) {
+        return 'NGen PDB'
+      }
+      elseif (Test-Path $SODbg) {
+        return 'DBG for SO'
+      }  
+      elseif (Test-Path $DylibDwarf) {
+        return 'Dwarf for Dylib'
+      }  
+      elseif (Test-Path $SymbolPath) {
+        return 'Module'
+      }
+      else {
+        return $null
+      }
+    }
+
+      $SymbolsOnMSDL = & $FirstMatchingSymbolDescriptionOrDefault $FileName '--microsoft-symbol-server' $SymbolsPath
+      $SymbolsOnSymWeb = & $FirstMatchingSymbolDescriptionOrDefault $FileName '--internal-server' $SymbolsPath
+
+      Write-Host -NoNewLine "`t Checking file " $FileName "... "
   
       if ($SymbolsOnMSDL -ne $null -and $SymbolsOnSymWeb -ne $null) {
         Write-Host "Symbols found on MSDL ($SymbolsOnMSDL) and SymWeb ($SymbolsOnSymWeb)"
@@ -116,6 +135,15 @@ function CountMissingSymbols {
       }
     }
   
+  if ($using:Clean) {
+    Remove-Item $ExtractPath -Recurse -Force
+  }
+
+  if ($MissingSymbols -ne 0)
+  {
+    Write-PipelineTelemetryError -Category 'CheckSymbols' -Message "Missing symbols for $MissingSymbols modules in the package $FileName"
+  }
+  
   Pop-Location
 
   return $MissingSymbols
@@ -131,6 +159,7 @@ function CheckSymbolsAvailable {
   Get-ChildItem "$InputPath\*.nupkg" |
     ForEach-Object {
       $FileName = $_.Name
+      $FullName = $_.FullName
 
       # These packages from Arcade-Services include some native libraries that
       # our current symbol uploader can't handle. Below is a workaround until
@@ -147,25 +176,38 @@ function CheckSymbolsAvailable {
       }
 
       Write-Host "Validating $FileName "
-      $Status = CountMissingSymbols "$InputPath\$FileName"
 
-      if ($Status -ne 0) {
-        Write-PipelineTelemetryError -Category 'CheckSymbols' -Message "Missing symbols for $Status modules in the package $FileName"
+      Start-Job -ScriptBlock $CountMissingSymbols -ArgumentList $FullName | Out-Null
 
-        if ($ContinueOnError) {
-          $TotalFailures++
-        }
-        else {
-          ExitWithExitCode 1
-        }
+      $NumJobs = @(Get-Job -State 'Running').Count
+      Write-Host $NumJobs
+
+      while ($NumJobs -ge $MaxParallelJobs) {
+        Write-Host "There are $NumJobs validation jobs running right now. Waiting $SecondsBetweenLoadChecks seconds to check again."
+        sleep $SecondsBetweenLoadChecks
+        $NumJobs = @(Get-Job -State 'Running').Count
       }
 
+      foreach ($Job in @(Get-Job -State 'Completed')) {
+        Receive-Job -Id $Job.Id
+      }
       Write-Host
     }
 
-  if ($TotalFailures -ne 0) {
+  foreach ($Job in @(Get-Job)) {
+    $jobResult = Wait-Job -Id $Job.Id | Receive-Job
+
+    if ($jobResult -ne '0') {
+      $TotalFailures++
+    }
+  }
+
+  if ($TotalFailures -gt 0) {
     Write-PipelineTelemetryError -Category 'CheckSymbols' -Message "Symbols missing for $TotalFailures packages"
     ExitWithExitCode 1
+  }
+  else {
+    Write-Host "All symbols validated!"
   }
 }
 
@@ -188,10 +230,12 @@ function InstallDotnetSymbol {
 
 try {
   . $PSScriptRoot\post-build-utils.ps1
-
-  Add-Type -AssemblyName System.IO.Compression.FileSystem
   
   InstallDotnetSymbol
+
+  foreach ($Job in @(Get-Job)) {
+    Remove-Job -Id $Job.Id
+  }
 
   CheckSymbolsAvailable
 }

--- a/eng/common/sdk-task.ps1
+++ b/eng/common/sdk-task.ps1
@@ -59,14 +59,20 @@ try {
 
   if( $msbuildEngine -eq "vs") {
     # Ensure desktop MSBuild is available for sdk tasks.
-    if( -not ($GlobalJson.tools.PSObject.Properties.Name -match "vs" )) {
-      $GlobalJson.tools | Add-Member -Name "vs" -Value (ConvertFrom-Json "{ `"version`": `"16.4`" }") -MemberType NoteProperty
+    if( -not ($GlobalJson.tools.PSObject.Properties.Name -contains "vs" )) {
+      $GlobalJson.tools | Add-Member -Name "vs" -Value (ConvertFrom-Json "{ `"version`": `"16.5`" }") -MemberType NoteProperty
     }
     if( -not ($GlobalJson.tools.PSObject.Properties.Name -match "xcopy-msbuild" )) {
-      $GlobalJson.tools | Add-Member -Name "xcopy-msbuild" -Value "16.4.0-alpha" -MemberType NoteProperty
+      $GlobalJson.tools | Add-Member -Name "xcopy-msbuild" -Value "16.5.0-alpha" -MemberType NoteProperty
+    }
+    if ($GlobalJson.tools."xcopy-msbuild".Trim() -ine "none") {
+        $xcopyMSBuildToolsFolder = InitializeXCopyMSBuild $GlobalJson.tools."xcopy-msbuild" -install $true
+    }
+    if ($xcopyMSBuildToolsFolder -eq $null) {
+      throw 'Unable to get xcopy downloadable version of msbuild'
     }
 
-    InitializeXCopyMSBuild $GlobalJson.tools."xcopy-msbuild" -install $true
+    $global:_MSBuildExe = "$($xcopyMSBuildToolsFolder)\MSBuild\Current\Bin\MSBuild.exe"
   }
 
   $taskProject = GetSdkTaskProject $task

--- a/eng/common/sdl/execute-all-sdl-tools.ps1
+++ b/eng/common/sdl/execute-all-sdl-tools.ps1
@@ -24,7 +24,8 @@ Param(
   [string] $TsaIterationPath,                                                                    # Optional: only needed if TsaOnboard is true; the iteration path where TSA will file bugs in AzDO; TSA is the automated framework used to upload test results as bugs.
   [string] $GuardianLoggerLevel='Standard',                                                      # Optional: the logger level for the Guardian CLI; options are Trace, Verbose, Standard, Warning, and Error
   [string[]] $CrScanAdditionalRunConfigParams,                                                   # Optional: Additional Params to custom build a CredScan run config in the format @("xyz:abc","sdf:1")
-  [string[]] $PoliCheckAdditionalRunConfigParams                                                 # Optional: Additional Params to custom build a Policheck run config in the format @("xyz:abc","sdf:1")
+  [string[]] $PoliCheckAdditionalRunConfigParams,                                                # Optional: Additional Params to custom build a Policheck run config in the format @("xyz:abc","sdf:1")
+  [bool] $BreakOnFailure=$False                                                                  # Optional: Fail the build if there were errors during the run
 )
 
 try {
@@ -105,6 +106,11 @@ try {
       Write-PipelineTelemetryError -Force -Category 'Sdl' -Message 'Could not publish to TSA -- not all required values ($TsaBranchName, $BuildNumber) were specified.'
       ExitWithExitCode 1
     }
+  }
+
+  if ($BreakOnFailure) {
+    Write-Host "Failing the build in case of breaking results..."
+    & $guardianCliLocation break
   }
 }
 catch {

--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -26,7 +26,7 @@ parameters:
   enablePublishUsingPipelines: false
   useBuildManifest: false
   mergeTestResults: false
-  testRunTitle: $(AgentOsName)-$(BuildConfiguration)-xunit
+  testRunTitle: ''
   name: ''
   preSteps: []
   runAsPublic: false
@@ -197,7 +197,7 @@ jobs:
         testResultsFormat: 'xUnit'
         testResultsFiles: '*.xml' 
         searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
-        testRunTitle: ${{ parameters.testRunTitle }}
+        testRunTitle: ${{ coalesce(parameters.testRunTitle, parameters.name, '$(System.JobName)') }}-xunit
         mergeTestResults: ${{ parameters.mergeTestResults }}
       continueOnError: true
       condition: always()

--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -1,4 +1,13 @@
 parameters:
+  # When set to true the publishing templates from the repo will be used
+  # otherwise Darc add-build-to-channel will be used to trigger the promotion pipeline
+  inline: true
+
+  # Only used if inline==false. When set to true will stall the current build until
+  # the Promotion Pipeline build finishes. Otherwise, the current build continue 
+  # execution concurrently with the promotion build.
+  waitPublishingFinish: true
+
   enableSourceLinkValidation: false
   enableSigningValidation: true
   enableSymbolValidation: false
@@ -37,374 +46,436 @@ parameters:
   NETCoreExperimentalChannelId: 562
   NetEngServicesIntChannelId: 678
   NetEngServicesProdChannelId: 679
-  Net5Preview3ChannelId: 739
-  Net5Preview4ChannelId: 856
   Net5Preview5ChannelId: 857
+  Net5Preview6ChannelId: 1013
+  Net5Preview7ChannelId: 1014
+  NetCoreSDK313xxChannelId: 759
+  NetCoreSDK313xxInternalChannelId: 760
   NetCoreSDK314xxChannelId: 921
   NetCoreSDK314xxInternalChannelId: 922
   
 stages:
-- stage: Validate
-  dependsOn: ${{ parameters.validateDependsOn }}
-  displayName: Validate
-  variables:
-    - template: common-variables.yml
-  jobs:
-  - template: setup-maestro-vars.yml
-
-  - job:
-    displayName: Post-build Checks
-    dependsOn: setupMaestroVars
-    variables:
-      - name: TargetChannels
-        value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.TargetChannels'] ]
-    pool:
-      vmImage: 'windows-2019'
-    steps:
-      - task: PowerShell@2
-        displayName: Maestro Channels Consistency
-        inputs:
-          filePath: $(Build.SourcesDirectory)/eng/common/post-build/check-channel-consistency.ps1
-          arguments: -PromoteToChannels "$(TargetChannels)"
-            -AvailableChannelIds ${{parameters.NetEngLatestChannelId}},${{parameters.NetEngValidationChannelId}},${{parameters.NetDev5ChannelId}},${{parameters.GeneralTestingChannelId}},${{parameters.NETCoreToolingDevChannelId}},${{parameters.NETCoreToolingReleaseChannelId}},${{parameters.NETInternalToolingChannelId}},${{parameters.NETCoreExperimentalChannelId}},${{parameters.NetEngServicesIntChannelId}},${{parameters.NetEngServicesProdChannelId}},${{parameters.Net5Preview3ChannelId}},${{parameters.Net5Preview4ChannelId}},${{parameters.Net5Preview5ChannelId}},${{parameters.NetCoreSDK314xxChannelId}},${{parameters.NetCoreSDK314xxInternalChannelId}}
-
-  - job:
-    displayName: NuGet Validation
-    dependsOn: setupMaestroVars
-    condition: eq( ${{ parameters.enableNugetValidation }}, 'true')
-    pool:
-      vmImage: 'windows-2019'
-    variables:
-      - name: AzDOProjectName
-        value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.AzDOProjectName'] ]
-      - name: AzDOPipelineId
-        value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.AzDOPipelineId'] ]
-      - name: AzDOBuildId
-        value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.AzDOBuildId'] ]
-    steps:
-      - task: DownloadBuildArtifacts@0
-        displayName: Download Package Artifacts
-        inputs:
-          buildType: specific
-          buildVersionToDownload: specific
-          project: $(AzDOProjectName)
-          pipeline: $(AzDOPipelineId)
-          buildId: $(AzDOBuildId)
-          artifactName: PackageArtifacts
-
-      - task: PowerShell@2
-        displayName: Validate
-        inputs:
-          filePath: $(Build.SourcesDirectory)/eng/common/post-build/nuget-validation.ps1
-          arguments: -PackagesPath $(Build.ArtifactStagingDirectory)/PackageArtifacts/ 
-            -ToolDestinationPath $(Agent.BuildDirectory)/Extract/ 
-
-  - job:
-    displayName: Signing Validation
-    dependsOn: setupMaestroVars
-    condition: eq( ${{ parameters.enableSigningValidation }}, 'true')
+- ${{ if ne(parameters.inline, 'true') }}:
+  - stage: publish_using_darc
+    dependsOn: ${{ parameters.validateDependsOn }}
+    displayName: Publish using Darc
     variables:
       - template: common-variables.yml
-      - name: AzDOProjectName
-        value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.AzDOProjectName'] ]
-      - name: AzDOPipelineId
-        value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.AzDOPipelineId'] ]
-      - name: AzDOBuildId
-        value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.AzDOBuildId'] ]
-    pool:
-      vmImage: 'windows-2019'
-    steps:
-      - ${{ if eq(parameters.useBuildManifest, true) }}:
+    jobs:
+    - template: setup-maestro-vars.yml
+
+    - job:
+      displayName: Publish Using Darc
+      dependsOn: setupMaestroVars
+      variables:
+        - name: BARBuildId
+          value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.BARBuildId'] ]
+      pool:
+        vmImage: 'windows-2019'
+      steps:
+        - task: PowerShell@2
+          displayName: Publish Using Darc
+          inputs:
+            filePath: $(Build.SourcesDirectory)/eng/common/post-build/publish-using-darc.ps1
+            arguments: -BuildId $(BARBuildId) 
+              -AzdoToken '$(publishing-dnceng-devdiv-code-r-build-re)'
+              -MaestroToken '$(MaestroApiAccessToken)'
+              -WaitPublishingFinish ${{ parameters.waitPublishingFinish }}
+              -EnableSourceLinkValidation ${{ parameters.enableSourceLinkValidation }}
+              -EnableSigningValidation ${{ parameters.enableSourceLinkValidation }}
+              -EnableNugetValidation ${{ parameters.enableSourceLinkValidation }}
+              -PublishInstallersAndChecksums ${{ parameters.publishInstallersAndChecksums }}
+              -ArtifactsPublishingAdditionalParameters '${{ parameters.artifactsPublishingAdditionalParameters }}'
+              -SigningValidationAdditionalParameters '${{ parameters.signingValidationAdditionalParameters }}'
+
+- ${{ if eq(parameters.inline, 'true') }}:
+  - stage: Validate
+    dependsOn: ${{ parameters.validateDependsOn }}
+    displayName: Validate Build Assets
+    variables:
+      - template: common-variables.yml
+    jobs:
+    - template: setup-maestro-vars.yml
+
+    - job:
+      displayName: Post-build Checks
+      dependsOn: setupMaestroVars
+      variables:
+        - name: TargetChannels
+          value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.TargetChannels'] ]
+      pool:
+        vmImage: 'windows-2019'
+      steps:
+        - task: PowerShell@2
+          displayName: Maestro Channels Consistency
+          inputs:
+            filePath: $(Build.SourcesDirectory)/eng/common/post-build/check-channel-consistency.ps1
+            arguments: -PromoteToChannels "$(TargetChannels)"
+              -AvailableChannelIds ${{parameters.NetEngLatestChannelId}},${{parameters.NetEngValidationChannelId}},${{parameters.NetDev5ChannelId}},${{parameters.GeneralTestingChannelId}},${{parameters.NETCoreToolingDevChannelId}},${{parameters.NETCoreToolingReleaseChannelId}},${{parameters.NETInternalToolingChannelId}},${{parameters.NETCoreExperimentalChannelId}},${{parameters.NetEngServicesIntChannelId}},${{parameters.NetEngServicesProdChannelId}},${{parameters.Net5Preview5ChannelId}},${{parameters.Net5Preview6ChannelId}},${{parameters.Net5Preview7ChannelId}},${{parameters.NetCoreSDK313xxChannelId}},${{parameters.NetCoreSDK313xxInternalChannelId}},${{parameters.NetCoreSDK314xxChannelId}},${{parameters.NetCoreSDK314xxInternalChannelId}}
+
+    - job:
+      displayName: NuGet Validation
+      dependsOn: setupMaestroVars
+      condition: eq( ${{ parameters.enableNugetValidation }}, 'true')
+      pool:
+        vmImage: 'windows-2019'
+      variables:
+        - name: AzDOProjectName
+          value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.AzDOProjectName'] ]
+        - name: AzDOPipelineId
+          value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.AzDOPipelineId'] ]
+        - name: AzDOBuildId
+          value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.AzDOBuildId'] ]
+      steps:
         - task: DownloadBuildArtifacts@0
-          displayName: Download build manifest
+          displayName: Download Package Artifacts
           inputs:
             buildType: specific
             buildVersionToDownload: specific
             project: $(AzDOProjectName)
             pipeline: $(AzDOPipelineId)
             buildId: $(AzDOBuildId)
-            artifactName: BuildManifests
-      - task: DownloadBuildArtifacts@0
-        displayName: Download Package Artifacts
-        inputs:
-          buildType: specific
-          buildVersionToDownload: specific
-          project: $(AzDOProjectName)
-          pipeline: $(AzDOPipelineId)
-          buildId: $(AzDOBuildId)
-          artifactName: PackageArtifacts
+            artifactName: PackageArtifacts
 
-      # This is necessary whenever we want to publish/restore to an AzDO private feed
-      # Since sdk-task.ps1 tries to restore packages we need to do this authentication here
-      # otherwise it'll complain about accessing a private feed.
-      - task: NuGetAuthenticate@0
-        displayName: 'Authenticate to AzDO Feeds'
+        - task: PowerShell@2
+          displayName: Validate
+          inputs:
+            filePath: $(Build.SourcesDirectory)/eng/common/post-build/nuget-validation.ps1
+            arguments: -PackagesPath $(Build.ArtifactStagingDirectory)/PackageArtifacts/ 
+              -ToolDestinationPath $(Agent.BuildDirectory)/Extract/ 
 
-      - task: PowerShell@2
-        displayName: Enable cross-org publishing
-        inputs:
-          filePath: eng\common\enable-cross-org-publishing.ps1
-          arguments: -token $(dn-bot-dnceng-artifact-feeds-rw)
-
-      # Signing validation will optionally work with the buildmanifest file which is downloaded from
-      # Azure DevOps above.
-      - task: PowerShell@2
-        displayName: Validate
-        inputs:
-          filePath: eng\common\sdk-task.ps1
-          arguments: -task SigningValidation -restore -msbuildEngine vs
-            /p:PackageBasePath='$(Build.ArtifactStagingDirectory)/PackageArtifacts'
-            /p:SignCheckExclusionsFile='$(Build.SourcesDirectory)/eng/SignCheckExclusionsFile.txt'
-            ${{ parameters.signingValidationAdditionalParameters }}
-
-      - template: ../steps/publish-logs.yml
-        parameters:
-          StageLabel: 'Validation'
-          JobLabel: 'Signing'
-
-  - job:
-    displayName: SourceLink Validation
-    dependsOn: setupMaestroVars
-    condition: eq( ${{ parameters.enableSourceLinkValidation }}, 'true')
-    variables:
-      - template: common-variables.yml
-      - name: AzDOProjectName
-        value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.AzDOProjectName'] ]
-      - name: AzDOPipelineId
-        value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.AzDOPipelineId'] ]
-      - name: AzDOBuildId
-        value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.AzDOBuildId'] ]
-    pool:
-      vmImage: 'windows-2019'
-    steps:
-      - task: DownloadBuildArtifacts@0
-        displayName: Download Blob Artifacts
-        inputs:
-          buildType: specific
-          buildVersionToDownload: specific
-          project: $(AzDOProjectName)
-          pipeline: $(AzDOPipelineId)
-          buildId: $(AzDOBuildId)
-          artifactName: BlobArtifacts
-
-      - task: PowerShell@2
-        displayName: Validate
-        inputs:
-          filePath: $(Build.SourcesDirectory)/eng/common/post-build/sourcelink-validation.ps1
-          arguments: -InputPath $(Build.ArtifactStagingDirectory)/BlobArtifacts/ 
-            -ExtractPath $(Agent.BuildDirectory)/Extract/ 
-            -GHRepoName $(Build.Repository.Name) 
-            -GHCommit $(Build.SourceVersion)
-            -SourcelinkCliVersion $(SourceLinkCLIVersion)
-        continueOnError: true
-
-  - template: /eng/common/templates/job/execute-sdl.yml
-    parameters:
-      enable: ${{ parameters.SDLValidationParameters.enable }}
+    - job:
+      displayName: Signing Validation
       dependsOn: setupMaestroVars
-      additionalParameters: ${{ parameters.SDLValidationParameters.params }}
-      continueOnError: ${{ parameters.SDLValidationParameters.continueOnError }}
-      artifactNames: ${{ parameters.SDLValidationParameters.artifactNames }}
-      downloadArtifacts: ${{ parameters.SDLValidationParameters.downloadArtifacts }}
+      condition: eq( ${{ parameters.enableSigningValidation }}, 'true')
+      variables:
+        - template: common-variables.yml
+        - name: AzDOProjectName
+          value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.AzDOProjectName'] ]
+        - name: AzDOPipelineId
+          value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.AzDOPipelineId'] ]
+        - name: AzDOBuildId
+          value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.AzDOBuildId'] ]
+      pool:
+        vmImage: 'windows-2019'
+      steps:
+        - ${{ if eq(parameters.useBuildManifest, true) }}:
+          - task: DownloadBuildArtifacts@0
+            displayName: Download build manifest
+            inputs:
+              buildType: specific
+              buildVersionToDownload: specific
+              project: $(AzDOProjectName)
+              pipeline: $(AzDOPipelineId)
+              buildId: $(AzDOBuildId)
+              artifactName: BuildManifests
+        - task: DownloadBuildArtifacts@0
+          displayName: Download Package Artifacts
+          inputs:
+            buildType: specific
+            buildVersionToDownload: specific
+            project: $(AzDOProjectName)
+            pipeline: $(AzDOPipelineId)
+            buildId: $(AzDOBuildId)
+            artifactName: PackageArtifacts
 
-- template: \eng\common\templates\post-build\channels\generic-public-channel.yml
-  parameters:
-    artifactsPublishingAdditionalParameters: ${{ parameters.artifactsPublishingAdditionalParameters }}
-    dependsOn: ${{ parameters.publishDependsOn }}
-    publishInstallersAndChecksums: ${{ parameters.publishInstallersAndChecksums }}
-    symbolPublishingAdditionalParameters: ${{ parameters.symbolPublishingAdditionalParameters }}
-    stageName: 'NetCore_Dev5_Publish'
-    channelName: '.NET 5 Dev'
-    akaMSChannelName: 'net5/dev'
-    channelId: ${{ parameters.NetDev5ChannelId }}
-    transportFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5-transport/nuget/v3/index.json'
-    shippingFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json'
-    symbolsFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5-symbols/nuget/v3/index.json'
+        # This is necessary whenever we want to publish/restore to an AzDO private feed
+        # Since sdk-task.ps1 tries to restore packages we need to do this authentication here
+        # otherwise it'll complain about accessing a private feed.
+        - task: NuGetAuthenticate@0
+          displayName: 'Authenticate to AzDO Feeds'
 
-- template: \eng\common\templates\post-build\channels\generic-public-channel.yml
-  parameters:
-    artifactsPublishingAdditionalParameters: ${{ parameters.artifactsPublishingAdditionalParameters }}
-    dependsOn: ${{ parameters.publishDependsOn }}
-    publishInstallersAndChecksums: ${{ parameters.publishInstallersAndChecksums }}
-    symbolPublishingAdditionalParameters: ${{ parameters.symbolPublishingAdditionalParameters }}
-    stageName: 'Net5_Preview3_Publish'
-    channelName: '.NET 5 Preview 3'
-    akaMSChannelName: 'net5/preview3'
-    channelId: ${{ parameters.Net5Preview3ChannelId }}
-    transportFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5-transport/nuget/v3/index.json'
-    shippingFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json'
-    symbolsFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5-symbols/nuget/v3/index.json'
+        - task: PowerShell@2
+          displayName: Enable cross-org publishing
+          inputs:
+            filePath: eng\common\enable-cross-org-publishing.ps1
+            arguments: -token $(dn-bot-dnceng-artifact-feeds-rw)
 
-- template: \eng\common\templates\post-build\channels\generic-public-channel.yml
-  parameters:
-    artifactsPublishingAdditionalParameters: ${{ parameters.artifactsPublishingAdditionalParameters }}
-    dependsOn: ${{ parameters.publishDependsOn }}
-    publishInstallersAndChecksums: ${{ parameters.publishInstallersAndChecksums }}
-    symbolPublishingAdditionalParameters: ${{ parameters.symbolPublishingAdditionalParameters }}
-    stageName: 'Net5_Preview4_Publish'
-    channelName: '.NET 5 Preview 4'
-    akaMSChannelName: 'net5/preview4'
-    channelId: ${{ parameters.Net5Preview4ChannelId }}
-    transportFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5-transport/nuget/v3/index.json'
-    shippingFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json'
-    symbolsFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5-symbols/nuget/v3/index.json'
+        # Signing validation will optionally work with the buildmanifest file which is downloaded from
+        # Azure DevOps above.
+        - task: PowerShell@2
+          displayName: Validate
+          inputs:
+            filePath: eng\common\sdk-task.ps1
+            arguments: -task SigningValidation -restore -msbuildEngine vs
+              /p:PackageBasePath='$(Build.ArtifactStagingDirectory)/PackageArtifacts'
+              /p:SignCheckExclusionsFile='$(Build.SourcesDirectory)/eng/SignCheckExclusionsFile.txt'
+              ${{ parameters.signingValidationAdditionalParameters }}
 
-- template: \eng\common\templates\post-build\channels\generic-public-channel.yml
-  parameters:
-    artifactsPublishingAdditionalParameters: ${{ parameters.artifactsPublishingAdditionalParameters }}
-    dependsOn: ${{ parameters.publishDependsOn }}
-    publishInstallersAndChecksums: ${{ parameters.publishInstallersAndChecksums }}
-    symbolPublishingAdditionalParameters: ${{ parameters.symbolPublishingAdditionalParameters }}
-    stageName: 'Net5_Preview5_Publish'
-    channelName: '.NET 5 Preview 5'
-    akaMSChannelName: 'net5/preview5'
-    channelId: ${{ parameters.Net5Preview5ChannelId }}
-    transportFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5-transport/nuget/v3/index.json'
-    shippingFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json'
-    symbolsFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5-symbols/nuget/v3/index.json'
+        - template: ../steps/publish-logs.yml
+          parameters:
+            StageLabel: 'Validation'
+            JobLabel: 'Signing'
 
-- template: \eng\common\templates\post-build\channels\generic-public-channel.yml
-  parameters:
-    artifactsPublishingAdditionalParameters: ${{ parameters.artifactsPublishingAdditionalParameters }}
-    dependsOn: ${{ parameters.publishDependsOn }}
-    publishInstallersAndChecksums: ${{ parameters.publishInstallersAndChecksums }}
-    symbolPublishingAdditionalParameters: ${{ parameters.symbolPublishingAdditionalParameters }}
-    stageName: 'Net_Eng_Latest_Publish'
-    channelName: '.NET Eng - Latest'
-    akaMSChannelName: 'eng/daily'
-    channelId: ${{ parameters.NetEngLatestChannelId }}
-    transportFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json'
-    shippingFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json'
-    symbolsFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng-symbols/nuget/v3/index.json'
+    - job:
+      displayName: SourceLink Validation
+      dependsOn: setupMaestroVars
+      condition: eq( ${{ parameters.enableSourceLinkValidation }}, 'true')
+      variables:
+        - template: common-variables.yml
+        - name: AzDOProjectName
+          value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.AzDOProjectName'] ]
+        - name: AzDOPipelineId
+          value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.AzDOPipelineId'] ]
+        - name: AzDOBuildId
+          value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.AzDOBuildId'] ]
+      pool:
+        vmImage: 'windows-2019'
+      steps:
+        - task: DownloadBuildArtifacts@0
+          displayName: Download Blob Artifacts
+          inputs:
+            buildType: specific
+            buildVersionToDownload: specific
+            project: $(AzDOProjectName)
+            pipeline: $(AzDOPipelineId)
+            buildId: $(AzDOBuildId)
+            artifactName: BlobArtifacts
 
-- template: \eng\common\templates\post-build\channels\generic-public-channel.yml
-  parameters:
-    artifactsPublishingAdditionalParameters: ${{ parameters.artifactsPublishingAdditionalParameters }}
-    dependsOn: ${{ parameters.publishDependsOn }}
-    publishInstallersAndChecksums: ${{ parameters.publishInstallersAndChecksums }}
-    symbolPublishingAdditionalParameters: ${{ parameters.symbolPublishingAdditionalParameters }}
-    stageName: 'Net_Eng_Validation_Publish'
-    channelName: '.NET Eng - Validation'
-    akaMSChannelName: 'eng/validation'
-    channelId: ${{ parameters.NetEngValidationChannelId }}
-    transportFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json'
-    shippingFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json'
-    symbolsFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng-symbols/nuget/v3/index.json'
+        - task: PowerShell@2
+          displayName: Validate
+          inputs:
+            filePath: $(Build.SourcesDirectory)/eng/common/post-build/sourcelink-validation.ps1
+            arguments: -InputPath $(Build.ArtifactStagingDirectory)/BlobArtifacts/ 
+              -ExtractPath $(Agent.BuildDirectory)/Extract/ 
+              -GHRepoName $(Build.Repository.Name) 
+              -GHCommit $(Build.SourceVersion)
+              -SourcelinkCliVersion $(SourceLinkCLIVersion)
+          continueOnError: true
 
-- template: \eng\common\templates\post-build\channels\generic-public-channel.yml
-  parameters:
-    artifactsPublishingAdditionalParameters: ${{ parameters.artifactsPublishingAdditionalParameters }}
-    dependsOn: ${{ parameters.publishDependsOn }}
-    publishInstallersAndChecksums: ${{ parameters.publishInstallersAndChecksums }}
-    symbolPublishingAdditionalParameters: ${{ parameters.symbolPublishingAdditionalParameters }}
-    stageName: 'General_Testing_Publish'
-    channelName: 'General Testing'
-    akaMSChannelName: 'generaltesting'
-    channelId: ${{ parameters.GeneralTestingChannelId }}
-    transportFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/general-testing/nuget/v3/index.json'
-    shippingFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/general-testing/nuget/v3/index.json'
-    symbolsFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/general-testing-symbols/nuget/v3/index.json'
+    - template: /eng/common/templates/job/execute-sdl.yml
+      parameters:
+        enable: ${{ parameters.SDLValidationParameters.enable }}
+        dependsOn: setupMaestroVars
+        additionalParameters: ${{ parameters.SDLValidationParameters.params }}
+        continueOnError: ${{ parameters.SDLValidationParameters.continueOnError }}
+        artifactNames: ${{ parameters.SDLValidationParameters.artifactNames }}
+        downloadArtifacts: ${{ parameters.SDLValidationParameters.downloadArtifacts }}
 
-- template: \eng\common\templates\post-build\channels\generic-public-channel.yml
-  parameters:
-    artifactsPublishingAdditionalParameters: ${{ parameters.artifactsPublishingAdditionalParameters }}
-    dependsOn: ${{ parameters.publishDependsOn }}
-    publishInstallersAndChecksums: ${{ parameters.publishInstallersAndChecksums }}
-    symbolPublishingAdditionalParameters: ${{ parameters.symbolPublishingAdditionalParameters }}
-    stageName: 'NETCore_Tooling_Dev_Publishing'
-    channelName: '.NET Core Tooling Dev'
-    channelId: ${{ parameters.NETCoreToolingDevChannelId }}
-    transportFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json'
-    shippingFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json'
-    symbolsFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools-symbols/nuget/v3/index.json'
+  - template: \eng\common\templates\post-build\channels\generic-public-channel.yml
+    parameters:
+      artifactsPublishingAdditionalParameters: ${{ parameters.artifactsPublishingAdditionalParameters }}
+      dependsOn: ${{ parameters.publishDependsOn }}
+      publishInstallersAndChecksums: ${{ parameters.publishInstallersAndChecksums }}
+      symbolPublishingAdditionalParameters: ${{ parameters.symbolPublishingAdditionalParameters }}
+      stageName: 'NetCore_Dev5_Publish'
+      channelName: '.NET 5 Dev'
+      akaMSChannelName: 'net5/dev'
+      channelId: ${{ parameters.NetDev5ChannelId }}
+      transportFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5-transport/nuget/v3/index.json'
+      shippingFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json'
+      symbolsFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5-symbols/nuget/v3/index.json'
 
-- template: \eng\common\templates\post-build\channels\generic-public-channel.yml
-  parameters:
-    artifactsPublishingAdditionalParameters: ${{ parameters.artifactsPublishingAdditionalParameters }}
-    dependsOn: ${{ parameters.publishDependsOn }}
-    publishInstallersAndChecksums: ${{ parameters.publishInstallersAndChecksums }}
-    symbolPublishingAdditionalParameters: ${{ parameters.symbolPublishingAdditionalParameters }}
-    stageName: 'NETCore_Tooling_Release_Publishing'
-    channelName: '.NET Core Tooling Release'
-    channelId: ${{ parameters.NETCoreToolingReleaseChannelId }}
-    transportFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json'
-    shippingFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json'
-    symbolsFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools-symbols/nuget/v3/index.json'
+  - template: \eng\common\templates\post-build\channels\generic-public-channel.yml
+    parameters:
+      artifactsPublishingAdditionalParameters: ${{ parameters.artifactsPublishingAdditionalParameters }}
+      dependsOn: ${{ parameters.publishDependsOn }}
+      publishInstallersAndChecksums: ${{ parameters.publishInstallersAndChecksums }}
+      symbolPublishingAdditionalParameters: ${{ parameters.symbolPublishingAdditionalParameters }}
+      stageName: 'Net5_Preview5_Publish'
+      channelName: '.NET 5 Preview 5'
+      akaMSChannelName: 'net5/preview5'
+      channelId: ${{ parameters.Net5Preview5ChannelId }}
+      transportFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5-transport/nuget/v3/index.json'
+      shippingFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json'
+      symbolsFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5-symbols/nuget/v3/index.json'
 
-- template: \eng\common\templates\post-build\channels\generic-internal-channel.yml
-  parameters:
-    artifactsPublishingAdditionalParameters: ${{ parameters.artifactsPublishingAdditionalParameters }}
-    dependsOn: ${{ parameters.publishDependsOn }}
-    publishInstallersAndChecksums: ${{ parameters.publishInstallersAndChecksums }}
-    symbolPublishingAdditionalParameters: ${{ parameters.symbolPublishingAdditionalParameters }}
-    stageName: 'NET_Internal_Tooling_Publishing'
-    channelName: '.NET Internal Tooling'
-    channelId: ${{ parameters.NETInternalToolingChannelId }}
-    transportFeed: 'https://pkgs.dev.azure.com/dnceng/internal/_packaging/dotnet-tools-internal/nuget/v3/index.json'
-    shippingFeed: 'https://pkgs.dev.azure.com/dnceng/internal/_packaging/dotnet-tools-internal/nuget/v3/index.json'
-    symbolsFeed: 'https://pkgs.dev.azure.com/dnceng/internal/_packaging/dotnet-tools-internal-symbols/nuget/v3/index.json'
+  - template: \eng\common\templates\post-build\channels\generic-public-channel.yml
+    parameters:
+      artifactsPublishingAdditionalParameters: ${{ parameters.artifactsPublishingAdditionalParameters }}
+      dependsOn: ${{ parameters.publishDependsOn }}
+      publishInstallersAndChecksums: ${{ parameters.publishInstallersAndChecksums }}
+      symbolPublishingAdditionalParameters: ${{ parameters.symbolPublishingAdditionalParameters }}
+      stageName: 'Net5_Preview6_Publish'
+      channelName: '.NET 5 Preview 6'
+      akaMSChannelName: 'net5/preview6'
+      channelId: ${{ parameters.Net5Preview6ChannelId }}
+      transportFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5-transport/nuget/v3/index.json'
+      shippingFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json'
+      symbolsFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5-symbols/nuget/v3/index.json'
 
-- template: \eng\common\templates\post-build\channels\generic-public-channel.yml
-  parameters:
-    artifactsPublishingAdditionalParameters: ${{ parameters.artifactsPublishingAdditionalParameters }}
-    dependsOn: ${{ parameters.publishDependsOn }}
-    publishInstallersAndChecksums: ${{ parameters.publishInstallersAndChecksums }}
-    symbolPublishingAdditionalParameters: ${{ parameters.symbolPublishingAdditionalParameters }}
-    stageName: 'NETCore_Experimental_Publishing'
-    channelName: '.NET Core Experimental'
-    channelId: ${{ parameters.NETCoreExperimentalChannelId }}
-    transportFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json'
-    shippingFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json'
-    symbolsFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental-symbols/nuget/v3/index.json'
+  - template: \eng\common\templates\post-build\channels\generic-public-channel.yml
+    parameters:
+      artifactsPublishingAdditionalParameters: ${{ parameters.artifactsPublishingAdditionalParameters }}
+      dependsOn: ${{ parameters.publishDependsOn }}
+      publishInstallersAndChecksums: ${{ parameters.publishInstallersAndChecksums }}
+      symbolPublishingAdditionalParameters: ${{ parameters.symbolPublishingAdditionalParameters }}
+      stageName: 'Net5_Preview7_Publish'
+      channelName: '.NET 5 Preview 7'
+      akaMSChannelName: 'net5/preview7'
+      channelId: ${{ parameters.Net5Preview7ChannelId }}
+      transportFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5-transport/nuget/v3/index.json'
+      shippingFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json'
+      symbolsFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5-symbols/nuget/v3/index.json'
 
-- template: \eng\common\templates\post-build\channels\generic-public-channel.yml
-  parameters:
-    artifactsPublishingAdditionalParameters: ${{ parameters.artifactsPublishingAdditionalParameters }}
-    dependsOn: ${{ parameters.publishDependsOn }}
-    publishInstallersAndChecksums: ${{ parameters.publishInstallersAndChecksums }}
-    symbolPublishingAdditionalParameters: ${{ parameters.symbolPublishingAdditionalParameters }}
-    stageName: 'Net_Eng_Services_Int_Publish'
-    channelName: '.NET Eng Services - Int'
-    channelId: ${{ parameters.NetEngServicesIntChannelId }}
-    transportFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json'
-    shippingFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json'
-    symbolsFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng-symbols/nuget/v3/index.json'
+  - template: \eng\common\templates\post-build\channels\generic-public-channel.yml
+    parameters:
+      artifactsPublishingAdditionalParameters: ${{ parameters.artifactsPublishingAdditionalParameters }}
+      dependsOn: ${{ parameters.publishDependsOn }}
+      publishInstallersAndChecksums: ${{ parameters.publishInstallersAndChecksums }}
+      symbolPublishingAdditionalParameters: ${{ parameters.symbolPublishingAdditionalParameters }}
+      stageName: 'Net_Eng_Latest_Publish'
+      channelName: '.NET Eng - Latest'
+      akaMSChannelName: 'eng/daily'
+      channelId: ${{ parameters.NetEngLatestChannelId }}
+      transportFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json'
+      shippingFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json'
+      symbolsFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng-symbols/nuget/v3/index.json'
 
-- template: \eng\common\templates\post-build\channels\generic-public-channel.yml
-  parameters:
-    artifactsPublishingAdditionalParameters: ${{ parameters.artifactsPublishingAdditionalParameters }}
-    dependsOn: ${{ parameters.publishDependsOn }}
-    publishInstallersAndChecksums: ${{ parameters.publishInstallersAndChecksums }}
-    symbolPublishingAdditionalParameters: ${{ parameters.symbolPublishingAdditionalParameters }}
-    stageName: 'Net_Eng_Services_Prod_Publish'
-    channelName: '.NET Eng Services - Prod'
-    channelId: ${{ parameters.NetEngServicesProdChannelId }}
-    transportFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json'
-    shippingFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json'
-    symbolsFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng-symbols/nuget/v3/index.json'
+  - template: \eng\common\templates\post-build\channels\generic-public-channel.yml
+    parameters:
+      artifactsPublishingAdditionalParameters: ${{ parameters.artifactsPublishingAdditionalParameters }}
+      dependsOn: ${{ parameters.publishDependsOn }}
+      publishInstallersAndChecksums: ${{ parameters.publishInstallersAndChecksums }}
+      symbolPublishingAdditionalParameters: ${{ parameters.symbolPublishingAdditionalParameters }}
+      stageName: 'Net_Eng_Validation_Publish'
+      channelName: '.NET Eng - Validation'
+      akaMSChannelName: 'eng/validation'
+      channelId: ${{ parameters.NetEngValidationChannelId }}
+      transportFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json'
+      shippingFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json'
+      symbolsFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng-symbols/nuget/v3/index.json'
 
-- template: \eng\common\templates\post-build\channels\generic-public-channel.yml
-  parameters:
-    artifactsPublishingAdditionalParameters: ${{ parameters.artifactsPublishingAdditionalParameters }}
-    dependsOn: ${{ parameters.publishDependsOn }}
-    publishInstallersAndChecksums: ${{ parameters.publishInstallersAndChecksums }}
-    symbolPublishingAdditionalParameters: ${{ parameters.symbolPublishingAdditionalParameters }}
-    stageName: 'NETCore_SDK_314xx_Publishing'
-    channelName: '.NET Core SDK 3.1.4xx'
-    channelId: ${{ parameters.NetCoreSDK314xxChannelId }}
-    transportFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1-transport/nuget/v3/index.json'
-    shippingFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1/nuget/v3/index.json'
-    symbolsFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1-symbols/nuget/v3/index.json'
+  - template: \eng\common\templates\post-build\channels\generic-public-channel.yml
+    parameters:
+      artifactsPublishingAdditionalParameters: ${{ parameters.artifactsPublishingAdditionalParameters }}
+      dependsOn: ${{ parameters.publishDependsOn }}
+      publishInstallersAndChecksums: ${{ parameters.publishInstallersAndChecksums }}
+      symbolPublishingAdditionalParameters: ${{ parameters.symbolPublishingAdditionalParameters }}
+      stageName: 'General_Testing_Publish'
+      channelName: 'General Testing'
+      akaMSChannelName: 'generaltesting'
+      channelId: ${{ parameters.GeneralTestingChannelId }}
+      transportFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/general-testing/nuget/v3/index.json'
+      shippingFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/general-testing/nuget/v3/index.json'
+      symbolsFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/general-testing-symbols/nuget/v3/index.json'
 
-- template: \eng\common\templates\post-build\channels\generic-internal-channel.yml
-  parameters:
-    artifactsPublishingAdditionalParameters: ${{ parameters.artifactsPublishingAdditionalParameters }}
-    dependsOn: ${{ parameters.publishDependsOn }}
-    publishInstallersAndChecksums: ${{ parameters.publishInstallersAndChecksums }}
-    symbolPublishingAdditionalParameters: ${{ parameters.symbolPublishingAdditionalParameters }}
-    stageName: 'NETCore_SDK_314xx_Internal_Publishing'
-    channelName: '.NET Core SDK 3.1.4xx Internal'
-    channelId: ${{ parameters.NetCoreSDK314xxInternalChannelId }}
-    transportFeed: 'https://pkgs.dev.azure.com/dnceng/_packaging/dotnet3.1-internal-transport/nuget/v3/index.json'
-    shippingFeed: 'https://pkgs.dev.azure.com/dnceng/_packaging/dotnet3.1-internal/nuget/v3/index.json'
-    symbolsFeed: 'https://pkgs.dev.azure.com/dnceng/_packaging/dotnet3.1-internal-symbols/nuget/v3/index.json' 
+  - template: \eng\common\templates\post-build\channels\generic-public-channel.yml
+    parameters:
+      artifactsPublishingAdditionalParameters: ${{ parameters.artifactsPublishingAdditionalParameters }}
+      dependsOn: ${{ parameters.publishDependsOn }}
+      publishInstallersAndChecksums: ${{ parameters.publishInstallersAndChecksums }}
+      symbolPublishingAdditionalParameters: ${{ parameters.symbolPublishingAdditionalParameters }}
+      stageName: 'NETCore_Tooling_Dev_Publishing'
+      channelName: '.NET Core Tooling Dev'
+      channelId: ${{ parameters.NETCoreToolingDevChannelId }}
+      transportFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json'
+      shippingFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json'
+      symbolsFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools-symbols/nuget/v3/index.json'
+
+  - template: \eng\common\templates\post-build\channels\generic-public-channel.yml
+    parameters:
+      artifactsPublishingAdditionalParameters: ${{ parameters.artifactsPublishingAdditionalParameters }}
+      dependsOn: ${{ parameters.publishDependsOn }}
+      publishInstallersAndChecksums: ${{ parameters.publishInstallersAndChecksums }}
+      symbolPublishingAdditionalParameters: ${{ parameters.symbolPublishingAdditionalParameters }}
+      stageName: 'NETCore_Tooling_Release_Publishing'
+      channelName: '.NET Core Tooling Release'
+      channelId: ${{ parameters.NETCoreToolingReleaseChannelId }}
+      transportFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json'
+      shippingFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json'
+      symbolsFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools-symbols/nuget/v3/index.json'
+
+  - template: \eng\common\templates\post-build\channels\generic-internal-channel.yml
+    parameters:
+      artifactsPublishingAdditionalParameters: ${{ parameters.artifactsPublishingAdditionalParameters }}
+      dependsOn: ${{ parameters.publishDependsOn }}
+      publishInstallersAndChecksums: ${{ parameters.publishInstallersAndChecksums }}
+      symbolPublishingAdditionalParameters: ${{ parameters.symbolPublishingAdditionalParameters }}
+      stageName: 'NET_Internal_Tooling_Publishing'
+      channelName: '.NET Internal Tooling'
+      channelId: ${{ parameters.NETInternalToolingChannelId }}
+      transportFeed: 'https://pkgs.dev.azure.com/dnceng/internal/_packaging/dotnet-tools-internal/nuget/v3/index.json'
+      shippingFeed: 'https://pkgs.dev.azure.com/dnceng/internal/_packaging/dotnet-tools-internal/nuget/v3/index.json'
+      symbolsFeed: 'https://pkgs.dev.azure.com/dnceng/internal/_packaging/dotnet-tools-internal-symbols/nuget/v3/index.json'
+
+  - template: \eng\common\templates\post-build\channels\generic-public-channel.yml
+    parameters:
+      artifactsPublishingAdditionalParameters: ${{ parameters.artifactsPublishingAdditionalParameters }}
+      dependsOn: ${{ parameters.publishDependsOn }}
+      publishInstallersAndChecksums: ${{ parameters.publishInstallersAndChecksums }}
+      symbolPublishingAdditionalParameters: ${{ parameters.symbolPublishingAdditionalParameters }}
+      stageName: 'NETCore_Experimental_Publishing'
+      channelName: '.NET Core Experimental'
+      channelId: ${{ parameters.NETCoreExperimentalChannelId }}
+      transportFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json'
+      shippingFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json'
+      symbolsFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental-symbols/nuget/v3/index.json'
+
+  - template: \eng\common\templates\post-build\channels\generic-public-channel.yml
+    parameters:
+      artifactsPublishingAdditionalParameters: ${{ parameters.artifactsPublishingAdditionalParameters }}
+      dependsOn: ${{ parameters.publishDependsOn }}
+      publishInstallersAndChecksums: ${{ parameters.publishInstallersAndChecksums }}
+      symbolPublishingAdditionalParameters: ${{ parameters.symbolPublishingAdditionalParameters }}
+      stageName: 'Net_Eng_Services_Int_Publish'
+      channelName: '.NET Eng Services - Int'
+      channelId: ${{ parameters.NetEngServicesIntChannelId }}
+      transportFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json'
+      shippingFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json'
+      symbolsFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng-symbols/nuget/v3/index.json'
+
+  - template: \eng\common\templates\post-build\channels\generic-public-channel.yml
+    parameters:
+      artifactsPublishingAdditionalParameters: ${{ parameters.artifactsPublishingAdditionalParameters }}
+      dependsOn: ${{ parameters.publishDependsOn }}
+      publishInstallersAndChecksums: ${{ parameters.publishInstallersAndChecksums }}
+      symbolPublishingAdditionalParameters: ${{ parameters.symbolPublishingAdditionalParameters }}
+      stageName: 'Net_Eng_Services_Prod_Publish'
+      channelName: '.NET Eng Services - Prod'
+      channelId: ${{ parameters.NetEngServicesProdChannelId }}
+      transportFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json'
+      shippingFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json'
+      symbolsFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng-symbols/nuget/v3/index.json'
+
+  - template: \eng\common\templates\post-build\channels\generic-public-channel.yml
+    parameters:
+      artifactsPublishingAdditionalParameters: ${{ parameters.artifactsPublishingAdditionalParameters }}
+      dependsOn: ${{ parameters.publishDependsOn }}
+      publishInstallersAndChecksums: ${{ parameters.publishInstallersAndChecksums }}
+      symbolPublishingAdditionalParameters: ${{ parameters.symbolPublishingAdditionalParameters }}
+      stageName: 'NETCore_SDK_314xx_Publishing'
+      channelName: '.NET Core SDK 3.1.4xx'
+      channelId: ${{ parameters.NetCoreSDK314xxChannelId }}
+      transportFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1-transport/nuget/v3/index.json'
+      shippingFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1/nuget/v3/index.json'
+      symbolsFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1-symbols/nuget/v3/index.json'
+
+  - template: \eng\common\templates\post-build\channels\generic-internal-channel.yml
+    parameters:
+      artifactsPublishingAdditionalParameters: ${{ parameters.artifactsPublishingAdditionalParameters }}
+      dependsOn: ${{ parameters.publishDependsOn }}
+      publishInstallersAndChecksums: ${{ parameters.publishInstallersAndChecksums }}
+      symbolPublishingAdditionalParameters: ${{ parameters.symbolPublishingAdditionalParameters }}
+      stageName: 'NETCore_SDK_314xx_Internal_Publishing'
+      channelName: '.NET Core SDK 3.1.4xx Internal'
+      channelId: ${{ parameters.NetCoreSDK314xxInternalChannelId }}
+      transportFeed: 'https://pkgs.dev.azure.com/dnceng/_packaging/dotnet3.1-internal-transport/nuget/v3/index.json'
+      shippingFeed: 'https://pkgs.dev.azure.com/dnceng/_packaging/dotnet3.1-internal/nuget/v3/index.json'
+      symbolsFeed: 'https://pkgs.dev.azure.com/dnceng/_packaging/dotnet3.1-internal-symbols/nuget/v3/index.json' 
+
+  - template: \eng\common\templates\post-build\channels\generic-public-channel.yml
+    parameters:
+      artifactsPublishingAdditionalParameters: ${{ parameters.artifactsPublishingAdditionalParameters }}
+      dependsOn: ${{ parameters.publishDependsOn }}
+      publishInstallersAndChecksums: ${{ parameters.publishInstallersAndChecksums }}
+      symbolPublishingAdditionalParameters: ${{ parameters.symbolPublishingAdditionalParameters }}
+      stageName: 'NETCore_SDK_313xx_Publishing'
+      channelName: '.NET Core SDK 3.1.3xx'
+      channelId: ${{ parameters.NetCoreSDK313xxChannelId }}
+      transportFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1-transport/nuget/v3/index.json'
+      shippingFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1/nuget/v3/index.json'
+      symbolsFeed: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1-symbols/nuget/v3/index.json'
+
+  - template: \eng\common\templates\post-build\channels\generic-internal-channel.yml
+    parameters:
+      artifactsPublishingAdditionalParameters: ${{ parameters.artifactsPublishingAdditionalParameters }}
+      dependsOn: ${{ parameters.publishDependsOn }}
+      publishInstallersAndChecksums: ${{ parameters.publishInstallersAndChecksums }}
+      symbolPublishingAdditionalParameters: ${{ parameters.symbolPublishingAdditionalParameters }}
+      stageName: 'NETCore_SDK_313xx_Internal_Publishing'
+      channelName: '.NET Core SDK 3.1.3xx Internal'
+      channelId: ${{ parameters.NetCoreSDK313xxInternalChannelId }}
+      transportFeed: 'https://pkgs.dev.azure.com/dnceng/_packaging/dotnet3.1-internal-transport/nuget/v3/index.json'
+      shippingFeed: 'https://pkgs.dev.azure.com/dnceng/_packaging/dotnet3.1-internal/nuget/v3/index.json'
+      symbolsFeed: 'https://pkgs.dev.azure.com/dnceng/_packaging/dotnet3.1-internal-symbols/nuget/v3/index.json' 

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -7,9 +7,11 @@
 # Build configuration. Common values include 'Debug' and 'Release', but the repository may use other names.
 [string]$configuration = if (Test-Path variable:configuration) { $configuration } else { 'Debug' }
 
+# Set to true to opt out of outputting binary log while running in CI
+[bool]$excludeCIBinarylog = if (Test-Path variable:excludeCIBinarylog) { $excludeCIBinarylog } else { $false }
+
 # Set to true to output binary log from msbuild. Note that emitting binary log slows down the build.
-# Binary log must be enabled on CI.
-[bool]$binaryLog = if (Test-Path variable:binaryLog) { $binaryLog } else { $ci }
+[bool]$binaryLog = if (Test-Path variable:binaryLog) { $binaryLog } else { $ci -and !$excludeCIBinarylog }
 
 # Set to true to use the pipelines logger which will enable Azure logging output.
 # https://github.com/Microsoft/azure-pipelines-tasks/blob/master/docs/authoring/commands.md
@@ -55,10 +57,8 @@ set-strictmode -version 2.0
 $ErrorActionPreference = 'Stop'
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
-function Create-Directory([string[]] $path) {
-  if (!(Test-Path $path)) {
-    New-Item -path $path -force -itemType 'Directory' | Out-Null
-  }
+function Create-Directory ([string[]] $path) {
+    New-Item -Path $path -Force -ItemType 'Directory' | Out-Null
 }
 
 function Unzip([string]$zipfile, [string]$outpath) {
@@ -124,7 +124,9 @@ function InitializeDotNetCli([bool]$install, [bool]$createSdkLocationFile) {
 
   # Find the first path on %PATH% that contains the dotnet.exe
   if ($useInstalledDotNetCli -and (-not $globalJsonHasRuntimes) -and ($env:DOTNET_INSTALL_DIR -eq $null)) {
-    $dotnetCmd = Get-Command 'dotnet.exe' -ErrorAction SilentlyContinue
+    $dotnetExecutable = GetExecutableFileName 'dotnet'
+    $dotnetCmd = Get-Command $dotnetExecutable -ErrorAction SilentlyContinue
+
     if ($dotnetCmd -ne $null) {
       $env:DOTNET_INSTALL_DIR = Split-Path $dotnetCmd.Path -Parent
     }
@@ -283,12 +285,19 @@ function InstallDotNet([string] $dotnetRoot,
 # Throws on failure.
 #
 function InitializeVisualStudioMSBuild([bool]$install, [object]$vsRequirements = $null) {
+  if (-not (IsWindowsPlatform)) {
+    throw "Cannot initialize Visual Studio on non-Windows"
+  }
+
   if (Test-Path variable:global:_MSBuildExe) {
     return $global:_MSBuildExe
   }
 
+  $vsMinVersionReqdStr = '16.5'
+  $vsMinVersionReqd = [Version]::new($vsMinVersionReqdStr)
+
   if (!$vsRequirements) { $vsRequirements = $GlobalJson.tools.vs }
-  $vsMinVersionStr = if ($vsRequirements.version) { $vsRequirements.version } else { '15.9' }
+  $vsMinVersionStr = if ($vsRequirements.version) { $vsRequirements.version } else { $vsMinVersionReqdStr }
   $vsMinVersion = [Version]::new($vsMinVersionStr)
 
   # Try msbuild command available in the environment.
@@ -321,8 +330,18 @@ function InitializeVisualStudioMSBuild([bool]$install, [object]$vsRequirements =
       $xcopyMSBuildVersion = $GlobalJson.tools.'xcopy-msbuild'
       $vsMajorVersion = $xcopyMSBuildVersion.Split('.')[0]
     } else {
-      $vsMajorVersion = $vsMinVersion.Major
-      $xcopyMSBuildVersion = "$vsMajorVersion.$($vsMinVersion.Minor).0-alpha"
+      #if vs version provided in global.json is incompatible then use the default version for xcopy msbuild download
+      if($vsMinVersion -lt $vsMinVersionReqd){
+        Write-Host "Using xcopy-msbuild version of $vsMinVersionReqdStr.0-alpha since VS version $vsMinVersionStr provided in global.json is not compatible"
+        $vsMajorVersion = $vsMinVersionReqd.Major
+        $vsMinorVersion = $vsMinVersionReqd.Minor
+      }
+      else{
+        $vsMajorVersion = $vsMinVersion.Major
+        $vsMinorVersion = $vsMinVersion.Minor
+      }
+
+      $xcopyMSBuildVersion = "$vsMajorVersion.$vsMinorVersion.0-alpha"
     }
 
     $vsInstallDir = $null
@@ -387,6 +406,10 @@ function InitializeXCopyMSBuild([string]$packageVersion, [bool]$install) {
 # or $null if no instance meeting the requirements is found on the machine.
 #
 function LocateVisualStudio([object]$vsRequirements = $null){
+  if (-not (IsWindowsPlatform)) {
+    throw "Cannot run vswhere on non-Windows platforms."
+  }
+
   if (Get-Member -InputObject $GlobalJson.tools -Name 'vswhere') {
     $vswhereVersion = $GlobalJson.tools.vswhere
   } else {
@@ -452,7 +475,8 @@ function InitializeBuildTool() {
       Write-PipelineTelemetryError -Category 'InitializeToolset' -Message "/global.json must specify 'tools.dotnet'."
       ExitWithExitCode 1
     }
-    $buildTool = @{ Path = Join-Path $dotnetRoot 'dotnet.exe'; Command = 'msbuild'; Tool = 'dotnet'; Framework = 'netcoreapp2.1' }
+    $dotnetPath = Join-Path $dotnetRoot (GetExecutableFileName 'dotnet')
+    $buildTool = @{ Path = $dotnetPath; Command = 'msbuild'; Tool = 'dotnet'; Framework = 'netcoreapp2.1' }
   } elseif ($msbuildEngine -eq "vs") {
     try {
       $msbuildPath = InitializeVisualStudioMSBuild -install:$restore
@@ -605,8 +629,8 @@ function MSBuild() {
 #
 function MSBuild-Core() {
   if ($ci) {
-    if (!$binaryLog) {
-      Write-PipelineTelemetryError -Category 'Build' -Message 'Binary log must be enabled in CI build.'
+    if (!$binaryLog -and !$excludeCIBinarylog) {
+      Write-PipelineTelemetryError -Category 'Build' -Message 'Binary log must be enabled in CI build, or explicitly opted-out from with the -excludeCIBinarylog switch.'
       ExitWithExitCode 1
     }
 
@@ -664,6 +688,19 @@ function GetMSBuildBinaryLogCommandLineArgument($arguments) {
   }
 
   return $null
+}
+
+function GetExecutableFileName($baseName) {
+  if (IsWindowsPlatform) {
+    return "$baseName.exe"
+  }
+  else {
+    return $baseName
+  }
+}
+
+function IsWindowsPlatform() {
+  return [environment]::OSVersion.Platform -eq [PlatformID]::Win32NT
 }
 
 . $PSScriptRoot\pipeline-logging-functions.ps1

--- a/global.json
+++ b/global.json
@@ -1,8 +1,8 @@
 {
   "tools": {
-    "dotnet": "3.1.101"
+    "dotnet": "5.0.100-preview.6.20266.3"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20228.4"
+    "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20280.1"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,11 @@
 {
   "tools": {
-    "dotnet": "5.0.100-preview.6.20266.3"
+    "dotnet": "5.0.100-preview.6.20266.3",
+    "runtimes": {
+      "dotnet": [
+        "3.1.4"
+      ]
+    }
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20280.1"

--- a/src/Microsoft.Diagnostics.TestHelpers/Microsoft.Diagnostics.TestHelpers.csproj
+++ b/src/Microsoft.Diagnostics.TestHelpers/Microsoft.Diagnostics.TestHelpers.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>;1591;1701</NoWarn>
+    <IsTestProject>false</IsTestProject>
     <IsPackable>true</IsPackable>
     <Description>Diagnostic test support</Description>
     <PackageReleaseNotes>$(Description)</PackageReleaseNotes>


### PR DESCRIPTION
Add the IsTestProject false property to TestHelpers so it will build with the new arcade.

Add the 3.1.4 runtime to global.json so the non-SOS tests (Microsoft.Diagnostics.NETCore.Client.UnitTests, etc.) run.

Remove always installing 2.1 in InstallRuntimes.proj since 3.1 is required for xunit tests and always installed.