### PR TITLE
Add proper error type to /logs call. This produces a clear json error…

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/Controllers/DiagController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/Controllers/DiagController.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
     {
         private const TraceProfile DefaultTraceProfiles = TraceProfile.Cpu | TraceProfile.Http | TraceProfile.Metrics;
         private const string ContentTypeNdJson = "application/x-ndjson";
+        private const string ContentTypeJson = "application/json";
         private const string ContentTypeEventStream = "text/event-stream";
         private static readonly MediaTypeHeaderValue NdJsonHeader = new MediaTypeHeaderValue(ContentTypeNdJson);
         private static readonly MediaTypeHeaderValue EventStreamHeader = new MediaTypeHeaderValue(ContentTypeEventStream);
@@ -157,7 +158,7 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
         }
 
         [HttpGet("logs/{pid?}")]
-        [Produces(ContentTypeEventStream, ContentTypeNdJson)]
+        [Produces(ContentTypeEventStream, ContentTypeNdJson, ContentTypeJson)]
         public ActionResult Logs(int? pid, [FromQuery][Range(-1, int.MaxValue)] int durationSeconds = 30, [FromQuery] LogLevel level = LogLevel.Debug)
         {
             TimeSpan duration = ConvertSecondsToTimeSpan(durationSeconds);


### PR DESCRIPTION
… when the pid is ambiguos, instead of a 406 response.