### PR TITLE
Fix a potential NullReferenceException when counter session hasn't started yet

### DIFF
--- a/src/Tools/dotnet-counters/CounterMonitor.cs
+++ b/src/Tools/dotnet-counters/CounterMonitor.cs
@@ -61,10 +61,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
         {
             try
             {
-                if (_session != null)
-                {
-                    _session.Stop();
-                }
+                _session?.Stop();
             }
             catch (EndOfStreamException ex)
             {

--- a/src/Tools/dotnet-counters/CounterMonitor.cs
+++ b/src/Tools/dotnet-counters/CounterMonitor.cs
@@ -61,7 +61,10 @@ namespace Microsoft.Diagnostics.Tools.Counters
         {
             try
             {
-                _session.Stop();
+                if (_session != null)
+                {
+                    _session.Stop();
+                }
             }
             catch (EndOfStreamException ex)
             {


### PR DESCRIPTION
Related issue: #1260. 

A `NullReferenceException` may be thrown when `_session` object hasn't been initialized (i.e. the tool tried to start an EventPipe session but it hasn't been able to establish a connection yet) and the user tries to exit the tool.

