### PR TITLE
Fix #1531: filter too long numbers in DiagnosticClient.GetPublishedProcesses

### DIFF
--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
@@ -217,11 +217,22 @@ namespace Microsoft.Diagnostics.NETCore.Client
         /// </returns>
         public static IEnumerable<int> GetPublishedProcesses()
         {
-            return Directory.GetFiles(PidIpcEndpoint.IpcRootPath)
-                .Select(namedPipe => (new FileInfo(namedPipe)).Name)
-                .Where(input => Regex.IsMatch(input, PidIpcEndpoint.DiagnosticsPortPattern))
-                .Select(input => int.Parse(Regex.Match(input, PidIpcEndpoint.DiagnosticsPortPattern).Groups[1].Value, NumberStyles.Integer))
-                .Distinct();
+            static IEnumerable<int> GetAllPublishedProcesses()
+            {
+                foreach (var namedPipe in Directory.GetFiles(PidIpcEndpoint.IpcRootPath))
+                {
+                    var fileName = new FileInfo(namedPipe).Name;
+                    var match = Regex.Match(fileName, PidIpcEndpoint.DiagnosticsPortPattern);
+                    if (!match.Success) continue;
+                    var group = match.Groups[1].Value;
+                    if (!int.TryParse(group, NumberStyles.Integer, CultureInfo.InvariantCulture, out var processId))
+                        continue;
+
+                    yield return processId;
+                }
+            }
+
+            return GetAllPublishedProcesses().Distinct();
         }
 
         private static byte[] SerializeCoreDump(string dumpName, DumpType dumpType, bool diagnostics)

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
@@ -219,9 +219,9 @@ namespace Microsoft.Diagnostics.NETCore.Client
         {
             static IEnumerable<int> GetAllPublishedProcesses()
             {
-                foreach (var namedPipe in Directory.GetFiles(PidIpcEndpoint.IpcRootPath))
+                foreach (var port in Directory.GetFiles(PidIpcEndpoint.IpcRootPath))
                 {
-                    var fileName = new FileInfo(namedPipe).Name;
+                    var fileName = new FileInfo(port).Name;
                     var match = Regex.Match(fileName, PidIpcEndpoint.DiagnosticsPortPattern);
                     if (!match.Success) continue;
                     var group = match.Groups[1].Value;


### PR DESCRIPTION
I have also chosen to improve the code by converting it into a generator method. This will save us from necessity to call `Regex.Match` twice and parse numbers twice (in a callback to `Where` and in a callback to `Select`).

Also, I've explicitly passed `CultureInfo.InvariantCulture` to the number parsing method, since I believe this is the right thing to do.