### PR TITLE
Simplify dotnet-trace main loop

### DIFF
--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
@@ -188,8 +188,6 @@ namespace Microsoft.Diagnostics.Tools.Trace
                             if (hasConsole)
                                 rewriter?.RewriteConsoleLine();
 
-                            Console.Error.WriteLine($"Writing to line: {Console.CursorTop}");
-
                             fileInfo.Refresh();
                             Console.Out.WriteLine($"[{stopwatch.Elapsed.ToString(@"dd\:hh\:mm\:ss")}]\tRecording trace {GetSize(fileInfo.Length)}");
                             Console.Out.WriteLine("Press <Enter> or <Ctrl+C> to exit...");
@@ -200,7 +198,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                         while (!shouldExit.WaitOne(100) && !(Console.KeyAvailable && Console.ReadKey(true).Key == ConsoleKey.Enter))
                             printStatus();
 
-                        if (hasConsole)
+                        if (hasConsole && Math.Abs(Console.CursorTop - Console.BufferHeight) == 1)
                             rewriter.LineToClear--;
                         durationTimer?.Stop();
                         rundownRequested = true;

--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
@@ -73,9 +73,6 @@ namespace Microsoft.Diagnostics.Tools.Trace
 
                 bool hasConsole = console.GetTerminal() != null;
 
-                // if (hasConsole)
-                //     Console.Clear();
-
                 if (profile.Length == 0 && providers.Length == 0 && clrevents.Length == 0)
                 {
                     Console.Out.WriteLine("No profile or providers specified, defaulting to trace profile 'cpu-sampling'");
@@ -206,6 +203,8 @@ namespace Microsoft.Diagnostics.Tools.Trace
 
                         await copyTask;
                         timer.Stop();
+                        // May have lost race between timer signalling and stopping,
+                        // so wait to make sure callback doesn't execute while printing the end.
                         await Task.Delay(100);
                     }
                 }

--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
@@ -198,7 +198,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
 
                         // This behavior is different between Console/Terminals on Windows and Mac/Linux
                         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Console.IsOutputRedirected && Math.Abs(Console.CursorTop - Console.BufferHeight) == 1)
-                            rewriter.LineToClear--;
+                            rewriter?.LineToClear--;
                         durationTimer?.Stop();
                         rundownRequested = true;
                         session.Stop();
@@ -209,8 +209,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                         } while (!copyTask.Wait(100));
                     }
 
-                    Console.Out.WriteLine();
-                    Console.Out.WriteLine("Trace completed.");
+                    Console.Out.WriteLine("\nTrace completed.");
 
                     if (format != TraceFileFormat.NetTrace)
                         TraceFileFormatConverter.ConvertToFormat(format, output.FullName);

--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
@@ -193,12 +193,18 @@ namespace Microsoft.Diagnostics.Tools.Trace
                                 Console.Out.WriteLine("Stopping the trace. This may take up to minutes depending on the application being traced.");
                         };
 
-                        while (!shouldExit.WaitOne(100) &&  !(!Console.IsInputRedirected &&Console.KeyAvailable && Console.ReadKey(true).Key == ConsoleKey.Enter))
+                        while (!shouldExit.WaitOne(100) &&  !(!Console.IsInputRedirected && Console.KeyAvailable && Console.ReadKey(true).Key == ConsoleKey.Enter))
                             printStatus();
 
-                        // This behavior is different between Console/Terminals on Windows and Mac/Linux
-                        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Console.IsOutputRedirected && Math.Abs(Console.CursorTop - Console.BufferHeight) == 1)
-                            rewriter?.LineToClear--;
+                        // Behavior concerning Enter moving text in the terminal buffer when at the bottom of the buffer
+                        // is different between Console/Terminals on Windows and Mac/Linux
+                        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && 
+                            !Console.IsOutputRedirected && 
+                            rewriter != null && 
+                            Math.Abs(Console.CursorTop - Console.BufferHeight) == 1)
+                        {
+                            rewriter.LineToClear--;
+                        }
                         durationTimer?.Stop();
                         rundownRequested = true;
                         session.Stop();

--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
@@ -174,9 +174,9 @@ namespace Microsoft.Diagnostics.Tools.Trace
 
                         Task copyTask = session.EventStream.CopyToAsync(fs);
                         lineToClear = Console.CursorTop - 1;
-                        Action printStatus = () =>
+                        Action timerCallback = () =>
                         {
-                            if (shouldExit.WaitOne(0) || (Console.KeyAvailable && Console.ReadKey(true).Key == ConsoleKey.Enter))
+                            if (!rundownRequested && (shouldExit.WaitOne(0) || (Console.KeyAvailable && Console.ReadKey(true).Key == ConsoleKey.Enter)))
                             {
                                 durationTimer?.Stop();
                                 rundownRequested = true;
@@ -197,8 +197,9 @@ namespace Microsoft.Diagnostics.Tools.Trace
                                 Console.Out.WriteLine("Stopping the trace. This may take up to minutes depending on the application being traced.");
                             }
                         };
+
                         System.Timers.Timer timer = new System.Timers.Timer(100);
-                        timer.Elapsed += (s,e) => printStatus();
+                        timer.Elapsed += (s,e) => timerCallback();
                         timer.Start();
 
                         await copyTask;

--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
@@ -13,6 +13,7 @@ using System.CommandLine.Rendering;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -171,7 +172,6 @@ namespace Microsoft.Diagnostics.Tools.Trace
                         Console.Out.WriteLine($"Output File    : {fs.Name}");
                         if (shouldStopAfterDuration)
                             Console.Out.WriteLine($"Trace Duration : {duration.ToString(@"dd\:hh\:mm\:ss")}");
-
                         Console.Out.WriteLine("\n\n");
 
                         var fileInfo = new FileInfo(output.FullName);
@@ -198,7 +198,8 @@ namespace Microsoft.Diagnostics.Tools.Trace
                         while (!shouldExit.WaitOne(100) && !(Console.KeyAvailable && Console.ReadKey(true).Key == ConsoleKey.Enter))
                             printStatus();
 
-                        if (hasConsole && Math.Abs(Console.CursorTop - Console.BufferHeight) == 1)
+                        // This behavior is different between Console/Terminals on Windows and Mac/Linux
+                        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && hasConsole && Math.Abs(Console.CursorTop - Console.BufferHeight) == 1)
                             rewriter.LineToClear--;
                         durationTimer?.Stop();
                         rundownRequested = true;


### PR DESCRIPTION
* Uses `Stream.CopyToAsync` instead of manually copying bytes using `Stream.Read` and `Stream.Write`
* Simplifies try/catch blocks
* Improves rendering of console text due to ordering of the new loop
* Removes need for polling in the UI thread, which greatly simplifies code
* Removes the console clear since the rendering is cleaner now 
* removes `hasConsole` to allow for redirection of input and output