### PR TITLE
Add check for the breaking change version with the new ISOSDacInterface9 interface

### DIFF
--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -2913,6 +2913,9 @@ DECLARE_API(PrintException)
     {
         return Status;
     }
+
+    CheckBreakingRuntimeChange();
+
     if (bLineNumbers)
     {
         ULONG symlines = 0;
@@ -7083,6 +7086,8 @@ DECLARE_API(Threads)
 
             if (bSupported)
             {
+                CheckBreakingRuntimeChange();
+
                 HRESULT Status2 = PrintSpecialThreads();
                 if (!SUCCEEDED(Status2))
                     Status = Status2;
@@ -10058,6 +10063,8 @@ DECLARE_API(DumpLog)
         ExtErr("DumpLog not supported on desktop runtime\n");
         return E_FAIL;
     }
+
+    CheckBreakingRuntimeChange();
 
     const char* fileName = "StressLog.txt";
     CLRDATA_ADDRESS StressLogAddress = NULL;

--- a/src/SOS/Strike/util.h
+++ b/src/SOS/Strike/util.h
@@ -1754,6 +1754,7 @@ bool IsRuntimeVersion(DWORD major);
 bool IsRuntimeVersion(VS_FIXEDFILEINFO& fileInfo, DWORD major);
 bool IsRuntimeVersionAtLeast(DWORD major);
 bool IsRuntimeVersionAtLeast(VS_FIXEDFILEINFO& fileInfo, DWORD major);
+bool CheckBreakingRuntimeChange(int* pVersion = nullptr);
 #ifndef FEATURE_PAL
 BOOL IsRetailBuild (size_t base);
 BOOL GetSOSVersion(VS_FIXEDFILEINFO *pFileInfo);

--- a/src/inc/sospriv.idl
+++ b/src/inc/sospriv.idl
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 /*****************************************************************************
  **                                                                         **
  ** sospriv.idl - The private interface that SOS uses to query the runtime  **
@@ -409,4 +408,19 @@ interface ISOSDacInterface8 : IUnknown
     HRESULT GetFinalizationFillPointersSvr(CLRDATA_ADDRESS heapAddr, unsigned int cFillPointers, CLRDATA_ADDRESS *pFinalizationFillPointers, unsigned int *pNeeded);
 
     HRESULT GetAssemblyLoadContext(CLRDATA_ADDRESS methodTable, CLRDATA_ADDRESS* assemblyLoadContext);
+}
+
+// Increment anytime there is a change in the data structures that SOS depends on like
+// stress log structs (StressMsg, StressLogChunck, ThreadStressLog, etc), exception
+// stack traces (StackTraceElement), the PredefinedTlsSlots enums, etc.
+cpp_quote("#define SOS_BREAKING_CHANGE_VERSION 1")
+
+[
+    object,
+    local,
+    uuid(4eca42d8-7e7b-4c8a-a116-7bfbf6929267)
+]
+interface ISOSDacInterface9 : IUnknown
+{
+    HRESULT GetBreakingChangeVersion(int* pVersion);
 }

--- a/src/pal/prebuilt/idl/sospriv_i.cpp
+++ b/src/pal/prebuilt/idl/sospriv_i.cpp
@@ -5,11 +5,11 @@
 /* link this file in with the server and any clients */
 
 
- /* File created by MIDL compiler version 8.00.0613 */
+ /* File created by MIDL compiler version 8.01.0622 */
 /* at Mon Jan 18 19:14:07 2038
  */
-/* Compiler settings for C:/ssd/coreclr/src/inc/sospriv.idl:
-    Oicf, W1, Zp8, env=Win32 (32b run), target_arch=X86 8.00.0613 
+/* Compiler settings for C:/ssd/runtime/src/coreclr/src/inc/sospriv.idl:
+    Oicf, W1, Zp8, env=Win32 (32b run), target_arch=X86 8.01.0622 
     protocol : dce , ms_ext, c_ext, robust
     error checks: allocation ref bounds_check enum stub_data 
     VC __declspec() decoration level: 
@@ -20,12 +20,14 @@
 
 #pragma warning( disable: 4049 )  /* more than 64k source lines */
 
-#include <rpc.h>
-#include <rpcndr.h>
 
 #ifdef __cplusplus
 extern "C"{
 #endif 
+
+
+#include <rpc.h>
+#include <rpcndr.h>
 
 #ifdef _MIDL_USE_GUIDDEF_
 
@@ -61,9 +63,9 @@ typedef IID CLSID;
 #endif // CLSID_DEFINED
 
 #define MIDL_DEFINE_GUID(type,name,l,w1,w2,b1,b2,b3,b4,b5,b6,b7,b8) \
-        const type name = {l,w1,w2,{b1,b2,b3,b4,b5,b6,b7,b8}}
+        EXTERN_C __declspec(selectany) const type name = {l,w1,w2,{b1,b2,b3,b4,b5,b6,b7,b8}}
 
-#endif !_MIDL_USE_GUIDDEF_
+#endif // !_MIDL_USE_GUIDDEF_
 
 MIDL_DEFINE_GUID(IID, IID_ISOSEnum,0x286CA186,0xE763,0x4F61,0x97,0x60,0x48,0x7D,0x43,0xAE,0x43,0x41);
 
@@ -92,7 +94,7 @@ MIDL_DEFINE_GUID(IID, IID_ISOSDacInterface4,0x74B9D34C,0xA612,0x4B07,0x93,0xDD,0
 MIDL_DEFINE_GUID(IID, IID_ISOSDacInterface5,0x127d6abe,0x6c86,0x4e48,0x8e,0x7b,0x22,0x07,0x81,0xc5,0x81,0x01);
 
 
-MIDL_DEFINE_GUID(IID, IID_ISOSDacInterface6,0x11206399,0x4b66,0x4edb,0x98,0xea,0x85,0x65,0x4e,0x59,0xad,0x45);
+MIDL_DEFINE_GUID(IID, IID_ISOSDacInterface6,0x11206399,0x4B66,0x4EDB,0x98,0xEA,0x85,0x65,0x4E,0x59,0xAD,0x45);
 
 
 MIDL_DEFINE_GUID(IID, IID_ISOSDacInterface7,0xc1020dde,0xfe98,0x4536,0xa5,0x3b,0xf3,0x5a,0x74,0xc3,0x27,0xeb);
@@ -100,6 +102,8 @@ MIDL_DEFINE_GUID(IID, IID_ISOSDacInterface7,0xc1020dde,0xfe98,0x4536,0xa5,0x3b,0
 
 MIDL_DEFINE_GUID(IID, IID_ISOSDacInterface8,0xc12f35a9,0xe55c,0x4520,0xa8,0x94,0xb3,0xdc,0x51,0x65,0xdf,0xce);
 
+
+MIDL_DEFINE_GUID(IID, IID_ISOSDacInterface9,0x4eca42d8,0x7e7b,0x4c8a,0xa1,0x16,0x7b,0xfb,0xf6,0x92,0x92,0x67);
 
 #undef MIDL_DEFINE_GUID
 

--- a/src/pal/prebuilt/inc/sospriv.h
+++ b/src/pal/prebuilt/inc/sospriv.h
@@ -1289,7 +1289,7 @@ EXTERN_C const IID IID_ISOSDacInterface;
             ISOSDacInterface * This,
             CLRDATA_ADDRESS ip,
             unsigned int count,
-            unsigned char *name,
+            char *name,
             unsigned int *pNeeded);
 
         HRESULT ( STDMETHODCALLTYPE *GetJumpThunkTarget )(
@@ -2550,7 +2550,7 @@ EXTERN_C const IID IID_ISOSDacInterface8;
 
         virtual HRESULT STDMETHODCALLTYPE GetAssemblyLoadContext(
             CLRDATA_ADDRESS methodTable,
-            CLRDATA_ADDRESS *assemblyLoadContext) = 0;
+            CLRDATA_ADDRESS* assemblyLoadContext) = 0;
     };
 
 
@@ -2606,7 +2606,7 @@ EXTERN_C const IID IID_ISOSDacInterface8;
             ISOSDacInterface8 * This,
             CLRDATA_ADDRESS methodTable,
             CLRDATA_ADDRESS *assemblyLoadContext);
-
+           
         END_INTERFACE
     } ISOSDacInterface8Vtbl;
 
