### PR TITLE
Add thread service

### DIFF
--- a/src/Microsoft.Diagnostics.DebugServices/AnalyzeContext.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/AnalyzeContext.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Diagnostics.DebugServices
         /// <summary>
         /// Current OS thread Id
         /// </summary>
-        public int CurrentThreadId { get; set; }
+        public uint? CurrentThreadId { get; set; }
 
         /// <summary>
         /// Cancellation token for current command

--- a/src/Microsoft.Diagnostics.DebugServices/DiagnosticsException.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/DiagnosticsException.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.Diagnostics.DebugServices
+{
+    /// <summary>
+    /// Diagnostics exception
+    /// </summary>
+    public class DiagnosticsException : Exception
+    {
+        public DiagnosticsException()
+            : base()
+        {
+        }
+
+        public DiagnosticsException(string message)
+            : base(message)
+        {
+        }
+
+        public DiagnosticsException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.DebugServices/IThreadService.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/IThreadService.cs
@@ -1,0 +1,92 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System;
+
+namespace Microsoft.Diagnostics.DebugServices
+{
+    /// <summary>
+    /// Provides thread and register info and values
+    /// </summary>
+    public interface IThreadService
+    {
+        /// <summary>
+        /// Details on all the supported registers
+        /// </summary>
+        IEnumerable<RegisterInfo> Registers { get; }
+
+        /// <summary>
+        /// The instruction pointer register index
+        /// </summary>
+        int InstructionPointerIndex { get; }
+
+        /// <summary>
+        /// The frame pointer register index
+        /// </summary>
+        int FramePointerIndex { get; }
+
+        /// <summary>
+        /// The stack pointer register index
+        /// </summary>
+        int StackPointerIndex { get; }
+
+        /// <summary>
+        /// Return the register index for the register name
+        /// </summary>
+        /// <param name="name">register name</param>
+        /// <param name="registerIndex">returns register index or -1</param>
+        /// <returns>true if name found</returns>
+        bool GetRegisterIndexByName(string name, out int registerIndex);
+
+        /// <summary>
+        /// Returns the register info (name, offset, size, etc).
+        /// </summary>
+        /// <param name="registerIndex">register index</param>
+        /// <param name="info">RegisterInfo</param>
+        /// <returns>true if index found</returns>
+        bool GetRegisterInfo(int registerIndex, out RegisterInfo info);
+
+        /// <summary>
+        /// Returns the register value for the thread and register index. This function
+        /// can only return register values that are 64 bits or less and currently the
+        /// clrmd data targets don't return any floating point or larger registers.
+        /// </summary>
+        /// <param name="threadId">thread id</param>
+        /// <param name="registerIndex">register index</param>
+        /// <param name="value">value returned</param>
+        /// <returns>true if value found</returns>
+        bool GetRegisterValue(uint threadId, int registerIndex, out ulong value);
+
+        /// <summary>
+        /// Returns the raw context buffer bytes for the specified thread.
+        /// </summary>
+        /// <param name="threadId">thread id</param>
+        /// <returns>register context</returns>
+        /// <exception cref="DiagnosticsException">invalid thread id</exception>
+        byte[] GetThreadContext(uint threadId);
+
+        /// <summary>
+        /// Enumerate all the native threads
+        /// </summary>
+        /// <returns>ThreadInfos for all the threads</returns>
+        IEnumerable<ThreadInfo> EnumerateThreads();
+
+        /// <summary>
+        /// Get the thread info from the thread index
+        /// </summary>
+        /// <param name="threadIndex">index</param>
+        /// <returns>thread info</returns>
+        /// <exception cref="DiagnosticsException">invalid thread index</exception>
+        ThreadInfo GetThreadInfoFromIndex(int threadIndex);
+
+        /// <summary>
+        /// Get the thread info from the OS thread id
+        /// </summary>
+        /// <param name="threadId">os id</param>
+        /// <returns>thread info</returns>
+        /// <exception cref="DiagnosticsException">invalid thread id</exception>
+        ThreadInfo GetThreadInfoFromId(uint threadId);
+    }
+}

--- a/src/Microsoft.Diagnostics.DebugServices/RegisterInfo.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/RegisterInfo.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Diagnostics.DebugServices
+{
+	/// <summary>
+	/// Details about a register
+	/// </summary>
+    public struct RegisterInfo
+    {
+        public readonly int RegisterIndex;
+        public readonly int RegisterOffset;
+        public readonly int RegisterSize;
+        public readonly string RegisterName;
+
+        public RegisterInfo(int registerIndex, int registerOffset, int registerSize, string registerName)
+        {
+            RegisterIndex = registerIndex;
+            RegisterOffset = registerOffset;
+            RegisterSize = registerSize;
+            RegisterName = registerName;
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.DebugServices/ThreadInfo.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/ThreadInfo.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Diagnostics.DebugServices
+{
+    /// <summary>
+    /// Details about a native thread
+    /// </summary>
+    public struct ThreadInfo
+    {
+        public readonly int ThreadIndex;
+        public readonly uint ThreadId;
+        public readonly ulong ThreadTeb;
+
+        public ThreadInfo(int index, uint id, ulong teb)
+        {
+            ThreadIndex = index;
+            ThreadId = id;
+            ThreadTeb = teb;
+        }
+    }
+}

--- a/src/SOS/SOS.Hosting/LLDBServices.cs
+++ b/src/SOS/SOS.Hosting/LLDBServices.cs
@@ -68,7 +68,7 @@ namespace SOS
             builder.AddMethod(new SetCurrentThreadIdDelegate(soshost.SetCurrentThreadId));
             builder.AddMethod(new GetCurrentThreadSystemIdDelegate(soshost.GetCurrentThreadSystemId));
             builder.AddMethod(new GetThreadIdBySystemIdDelegate(soshost.GetThreadIdBySystemId));
-            builder.AddMethod(new GetThreadContextByIdDelegate(GetThreadContextById));
+            builder.AddMethod(new GetThreadContextByIdDelegate(soshost.GetThreadContextById));
 
             builder.AddMethod(new GetValueByNameDelegate(GetValueByName));
             builder.AddMethod(new GetInstructionOffsetDelegate(soshost.GetInstructionOffset));
@@ -141,19 +141,6 @@ namespace SOS
             // Don't fail, but always return 0 native frames so "clrstack -f" still prints the managed frames
             SOSHost.Write(framesFilled);
             return S_OK;
-        }
-
-        int GetThreadContextById(
-            IntPtr self,
-            uint threadId,
-            uint contextFlags,
-            uint contextSize,
-            IntPtr context)
-        {
-            if (_soshost.DataReader.GetThreadContext(threadId, contextFlags, contextSize, context)) {
-                return S_OK;
-            }
-            return E_FAIL;
         }
 
         int GetValueByName(

--- a/src/SOS/SOS.UnitTests/Scripts/OtherCommands.script
+++ b/src/SOS/SOS.UnitTests/Scripts/OtherCommands.script
@@ -70,7 +70,7 @@ VERIFY:\s*<HEXVAL>\s+<HEXVAL>.*
 COMMAND:threads
 VERIFY:\s*<DECVAL>\s+0x<HEXVAL>\s+\(<DECVAL>\)\s+
 COMMAND:registers
-VERIFY:\s*([r|e]ip|pc) = <HEXVAL>\s+
+VERIFY:\s*([r|e]ip|pc) = 0x<HEXVAL>\s+
 ENDIF:DOTNETDUMP
 
 # Issue: https://github.com/dotnet/diagnostics/issues/503

--- a/src/SOS/SOS.UnitTests/Scripts/WebApp.script
+++ b/src/SOS/SOS.UnitTests/Scripts/WebApp.script
@@ -22,7 +22,7 @@ VERIFY:\s*<HEXVAL>\s+<HEXVAL>.*
 COMMAND:threads
 VERIFY:\s*<DECVAL>\s+0x<HEXVAL>\s+\(<DECVAL>\)\s+
 COMMAND:registers
-VERIFY:\s*([r|e]ip|pc) = <HEXVAL>\s+
+VERIFY:\s*([r|e]ip|pc) = 0x<HEXVAL>\s+
 ENDIF:DOTNETDUMP
 
 # Verify that ClrStack with no options works

--- a/src/Tools/dotnet-dump/Analyzer.cs
+++ b/src/Tools/dotnet-dump/Analyzer.cs
@@ -143,13 +143,13 @@ namespace Microsoft.Diagnostics.Tools.Dump
 
             // Create common analyze context for commands
             var analyzeContext = new AnalyzeContext() {
-                CurrentThreadId = unchecked((int)target.DataReader.EnumerateAllThreads().FirstOrDefault())
+                CurrentThreadId = target.DataReader.EnumerateAllThreads().FirstOrDefault()
             };
             _serviceProvider.AddService(analyzeContext);
 
-            // Add the register, memory, SOSHost and ClrRuntime services
-            var registerService = new RegisterService(target);
-            _serviceProvider.AddService(registerService);
+            // Add the thread, memory, SOSHost and ClrRuntime services
+            var threadService = new ThreadService(target.DataReader);
+            _serviceProvider.AddService<IThreadService>(threadService);
 
             var memoryService = new MemoryService(target.DataReader);
             _serviceProvider.AddService(memoryService);

--- a/src/Tools/dotnet-dump/Commands/RegistersCommand.cs
+++ b/src/Tools/dotnet-dump/Commands/RegistersCommand.cs
@@ -4,60 +4,48 @@
 
 using Microsoft.Diagnostics.DebugServices;
 using Microsoft.Diagnostics.Repl;
-using Microsoft.Diagnostics.Runtime;
-using System;
-using System.Collections.Generic;
-using System.CommandLine;
-using System.Linq;
 
 namespace Microsoft.Diagnostics.Tools.Dump
 {
     [Command(Name = "registers", Help = "Displays the thread's registers.")]
+    [CommandAlias(Name = "r")]
     public class RegistersCommand : CommandBase
     {
         [Argument(Help = "The thread index to display, otherwise use the current thread.")]
         public int? ThreadIndex { get; set; } = null;
 
-        public DataTarget DataTarget { get; set; }
-
         public AnalyzeContext AnalyzeContext { get; set; }
 
-        public RegisterService RegisterService { get; set; }
+        public IThreadService ThreadService { get; set; }
 
         public override void Invoke()
         {
-            IEnumerable<uint> threads = DataTarget.DataReader.EnumerateAllThreads();
             uint threadId;
-
             if (ThreadIndex.HasValue)
             {
-                if (ThreadIndex.Value >= threads.Count()) {
-                    throw new InvalidOperationException($"Invalid thread index {ThreadIndex.Value}");
-                }
-                threadId = threads.ElementAt(ThreadIndex.Value);
+                threadId = ThreadService.GetThreadInfoFromIndex(ThreadIndex.Value).ThreadId;
             }
             else
             {
-                threadId = (uint)AnalyzeContext.CurrentThreadId;
+                threadId = AnalyzeContext.CurrentThreadId.Value;
             }
-
-            foreach (RegisterService.RegisterInfo register in RegisterService.Registers)
+            foreach (RegisterInfo register in ThreadService.Registers)
             {
-                if (RegisterService.GetRegisterValue(threadId, register.RegisterIndex, out ulong value))
+                if (ThreadService.GetRegisterValue(threadId, register.RegisterIndex, out ulong value))
                 {
                     switch (register.RegisterSize)
                     {
                         case 1:
-                            WriteLine("{0} = {1:X1}", register.RegisterName, value);
+                            WriteLine("{0} = 0x{1:X1}", register.RegisterName, value);
                             break;
                         case 2:
-                            WriteLine("{0} = {1:X4}", register.RegisterName, value);
+                            WriteLine("{0} = 0x{1:X4}", register.RegisterName, value);
                             break;
                         case 4:
-                            WriteLine("{0} = {1:X8}", register.RegisterName, value);
+                            WriteLine("{0} = 0x{1:X8}", register.RegisterName, value);
                             break;
                         case 8:
-                            WriteLine("{0} = {1:X16}", register.RegisterName, value);
+                            WriteLine("{0} = 0x{1:X16}", register.RegisterName, value);
                             break;
                     }
                 }

--- a/src/Tools/dotnet-dump/Commands/SOSCommand.cs
+++ b/src/Tools/dotnet-dump/Commands/SOSCommand.cs
@@ -2,11 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.Diagnostics.DebugServices;
 using Microsoft.Diagnostics.Repl;
 using SOS;
 using System;
-using System.CommandLine;
 using System.IO;
 using System.Linq;
 
@@ -28,6 +26,7 @@ namespace Microsoft.Diagnostics.Tools.Dump
     [Command(Name = "dumpmodule",       AliasExpansion = "DumpModule",          Help = "Displays information about a EE module structure at the specified address.")]
     [Command(Name = "dumpmt",           AliasExpansion = "DumpMT",              Help = "Displays information about a method table at the specified address.")]
     [Command(Name = "dumpobj",          AliasExpansion = "DumpObj",             Help = "Displays info about an object at the specified address.")]
+    [CommandAlias(Name = "do")]
     [Command(Name = "dumpvc",           AliasExpansion = "DumpVC",              Help = "Displays info about the fields of a value class.")]
     [Command(Name = "dumpstackobjects", AliasExpansion = "DumpStackObjects",    Help = "Displays all managed objects found within the bounds of the current stack.")]
     [CommandAlias(Name = "dso")]


### PR DESCRIPTION
Renames the RegisterService to ThreadService and adds methods to implement these issues:

https://github.com/dotnet/diagnostics/issues/558 "setthread should support different types of thread ids"
https://github.com/dotnet/diagnostics/issues/559 "Sort threads by thread id"