### PR TITLE
Add MacOS dotnet-dump support

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -36,7 +36,7 @@
     <MicrosoftAspNetCoreResponseCompressionVersion>2.1.1</MicrosoftAspNetCoreResponseCompressionVersion>
     <MicrosoftBclHashCodeVersion>1.1.0</MicrosoftBclHashCodeVersion>
     <MicrosoftBclAsyncInterfacesVersion>1.1.0</MicrosoftBclAsyncInterfacesVersion>
-    <MicrosoftDiagnosticsRuntimeVersion>1.1.122004</MicrosoftDiagnosticsRuntimeVersion>
+    <MicrosoftDiagnosticsRuntimeVersion>1.1.127808</MicrosoftDiagnosticsRuntimeVersion>
     <MicrosoftDiaSymReaderNativePackageVersion>1.7.0</MicrosoftDiaSymReaderNativePackageVersion>
     <MicrosoftDiagnosticsTracingTraceEventVersion>2.0.51</MicrosoftDiagnosticsTracingTraceEventVersion>
     <MicrosoftExtensionsConfigurationJsonVersion>2.1.1</MicrosoftExtensionsConfigurationJsonVersion>

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
@@ -57,9 +57,6 @@ namespace Microsoft.Diagnostics.NETCore.Client
         /// <param name="logDumpGeneration">When set to true, display the dump generation debug log to the console.</param>
         public void WriteDump(DumpType dumpType, string dumpPath, bool logDumpGeneration=false)
         {
-            if (!(RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.Windows)))
-                throw new PlatformNotSupportedException($"Unsupported operating system: {RuntimeInformation.OSDescription}");
-
             if (string.IsNullOrEmpty(dumpPath))
                 throw new ArgumentNullException($"{nameof(dumpPath)} required");
 

--- a/src/SOS/SOS.Hosting/SOSHost.cs
+++ b/src/SOS/SOS.Hosting/SOSHost.cs
@@ -233,7 +233,20 @@ namespace SOS
         {
             if (_sosLibrary == IntPtr.Zero)
             {
-                string sosPath = Path.Combine(SOSPath, RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "sos.dll" : "libsos.so");
+                string sos;
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+                    sos = "sos.dll";
+                }
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) {
+                    sos = "libsos.so";
+                }
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
+                    sos = "libsos.dylib";
+                }
+                else {
+                    throw new PlatformNotSupportedException($"Unsupported operating system: {RuntimeInformation.OSDescription}");
+                }
+                string sosPath = Path.Combine(SOSPath, sos);
                 try
                 {
                     _sosLibrary = DataTarget.PlatformFunctions.LoadLibrary(sosPath);

--- a/src/SOS/Strike/runtime.cpp
+++ b/src/SOS/Strike/runtime.cpp
@@ -445,6 +445,7 @@ HRESULT Runtime::GetClrDataProcess(IXCLRDataProcess** ppClrDataProcess)
         HMODULE hdac = LoadLibraryA(dacFilePath);
         if (hdac == NULL)
         {
+            ExtDbgOut("LoadLibrary(%s) FAILED %08x\n", dacFilePath, HRESULT_FROM_WIN32(GetLastError()));
             return CORDBG_E_MISSING_DEBUGGER_EXPORTS;
         }
         PFN_CLRDataCreateInstance pfnCLRDataCreateInstance = (PFN_CLRDataCreateInstance)GetProcAddress(hdac, "CLRDataCreateInstance");

--- a/src/Tools/dotnet-dump/Analyzer.cs
+++ b/src/Tools/dotnet-dump/Analyzer.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Diagnostics.Tools.Dump
             try
             { 
                 DataTarget target = null;
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) {
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
                     target = DataTarget.LoadCoreDump(dump_path.FullName);
                 }
                 else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
@@ -219,44 +219,34 @@ namespace Microsoft.Diagnostics.Tools.Dump
             return runtime;
         }
 
