### PR TITLE
Misc SOS changes

### DIFF
--- a/diagnostics.yml
+++ b/diagnostics.yml
@@ -457,7 +457,7 @@ stages:
         publishInstallersAndChecksums: true
         SDLValidationParameters:
           enable: true
-          continueOnError: false
+          continueOnError: true
           params: ' -SourceToolsList @("policheck","credscan")
           -TsaInstanceURL $(_TsaInstanceURL)
           -TsaProjectName $(_TsaProjectName)

--- a/src/SOS/SOS.Package/SOS.Package.csproj
+++ b/src/SOS/SOS.Package/SOS.Package.csproj
@@ -49,7 +49,6 @@
                 </TriggerSet>
                 <TriggerSet>
                     <ModuleTrigger Name="libcoreclr.so" />
-                    <OSTrigger Name="Linux" />
                 </TriggerSet>
             </LoadTriggers>
             <EngineCommands>

--- a/src/SOS/Strike/runtime.cpp
+++ b/src/SOS/Strike/runtime.cpp
@@ -105,7 +105,7 @@ static HRESULT GetSingleFileInfo(PULONG pModuleIndex, PULONG64 pModuleAddress, R
 \**********************************************************************/
 HRESULT Runtime::CreateInstance(RuntimeConfiguration configuration, Runtime **ppRuntime)
 {
-    PCSTR runtimeModuleName = GetRuntimeModuleName(configuration);
+    PCSTR runtimeModuleName = ::GetRuntimeModuleName(configuration);
     ULONG moduleIndex = 0;
     ULONG64 moduleAddress = 0;
     ULONG64 moduleSize = 0;
@@ -142,16 +142,16 @@ HRESULT Runtime::CreateInstance(RuntimeConfiguration configuration, Runtime **pp
 
                 if (params.SymbolType == SymDeferred)
                 {
+                    PCSTR runtimeDllName = ::GetRuntimeDllName(configuration);
                     std::string reloadCommand;
                     reloadCommand.append("/f ");
-                    reloadCommand.append(runtimeModuleName);
-                    reloadCommand.append(".dll");
+                    reloadCommand.append(runtimeDllName);
                     g_ExtSymbols->Reload(reloadCommand.c_str());
                     g_ExtSymbols->GetModuleParameters(1, &moduleAddress, 0, &params);
 
                     if (params.SymbolType != SymPdb && params.SymbolType != SymDia)
                     {
-                        ExtOut("PDB symbol for %s not loaded\n", runtimeModuleName);
+                        ExtOut("Symbols for %s not loaded. Some SOS commands may not work.\n", runtimeDllName);
                     }
                 }
             }

--- a/src/SOS/Strike/runtime.cpp
+++ b/src/SOS/Strike/runtime.cpp
@@ -322,7 +322,7 @@ LPCSTR Runtime::GetRuntimeDirectory()
                 return nullptr;
             }
             // Parse off the file name
-            char* lastSlash = strrchr(szModuleName, DIRECTORY_SEPARATOR_CHAR_A);
+            char* lastSlash = strrchr(szModuleName, GetTargetDirectorySeparatorW());
             if (lastSlash != nullptr)
             {
                 *lastSlash = '\0';

--- a/src/SOS/Strike/util.cpp
+++ b/src/SOS/Strike/util.cpp
@@ -234,6 +234,16 @@ ULONG DebuggeeType()
     return Class;
 }
 
+const WCHAR GetTargetDirectorySeparatorW()
+{
+    if (IsWindowsTarget()) {
+        return W('\\');
+    }
+    else {
+        return W('/');
+    }
+}
+
 #ifndef FEATURE_PAL
 
 // Check if a file exist
@@ -5189,7 +5199,7 @@ static void AddAssemblyName(WString& methodOutput, CLRDATA_ADDRESS mdesc)
                 {
                     if (wszFileName[0] != W('\0'))
                     {
-                        WCHAR *pJustName = _wcsrchr(wszFileName, DIRECTORY_SEPARATOR_CHAR_W);
+                        WCHAR *pJustName = _wcsrchr(wszFileName, GetTargetDirectorySeparatorW());
                         if (pJustName == NULL)
                             pJustName = wszFileName - 1;
                         methodOutput += (pJustName + 1);

--- a/src/SOS/Strike/util.h
+++ b/src/SOS/Strike/util.h
@@ -1761,6 +1761,7 @@ BOOL GetSOSVersion(VS_FIXEDFILEINFO *pFileInfo);
 #endif
 
 BOOL IsDumpFile ();
+const WCHAR GetTargetDirectorySeparatorW();
 
 // IsMiniDumpFile will return true if 1) we are in
 // a small format minidump, and g_InMinidumpSafeMode is true.


### PR DESCRIPTION
Extension gallery manifest fix.

Fix coreclr reload message for linux dumps on Windows.

Fallback to getting assembly name (like when SOS is running on Linux/OSX) when building a function name when either GetModuleByteOffset or GetModuleNames fail.

Add target based get directory separator char function (GetTargetDirectorySeparatorW) to use in the linux module name returned by dbgeng for linux core dumps on Windows.