### PR TITLE
Handle 32-bit CLRDATA_ADDRESS semantics in ReadMemory

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -36,7 +36,7 @@
     <MicrosoftAspNetCoreResponseCompressionVersion>2.1.1</MicrosoftAspNetCoreResponseCompressionVersion>
     <MicrosoftBclHashCodeVersion>1.1.0</MicrosoftBclHashCodeVersion>
     <MicrosoftBclAsyncInterfacesVersion>1.1.0</MicrosoftBclAsyncInterfacesVersion>
-    <MicrosoftDiagnosticsRuntimeVersion>1.1.127808</MicrosoftDiagnosticsRuntimeVersion>
+    <MicrosoftDiagnosticsRuntimeVersion>1.1.132302</MicrosoftDiagnosticsRuntimeVersion>
     <MicrosoftDiaSymReaderNativePackageVersion>1.7.0</MicrosoftDiaSymReaderNativePackageVersion>
     <MicrosoftDiagnosticsTracingTraceEventVersion>2.0.51</MicrosoftDiagnosticsTracingTraceEventVersion>
     <MicrosoftExtensionsConfigurationJsonVersion>2.1.1</MicrosoftExtensionsConfigurationJsonVersion>

--- a/src/Microsoft.Diagnostics.DebugServices/MemoryService.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/MemoryService.cs
@@ -80,15 +80,6 @@ namespace Microsoft.Diagnostics.DebugServices
                 fixed (byte* ptr = buffer)
                 {
                     result = _dataReader.ReadMemory(address, new IntPtr(ptr), bytesRequested, out bytesRead);
-
-                    if (!result && (_dataReader.GetPointerSize() == 4) && ((address & 0x80000000) != 0))
-                    {
-                        // dataReader should expect sign extended pointers from 32-bit processes.
-                        // However this is currently not true at least for ELF Core dumps.
-                        // Work around the issue by retrying the memory read with non-sign extended address.
-                        // Consider removing when microsoft/clrmd#774 is fixed
-                        result = _dataReader.ReadMemory(address & 0xffffffff, new IntPtr(ptr), bytesRequested, out bytesRead);
-                    }
                 }
             }
             // If the read failed or a successful partial read


### PR DESCRIPTION
This is at least an interim fix until microsoft/clrmd#774 is fixed.

/cc @leculver @hoyosjs