### PR TITLE
Fix module lookup by name

### DIFF
--- a/src/SOS/Strike/util.cpp
+++ b/src/SOS/Strike/util.cpp
@@ -1467,7 +1467,7 @@ HRESULT FileNameForModule (DWORD_PTR pModuleAddr, __out_ecount (MAX_LONGPATH) WC
 *                                                                      *
 \**********************************************************************/
 // fileName should be at least MAX_LONGPATH
-HRESULT FileNameForModule (DacpModuleData *pModule, __out_ecount (MAX_LONGPATH) WCHAR *fileName)
+HRESULT FileNameForModule (const DacpModuleData * const pModule, __out_ecount (MAX_LONGPATH) WCHAR *fileName)
 {
     fileName[0] = L'\0';
     
@@ -1763,7 +1763,7 @@ BOOL IsSameModuleName (const char *str1, const char *str2)
         ptr2--;
         ptr1--;
     }
-    if (ptr1 >= str1 && *ptr1 != DIRECTORY_SEPARATOR_CHAR_A && *ptr1 != ':')
+    if (ptr1 >= str1 && *ptr1 != GetTargetDirectorySeparatorW() && *ptr1 != ':')
     {
         return FALSE;
     }
@@ -2273,7 +2273,7 @@ DWORD_PTR *ModuleFromName(__in_opt LPSTR mName, int *numModule)
                     if (mName != NULL)
                     {
                         ArrayHolder<WCHAR> moduleName = new WCHAR[MAX_LONGPATH];
-                        FileNameForModule((DWORD_PTR)ModuleAddr, moduleName);
+                        FileNameForModule(&ModuleData, moduleName);
 
                         int bytesWritten = WideCharToMultiByte(CP_ACP, 0, moduleName, -1, fileName, MAX_LONGPATH, NULL, NULL);
                         _ASSERTE(bytesWritten > 0);

--- a/src/SOS/Strike/util.h
+++ b/src/SOS/Strike/util.h
@@ -1593,7 +1593,7 @@ HRESULT GetClrModuleImages(__in IXCLRDataModule* module, __in CLRDataModuleExten
 HRESULT GetMethodDefinitionsFromName(DWORD_PTR ModulePtr, IXCLRDataModule* mod, const char* name, IXCLRDataMethodDefinition **ppMethodDefinitions, int numMethods, int *numMethodsNeeded);
 HRESULT GetMethodDescsFromName(DWORD_PTR ModulePtr, IXCLRDataModule* mod, const char* name, DWORD_PTR **pOut, int *numMethodDescs);
 
-HRESULT FileNameForModule (DacpModuleData *pModule, __out_ecount (MAX_LONGPATH) WCHAR *fileName);
+HRESULT FileNameForModule (const DacpModuleData * const pModule, __out_ecount (MAX_LONGPATH) WCHAR *fileName);
 HRESULT FileNameForModule (DWORD_PTR pModuleAddr, __out_ecount (MAX_LONGPATH) WCHAR *fileName);
 void IP2MethodDesc (DWORD_PTR IP, DWORD_PTR &methodDesc, JITTypes &jitType,
                     DWORD_PTR &gcinfoAddr);


### PR DESCRIPTION
When helping one of our customers, we noticed dump async didn't work.
We were trying to lookup SPC by name, but the path separator was assuming a target=host separator.