### PR TITLE
Make underlying stream own the socket

### DIFF
--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcClient.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcClient.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
 
                 var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
                 socket.Connect(remoteEP);
-                return new NetworkStream(socket);
+                return new NetworkStream(socket, ownsSocket: true);
             }
         }
 


### PR DESCRIPTION
The speculation here:
- In docker scenarios where the main process is pid 1 and so is the dotnet monitor process, we open the stream to verify it exists, and then open it again and use it. The first creates a file which the second call might attempt to use to communicate with the event pipe.