### PR TITLE
Fix Windows x86 dumpheap

### DIFF
--- a/src/SOS/SOS.UnitTests/SOS.cs
+++ b/src/SOS/SOS.UnitTests/SOS.cs
@@ -106,15 +106,6 @@ public class SOS
         }
     }
 
-    private static void SkipForIssue1289(TestConfiguration config)
-    {
-        // https://github.com/dotnet/diagnostics/issues/1289
-        if (config.IsNETCore && config.RuntimeFrameworkVersionMajor == 5 && config.TargetArchitecture == "x86")
-        {
-            throw new SkipTestException("DumpHeap command output does not contain 'Statistics' on .NET 5.0 x86.");
-        }
-    }
-
     [SkippableTheory, MemberData(nameof(Configurations))]
     public async Task DivZero(TestConfiguration config)
     {
@@ -124,8 +115,6 @@ public class SOS
     [SkippableTheory, MemberData(nameof(Configurations))]
     public async Task GCTests(TestConfiguration config)
     {
-        SkipForIssue1289(config);
-
         SkipIfArm(config);
 
         // Live only
@@ -193,8 +182,6 @@ public class SOS
     [SkippableTheory, MemberData(nameof(Configurations))]
     public async Task OtherCommands(TestConfiguration config)
     {
-        SkipForIssue1289(config);
-
         // This debuggee needs the directory of the exes/dlls to load the SymbolTestDll assembly.
         await RunTest("OtherCommands.script", information: new SOSRunner.TestInformation {
             TestConfiguration = config,
@@ -233,8 +220,6 @@ public class SOS
     [SkippableTheory, MemberData(nameof(GetConfigurations), "TestName", "SOS.WebApp3")]
     public async Task WebApp3(TestConfiguration config)
     {
-        SkipForIssue1289(config);
-
         await RunTest("WebApp.script", testLive: false, information: new SOSRunner.TestInformation {
             TestConfiguration = config,
             DebuggeeName = "WebApp3",
@@ -246,8 +231,6 @@ public class SOS
     [SkippableTheory, MemberData(nameof(GetConfigurations), "TestName", "SOS.DualRuntimes")]
     public async Task DualRuntimes(TestConfiguration config)
     {
-        SkipForIssue1289(config);
-
         // The assembly path, class and function name of the desktop test code to load/run
         string desktopTestParameters = TestConfiguration.MakeCanonicalPath(config.GetValue("DesktopTestParameters"));
         if (string.IsNullOrEmpty(desktopTestParameters))

--- a/src/SOS/Strike/sos.cpp
+++ b/src/SOS/Strike/sos.cpp
@@ -733,7 +733,7 @@ namespace sos
     void ObjectIterator::MoveToNextObject()
     {
         // Object::GetSize can be unaligned, so we must align it ourselves.
-        size_t size = (bLarge ? AlignLarge(mCurrObj.GetSize()) : Align(mCurrObj.GetSize()));
+        size_t size = (bLarge || bPinned) ? AlignLarge(mCurrObj.GetSize()) : Align(mCurrObj.GetSize());
 
         mLastObj = mCurrObj;
         mCurrObj = mCurrObj.GetAddress() + size;


### PR DESCRIPTION
Re-enable GC tests for Windows x86 disabled in https://github.com/dotnet/diagnostics/issues/1289