### PR TITLE
Fix up SOS PrintManagedFrameContext

### DIFF
--- a/src/SOS/Strike/exts.h
+++ b/src/SOS/Strike/exts.h
@@ -409,6 +409,7 @@ extern IMachine* g_targetMachine;
 inline BOOL IsDbgTargetX86()    { return g_targetMachine->GetPlatform() == IMAGE_FILE_MACHINE_I386; }
 inline BOOL IsDbgTargetAmd64()  { return g_targetMachine->GetPlatform() == IMAGE_FILE_MACHINE_AMD64; }
 inline BOOL IsDbgTargetArm()    { return g_targetMachine->GetPlatform() == IMAGE_FILE_MACHINE_ARMNT; }
+inline BOOL IsDbgTargetArm64()  { return g_targetMachine->GetPlatform() == IMAGE_FILE_MACHINE_ARM64; }
 inline BOOL IsDbgTargetWin64()  { return IsDbgTargetAmd64(); }
 
 /* Returns the instruction pointer for the given CONTEXT.  We need this and its family of


### PR DESCRIPTION
Choose registers to display at runtime based on actual target

Fixup Arm64 to use the Arm64Context (not the ArmContext)
Fixup Arm64 to display all registers (instead of displaying some multiple times)
Fixup Arm64 formatting to right justify register values in three columns.

Fixes #1245 
Fixes #1246