### PR TITLE
Add --runtime-version flag to dotnet-counters list command

### DIFF
--- a/src/Tools/dotnet-counters/CounterProvider.cs
+++ b/src/Tools/dotnet-counters/CounterProvider.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
         public string Level { get; }
         public Dictionary<string, CounterProfile> Counters { get; }
 
-        public CounterProvider(string name, string description, string keywords, string level, IEnumerable<CounterProfile> counters)
+        public CounterProvider(string name, string description, string keywords, string level, IEnumerable<CounterProfile> counters, string version)
         {
             Name = name;
             Description = description;
@@ -25,7 +25,10 @@ namespace Microsoft.Diagnostics.Tools.Counters
             Counters = new Dictionary<string, CounterProfile>();
             foreach (CounterProfile counter in counters)
             {
-                Counters.Add(counter.Name, counter);
+                if (counter.SupportedVersions.Contains(version))
+                {
+                    Counters.Add(counter.Name, counter);
+                }
             }
         }
 
@@ -40,12 +43,12 @@ namespace Microsoft.Diagnostics.Tools.Counters
         }
 
         public IReadOnlyList<CounterProfile> GetAllCounters() => Counters.Values.ToList();
-
     }
 
     public class CounterProfile
     {
         public string Name { get; set; }
         public string Description { get; set; }
+        public string[] SupportedVersions { get; set; }
     }
 }

--- a/src/Tools/dotnet-counters/KnownData.cs
+++ b/src/Tools/dotnet-counters/KnownData.cs
@@ -16,6 +16,10 @@ namespace Microsoft.Diagnostics.Tools.Counters
         private static readonly IReadOnlyDictionary<string, CounterProvider> _knownProviders =
             CreateKnownProviders(maxVersion).ToDictionary(p => p.Name, StringComparer.OrdinalIgnoreCase);
 
