### PR TITLE
Remove quotations from dictionary values when populating the argument dictionary for EventPipeProvider

### DIFF
--- a/src/Tools/dotnet-trace/Extensions.cs
+++ b/src/Tools/dotnet-trace/Extensions.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.Tracing;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace Microsoft.Diagnostics.Tools.Trace
 {
@@ -163,6 +164,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
             int valEnd = 0;
             int curIdx = 0;
             bool inQuote = false;
+            argument = Regex.Unescape(argument);
             foreach (var c in argument)
             {
                 if (inQuote)
@@ -182,7 +184,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                     else if (c == ';')
                     {
                         valEnd = curIdx;
-                        argumentDict.Add(argument.Substring(keyStart, keyEnd-keyStart), argument.Substring(valStart, valEnd-valStart));
+                        AddKeyValueToArgumentDict(argumentDict, argument, keyStart, keyEnd, valStart, valEnd);
                         keyStart = curIdx+1; // new key starts
                     }
                     else if (c == '\"')
@@ -192,10 +194,19 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 }
                 curIdx += 1;
             }
+            AddKeyValueToArgumentDict(argumentDict, argument, keyStart, keyEnd, valStart, valEnd);
+            return argumentDict;
+        }
+
+        private static void AddKeyValueToArgumentDict(Dictionary<string, string> argumentDict, string argument, int keyStart, int keyEnd, int valStart, int valEnd)
+        {
             string key = argument.Substring(keyStart, keyEnd - keyStart);
             string val = argument.Substring(valStart);
+            if (val.StartsWith("\"") && val.EndsWith("\""))
+            {
+                val = val.Substring(1, val.Length - 2);
+            }
             argumentDict.Add(key, val);
-            return argumentDict;
         }
     }
 }

--- a/src/tests/dotnet-trace/ProviderParsing.cs
+++ b/src/tests/dotnet-trace/ProviderParsing.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
             Assert.True(provider.Keywords == 1);
             Assert.True(provider.EventLevel == System.Diagnostics.Tracing.EventLevel.Verbose);
             Assert.True(provider.Arguments.Count == 1);
-            Assert.True(provider.Arguments["FilterAndPayloadSpecs"] == "\"QuotedValue\"");
+            Assert.True(provider.Arguments["FilterAndPayloadSpecs"] == "QuotedValue");
         }
 
         [Theory]
@@ -38,7 +38,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
             Assert.True(provider.Keywords == 1);
             Assert.True(provider.EventLevel == System.Diagnostics.Tracing.EventLevel.Verbose);
             Assert.True(provider.Arguments.Count == 1);
-            Assert.True(provider.Arguments["FilterAndPayloadSpecs"] == "\"QuotedValue:-\r\nQuoted/Value\"");
+            Assert.True(provider.Arguments["FilterAndPayloadSpecs"] == "QuotedValue:-\r\nQuoted/Value");
         }
 
         [Theory]
@@ -68,7 +68,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
             Assert.True(provider.Keywords == (long)(-1));
             Assert.True(provider.EventLevel == System.Diagnostics.Tracing.EventLevel.Verbose);
             Assert.True(provider.Arguments.Count == 1);
-            Assert.True(provider.Arguments["FilterAndPayloadSpecs"] == "\"QuotedValue\"");
+            Assert.True(provider.Arguments["FilterAndPayloadSpecs"] == "QuotedValue");
         }
 
         [Theory]
@@ -83,7 +83,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
             Assert.True(provider.Keywords == (long)(-1));
             Assert.True(provider.EventLevel == System.Diagnostics.Tracing.EventLevel.Verbose);
             Assert.True(provider.Arguments.Count == 1);
-            Assert.True(provider.Arguments["FilterAndPayloadSpecs"] == "\"QuotedValue\"");
+            Assert.True(provider.Arguments["FilterAndPayloadSpecs"] == "QuotedValue");
         }
 
         [Theory]
@@ -117,7 +117,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
             Assert.True(providerOne.Keywords == 1);
             Assert.True(providerOne.EventLevel == System.Diagnostics.Tracing.EventLevel.Critical);
             Assert.True(providerOne.Arguments.Count == 1);
-            Assert.True(providerOne.Arguments["FilterAndPayloadSpecs"] == "\"QuotedValue\"");
+            Assert.True(providerOne.Arguments["FilterAndPayloadSpecs"] == "QuotedValue");
 
             Assert.True(providerTwo.Name == "ProviderTwo");
             Assert.True(providerTwo.Keywords == 2);
@@ -173,19 +173,19 @@ namespace Microsoft.Diagnostics.Tools.Trace
             Assert.True(providerOne.Keywords == 1);
             Assert.True(providerOne.EventLevel == System.Diagnostics.Tracing.EventLevel.Critical);
             Assert.True(providerOne.Arguments.Count == 1);
-            Assert.True(providerOne.Arguments["FilterAndPayloadSpecs"] == "\"QuotedValue:-\r\nQuoted/Value:-A=B;C=D;\"");
+            Assert.True(providerOne.Arguments["FilterAndPayloadSpecs"] == "QuotedValue:-\r\nQuoted/Value:-A=B;C=D;");
 
             Assert.True(providerTwo.Name == "ProviderTwo");
             Assert.True(providerTwo.Keywords == 2);
             Assert.True(providerTwo.EventLevel == System.Diagnostics.Tracing.EventLevel.Error);
             Assert.True(providerTwo.Arguments.Count == 1);
-            Assert.True(providerTwo.Arguments["FilterAndPayloadSpecs"]== "\"QuotedValue\"");
+            Assert.True(providerTwo.Arguments["FilterAndPayloadSpecs"]== "QuotedValue");
 
             Assert.True(providerThree.Name == "ProviderThree");
             Assert.True(providerThree.Keywords == 3);
             Assert.True(providerThree.EventLevel == System.Diagnostics.Tracing.EventLevel.Warning);
             Assert.True(providerThree.Arguments.Count == 1);
-            Assert.True(providerThree.Arguments["FilterAndPayloadSpecs"] == "\"QuotedValue:-\r\nQuoted/Value:-A=B;C=D;\"");
+            Assert.True(providerThree.Arguments["FilterAndPayloadSpecs"] == "QuotedValue:-\r\nQuoted/Value:-A=B;C=D;");
         }
 
         [Theory]


### PR DESCRIPTION
Fix #1190. 

The issue was caused by two issues:

1) When you specify argument filter string via dotnet-trace and the character `"` is used to escape the argument string, it gets double-escaped by the logic in DiagnosticsClient library that tries to escape characters that have special characters (`=`, `;`) in them.

2) `\r\n` is not properly passed in.  

To avoid this, we can remove the wrapping `"` character from dotnet-trace side before we pass it to `EventPipeProvider`. To solve the second issue, we can just apply `Regex.Unescape`.

cc @davidmikh 