### PR TITLE
Bump dotnet-monitor to 5.0.0-preview.3.*

### DIFF
--- a/src/Tools/dotnet-monitor/dotnet-monitor.csproj
+++ b/src/Tools/dotnet-monitor/dotnet-monitor.csproj
@@ -17,7 +17,7 @@
     <!-- Version information -->
     <VersionPrefix>5.0.0</VersionPrefix>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
-    <PreReleaseVersionIteration>2</PreReleaseVersionIteration>
+    <PreReleaseVersionIteration>3</PreReleaseVersionIteration>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Bumping the dotnet-monitor version to preview 3 to version the newer packages above the ones that used the older version scheme.