-        private string GetPlatformDacFileName(string dacFileName)
-        {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                return dacFileName.Replace("libmscordaccore.so", "mscordaccore.dll");
-            }
-            return dacFileName;
-        }
-
         private string GetDacFile(ClrInfo clrInfo)
         {
             if (_dacFilePath == null)
-            {            
-                Debug.Assert(!string.IsNullOrEmpty(clrInfo.DacInfo.FileName));
-                var analyzeContext = _serviceProvider.GetService<AnalyzeContext>();
-                string dacFilePath = null;
-                if (!string.IsNullOrEmpty(analyzeContext.RuntimeModuleDirectory))
-                {
-                    dacFilePath = Path.Combine(analyzeContext.RuntimeModuleDirectory, GetPlatformDacFileName(clrInfo.DacInfo.FileName));
-                    if (File.Exists(dacFilePath))
-                    {
-                        _dacFilePath = dacFilePath;
-                    }
-                }
+            {
+                string dacFileName = GetDacFileName(clrInfo, out OSPlatform platform);
+                _dacFilePath = GetLocalDacPath(clrInfo, dacFileName);
                 if (_dacFilePath == null)
                 {
-                    dacFilePath = GetPlatformDacFileName(clrInfo.LocalMatchingDac);
-                    if (!string.IsNullOrEmpty(dacFilePath) && File.Exists(dacFilePath))
+                    if (SymbolReader.IsSymbolStoreEnabled())
                     {
-                        _dacFilePath = dacFilePath;
-                    }
-                    else if (SymbolReader.IsSymbolStoreEnabled())
-                    {
-                        string dacFileName = Path.GetFileName(dacFilePath ?? GetPlatformDacFileName(clrInfo.DacInfo.FileName));
-                        if (dacFileName != null)
-                        {
-                            SymbolStoreKey key = null;
+                        SymbolStoreKey key = null;
 
+                        if (platform == OSPlatform.OSX)
+                        {
+                            unsafe
+                            {
+                                var memoryService = _serviceProvider.GetService<MemoryService>();
+                                SymbolReader.ReadMemoryDelegate readMemory = (ulong address, byte* buffer, int count) => {
+                                    return memoryService.ReadMemory(address, new Span<byte>(buffer, count), out int bytesRead) ? bytesRead : 0;
+                                };
+                                KeyGenerator generator = SymbolReader.GetKeyGenerator(
+                                    SymbolReader.RuntimeConfiguration.OSXCore, clrInfo.ModuleInfo.FileName, clrInfo.ModuleInfo.ImageBase, unchecked((int)clrInfo.ModuleInfo.FileSize), readMemory);
+
+                                key = generator.GetKeys(KeyTypeFlags.DacDbiKeys).SingleOrDefault((k) => Path.GetFileName(k.FullPathName) == dacFileName);
+                            }
+                        }
+                        else if (platform == OSPlatform.Linux)
+                        {
                             if (clrInfo.ModuleInfo.BuildId != null)
                             {
                                 IEnumerable<SymbolStoreKey> keys = ELFFileKeyGenerator.GetKeys(
@@ -264,17 +254,17 @@ namespace Microsoft.Diagnostics.Tools.Dump
 
                                 key = keys.SingleOrDefault((k) => Path.GetFileName(k.FullPathName) == dacFileName);
                             }
-                            else
-                            {
-                                // Use the coreclr.dll's id (timestamp/filesize) to download the the dac module.
-                                key = PEFileKeyGenerator.GetKey(dacFileName, clrInfo.ModuleInfo.TimeStamp, clrInfo.ModuleInfo.FileSize);
-                            }
+                        }
+                        else if (platform == OSPlatform.Windows)
+                        {
+                            // Use the coreclr.dll's id (timestamp/filesize) to download the the dac module.
+                            key = PEFileKeyGenerator.GetKey(dacFileName, clrInfo.ModuleInfo.TimeStamp, clrInfo.ModuleInfo.FileSize);
+                        }
 
-                            if (key != null)
-                            {
-                                // Now download the DAC module from the symbol server
-                                _dacFilePath = SymbolReader.GetSymbolFile(key);
-                            }
+                        if (key != null)
+                        {
+                            // Now download the DAC module from the symbol server
+                            _dacFilePath = SymbolReader.GetSymbolFile(key);
                         }
                     }
 
@@ -286,6 +276,51 @@ namespace Microsoft.Diagnostics.Tools.Dump
                 _isDesktop = clrInfo.Flavor == ClrFlavor.Desktop;
             }
             return _dacFilePath;
+        }
+
+        private static string GetDacFileName(ClrInfo clrInfo, out OSPlatform platform)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(clrInfo.ModuleInfo.FileName));
+            Debug.Assert(!string.IsNullOrEmpty(clrInfo.DacInfo.FileName));
+
+            platform = OSPlatform.Windows;
+
+            switch (Path.GetFileName(clrInfo.ModuleInfo.FileName))
+            {
+                case "libcoreclr.dylib":
+                    platform = OSPlatform.OSX;
+                    return "libmscordaccore.dylib";
+
+                case "libcoreclr.so":
+                    platform = OSPlatform.Linux;
+
+                    // If this is the Linux runtime module name, but we are running on Windows return the cross-OS DAC name.
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                    {
+                        return "mscordaccore.dll";
+                    }
+                    break;
+            }
+            return clrInfo.DacInfo.FileName;
+        }
+
+        private string GetLocalDacPath(ClrInfo clrInfo, string dacFileName)
+        {
+            string dacFilePath;
+            var analyzeContext = _serviceProvider.GetService<AnalyzeContext>();
+            if (!string.IsNullOrEmpty(analyzeContext.RuntimeModuleDirectory))
+            {
+                dacFilePath = Path.Combine(analyzeContext.RuntimeModuleDirectory, dacFileName);
+            }
+            else
+            {
+                dacFilePath = Path.Combine(Path.GetDirectoryName(clrInfo.ModuleInfo.FileName), dacFileName);
+            }
+            if (!File.Exists(dacFilePath))
+            {
+                dacFilePath = null;
+            }
+            return dacFilePath;
         }
     }
 }

