### PR TITLE
Upload NuGet packages with blob group to installers blob feed

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -19,22 +19,21 @@
     <PropertyGroup>
       <_BlobGroupFilePath>%(PackageFile.FullPath).blobgroup</_BlobGroupFilePath>
       <_ChecksumFilePath>%(PackageFile.FullPath).sha512</_ChecksumFilePath>
-      <_VersionFilePath>%(PackageFile.FullPath).version</_VersionFilePath>
     </PropertyGroup>    
     <!-- Read in blob group name, if it exists -->
     <ReadLinesFromFile File="$(_BlobGroupFilePath)" Condition="Exists('$(_BlobGroupFilePath)')">
       <Output TaskParameter="Lines" PropertyName="_BlobGroupName"/>
     </ReadLinesFromFile>
     <ItemGroup>
-      <!-- Capture package checksum artifact -->
-      <_PackageArtifact Include="$(_ChecksumFilePath)" Condition="Exists('$(_ChecksumFilePath)')" />
-      <!-- Capture version checksum artifact -->
-      <_PackageArtifact Include="$(_VersionFilePath)" Condition="Exists('$(_VersionFilePath)')" />
+      <!-- Capture package; setting cateogry to Other will upload to installers blob feed. -->
+      <_BlobItem Include="%(PackageFile.FullPath)" Category="Other" />
+      <!-- Capture checksum -->
+      <_BlobItem Include="$(_ChecksumFilePath)" Condition="Exists('$(_ChecksumFilePath)')" />
     </ItemGroup>
     <ItemGroup>
       <!-- Add artifact items to be pushed to blob feed -->
-      <ItemsToPushToBlobFeed Include="%(_PackageArtifact.Identity)" Condition="'$(_BlobGroupName)' != ''">
-        <RelativeBlobPath>diagnostics/$(_BlobGroupName)/%(_PackageArtifact.Filename)%(_PackageArtifact.Extension)</RelativeBlobPath>
+      <ItemsToPushToBlobFeed Include="@(_BlobItem)" Condition="'$(_BlobGroupName)' != ''">
+        <RelativeBlobPath>diagnostics/$(_BlobGroupName)/%(_BlobItem.Filename)%(_BlobItem.Extension)</RelativeBlobPath>
         <ManifestArtifactData Condition="'%(PackageFile.IsShipping)' != 'true'">NonShipping=true</ManifestArtifactData>
         <PublishFlatContainer>true</PublishFlatContainer>
       </ItemsToPushToBlobFeed>

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,35 +1,41 @@
 <Project>
 
   <PropertyGroup>
-    <PublishDependsOnTargets>$(PublishDependsOnTargets);CollectPackageChecksumFiles</PublishDependsOnTargets>
+    <PublishDependsOnTargets>$(PublishDependsOnTargets);CollectPackageArtifactFiles</PublishDependsOnTargets>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageChecksumFile Include="$(ArtifactsShippingPackagesDir)**\*.sha512" IsShipping="true" />
-    <PackageChecksumFile Include="$(ArtifactsNonShippingPackagesDir)**\*.sha512" IsShipping="false" />
+    <PackageFile Include="$(ArtifactsShippingPackagesDir)**\*.nupkg" IsShipping="true" />
+    <PackageFile Include="$(ArtifactsNonShippingPackagesDir)**\*.nupkg" IsShipping="false" />
   </ItemGroup>
 
-  <!-- Run the CollectPackageChecksumFiles target on each PackageChecksunFile by target batching on a non-existing file.
+  <!-- Run the CollectPackageArtifactFiles target on each PackageFile by target batching on a non-existing file.
        This allows using the ReadLinesFromFile task to read the blob group file, which was written with WriteLinesToFile,
        thus avoiding erroneously reading in the newline at the end of the blob group file. -->
-  <Target Name="CollectPackageChecksumFiles"
-          Inputs="@(PackageChecksumFile)"
-          Outputs="%(PackageChecksumFile.Identity).notexist">
-    <!-- Find the blob group file next to the checksum file. -->
+  <Target Name="CollectPackageArtifactFiles"
+          Inputs="@(PackageFile)"
+          Outputs="%(PackageFile.Identity).notexist">
+    <!-- Find the artifact files next to the package file. -->
     <PropertyGroup>
