### PR TITLE
Fill ThreadPool command data from portable thread pool info when enabled

### DIFF
--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -8643,7 +8643,7 @@ DECLARE_API(ThreadPool)
         CLRDATA_ADDRESS cdaTpMethodTable;
         {
             TADDR tpMethodTableAddr = NULL;
-            if (FAILED(GetMTOfObject(cdaTpInstance, &tpMethodTableAddr)))
+            if (FAILED(GetMTOfObject(TO_TADDR(cdaTpInstance), &tpMethodTableAddr)))
             {
                 break;
             }
@@ -8728,13 +8728,13 @@ DECLARE_API(ThreadPool)
             threadpool.HillClimbingLogSize = 0;
 
             // Get the hill climbing instance
-            if (FAILED(Status =
-                GetNonSharedStaticFieldValueFromName(
-                    &ui64Value,
-                    corelibModule,
-                    "System.Threading.PortableThreadPool+HillClimbing",
-                    W("ThreadPoolHillClimber"),
-                    ELEMENT_TYPE_CLASS)) ||
+            if (FAILED(
+                    GetNonSharedStaticFieldValueFromName(
+                        &ui64Value,
+                        corelibModule,
+                        "System.Threading.PortableThreadPool+HillClimbing",
+                        W("ThreadPoolHillClimber"),
+                        ELEMENT_TYPE_CLASS)) ||
                 ui64Value == 0)
             {
                 // The type was not loaded yet, or the static field was not found, etc. For now assume that the hill climber has
@@ -8747,7 +8747,7 @@ DECLARE_API(ThreadPool)
             CLRDATA_ADDRESS cdaTpHcMethodTable;
             {
                 TADDR tpHcMethodTableAddr = NULL;
-                if (FAILED(GetMTOfObject(cdaTpHcInstance, &tpHcMethodTableAddr)))
+                if (FAILED(GetMTOfObject(TO_TADDR(cdaTpHcInstance), &tpHcMethodTableAddr)))
                 {
                     ExtOut("    %s\n", "Failed to get method table for PortableThreadPool.HillClimbing");
                     break;

--- a/src/SOS/Strike/util.cpp
+++ b/src/SOS/Strike/util.cpp
@@ -1068,6 +1068,125 @@ void DisplayFields(CLRDATA_ADDRESS cdaMT, DacpMethodTableData *pMTD, DacpMethodT
     return;
 }
 
+HRESULT GetNonSharedStaticFieldValueFromName(
+    UINT64* pValue,
+    DWORD_PTR moduleAddr,
+    const char *typeName,
+    __in_z LPCWSTR wszFieldName,
+    CorElementType fieldType)
+{
+    HRESULT hr = S_OK;
+
+    mdTypeDef mdType = 0;
+    GetInfoFromName(moduleAddr, typeName, &mdType);
+    if (mdType == 0)
+    {
+        return E_FAIL; // Failed to find type token
+    }
+
+    CLRDATA_ADDRESS cdaMethodTable = 0;
+    if (FAILED(hr = g_sos->GetMethodDescFromToken(moduleAddr, mdType, &cdaMethodTable)) ||
+        !IsValidToken(moduleAddr, mdType) ||
+        cdaMethodTable == 0)
+    {
+        return FAILED(hr) ? hr : E_FAIL; // Invalid type token or type is not loaded yet
+    }
+
+    DacpMethodTableData vMethodTable;
+    if ((hr = vMethodTable.Request(g_sos, cdaMethodTable)) != S_OK)
+    {
+        return FAILED(hr) ? hr : E_FAIL; // Failed to get method table data
+    }
+    if (vMethodTable.bIsShared)
+    {
+        ExtOut("    %s: %s\n", "Method table is shared (not implemented)", typeName);
+        return E_NOTIMPL;
+    }
+
+    DacpMethodTableFieldData vMethodTableFields;
+    if (FAILED(hr = vMethodTableFields.Request(g_sos, cdaMethodTable)))
+    {
+        return hr; // Failed to get field data
+    }
+
+    DacpModuleData vModule;
+    if ((hr = vModule.Request(g_sos, vMethodTable.Module)) != S_OK)
+    {
+        return FAILED(hr) ? hr : E_FAIL; // Failed to get module data
+    }
+
+    DacpDomainLocalModuleData vDomainLocalModule;
+    if ((hr = g_sos->GetDomainLocalModuleDataFromModule(vMethodTable.Module, &vDomainLocalModule)) != S_OK)
+    {
+        return FAILED(hr) ? hr : E_FAIL; // Failed to get domain local module data
+    }
+
+    ToRelease<IMetaDataImport> pImport = MDImportForModule(&vModule);
+    CLRDATA_ADDRESS cdaField = vMethodTableFields.FirstField;
+    DacpFieldDescData vFieldDesc;
+    bool found = false;
+    for (DWORD staticFieldIndex = 0; staticFieldIndex < vMethodTableFields.wNumStaticFields; )
+    {
+        if ((hr = vFieldDesc.Request(g_sos, cdaField)) != S_OK || vFieldDesc.Type >= ELEMENT_TYPE_MAX)
+        {
+            return FAILED(hr) ? hr : E_FAIL; // Failed to get member field desc
+        }
+        cdaField = vFieldDesc.NextField;
+
+        if (!vFieldDesc.bIsStatic)
+        {
+            continue;
+        }
+
+        ++staticFieldIndex;
+
+        if (vFieldDesc.Type != fieldType)
+        {
+            continue;
+        }
+
+        if (FAILED(hr = NameForToken_s(TokenFromRid(vFieldDesc.mb, mdtFieldDef), pImport, g_mdName, mdNameLen, false)))
+        {
+            return hr; // Failed to get member field name
+        }
+
+        if (_wcscmp(g_mdName, wszFieldName) != 0)
+        {
+            continue;
+        }
+
+        if (vFieldDesc.bIsThreadLocal || vFieldDesc.bIsContextLocal)
+        {
+            ExtOut("    %s: %s.%S\n", "Static field is thread-local or context-local (not implemented)", typeName, wszFieldName);
+            return E_NOTIMPL;
+        }
+
+        found = true;
+        break;
+    }
+
+    if (!found)
+    {
+        return E_FAIL; // Static field not found
+    }
+
+    DWORD_PTR pValueAddr = 0;
+    GetStaticFieldPTR(&pValueAddr, &vDomainLocalModule, &vMethodTable, &vFieldDesc);
+    if (pValueAddr == 0)
+    {
+        return E_FAIL; // Failed to get static field address
+    }
+
+    UINT64 value = 0;
+    if (FAILED(MOVEBLOCK(value, pValueAddr, gElementTypeInfo[fieldType])))
+    {
+        return E_FAIL; // Failed to read static field
+    }
+
+    *pValue = value;
+    return S_OK;
+}
+
 // Return value: -1 = error, 
 //                0 = field not found, 
 //              > 0 = offset to field from objAddr

--- a/src/SOS/Strike/util.h
+++ b/src/SOS/Strike/util.h
@@ -1604,9 +1604,10 @@ void IP2MethodDesc (DWORD_PTR IP, DWORD_PTR &methodDesc, JITTypes &jitType,
 const char *ElementTypeName (unsigned type);
 void DisplayFields (CLRDATA_ADDRESS cdaMT, DacpMethodTableData *pMTD, DacpMethodTableFieldData *pMTFD,
                     DWORD_PTR dwStartAddr = 0, BOOL bFirst=TRUE, BOOL bValueClass=FALSE);
+HRESULT GetNonSharedStaticFieldValueFromName(UINT64* pValue, DWORD_PTR moduleAddr, const char *typeName, __in_z LPCWSTR wszFieldName, CorElementType fieldType);
 int GetObjFieldOffset(CLRDATA_ADDRESS cdaObj, __in_z LPCWSTR wszFieldName, BOOL bFirst=TRUE);
 int GetObjFieldOffset(CLRDATA_ADDRESS cdaObj, CLRDATA_ADDRESS cdaMT, __in_z LPCWSTR wszFieldName, BOOL bFirst=TRUE, DacpFieldDescData* pDacpFieldDescData=NULL);
-int GetValueFieldOffset(CLRDATA_ADDRESS cdaMT, __in_z LPCWSTR wszFieldName, DacpFieldDescData* pDacpFieldDescData);
+int GetValueFieldOffset(CLRDATA_ADDRESS cdaMT, __in_z LPCWSTR wszFieldName, DacpFieldDescData* pDacpFieldDescData=NULL);
 
 BOOL IsValidToken(DWORD_PTR ModuleAddr, mdTypeDef mb);
 void NameForToken_s(DacpModuleData *pModule, mdTypeDef mb, __out_ecount (capacity_mdName) WCHAR *mdName, size_t capacity_mdName,


### PR DESCRIPTION
Related to and depends on https://github.com/dotnet/runtime/pull/38225

When the managed portable thread pool is enabled:
- Made the `ThreadPool` command work as expected, including `ThreadPool -ti` to show in-memory hill climbing thread adjustment history
- After the command queries the native side for info, it looks for a couple of static variables to determine if the portable thread pool is available and enabled
- If it's enabled, it collects equivalent information from the managed side
- Verified that the command works with and without the changes in https://github.com/dotnet/runtime/pull/38225, and with the changes in both modes (portable thread pool enabled and disabled)