### PR TITLE
Fix diagnostics client test hang in CentOS 

### DIFF
--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/EventPipeSessionTests.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/EventPipeSessionTests.cs
@@ -80,6 +80,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
                     }
                     catch (Exception e)
                     {
+                        // This exception can happen if the target process exits while EventPipeEventSource is in the middle of reading from the pipe.
                         Console.WriteLine("Error encountered while processing events");
                         Console.WriteLine(e.ToString());
                     }

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/EventPipeSessionTests.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/EventPipeSessionTests.cs
@@ -81,6 +81,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
                     catch (Exception e)
                     {
                         Console.WriteLine("Error encountered while processing events");
+                        Console.WriteLine(e.ToString());
                         Assert.Equal("", e.ToString());
                     }
                     finally

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/EventPipeSessionTests.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/EventPipeSessionTests.cs
@@ -82,7 +82,6 @@ namespace Microsoft.Diagnostics.NETCore.Client
                     {
                         Console.WriteLine("Error encountered while processing events");
                         Console.WriteLine(e.ToString());
-                        Assert.Equal("", e.ToString());
                     }
                     finally
                     {


### PR DESCRIPTION
This fixes #1389. 