### PR TITLE
Fix performance issue with gcroot

### DIFF
--- a/src/SOS/Strike/gcroot.cpp
+++ b/src/SOS/Strike/gcroot.cpp
@@ -178,7 +178,7 @@ GCRootImpl::RootNode *GCRootImpl::NewNode(TADDR obj, MTInfo *mtInfo, bool fromDe
     // nodes unless we have to.  Instead we keep a stl list with free nodes to use.
     RootNode *toReturn = NULL;
 
-    if (mRootNewList.size())
+    if (!mRootNewList.empty())
     {
         toReturn = mRootNewList.back();
         mRootNewList.pop_back();


### PR DESCRIPTION
The std::List<t>::size() method was not guaranteed to be linear complexity
until C++11.  Apparently the Centos Containers we are using to build the
diagnostic repo do not have C+11 compliant StdLib headers installed.

Fixes #633