### PR TITLE
Handle 32-bit CLRDATA_ADDRESS semantics in ReadMemory (#1280)

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -37,7 +37,7 @@
     <MicrosoftAspNetCoreHttpsPolicyVersion>2.1.1</MicrosoftAspNetCoreHttpsPolicyVersion>
     <MicrosoftAspNetCoreMvcVersion>2.1.3</MicrosoftAspNetCoreMvcVersion>
     <MicrosoftAspNetCoreResponseCompressionVersion>2.1.1</MicrosoftAspNetCoreResponseCompressionVersion>
-    <MicrosoftDiagnosticsRuntimeVersion>1.1.122004</MicrosoftDiagnosticsRuntimeVersion>
+    <MicrosoftDiagnosticsRuntimeVersion>1.1.132302</MicrosoftDiagnosticsRuntimeVersion>
     <MicrosoftDiaSymReaderNativePackageVersion>1.7.0</MicrosoftDiaSymReaderNativePackageVersion>
     <MicrosoftDiagnosticsTracingTraceEventVersion>2.0.51</MicrosoftDiagnosticsTracingTraceEventVersion>
     <MicrosoftExtensionsConfigurationJsonVersion>3.1.2</MicrosoftExtensionsConfigurationJsonVersion>

--- a/src/Microsoft.Diagnostics.DebugServices/MemoryService.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/MemoryService.cs
@@ -108,10 +108,13 @@ namespace Microsoft.Diagnostics.DebugServices
         /// <returns>bytes read or null if error</returns>
         private byte[] ReadMemoryFromModule(ulong address, int bytesRequested)
         {
+            ulong ignoreAddressBitsMask = _dataReader.GetPointerSize() == 4 ? 0xffffffff00000000 : 0;
+            address = address & ~ignoreAddressBitsMask;
+
             // Check if there is a module that contains the address range being read and map it into the virtual address space.
             foreach (ModuleInfo module in _dataReader.EnumerateModules())
             {
-                ulong start = module.ImageBase;
+                ulong start = module.ImageBase & ~ignoreAddressBitsMask;
                 ulong end = start + module.FileSize;
                 if (address >= start && address < end)
                 {


### PR DESCRIPTION
* Handle 32-bit CLRDATA_ADDRESS semantics in ReadMemory

* Use clrMD 1.1.132302