### PR TITLE
Fix bug in SOS PrintManagedFrameContext (64-bit regs)

### DIFF
--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -13825,8 +13825,8 @@ public:
         if (IsDbgTargetAmd64())
         {
             foundPlatform = true;
-            String outputFormat3 = "    %3s=%016" PRIx64" %3s=%016" PRIx64" %3s=%016" PRIx64"\n";
-            String outputFormat2 = "    %3s=%016" PRIx64" %3s=%016" PRIx64"\n";
+            String outputFormat3 = "    %3s=%016llx %3s=%016llx %3s=%016llx\n";
+            String outputFormat2 = "    %3s=%016llx %3s=%016llx\n";
             ExtOut(outputFormat3, "rsp", context.Amd64Context.Rsp, "rbp", context.Amd64Context.Rbp, "rip", context.Amd64Context.Rip);
             ExtOut(outputFormat3, "rax", context.Amd64Context.Rax, "rbx", context.Amd64Context.Rbx, "rcx", context.Amd64Context.Rcx);
             ExtOut(outputFormat3, "rdx", context.Amd64Context.Rdx, "rsi", context.Amd64Context.Rsi, "rdi", context.Amd64Context.Rdi);
@@ -13872,11 +13872,11 @@ public:
             for (int i = 0; i < 29; ++i)
             {
                 if (i <10) ExtOut(" ");
-                ExtOut(" x%d=%016" PRIx64, i, X[i]);
+                ExtOut(" x%d=%016llx", i, X[i]);
                 if ((i % 3) == 2) ExtOut("\n   ");
             }
-            ExtOut("  fp=%016" PRIx64"\n", context.Arm64Context.Fp);
-            ExtOut("     lr=%016" PRIx64"  sp=%016" PRIx64"  pc=%016" PRIx64"\n", context.Arm64Context.Lr, context.Arm64Context.Sp, context.Arm64Context.Pc);
+            ExtOut("  fp=%016llx\n", context.Arm64Context.Fp);
+            ExtOut("     lr=%016llx  sp=%016llx  pc=%016llx\n", context.Arm64Context.Lr, context.Arm64Context.Sp, context.Arm64Context.Pc);
             ExtOut("           cpsr=%08x        fpcr=%08x        fpsr=%08x\n", context.Arm64Context.Cpsr, context.Arm64Context.Fpcr, context.Arm64Context.Fpsr);
         }
 #endif


### PR DESCRIPTION
On ARM64, running on Linux, 64-bit registers printed in truncated form: only least significant 32 bits. This PR fixes this issue. Basically, issue caused by usage of PRIxxx macro from inttypes.h. See details in commit commentary.

Issue caused by #1250 (when "%llx" was changed to PRIx64).

Related PRs: #1249 and #1250 
