### PR TITLE
Allow netperf to be used as a supported trace format in Diagnostics Client Library

### DIFF
--- a/documentation/diagnostics-client-library-instructions.md
+++ b/documentation/diagnostics-client-library-instructions.md
@@ -242,7 +242,7 @@ This section describes the APIs of the library.
 public DiagnosticsClient
 {
     public DiagnosticsClient(int processId);
-    public EventPipeSession StartEventPipeSession(IEnumerable<EventPipeProvider> providers, bool requestRundown=true, int circularBufferMB=256);
+    public EventPipeSession StartEventPipeSession(IEnumerable<EventPipeProvider> providers, bool requestRundown=true, int circularBufferMB=256, EventPipeSerializationFormat traceFormat=EventPipeSerializationFormat.NetTrace);
     public void WriteDump(DumpType dumpType, string dumpPath=null, bool logDumpGeneration=false);
     public void AttachProfiler(TimeSpan attachTimeout, Guid profilerGuid, string profilerPath, byte[] additionalData=null);
     public static IEnumerable<int> GetPublishedProcesses();        
@@ -264,7 +264,7 @@ Creates a new instance of `DiagnosticsClient` for a compatible .NET process runn
 
 
 ```csharp
-public EventPipeSession StartEventPipeSession(IEnumerable<EventPipeProvider> providers, bool requestRundown=true, int circularBufferMB=256)
+public EventPipeSession StartEventPipeSession(IEnumerable<EventPipeProvider> providers, bool requestRundown=true, int circularBufferMB=256, EventPipeSerializationFormat traceFormat=EventPipeSerializationFormat.NetTrace)
 ```
 
 Starts an EventPipe tracing session using the given providers and settings. 
@@ -272,6 +272,7 @@ Starts an EventPipe tracing session using the given providers and settings.
 * `providers` : An `IEnumerable` of [`EventPipeProvider`](#class-eventpipeprovider)s to start tracing.
 * `requestRundown`: A `bool` specifying whether rundown provider events from the target app's runtime should be requested.
 * `circularBufferMB`: An `int` specifying the total size of circular buffer used by the target app's runtime on collecting events.
+* `EventPipeSerializationFormat`: An `EventPipeSerializationFormat` enum specifying the trace format to be used when requesting a trace session. Currently supported types: `EventPipeSerializationFormat.NetPerf` (legacy), and `EventPipeSerializationFormat.NetTrace` (default).
 
 
 ```csharp
@@ -463,6 +464,20 @@ Represents the type of dump that can be requested.
 * `Full`: Include all accessible memory in the process. The raw memory data is included at the end, so that the initial structures can be mapped directly without the raw memory information. This option can result in a very large dump file.
 
 
+### enum EventPipeSerializationFormat
+
+```csharp
+public enum EventPipeSerializationFormat
+{
+    NetPerf,
+    NetTrace
+}
+```
+
+Represents the serialization format that EventPipe can use for producing the trace.
+
+* `NetPerf`: This is the format that EventPipe first used in .NET Core 2.2 and early preview releases of .NET Core 3.0. It is a legacy format that is still supported by CoreCLR.
+* `NetTrace`: This is the default format chosen if it is not specified. It is the most up-to-date EventPipe serialization format. This option should be used in most cases unless there is a specific reason to use the legacy NetPerf format.
 
 ### Exceptions
 

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
@@ -41,12 +41,18 @@ namespace Microsoft.Diagnostics.NETCore.Client
         /// <param name="providers">An IEnumerable containing the list of Providers to turn on.</param>
         /// <param name="requestRundown">If true, request rundown events from the runtime</param>
         /// <param name="circularBufferMB">The size of the runtime's buffer for collecting events in MB</param>
+        /// <param name="traceFormat">The serialization format to be used for the trace. Default is NetTrace format.</param>
         /// <returns>
         /// An EventPipeSession object representing the EventPipe session that just started.
         /// </returns> 
-        public EventPipeSession StartEventPipeSession(IEnumerable<EventPipeProvider> providers, bool requestRundown=true, int circularBufferMB=256)
+        public EventPipeSession StartEventPipeSession(
+            IEnumerable<EventPipeProvider> providers,
+            bool requestRundown=true,
+            int circularBufferMB=256,
+            EventPipeSerializationFormat traceFormat=EventPipeSerializationFormat.NetTrace
+        )
         {
-            return new EventPipeSession(_processId, providers, requestRundown, circularBufferMB);
+            return new EventPipeSession(_processId, providers, requestRundown, circularBufferMB, traceFormat);
         }
 
         /// <summary>
@@ -55,12 +61,18 @@ namespace Microsoft.Diagnostics.NETCore.Client
         /// <param name="provider">An EventPipeProvider to turn on.</param>
         /// <param name="requestRundown">If true, request rundown events from the runtime</param>
         /// <param name="circularBufferMB">The size of the runtime's buffer for collecting events in MB</param>
+        /// <param name="traceFormat">The serialization format to be used for the trace. Default is NetTrace format.</param>
         /// <returns>
         /// An EventPipeSession object representing the EventPipe session that just started.
         /// </returns> 
-        public EventPipeSession StartEventPipeSession(EventPipeProvider provider, bool requestRundown=true, int circularBufferMB=256)
+        public EventPipeSession StartEventPipeSession(
+            EventPipeProvider provider,
+            bool requestRundown=true,
+            int circularBufferMB=256,
+            EventPipeSerializationFormat traceFormat=EventPipeSerializationFormat.NetTrace
+        )
         {
-            return new EventPipeSession(_processId, new[] { provider }, requestRundown, circularBufferMB);
+            return new EventPipeSession(_processId, new[] { provider }, requestRundown, circularBufferMB, traceFormat);
         }
 
         /// <summary>

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/EventPipeSession.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/EventPipeSession.cs
@@ -18,14 +18,14 @@ namespace Microsoft.Diagnostics.NETCore.Client
         private int _processId;
         private bool disposedValue = false; // To detect redundant calls
 
-        internal EventPipeSession(int processId, IEnumerable<EventPipeProvider> providers, bool requestRundown, int circularBufferMB)
+        internal EventPipeSession(int processId, IEnumerable<EventPipeProvider> providers, bool requestRundown, int circularBufferMB, EventPipeSerializationFormat traceFormat)
         {
             _processId = processId;
             _providers = providers;
             _requestRundown = requestRundown;
             _circularBufferMB = circularBufferMB;
             
-            var config = new EventPipeSessionConfiguration(circularBufferMB, EventPipeSerializationFormat.NetTrace, providers, requestRundown);
+            var config = new EventPipeSessionConfiguration(circularBufferMB, traceFormat, providers, requestRundown);
             var message = new IpcMessage(DiagnosticsServerCommandSet.EventPipe, (byte)EventPipeCommandId.CollectTracing2, config.SerializeV2());
             EventStream = IpcClient.SendMessage(processId, message, out var response);
             switch ((DiagnosticsServerCommandId)response.Header.CommandId)

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/EventPipeSessionConfiguration.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/EventPipeSessionConfiguration.cs
@@ -9,7 +9,7 @@ using System.Linq;
 
 namespace Microsoft.Diagnostics.NETCore.Client
 {
-    internal enum EventPipeSerializationFormat
+    public enum EventPipeSerializationFormat
     {
         NetPerf,
         NetTrace

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/EventPipeSessionTests.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/EventPipeSessionTests.cs
@@ -127,5 +127,23 @@ namespace Microsoft.Diagnostics.NETCore.Client
             }
             runner.Stop();
         }
+
+        /// <summary>
+        /// A test that checks if we can create an EventPipeSession on a child process with the legacy NetPerf format.
+        /// </summary>
+        [Fact]
+        public void EventPipeNetPerfSessionTest()
+        {
+            TestRunner runner = new TestRunner(CommonHelper.GetTraceePath(), output);
+            runner.Start(3000);
+            DiagnosticsClient client = new DiagnosticsClient(runner.Pid);
+            using (var session = client.StartEventPipeSession(
+                new EventPipeProvider("Microsoft-Windows-DotNETRuntime", EventLevel.Informational), true, 256, EventPipeSerializationFormat.NetPerf))
+            {
+                Assert.True(session.EventStream != null);
+            }
+            runner.Stop();
+        }
+
     }
 }


### PR DESCRIPTION
For #1381. 

