### PR TITLE
respect --buffersize flag in dotnet-trace

### DIFF
--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                     EventPipeSession session = null;
                     try
                     {
-                        session = diagnosticsClient.StartEventPipeSession(providerCollection, true);
+                        session = diagnosticsClient.StartEventPipeSession(providerCollection, true, (int)buffersize);
                     }
                     catch (DiagnosticsClientException e)
                     {


### PR DESCRIPTION
dotnet-trace was not respecting the --buffersize flag. 