### PR TITLE
Add process environment spec command and impl

### DIFF
--- a/documentation/design-docs/ipc-protocol.md
+++ b/documentation/design-docs/ipc-protocol.md
@@ -749,6 +749,44 @@ Header: `{ Magic; size; 0xFF00; 0x0000; }`
 
 There is no payload.
 
+### `ProcessEnvironment`
+
+Command Code: `0x0402`
+
+The `ProcessEnvironment` command queries the runtime for its environment block.
+
+In the event of an [error](#Errors), the runtime will attempt to send an error message and subsequently close the connection.
+
+#### Inputs:
+
+Header: `{ Magic; Size; 0x0402; 0x0000 }`
+
+There is no payload.
+
+#### Returns (as an IPC Message Payload + continuation):
+
+Header: `{ Magic; size; 0xFF00; 0x0000; }`
+
+Payload:
+* `uint32_t nIncomingBytes`: the number of bytes to expect in the continuation stream
+* `uint16_t future`: unused
+
+Continuation:
+* `Array<Array<WCHAR>> environmentBlock`: The environment block written as a length prefixed array of length prefixed arrays of `WCHAR`.
+
+Note: it is valid for `nIncomingBytes` to be `4` and the continuation to simply contain the value `0`.
+
+##### Details:
+
+Returns:
+```c++
+struct Payload
+{
+    uint32_t nIncomingBytes;
+    uint16_t future;
+}
+```
+
 ## Errors
 
 In the event an error occurs in the handling of an Ipc Message, the Diagnostic Server will attempt to send an Ipc Message encoding the error and subsequently close the connection.  The connection will be closed **regardless** of the success of sending the error message.  The Client is expected to be resilient in the event of a connection being abruptly closed.

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
@@ -190,6 +190,25 @@ namespace Microsoft.Diagnostics.NETCore.Client
             }
         }
 
+        public Dictionary<string,string> GetProcessEnvironment()
+        {
+            var message = new IpcMessage(DiagnosticsServerCommandSet.Process, (byte)ProcessCommandId.GetProcessEnvironment);
+            Stream continuation = IpcClient.SendMessage(_endpoint, message, out IpcMessage response);
+            switch ((DiagnosticsServerResponseId)response.Header.CommandId)
+            {
+                case DiagnosticsServerResponseId.Error:
+                    int hr = BitConverter.ToInt32(response.Payload, 0);
+                    throw new ServerErrorException($"Get process environment failed (HRESULT: 0x{hr:X8})");
+                case DiagnosticsServerResponseId.OK:
+                    ProcessEnvironmentHelper helper = ProcessEnvironmentHelper.Parse(response.Payload);
+                    Task<Dictionary<string,string>> envTask = helper.ReadEnvironmentAsync(continuation);
+                    envTask.Wait();
+                    return envTask.Result;
+                default:
+                    throw new ServerErrorException($"Get process environment failed - server responded with unknown command");
+            }
+        }
+
         /// <summary>
         /// Get all the active processes that can be attached to.
         /// </summary>

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcCommands.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcCommands.cs
@@ -56,6 +56,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
     internal enum ProcessCommandId : byte
     {
         GetProcessInfo = 0x00,
-        ResumeRuntime  = 0x01
+        ResumeRuntime  = 0x01,
+        GetProcessEnvironment = 0x02,
     }
 }

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/ProcessEnvironment.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/ProcessEnvironment.cs
@@ -1,0 +1,69 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.NETCore.Client
+{
+    internal class ProcessEnvironmentHelper
+    {
+        private ProcessEnvironmentHelper() {}
+        public static ProcessEnvironmentHelper Parse(byte[] payload)
+        {
+            ProcessEnvironmentHelper helper = new ProcessEnvironmentHelper();
+
+            helper.ExpectedSizeInBytes = BitConverter.ToUInt32(payload, 0);
+            helper.Future = BitConverter.ToUInt16(payload, 4);
+
+            return helper;
+        }
+
+        public async Task<Dictionary<string,string>> ReadEnvironmentAsync(Stream continuation, CancellationToken token = default(CancellationToken))
+        {
+            var env = new Dictionary<string,string>();
+
+            using var memoryStream = new MemoryStream();
+            await continuation.CopyToAsync(memoryStream, (16 << 10) /* 16KiB */, token);
+            memoryStream.Seek(0, SeekOrigin.Begin);
+            byte[] envBlock = memoryStream.ToArray();
+
+            if (envBlock.Length != (long)ExpectedSizeInBytes)
+                throw new ApplicationException($"ProcessEnvironment continuation length did not match expected length. Expected: {ExpectedSizeInBytes} bytes, Received: {envBlock.Length} bytes");
+
+            int cursor = 0;
+            UInt32 nElements = BitConverter.ToUInt32(envBlock, cursor);
+            cursor += sizeof(UInt32);
+            while (cursor < envBlock.Length)
+            {
+                string pair = ReadString(envBlock, ref cursor);
+                int equalsIdx = pair.IndexOf('=');
+                env[pair.Substring(0,equalsIdx)] = equalsIdx != pair.Length - 1 ? pair.Substring(equalsIdx+1) : "";
+            }
+
+            return env;
+        }
+
+        private static string ReadString(byte[] buffer, ref int index)
+        {
+            // Length of the string of UTF-16 characters
+            int length = (int)BitConverter.ToUInt32(buffer, index);
+            index += sizeof(UInt32);
+
+            int size = (int)length * sizeof(char);
+            // The string contains an ending null character; remove it before returning the value
+            string value = Encoding.Unicode.GetString(buffer, index, size).Substring(0, length - 1);
+            index += size;
+            return value;
+        }
+
+        private UInt32 ExpectedSizeInBytes { get; set; }
+        private UInt16 Future { get; set; }
+    }
+}

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/GetProcessEnvironmentTests.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/GetProcessEnvironmentTests.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using Xunit;
+using Xunit.Abstractions;
+
+using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.TestHelpers;
+using Microsoft.Diagnostics.NETCore.Client;
+using Xunit.Extensions;
+
+namespace Microsoft.Diagnostics.NETCore.Client
+{
+    public class ProcessEnvironmentTests
+    {
+        private readonly ITestOutputHelper output;
+
+        public ProcessEnvironmentTests(ITestOutputHelper outputHelper)
+        {
+            output = outputHelper;
+        }
+
+        /// <summary>
+        /// A simple test that collects process environment.
+        /// </summary>
+        [Fact(Skip="Requires 5.0-rc1* or newer.  Re-enable once consuming this version or newer.")]
+        public void BasicEnvTest()
+        {
+            // as the attribute says, this test requires 5.0-rc1 or newer.  This has been tested locally on
+            // an rc1 build and passes.  It is equivalent to the dotnet/runtime version of this test.
+            TestRunner runner = new TestRunner(CommonHelper.GetTraceePath(targetFramework: "net5.0"), output);
+            string testKey = "FOO";
+            string testVal = "BAR";
+            runner.AddEnvVar(testKey, testVal);
+            runner.Start(3000);
+            DiagnosticsClient client = new DiagnosticsClient(runner.Pid);
+            Dictionary<string,string> env = client.GetProcessEnvironment();
+
+            Assert.True(env.ContainsKey(testKey) && env[testKey].Equals(testVal));
+
+            runner.Stop();
+        }
+    }
+}


### PR DESCRIPTION
Adds the spec and implementation for the GetProcessEnvironment command in `DiagnosticClient`.

CC @jander-msft @tommcdon @noahfalk 