### PR TITLE
fix UnixDomainSocketEndPoint type exception on Mono

### DIFF
--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/UnixDomainSocket.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/UnixDomainSocket.cs
@@ -111,7 +111,8 @@ namespace Microsoft.Diagnostics.NETCore.Client
             return new UnixDomainSocketEndPoint(path);
 #elif NETSTANDARD2_0
             // UnixDomainSocketEndPoint is not part of .NET Standard 2.0
-            var type = typeof(Socket).Assembly.GetType("System.Net.Sockets.UnixDomainSocketEndPoint");
+            var type = typeof(Socket).Assembly.GetType("System.Net.Sockets.UnixDomainSocketEndPoint")
+                        ?? Type.GetType("System.Net.Sockets.UnixDomainSocketEndPoint, System.Core");
             if (type == null)
             {
                 throw new PlatformNotSupportedException("Current process is not running a compatible .NET runtime.");


### PR DESCRIPTION
Fix #821 again because it broke after we moved the code to UnixDomainSocket.cs. 

