### PR TITLE
Use 24 Hour Time in Default Output Format

### DIFF
--- a/src/Tools/dotnet-gcdump/CommandLine/CollectCommandHandler.cs
+++ b/src/Tools/dotnet-gcdump/CommandLine/CollectCommandHandler.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Diagnostics.Tools.GCDump
                 }
                 
                 output = string.IsNullOrEmpty(output)
-                    ? $"{DateTime.Now:yyyyMMdd\\_hhmmss}_{processId}.gcdump"
+                    ? $"{DateTime.Now:yyyyMMdd\\_HHmmss}_{processId}.gcdump"
                     : output;
 
                 FileInfo outputFileInfo = new FileInfo(output);


### PR DESCRIPTION
This ensures that collection taken in the afternoon are sorted after
those taken in the morning.