-      <_BlobGroupFilePath>%(PackageChecksumFile.RootDir)%(PackageChecksumFile.Directory)%(PackageChecksumFile.Filename).blobgroup</_BlobGroupFilePath>
-    </PropertyGroup>
-    <Error Message="Blob group file '$(_BlobGroupFilePath)' does not exist."
-           Condition="!Exists('$(_BlobGroupFilePath)')" />
-    <!-- Read in blob group name -->
-    <ReadLinesFromFile File="$(_BlobGroupFilePath)">
+      <_BlobGroupFilePath>%(PackageFile.FullPath).blobgroup</_BlobGroupFilePath>
+      <_ChecksumFilePath>%(PackageFile.FullPath).sha512</_ChecksumFilePath>
+      <_VersionFilePath>%(PackageFile.FullPath).version</_VersionFilePath>
+    </PropertyGroup>    
+    <!-- Read in blob group name, if it exists -->
+    <ReadLinesFromFile File="$(_BlobGroupFilePath)" Condition="Exists('$(_BlobGroupFilePath)')">
       <Output TaskParameter="Lines" PropertyName="_BlobGroupName"/>
     </ReadLinesFromFile>
-    <!-- Add ItemsToPushToBlobFeed for checksum file using blob group in relative blob path. -->
     <ItemGroup>
-      <ItemsToPushToBlobFeed Include="%(PackageChecksumFile.Identity)">
-        <RelativeBlobPath>diagnostics/$(_BlobGroupName)/%(PackageChecksumFile.Filename)%(PackageChecksumFile.Extension)</RelativeBlobPath>
-        <ManifestArtifactData Condition="'%(PackageChecksumFile.IsShipping)' != 'true'">NonShipping=true</ManifestArtifactData>
+      <!-- Capture package checksum artifact -->
+      <_PackageArtifact Include="$(_ChecksumFilePath)" Condition="Exists('$(_ChecksumFilePath)')" />
+      <!-- Capture version checksum artifact -->
+      <_PackageArtifact Include="$(_VersionFilePath)" Condition="Exists('$(_VersionFilePath)')" />
+    </ItemGroup>
+    <ItemGroup>
+      <!-- Add artifact items to be pushed to blob feed -->
+      <ItemsToPushToBlobFeed Include="%(_PackageArtifact.Identity)" Condition="'$(_BlobGroupName)' != ''">
+        <RelativeBlobPath>diagnostics/$(_BlobGroupName)/%(_PackageArtifact.Filename)%(_PackageArtifact.Extension)</RelativeBlobPath>
+        <ManifestArtifactData Condition="'%(PackageFile.IsShipping)' != 'true'">NonShipping=true</ManifestArtifactData>
         <PublishFlatContainer>true</PublishFlatContainer>
       </ItemsToPushToBlobFeed>
     </ItemGroup>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -47,11 +47,6 @@
     <WriteLinesToFile File="$(PackageOutputPath)\$(PackageId).$(PackageVersion).nupkg.blobgroup"
                       Lines="$(_BlobGroupName)"
                       Overwrite="true" />
-    <!-- A file that contains the package version so that aka.ms latest links can point to the latest
-         version within a blob group. -->
-    <WriteLinesToFile File="$(PackageOutputPath)\$(PackageId).$(PackageVersion).nupkg.version"
-                      Lines="$(PackageVersion)"
-                      Overwrite="true" />
   </Target>
 
 </Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -34,9 +34,8 @@
           Condition="$(NeedsPublishing) == 'true'"
           DependsOnTargets="$(_BeforePublishNoBuildTargets);$(_CorePublishTargets)" />
 
-  <!-- Creates a file for packaged projects that declare a blog group prefix so that
-      publishing can use it in the blob path calculation. -->
-  <Target Name="GenerateBlobGroupFile"
+  <!-- Creates artifact files related to the package that will be uploaded to blob storage during publish. -->
+  <Target Name="GeneratePackageArtifactFiles"
           AfterTargets="Pack"
           Condition="'$(IsPackable)' == 'true' and '$(BlobGroupPrefix)' != ''">
     <PropertyGroup>
@@ -44,8 +43,15 @@
       <_BlobGroupVersionMinor>$(PackageVersion.Split('.')[1])</_BlobGroupVersionMinor>
       <_BlobGroupName>$(BlobGroupPrefix)$(_BlobGroupVersionMajor).$(_BlobGroupVersionMinor)</_BlobGroupName>
     </PropertyGroup>
+    <!-- A file that contains the blob group so that publishing can use it in the blob path calculation. -->
     <WriteLinesToFile File="$(PackageOutputPath)\$(PackageId).$(PackageVersion).nupkg.blobgroup"
                       Lines="$(_BlobGroupName)"
                       Overwrite="true" />
+    <!-- A file that contains the package version so that aka.ms latest links can point to the latest
+         version within a blob group. -->
+    <WriteLinesToFile File="$(PackageOutputPath)\$(PackageId).$(PackageVersion).nupkg.version"
+                      Lines="$(PackageVersion)"
+                      Overwrite="true" />
   </Target>
+
 </Project>


### PR DESCRIPTION
These changes generate and publish package version files to blob feed so that other processes can determine the latest package version within a blob group. These changes also refactor how the package artifact files (namely, checksum and version) are discovered by keying off of each package file and attempting to discover the related files rather than keying off of the checksum files.