+        private static readonly string net50 = "5.0";
+        private static readonly string net31 = "3.1";
+        private static readonly string net30 = "3.0";
+
         private static IEnumerable<CounterProvider> CreateKnownProviders(string runtimeVersion)
         {
             yield return new CounterProvider(
@@ -24,28 +28,28 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 "0xffffffff", // Keywords
                 "5", // Level 
                 new[] { // Counters
-                    new CounterProfile{ Name="cpu-usage", Description="Amount of time the process has utilized the CPU (ms)", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
-                    new CounterProfile{ Name="working-set", Description="Amount of working set used by the process (MB)", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
-                    new CounterProfile{ Name="gc-heap-size", Description="Total heap size reported by the GC (MB)", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
-                    new CounterProfile{ Name="gen-0-gc-count", Description="Number of Gen 0 GCs / min", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
-                    new CounterProfile{ Name="gen-1-gc-count", Description="Number of Gen 1 GCs / min", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
-                    new CounterProfile{ Name="gen-2-gc-count", Description="Number of Gen 2 GCs / min", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
-                    new CounterProfile{ Name="time-in-gc", Description="% time in GC since the last GC", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
-                    new CounterProfile{ Name="gen-0-size", Description="Gen 0 Heap Size", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
-                    new CounterProfile{ Name="gen-1-size", Description="Gen 1 Heap Size", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
-                    new CounterProfile{ Name="gen-2-size", Description="Gen 2 Heap Size", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
-                    new CounterProfile{ Name="loh-size", Description="LOH Size", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
-                    new CounterProfile{ Name="poh-size", Description="POH (Pinned Object Heap) Size", SupportedVersions=new[] { "5.0" } },
-                    new CounterProfile{ Name="alloc-rate", Description="Number of bytes allocated in the managed heap per second", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
-                    new CounterProfile{ Name="assembly-count", Description="Number of Assemblies Loaded", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
-                    new CounterProfile{ Name="exception-count", Description="Number of Exceptions / sec", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
-                    new CounterProfile{ Name="threadpool-thread-count", Description="Number of ThreadPool Threads", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
-                    new CounterProfile{ Name="monitor-lock-contention-count", Description="Number of times there were contention when trying to take the monitor lock per second", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
-                    new CounterProfile{ Name="threadpool-queue-length", Description="ThreadPool Work Items Queue Length", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
-                    new CounterProfile{ Name="threadpool-completed-items-count", Description="ThreadPool Completed Work Items Count", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
-                    new CounterProfile{ Name="active-timer-count", Description="Number of timers that are currently active", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
-                    new CounterProfile{ Name="il-bytes-jitted", Description="Total IL bytes jitted", SupportedVersions=new[] { "5.0" } },
-                    new CounterProfile{ Name="methods-jitted-count", Description="Number of methods jitted", SupportedVersions=new[] { "5.0" } }
+                    new CounterProfile{ Name="cpu-usage", Description="Amount of time the process has utilized the CPU (ms)", SupportedVersions=new[] { net30, net31, net50 } },
+                    new CounterProfile{ Name="working-set", Description="Amount of working set used by the process (MB)", SupportedVersions=new[] { net30, net31, net50 } },
+                    new CounterProfile{ Name="gc-heap-size", Description="Total heap size reported by the GC (MB)", SupportedVersions=new[] { net30, net31, net50 } },
+                    new CounterProfile{ Name="gen-0-gc-count", Description="Number of Gen 0 GCs / min", SupportedVersions=new[] { net30, net31, net50 } },
+                    new CounterProfile{ Name="gen-1-gc-count", Description="Number of Gen 1 GCs / min", SupportedVersions=new[] { net30, net31, net50 } },
+                    new CounterProfile{ Name="gen-2-gc-count", Description="Number of Gen 2 GCs / min", SupportedVersions=new[] { net30, net31, net50 } },
+                    new CounterProfile{ Name="time-in-gc", Description="% time in GC since the last GC", SupportedVersions=new[] { net30, net31, net50 } },
+                    new CounterProfile{ Name="gen-0-size", Description="Gen 0 Heap Size", SupportedVersions=new[] { net30, net31, net50 } },
+                    new CounterProfile{ Name="gen-1-size", Description="Gen 1 Heap Size", SupportedVersions=new[] { net30, net31, net50 } },
+                    new CounterProfile{ Name="gen-2-size", Description="Gen 2 Heap Size", SupportedVersions=new[] { net30, net31, net50 } },
+                    new CounterProfile{ Name="loh-size", Description="LOH Size", SupportedVersions=new[] { net30, net31, net50 } },
+                    new CounterProfile{ Name="poh-size", Description="POH (Pinned Object Heap) Size", SupportedVersions=new[] { net50 } },
+                    new CounterProfile{ Name="alloc-rate", Description="Number of bytes allocated in the managed heap per second", SupportedVersions=new[] { net30, net31, net50 } },
+                    new CounterProfile{ Name="assembly-count", Description="Number of Assemblies Loaded", SupportedVersions=new[] { net30, net31, net50 } },
+                    new CounterProfile{ Name="exception-count", Description="Number of Exceptions / sec", SupportedVersions=new[] { net30, net31, net50 } },
+                    new CounterProfile{ Name="threadpool-thread-count", Description="Number of ThreadPool Threads", SupportedVersions=new[] { net30, net31, net50 } },
+                    new CounterProfile{ Name="monitor-lock-contention-count", Description="Number of times there were contention when trying to take the monitor lock per second", SupportedVersions=new[] { net30, net31, net50 } },
+                    new CounterProfile{ Name="threadpool-queue-length", Description="ThreadPool Work Items Queue Length", SupportedVersions=new[] { net30, net31, net50 } },
+                    new CounterProfile{ Name="threadpool-completed-items-count", Description="ThreadPool Completed Work Items Count", SupportedVersions=new[] { net30, net31, net50 } },
+                    new CounterProfile{ Name="active-timer-count", Description="Number of timers that are currently active", SupportedVersions=new[] { net30, net31, net50 } },
+                    new CounterProfile{ Name="il-bytes-jitted", Description="Total IL bytes jitted", SupportedVersions=new[] { net50 } },
+                    new CounterProfile{ Name="methods-jitted-count", Description="Number of methods jitted", SupportedVersions=new[] { net50 } }
                 },
                 runtimeVersion // RuntimeVersion
             );
@@ -55,10 +59,10 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 "0x0", // Keywords
                 "4", // Level 
                 new[] { // Counters
-                    new CounterProfile{ Name="requests-per-second", Description="Request rate", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
-                    new CounterProfile{ Name="total-requests", Description="Total number of requests", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
-                    new CounterProfile{ Name="current-requests", Description="Current number of requests", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
-                    new CounterProfile{ Name="failed-requests", Description="Failed number of requests", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
+                    new CounterProfile{ Name="requests-per-second", Description="Request rate", SupportedVersions=new[] { net30, net31, net50 } },
+                    new CounterProfile{ Name="total-requests", Description="Total number of requests", SupportedVersions=new[] { net30, net31, net50 } },
+                    new CounterProfile{ Name="current-requests", Description="Current number of requests", SupportedVersions=new[] { net30, net31, net50 } },
+                    new CounterProfile{ Name="failed-requests", Description="Failed number of requests", SupportedVersions=new[] { net30, net31, net50 } },
                 },
                 runtimeVersion
             );
@@ -68,15 +72,15 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 "0x0", // Keywords
                 "4", // Level
                 new[] {
-                    new CounterProfile{ Name="connections-per-second", Description="Connection Rate", SupportedVersions=new[] { "5.0" } },
-                    new CounterProfile{ Name="total-connections", Description="Total Connections", SupportedVersions=new[] { "5.0" } },
-                    new CounterProfile{ Name="tls-handshakes-per-second", Description="Rate at which TLS Handshakes are made", SupportedVersions=new[] { "5.0" } },
-                    new CounterProfile{ Name="total-tls-handshakes", Description="Total number of TLS handshakes made", SupportedVersions=new[] { "5.0" } },
-                    new CounterProfile{ Name="current-tls-handshakes", Description="Number of currently active TLS handshakes", SupportedVersions=new[] { "5.0" } },
-                    new CounterProfile{ Name="failed-tls-handshakes", Description="Total number of failed TLS handshakes", SupportedVersions=new[] { "5.0" } },
-                    new CounterProfile{ Name="current-connections", Description="Number of current connections", SupportedVersions=new[] { "5.0" } },
-                    new CounterProfile{ Name="connection-queue-length", Description="Length of Kestrel Connection Queue", SupportedVersions=new[] { "5.0" } },
-                    new CounterProfile{ Name="request-queue-length", Description="Length total HTTP request queue", SupportedVersions=new[] { "5.0" } },
+                    new CounterProfile{ Name="connections-per-second", Description="Connection Rate", SupportedVersions=new[] { net50 } },
+                    new CounterProfile{ Name="total-connections", Description="Total Connections", SupportedVersions=new[] { net50 } },
+                    new CounterProfile{ Name="tls-handshakes-per-second", Description="Rate at which TLS Handshakes are made", SupportedVersions=new[] { net50 } },
+                    new CounterProfile{ Name="total-tls-handshakes", Description="Total number of TLS handshakes made", SupportedVersions=new[] { net50 } },
+                    new CounterProfile{ Name="current-tls-handshakes", Description="Number of currently active TLS handshakes", SupportedVersions=new[] { net50 } },
+                    new CounterProfile{ Name="failed-tls-handshakes", Description="Total number of failed TLS handshakes", SupportedVersions=new[] { net50 } },
+                    new CounterProfile{ Name="current-connections", Description="Number of current connections", SupportedVersions=new[] { net50 } },
+                    new CounterProfile{ Name="connection-queue-length", Description="Length of Kestrel Connection Queue", SupportedVersions=new[] { net50 } },
+                    new CounterProfile{ Name="request-queue-length", Description="Length total HTTP request queue", SupportedVersions=new[] { net50 } },
                 },
                 runtimeVersion
             );
@@ -86,11 +90,11 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 "0x0", // Keywords
                 "4", // Level
                 new[] {
-                    new CounterProfile{ Name="requests-started", Description="Requests Started", SupportedVersions=new[] { "5.0" } },
-                    new CounterProfile{ Name="requests-started-rate", Description="Requests Started Rate", SupportedVersions=new[] { "5.0" } },
-                    new CounterProfile{ Name="requests-aborted", Description="Requests Aborted", SupportedVersions=new[] { "5.0" } },
-                    new CounterProfile{ Name="requests-aborted-rate", Description="Requests Aborted Rate", SupportedVersions=new[] { "5.0" } },
-                    new CounterProfile{ Name="current-requests", Description="Current Requests", SupportedVersions=new[] { "5.0" } }
+                    new CounterProfile{ Name="requests-started", Description="Requests Started", SupportedVersions=new[] { net50 } },
+                    new CounterProfile{ Name="requests-started-rate", Description="Requests Started Rate", SupportedVersions=new[] { net50 } },
+                    new CounterProfile{ Name="requests-aborted", Description="Requests Aborted", SupportedVersions=new[] { net50 } },
+                    new CounterProfile{ Name="requests-aborted-rate", Description="Requests Aborted Rate", SupportedVersions=new[] { net50 } },
+                    new CounterProfile{ Name="current-requests", Description="Current Requests", SupportedVersions=new[] { net50 } }
                 },
                 runtimeVersion
             );

--- a/src/Tools/dotnet-counters/KnownData.cs
+++ b/src/Tools/dotnet-counters/KnownData.cs
@@ -12,10 +12,11 @@ namespace Microsoft.Diagnostics.Tools.Counters
 {
     internal static class KnownData
     {
+        private static readonly string defaultVersion = "5.0";
         private static readonly IReadOnlyDictionary<string, CounterProvider> _knownProviders =
-            CreateKnownProviders().ToDictionary(p => p.Name, StringComparer.OrdinalIgnoreCase);
+            CreateKnownProviders(defaultVersion).ToDictionary(p => p.Name, StringComparer.OrdinalIgnoreCase);
 
-        private static IEnumerable<CounterProvider> CreateKnownProviders()
+        private static IEnumerable<CounterProvider> CreateKnownProviders(string runtimeVersion)
         {
             yield return new CounterProvider(
                 "System.Runtime", // Name
@@ -23,71 +24,82 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 "0xffffffff", // Keywords
                 "5", // Level 
                 new[] { // Counters
-                    new CounterProfile{ Name="cpu-usage", Description="Amount of time the process has utilized the CPU (ms)" },
-                    new CounterProfile{ Name="working-set", Description="Amount of working set used by the process (MB)" },
-                    new CounterProfile{ Name="gc-heap-size", Description="Total heap size reported by the GC (MB)" },
-                    new CounterProfile{ Name="gen-0-gc-count", Description="Number of Gen 0 GCs / min" },
-                    new CounterProfile{ Name="gen-1-gc-count", Description="Number of Gen 1 GCs / min" },
-                    new CounterProfile{ Name="gen-2-gc-count", Description="Number of Gen 2 GCs / min" },
-                    new CounterProfile{ Name="time-in-gc", Description="% time in GC since the last GC" },
-                    new CounterProfile{ Name="gen-0-size", Description="Gen 0 Heap Size" },
-                    new CounterProfile{ Name="gen-1-size", Description="Gen 1 Heap Size" },
-                    new CounterProfile{ Name="gen-2-size", Description="Gen 2 Heap Size" },
-                    new CounterProfile{ Name="loh-size", Description="LOH Size" },
-                    new CounterProfile{ Name="poh-size", Description="POH (Pinned Object Heap) Size" },
-                    new CounterProfile{ Name="alloc-rate", Description="Number of bytes allocated in the managed heap per second" },
-                    new CounterProfile{ Name="assembly-count", Description="Number of Assemblies Loaded" },
-                    new CounterProfile{ Name="exception-count", Description="Number of Exceptions / sec" },
-                    new CounterProfile{ Name="threadpool-thread-count", Description="Number of ThreadPool Threads" },
-                    new CounterProfile{ Name="monitor-lock-contention-count", Description="Number of times there were contention when trying to take the monitor lock per second" },
-                    new CounterProfile{ Name="threadpool-queue-length", Description="ThreadPool Work Items Queue Length" },
-                    new CounterProfile{ Name="threadpool-completed-items-count", Description="ThreadPool Completed Work Items Count" },
-                    new CounterProfile{ Name="active-timer-count", Description="Number of timers that are currently active" },
-                    new CounterProfile{ Name="il-bytes-jitted", Description="Total IL bytes jitted" },
-                    new CounterProfile{ Name="methods-jitted-count", Description="Number of methods jitted" }
-                });
+                    new CounterProfile{ Name="cpu-usage", Description="Amount of time the process has utilized the CPU (ms)", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
+                    new CounterProfile{ Name="working-set", Description="Amount of working set used by the process (MB)", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
+                    new CounterProfile{ Name="gc-heap-size", Description="Total heap size reported by the GC (MB)", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
+                    new CounterProfile{ Name="gen-0-gc-count", Description="Number of Gen 0 GCs / min", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
+                    new CounterProfile{ Name="gen-1-gc-count", Description="Number of Gen 1 GCs / min", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
+                    new CounterProfile{ Name="gen-2-gc-count", Description="Number of Gen 2 GCs / min", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
+                    new CounterProfile{ Name="time-in-gc", Description="% time in GC since the last GC", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
+                    new CounterProfile{ Name="gen-0-size", Description="Gen 0 Heap Size", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
+                    new CounterProfile{ Name="gen-1-size", Description="Gen 1 Heap Size", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
+                    new CounterProfile{ Name="gen-2-size", Description="Gen 2 Heap Size", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
+                    new CounterProfile{ Name="loh-size", Description="LOH Size", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
+                    new CounterProfile{ Name="poh-size", Description="POH (Pinned Object Heap) Size", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
+                    new CounterProfile{ Name="alloc-rate", Description="Number of bytes allocated in the managed heap per second", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
+                    new CounterProfile{ Name="assembly-count", Description="Number of Assemblies Loaded", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
+                    new CounterProfile{ Name="exception-count", Description="Number of Exceptions / sec", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
+                    new CounterProfile{ Name="threadpool-thread-count", Description="Number of ThreadPool Threads", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
+                    new CounterProfile{ Name="monitor-lock-contention-count", Description="Number of times there were contention when trying to take the monitor lock per second", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
+                    new CounterProfile{ Name="threadpool-queue-length", Description="ThreadPool Work Items Queue Length", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
+                    new CounterProfile{ Name="threadpool-completed-items-count", Description="ThreadPool Completed Work Items Count", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
+                    new CounterProfile{ Name="active-timer-count", Description="Number of timers that are currently active", SupportedVersions=new[] { "5.0" } },
+                    new CounterProfile{ Name="il-bytes-jitted", Description="Total IL bytes jitted", SupportedVersions=new[] { "5.0" } },
+                    new CounterProfile{ Name="methods-jitted-count", Description="Number of methods jitted", SupportedVersions=new[] { "5.0" } }
+                },
+                runtimeVersion // RuntimeVersion
+            );
             yield return new CounterProvider(
                 "Microsoft.AspNetCore.Hosting", // Name
                 "A set of performance counters provided by ASP.NET Core.", // Description
                 "0x0", // Keywords
                 "4", // Level 
                 new[] { // Counters
-                    new CounterProfile{ Name="requests-per-second", Description="Request rate" },
-                    new CounterProfile{ Name="total-requests", Description="Total number of requests" },
-                    new CounterProfile{ Name="current-requests", Description="Current number of requests" },
-                    new CounterProfile{ Name="failed-requests", Description="Failed number of requests" },
-                });
+                    new CounterProfile{ Name="requests-per-second", Description="Request rate", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
+                    new CounterProfile{ Name="total-requests", Description="Total number of requests", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
+                    new CounterProfile{ Name="current-requests", Description="Current number of requests", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
+                    new CounterProfile{ Name="failed-requests", Description="Failed number of requests", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
+                },
+                runtimeVersion
+            );
             yield return new CounterProvider(
                 "Microsoft-AspNetCore-Server-Kestrel", // Name
                 "A set of performance counters provided by Kestrel.", // Description
                 "0x0", // Keywords
                 "4", // Level
                 new[] {
-                    new CounterProfile{ Name="connections-per-second", Description="Connection Rate" },
-                    new CounterProfile{ Name="total-connections", Description="Total Connections" },
-                    new CounterProfile{ Name="tls-handshakes-per-second", Description="Rate at which TLS Handshakes are made" },
-                    new CounterProfile{ Name="total-tls-handshakes", Description="Total number of TLS handshakes made" },
-                    new CounterProfile{ Name="current-tls-handshakes", Description="Number of currently active TLS handshakes" },
-                    new CounterProfile{ Name="failed-tls-handshakes", Description="Total number of failed TLS handshakes" },
-                    new CounterProfile{ Name="current-connections", Description="Number of current connections" },
-                    new CounterProfile{ Name="connection-queue-length", Description="Length of Kestrel Connection Queue" },
-                    new CounterProfile{ Name="request-queue-length", Description="Length total HTTP request queue" },
-                });
+                    new CounterProfile{ Name="connections-per-second", Description="Connection Rate", SupportedVersions=new[] { "5.0" } },
+                    new CounterProfile{ Name="total-connections", Description="Total Connections", SupportedVersions=new[] { "5.0" } },
+                    new CounterProfile{ Name="tls-handshakes-per-second", Description="Rate at which TLS Handshakes are made", SupportedVersions=new[] { "5.0" } },
+                    new CounterProfile{ Name="total-tls-handshakes", Description="Total number of TLS handshakes made", SupportedVersions=new[] { "5.0" } },
+                    new CounterProfile{ Name="current-tls-handshakes", Description="Number of currently active TLS handshakes", SupportedVersions=new[] { "5.0" } },
+                    new CounterProfile{ Name="failed-tls-handshakes", Description="Total number of failed TLS handshakes", SupportedVersions=new[] { "5.0" } },
+                    new CounterProfile{ Name="current-connections", Description="Number of current connections", SupportedVersions=new[] { "5.0" } },
+                    new CounterProfile{ Name="connection-queue-length", Description="Length of Kestrel Connection Queue", SupportedVersions=new[] { "5.0" } },
+                    new CounterProfile{ Name="request-queue-length", Description="Length total HTTP request queue", SupportedVersions=new[] { "5.0" } },
+                },
+                runtimeVersion
+            );
             yield return new CounterProvider(
                 "System.Net.Http",
                 "A set of performance counters for System.Net.Http",
                 "0x0", // Keywords
                 "4", // Level
                 new[] {
-                    new CounterProfile{ Name="requests-started", Description="Requests Started" },
-                    new CounterProfile{ Name="requests-started-rate", Description="Requests Started Rate" },
-                    new CounterProfile{ Name="requests-aborted", Description="Requests Aborted" },
-                    new CounterProfile{ Name="requests-aborted-rate", Description="Requests Aborted Rate" },
-                    new CounterProfile{ Name="current-requests", Description="Current Requests" }
-                });
+                    new CounterProfile{ Name="requests-started", Description="Requests Started", SupportedVersions=new[] { "5.0" } },
+                    new CounterProfile{ Name="requests-started-rate", Description="Requests Started Rate", SupportedVersions=new[] { "5.0" } },
+                    new CounterProfile{ Name="requests-aborted", Description="Requests Aborted", SupportedVersions=new[] { "5.0" } },
+                    new CounterProfile{ Name="requests-aborted-rate", Description="Requests Aborted Rate", SupportedVersions=new[] { "5.0" } },
+                    new CounterProfile{ Name="current-requests", Description="Current Requests", SupportedVersions=new[] { "5.0" } }
+                },
+                runtimeVersion
+            );
         }
 
-        public static IReadOnlyList<CounterProvider> GetAllProviders() => _knownProviders.Values.ToList();
+        public static IReadOnlyList<CounterProvider> GetAllProviders(string version)
+        {
+            return CreateKnownProviders(version).Where(p => p.Counters.Count > 0).ToDictionary(p => p.Name, StringComparer.OrdinalIgnoreCase).Values.ToList();
+        }
 
         public static bool TryGetProvider(string providerName, out CounterProvider provider) => _knownProviders.TryGetValue(providerName, out provider);
     }

--- a/src/Tools/dotnet-counters/KnownData.cs
+++ b/src/Tools/dotnet-counters/KnownData.cs
@@ -12,9 +12,9 @@ namespace Microsoft.Diagnostics.Tools.Counters
 {
     internal static class KnownData
     {
-        private static readonly string defaultVersion = "5.0";
+        private static readonly string maxVersion = "5.0";
         private static readonly IReadOnlyDictionary<string, CounterProvider> _knownProviders =
-            CreateKnownProviders(defaultVersion).ToDictionary(p => p.Name, StringComparer.OrdinalIgnoreCase);
+            CreateKnownProviders(maxVersion).ToDictionary(p => p.Name, StringComparer.OrdinalIgnoreCase);
 
         private static IEnumerable<CounterProvider> CreateKnownProviders(string runtimeVersion)
         {

--- a/src/Tools/dotnet-counters/KnownData.cs
+++ b/src/Tools/dotnet-counters/KnownData.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
                     new CounterProfile{ Name="gen-1-size", Description="Gen 1 Heap Size", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
                     new CounterProfile{ Name="gen-2-size", Description="Gen 2 Heap Size", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
                     new CounterProfile{ Name="loh-size", Description="LOH Size", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
-                    new CounterProfile{ Name="poh-size", Description="POH (Pinned Object Heap) Size", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
+                    new CounterProfile{ Name="poh-size", Description="POH (Pinned Object Heap) Size", SupportedVersions=new[] { "5.0" } },
                     new CounterProfile{ Name="alloc-rate", Description="Number of bytes allocated in the managed heap per second", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
                     new CounterProfile{ Name="assembly-count", Description="Number of Assemblies Loaded", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
                     new CounterProfile{ Name="exception-count", Description="Number of Exceptions / sec", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
@@ -43,7 +43,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
                     new CounterProfile{ Name="monitor-lock-contention-count", Description="Number of times there were contention when trying to take the monitor lock per second", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
                     new CounterProfile{ Name="threadpool-queue-length", Description="ThreadPool Work Items Queue Length", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
                     new CounterProfile{ Name="threadpool-completed-items-count", Description="ThreadPool Completed Work Items Count", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
-                    new CounterProfile{ Name="active-timer-count", Description="Number of timers that are currently active", SupportedVersions=new[] { "5.0" } },
+                    new CounterProfile{ Name="active-timer-count", Description="Number of timers that are currently active", SupportedVersions=new[] { "3.0", "3.1", "5.0" } },
                     new CounterProfile{ Name="il-bytes-jitted", Description="Total IL bytes jitted", SupportedVersions=new[] { "5.0" } },
                     new CounterProfile{ Name="methods-jitted-count", Description="Number of methods jitted", SupportedVersions=new[] { "5.0" } }
                 },

--- a/src/Tools/dotnet-counters/Program.cs
+++ b/src/Tools/dotnet-counters/Program.cs
@@ -121,7 +121,6 @@ namespace Microsoft.Diagnostics.Tools.Counters
             var profiles = KnownData.GetAllProviders(runtimeVersion);
             var maxNameLength = profiles.Max(p => p.Name.Length);
             Console.WriteLine($"Showing well-known counters for .NET (Core) version {runtimeVersion} only. Specific processes may support additional counters.");
-            Console.WriteLine("To see counters supported in other veresions of .NET (Core), try using --runtime-version flag.\n");
             foreach (var profile in profiles)
             {
                 var counters = profile.GetAllCounters();

--- a/src/Tools/dotnet-counters/Program.cs
+++ b/src/Tools/dotnet-counters/Program.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 aliases: new[] { "-r", "--runtime-version" },
                 description: "Version of runtime. Supported runtime version: 3.0, 3.1, 5.0") 
             {
-                Argument = new Argument<string>(name: "runtimeVersion", defaultValue: "5.0")
+                Argument = new Argument<string>(name: "runtimeVersion", defaultValue: "3.1")
             };
 
         private static readonly string[] s_SupportedRuntimeVersions = new[] { "3.0", "3.1", "5.0" };

--- a/src/Tools/dotnet-counters/Program.cs
+++ b/src/Tools/dotnet-counters/Program.cs
@@ -115,7 +115,8 @@ namespace Microsoft.Diagnostics.Tools.Counters
         {
             if (!s_SupportedRuntimeVersions.Contains(runtimeVersion))
             {
-                Console.WriteLine($"{runtimeVersion} is not a supported version.");
+                Console.WriteLine($"{runtimeVersion} is not a supported version string or a supported runtime version.");
+                Console.WriteLine("Supported version strings: 3.0, 3.1, 5.0");
                 return 0;
             }
             var profiles = KnownData.GetAllProviders(runtimeVersion);

--- a/src/Tools/dotnet-counters/Program.cs
+++ b/src/Tools/dotnet-counters/Program.cs
@@ -97,14 +97,31 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 name: "list",
                 description: "Display a list of counter names and descriptions, grouped by provider.")
             {
-                Handler = CommandHandler.Create<IConsole>(List)
+                CommandHandler.Create<IConsole, string>(List),
+                RuntimeVersionOption()
             };
 
-        public static int List(IConsole console)
+        private static Option RuntimeVersionOption() =>
+            new Option(
+                aliases: new[] { "-r", "--runtime-version" },
+                description: "Version of runtime. Supported runtime version: 3.0, 3.1, 5.0") 
+            {
+                Argument = new Argument<string>(name: "runtimeVersion", defaultValue: "5.0")
+            };
+
+        private static readonly string[] s_SupportedRuntimeVersions = new[] { "3.0", "3.1", "5.0" };
+
+        public static int List(IConsole console, string runtimeVersion)
         {
-            var profiles = KnownData.GetAllProviders();
+            if (!s_SupportedRuntimeVersions.Contains(runtimeVersion))
+            {
+                Console.WriteLine($"{runtimeVersion} is not a supported version.");
+                return 0;
+            }
+            var profiles = KnownData.GetAllProviders(runtimeVersion);
             var maxNameLength = profiles.Max(p => p.Name.Length);
-            Console.WriteLine("Showing well-known counters only. Specific processes may support additional counters.\n");
+            Console.WriteLine($"Showing well-known counters for .NET (Core) version {runtimeVersion} only. Specific processes may support additional counters.");
+            Console.WriteLine("To see counters supported in other veresions of .NET (Core), try using --runtime-version flag.\n");
             foreach (var profile in profiles)
             {
                 var counters = profile.GetAllCounters();


### PR DESCRIPTION
For #1368. 

Note that the default runtime version is chosen to be 3.1 (since 5.0 is still in Preview and won't ship till later this year). 

Example output:

```
➜  dotnet-counters git:(dev/suwhang/1368) dotnet-counters list --runtime-version 5.0
Showing well-known counters for .NET (Core) version 5.0 only. Specific processes may support additional counters.
To see counters supported in other veresions of .NET (Core), try using --runtime-version flag.

System.Runtime
    cpu-usage                        		 Amount of time the process has utilized the CPU (ms)
    working-set                      		 Amount of working set used by the process (MB)
    gc-heap-size                     		 Total heap size reported by the GC (MB)
    gen-0-gc-count                   		 Number of Gen 0 GCs / min
    gen-1-gc-count                   		 Number of Gen 1 GCs / min
    gen-2-gc-count                   		 Number of Gen 2 GCs / min
    time-in-gc                       		 % time in GC since the last GC
    gen-0-size                       		 Gen 0 Heap Size
    gen-1-size                       		 Gen 1 Heap Size
    gen-2-size                       		 Gen 2 Heap Size
    loh-size                         		 LOH Size
    poh-size                         		 POH (Pinned Object Heap) Size
    alloc-rate                       		 Number of bytes allocated in the managed heap per second
    assembly-count                   		 Number of Assemblies Loaded
    exception-count                  		 Number of Exceptions / sec
    threadpool-thread-count          		 Number of ThreadPool Threads
    monitor-lock-contention-count    		 Number of times there were contention when trying to take the monitor lock per second
    threadpool-queue-length          		 ThreadPool Work Items Queue Length
    threadpool-completed-items-count 		 ThreadPool Completed Work Items Count
    active-timer-count               		 Number of timers that are currently active
    il-bytes-jitted                  		 Total IL bytes jitted
    methods-jitted-count             		 Number of methods jitted

Microsoft.AspNetCore.Hosting
    requests-per-second 		 Request rate
    total-requests      		 Total number of requests
    current-requests    		 Current number of requests
    failed-requests     		 Failed number of requests

Microsoft-AspNetCore-Server-Kestrel
    connections-per-second    		 Connection Rate
    total-connections         		 Total Connections
    tls-handshakes-per-second 		 Rate at which TLS Handshakes are made
    total-tls-handshakes      		 Total number of TLS handshakes made
    current-tls-handshakes    		 Number of currently active TLS handshakes
    failed-tls-handshakes     		 Total number of failed TLS handshakes
    current-connections       		 Number of current connections
    connection-queue-length   		 Length of Kestrel Connection Queue
    request-queue-length      		 Length total HTTP request queue

System.Net.Http
    requests-started      		 Requests Started
    requests-started-rate 		 Requests Started Rate
    requests-aborted      		 Requests Aborted
    requests-aborted-rate 		 Requests Aborted Rate
    current-requests      		 Current Requests
```

```
➜  dotnet-counters git:(dev/suwhang/1368) dotnet run list --runtime-version 3.1
Showing well-known counters for .NET (Core) version 3.1 only. Specific processes may support additional counters.
To see counters supported in other veresions of .NET (Core), try using --runtime-version flag.

System.Runtime
    cpu-usage                        		 Amount of time the process has utilized the CPU (ms)
    working-set                      		 Amount of working set used by the process (MB)
    gc-heap-size                     		 Total heap size reported by the GC (MB)
    gen-0-gc-count                   		 Number of Gen 0 GCs / min
    gen-1-gc-count                   		 Number of Gen 1 GCs / min
    gen-2-gc-count                   		 Number of Gen 2 GCs / min
    time-in-gc                       		 % time in GC since the last GC
    gen-0-size                       		 Gen 0 Heap Size
    gen-1-size                       		 Gen 1 Heap Size
    gen-2-size                       		 Gen 2 Heap Size
    loh-size                         		 LOH Size
    alloc-rate                       		 Number of bytes allocated in the managed heap per second
    assembly-count                   		 Number of Assemblies Loaded
    exception-count                  		 Number of Exceptions / sec
    threadpool-thread-count          		 Number of ThreadPool Threads
    monitor-lock-contention-count    		 Number of times there were contention when trying to take the monitor lock per second
    threadpool-queue-length          		 ThreadPool Work Items Queue Length
    threadpool-completed-items-count 		 ThreadPool Completed Work Items Count
    active-timer-count               		 Number of timers that are currently active

Microsoft.AspNetCore.Hosting
    requests-per-second 		 Request rate
    total-requests      		 Total number of requests
    current-requests    		 Current number of requests
    failed-requests     		 Failed number of requests
```