### PR TITLE
Set dotnet-monitor to Preview 1

### DIFF
--- a/src/Tools/dotnet-monitor/dotnet-monitor.csproj
+++ b/src/Tools/dotnet-monitor/dotnet-monitor.csproj
@@ -13,6 +13,7 @@
     <!-- This forces the creation of a checksum file and uploads it to blob storage
          using this name as part of the blob relative path. -->
     <BlobGroupPrefix>monitor</BlobGroupPrefix>
+    <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Set dotnet-monitor version to preview 1. This is mostly used to allow the dotnet-docker dependency update mechanism to correctly update the dotnet-monitor version in the docker file manifest.