@@ -2614,7 +2614,6 @@ EXTERN_C const IID IID_ISOSDacInterface8;
     {
         CONST_VTBL struct ISOSDacInterface8Vtbl *lpVtbl;
     };
-
 
 
 #ifdef COBJMACROS
@@ -2659,6 +2658,93 @@ EXTERN_C const IID IID_ISOSDacInterface8;
 #endif  /* __ISOSDacInterface8_INTERFACE_DEFINED__ */
 
 
+/* interface __MIDL_itf_sospriv_0000_0012 */
+/* [local] */ 
+
+#define SOS_BREAKING_CHANGE_VERSION 1
+
+
+extern RPC_IF_HANDLE __MIDL_itf_sospriv_0000_0012_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_sospriv_0000_0012_v0_0_s_ifspec;
+
+#ifndef __ISOSDacInterface9_INTERFACE_DEFINED__
+#define __ISOSDacInterface9_INTERFACE_DEFINED__
+
+/* interface ISOSDacInterface9 */
+/* [uuid][local][object] */ 
+
+
+EXTERN_C const IID IID_ISOSDacInterface9;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("4eca42d8-7e7b-4c8a-a116-7bfbf6929267")
+    ISOSDacInterface9 : public IUnknown
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE GetBreakingChangeVersion( 
+            int *pVersion) = 0;
+        
+    };
+    
+    
+#else  /* C style interface */
+
+    typedef struct ISOSDacInterface9Vtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            ISOSDacInterface9 * This,
+            /* [in] */ REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            ISOSDacInterface9 * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            ISOSDacInterface9 * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetBreakingChangeVersion )( 
+            ISOSDacInterface9 * This,
+            int *pVersion);
+        
+        END_INTERFACE
+    } ISOSDacInterface9Vtbl;
+
+    interface ISOSDacInterface9
+    {
+        CONST_VTBL struct ISOSDacInterface9Vtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define ISOSDacInterface9_QueryInterface(This,riid,ppvObject) \
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define ISOSDacInterface9_AddRef(This) \
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define ISOSDacInterface9_Release(This) \
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define ISOSDacInterface9_GetBreakingChangeVersion(This,pVersion) \
+    ( (This)->lpVtbl -> GetBreakingChangeVersion(This,pVersion) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif  /* C style interface */
+
+
+#endif  /* __ISOSDacInterface9_INTERFACE_DEFINED__ */
+
+
 /* Additional Prototypes for ALL interfaces */
 
 /* end of Additional Prototypes */
@@ -2668,5 +2754,4 @@ EXTERN_C const IID IID_ISOSDacInterface8;
 #endif
 
 #endif
-
 


### PR DESCRIPTION
Issue: https://github.com/dotnet/runtime/issues/27309

We should get this version check in for our next SOS/global tools release next week.