### PR TITLE
Update DacCompareNativeTypes

### DIFF
--- a/src/tests/DacCompareNativeTypes/DwarfParse.cs
+++ b/src/tests/DacCompareNativeTypes/DwarfParse.cs
@@ -16,15 +16,15 @@ using static ParserExtensions;
 #nullable enable
 class DwarfParser
 {
-    static Regex typeNameRegEx = new Regex(@"^<(?<nesting>\d+)><.*GOFF=0x(?<goff>[0-9a-fA-F]+)><DW_TAG_((class_type)|(structure_type)|(union_type)|(typedef))>(.*DW_AT_name<\u0022(?<name>.+?)\u0022>)?");
-    // <1><0x9ad2 GOFF=0x1e17b22><DW_TAG_structure_type> DW_AT_name<"STORAGESIGNATURE"> DW_AT_byte_size<0x00000010> DW_AT_decl_file<0x00000014 /home/stmaclea/git/runtime/src/coreclr/src/md/inc/mdfileformat.h> DW_AT_decl_line<0x0000003f>
-    static Regex typeRegEx = new Regex(@"^<(?<nesting>\d+)><.*GOFF=0x(?<goff>[0-9a-fA-F]+)><DW_TAG_((class)|(structure)|(union))_type>(.*DW_AT_name<\u0022(?<name>.+?)\u0022>)?.*?DW_AT_decl_file");
+    static Regex typeNameRegEx = new Regex(@"^<(?<nesting>\d+)><.*GOFF=0x(?<goff>[0-9a-fA-F]+)><DW_TAG_((class_type)|(structure_type)|(union_type)|(typedef))>(.*DW_AT_name<(?<name>[^<>]*(((?'Open'<)[^<>]*)+((?'Close-Open'>)[^<>]*)+)*(?(Open)(?!)))>)?");
+    // <1><0x9ad2 GOFF=0x1e17b22><DW_TAG_structure_type> DW_AT_name<STORAGESIGNATURE> DW_AT_byte_size<0x00000010> DW_AT_decl_file<0x00000014 /home/stmaclea/git/runtime/src/coreclr/src/md/inc/mdfileformat.h> DW_AT_decl_line<0x0000003f>
+    static Regex typeRegEx = new Regex(@"^<(?<nesting>\d+)><.*GOFF=0x(?<goff>[0-9a-fA-F]+)><DW_TAG_((class)|(structure)|(union))_type>(.*DW_AT_name<(?<name>[^<>]*(((?'Open'<)[^<>]*)+((?'Close-Open'>)[^<>]*)+)*(?(Open)(?!)))>)?.*?DW_AT_decl_file");
 
-    // <2><0x4d GOFF=0x1b5a><DW_TAG_member> DW_AT_name<"Data1"> DW_AT_type<<0x00000082 GOFF=0x00001b8f>> DW_AT_decl_file<0x00000001 /home/stmaclea/git/runtime/src/coreclr/src/pal/inc/pal_mstypes.h> DW_AT_decl_line<0x000002ac> DW_AT_data_member_location<0>
-    static Regex memberRegEx = new Regex(@"^<(?<nesting>\d+)><.*GOFF=0x(?<goff>[0-9a-fA-F]+)><DW_TAG_member>.*.*?DW_AT_data_member_location<(?<offset>\d+)([(][^)]*[)])?>");
+    // <2><0x4d GOFF=0x1b5a><DW_TAG_member> DW_AT_name<Data1> DW_AT_type<<0x00000082 GOFF=0x00001b8f>> DW_AT_decl_file<0x00000001 /home/stmaclea/git/runtime/src/coreclr/src/pal/inc/pal_mstypes.h> DW_AT_decl_line<0x000002ac> DW_AT_data_member_location<0>
+    static Regex memberRegEx = new Regex(@"^<(?<nesting>\d+)><.*GOFF=0x(?<goff>[0-9a-fA-F]+)><DW_TAG_member>.*.*?DW_AT_data_member_location<(?<offset>\d+) *([(][^)]*[)])?>");
 
-    // DW_AT_name<"Data1">
-    static Regex nameRegEx = new Regex(@"DW_AT_name<\u0022(?<name>.+?)\u0022>");
+    // DW_AT_name<Data1>
+    static Regex nameRegEx = new Regex(@"DW_AT_name<(?<name>[^<>]*(((?'Open'<)[^<>]*)+((?'Close-Open'>)[^<>]*)+)*(?(Open)(?!)))>");
 
     // DW_AT_type<<0x00000082 GOFF=0x00001b8f>>
     static Regex typeRefRegEx = new Regex(@"DW_AT_type<<[^>]*GOFF=0x(?<goff>[0-9a-fA-F]+)>>");


### PR DESCRIPTION
Adjust Regex expressions to match dwarfdump in Ubuntu 20.04.
Latest version of dwarfdump dropped quotation marks off tyoe names.
Remove unicode quotes from expression. Use closing group syntax to
match opening '<' to closing '>'.

Extend ignore list for libunwind types. CrossOS DAC is using a different version
of libunwind (1.5+) than the Linux DAC (1.3).  Also add dbi's Target_CLiteWeightStgdbRW

Add stats output to Main()

Add return exit code to Main()