### PR TITLE
Fix dotnet-trace crashing when trying to stop tracing an app that has exited

### DIFF
--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
@@ -209,7 +209,14 @@ namespace Microsoft.Diagnostics.Tools.Trace
                         }
                         durationTimer?.Stop();
                         rundownRequested = true;
-                        session.Stop();
+                        try
+                        {
+                            session.Stop();
+                        }
+                        // Timeout exception can occur if the target app has exited prior to requesting session to be stopped.
+                        catch (System.TimeoutException)
+                        {
+                        }
 
                         do
                         {


### PR DESCRIPTION
If user tries to stop dotnet-trace session after the target app has exited, it will throw a TimeoutException. We should catch this and handle it gracefully instead of lousy crashing.