--- a/src/Tools/dotnet-dump/Dumper.cs
+++ b/src/Tools/dotnet-dump/Dumper.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Diagnostics.Tools.Dump
 
                     Windows.CollectDump(process, output, type);
                 }
-                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                else
                 {
                     var client = new DiagnosticsClient(processId);
 
@@ -110,9 +110,6 @@ namespace Microsoft.Diagnostics.Tools.Dump
 
                     // Send the command to the runtime to initiate the core dump
                     client.WriteDump(dumpType, output, diag);
-                }
-                else {
-                    throw new PlatformNotSupportedException($"Unsupported operating system: {RuntimeInformation.OSDescription}");
                 }
             }
             catch (Exception ex) when 

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/WriteDumpTests.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/WriteDumpTests.cs
@@ -32,24 +32,27 @@ namespace Microsoft.Diagnostics.NETCore.Client
         [Fact]
         public void BasicWriteDumpTest()
         {
-            var dumpPath = "./myDump.dmp";
-            TestRunner runner = new TestRunner(CommonHelper.GetTraceePath(), output);
-            runner.Start(3000);
-            DiagnosticsClient client = new DiagnosticsClient(runner.Pid);
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                Assert.Throws<PlatformNotSupportedException>(() => client.WriteDump(DumpType.Normal, dumpPath));
-            }
-            else
-            {
-                output.WriteLine($"Requesting dump at {DateTime.Now.ToString()}");
-                client.WriteDump(DumpType.Normal, dumpPath);
-                Assert.True(File.Exists(dumpPath));
-                File.Delete(dumpPath);
-            }
+                var dumpPath = "./myDump.dmp";
+                TestRunner runner = new TestRunner(CommonHelper.GetTraceePath(), output);
+                runner.Start(3000);
+                DiagnosticsClient client = new DiagnosticsClient(runner.Pid);
 
-            runner.Stop();
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    Assert.Throws<PlatformNotSupportedException>(() => client.WriteDump(DumpType.Normal, dumpPath));
+                }
+                else
+                {
+                    output.WriteLine($"Requesting dump at {DateTime.Now.ToString()}");
+                    client.WriteDump(DumpType.Normal, dumpPath);
+                    Assert.True(File.Exists(dumpPath));
+                    File.Delete(dumpPath);
+                }
+
+                runner.Stop();
+            }
         }
 
         /// <summary>

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/WriteDumpTests.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/WriteDumpTests.cs
@@ -37,17 +37,11 @@ namespace Microsoft.Diagnostics.NETCore.Client
             runner.Start(3000);
             DiagnosticsClient client = new DiagnosticsClient(runner.Pid);
 
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                Assert.Throws<PlatformNotSupportedException>(() => client.WriteDump(DumpType.Normal, dumpPath));
-            }
-            else
-            {
-                output.WriteLine($"Requesting dump at {DateTime.Now.ToString()}");
-                client.WriteDump(DumpType.Normal, dumpPath);
-                Assert.True(File.Exists(dumpPath));
-                File.Delete(dumpPath);
-            }
+            output.WriteLine($"Requesting dump at {DateTime.Now.ToString()}");
+            client.WriteDump(DumpType.Normal, dumpPath);
+            Assert.True(File.Exists(dumpPath));
+            File.Delete(dumpPath);
+
             runner.Stop();
         }
 
@@ -111,14 +105,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
             }
 
             var client = new DiagnosticsClient(arbitraryPid);
-            if (!(RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.Windows)))
-            {
-                Assert.Throws<PlatformNotSupportedException>(() => client.WriteDump(DumpType.Normal, dumpPath));
-            }
-            else
-            {
-                Assert.Throws<ServerNotAvailableException>(() => client.WriteDump(DumpType.Normal, "./myDump.dmp"));
-            }
+            Assert.Throws<ServerNotAvailableException>(() => client.WriteDump(DumpType.Normal, dumpPath));
         }
     }
 }

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/WriteDumpTests.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/WriteDumpTests.cs
@@ -37,10 +37,17 @@ namespace Microsoft.Diagnostics.NETCore.Client
             runner.Start(3000);
             DiagnosticsClient client = new DiagnosticsClient(runner.Pid);
 
-            output.WriteLine($"Requesting dump at {DateTime.Now.ToString()}");
-            client.WriteDump(DumpType.Normal, dumpPath);
-            Assert.True(File.Exists(dumpPath));
-            File.Delete(dumpPath);
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Assert.Throws<PlatformNotSupportedException>(() => client.WriteDump(DumpType.Normal, dumpPath));
+            }
+            else
+            {
+                output.WriteLine($"Requesting dump at {DateTime.Now.ToString()}");
+                client.WriteDump(DumpType.Normal, dumpPath);
+                Assert.True(File.Exists(dumpPath));
+                File.Delete(dumpPath);
+            }
 
             runner.Stop();
         }


### PR DESCRIPTION
Update to CLRMD version 1.1.127808

Enabled dotnet-dump collect for MacOS