### PR TITLE
Add support for CORS

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/CorsConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/CorsConfiguration.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.Monitoring.RestServer
+{
+    public class CorsConfiguration
+    {
+        public string AllowedOrigins { get; set; }
+
+        public string[] GetOrigins() => AllowedOrigins?.Split(';');
+    }
+}

--- a/src/Tools/dotnet-monitor/Startup.cs
+++ b/src/Tools/dotnet-monitor/Startup.cs
@@ -72,6 +72,13 @@ namespace Microsoft.Diagnostics.Monitoring
                 app.UseHsts();
             }
 
+            CorsConfiguration corsConfiguration = new CorsConfiguration();
+            Configuration.Bind(nameof(CorsConfiguration), corsConfiguration);
+            if (!string.IsNullOrEmpty(corsConfiguration.AllowedOrigins))
+            {
+                app.UseCors(builder => builder.WithOrigins(corsConfiguration.GetOrigins()).AllowAnyHeader().AllowAnyMethod());
+            }
+
             app.UseResponseCompression();
             app.UseMvc();
         }


### PR DESCRIPTION
Enable Cors policy to allow client side script apps to access dotnet monitor apis.

Resolves #1346 

Note there are some simplifications here from the original proposed solution:
- Policy is for origins only, no granular policy for methods or headers
- Origins can be specified through environment variables: 
e.g. `DotnetMonitor_CorsConfiguration__AllowedOrigins=http://localhost`
or through appsettings.json:
`{
  "Logging": {
    "LogLevel": {
      "Default": "Warning"
    }
  },
  "AllowedHosts": "*",
  "CorsConfiguration": {
    "AllowedOrigins":  "http://localhost"
  }
}
`
