### PR TITLE
Change blob item category to uppercase.

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -34,7 +34,8 @@
     <ItemGroup>
       <_PackageArtifactData Include="@(_CommonArtifactData)" />
       <!-- Setting Category to Other will upload to installers blob feed. -->
-      <_PackageArtifactData Include="Category=Other" />
+      <!-- Feed configuration categories are uppercase and case sensitive in PublishArtifactsInManifest task. -->
+      <_PackageArtifactData Include="Category=OTHER" />
     </ItemGroup>
 
     <!-- Capture each blob item to upload to blob feed -->


### PR DESCRIPTION
Publish Assets pipeline step failed to upload the dotnet-monitor nupkg file to the other category feed because the categories are put into a case sensitive dictionary as uppercased keys (see https://github.com/dotnet/arcade/blob/74b625183ecd38826808b62118bafa22b2daf182/src/Microsoft.DotNet.Build.Tasks.Feed/src/PublishArtifactsInManifest.cs#L437). Fixing it here to specify the Other category as uppercase.