### PR TITLE
Migrate to latest System.CommandLine

### DIFF
--- a/diagnostics.sln
+++ b/diagnostics.sln
@@ -64,6 +64,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Common", "Common", "{298AE119-6625-4604-BDE5-0765DC34C856}"
 	ProjectSection(SolutionItems) = preProject
 		src\Tools\Common\CommandExtensions.cs = src\Tools\Common\CommandExtensions.cs
+		src\Tools\Common\CommandLineExtensions.cs = src\Tools\Common\CommandLineExtensions.cs
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Commands", "Commands", "{C457CBCD-3A8D-4402-9A2B-693A0390D3F9}"

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -50,7 +50,7 @@
     <MicrosoftExtensionsLoggingConsoleVersion>2.1.1</MicrosoftExtensionsLoggingConsoleVersion>
     <!-- We use a newer version of LoggingEventSource due to a bug in an older version-->
     <MicrosoftExtensionsLoggingEventSourceVersion>3.1.4</MicrosoftExtensionsLoggingEventSourceVersion>
-    <SystemCommandLineExperimentalVersion>0.3.0-alpha.19602.1</SystemCommandLineExperimentalVersion>
+    <SystemCommandLineVersion>2.0.0-beta1.20427.1</SystemCommandLineVersion>
     <SystemCommandLineRenderingVersion>0.3.0-alpha.19602.1</SystemCommandLineRenderingVersion>
     <SystemMemoryVersion>4.5.4</SystemMemoryVersion>
     <SystemTextJsonVersion>4.7.1</SystemTextJsonVersion>

--- a/src/Microsoft.Diagnostics.Repl/Command/CommandProcessor.cs
+++ b/src/Microsoft.Diagnostics.Repl/Command/CommandProcessor.cs
@@ -6,7 +6,9 @@ using System;
 using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Builder;
+using System.CommandLine.Help;
 using System.CommandLine.Invocation;
+using System.CommandLine.Parsing;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
@@ -70,8 +72,7 @@ namespace Microsoft.Diagnostics.Repl
         /// <returns>exit code</returns>
         public Task<int> Parse(string commandLine)
         {
-            ParseResult result = _parser.Parse(commandLine);
-            return _parser.InvokeAsync(result, _console);
+            return _parser.InvokeAsync(commandLine, _console);
         }
 
         /// <summary>

--- a/src/Microsoft.Diagnostics.Repl/Console/ConsoleProvider.cs
+++ b/src/Microsoft.Diagnostics.Repl/Console/ConsoleProvider.cs
@@ -6,6 +6,7 @@ using Microsoft.Diagnostics.DebugServices;
 using System;
 using System.Collections.Generic;
 using System.CommandLine;
+using System.CommandLine.IO;
 using System.IO;
 using System.Text;
 using System.Threading;

--- a/src/Microsoft.Diagnostics.Repl/Microsoft.Diagnostics.Repl.csproj
+++ b/src/Microsoft.Diagnostics.Repl/Microsoft.Diagnostics.Repl.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="System.CommandLine.Experimental" Version="$(SystemCommandLineExperimentalVersion)" />
+    <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Tools/Common/CommandLineExtensions.cs
+++ b/src/Tools/Common/CommandLineExtensions.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.CommandLine.IO;
+
+namespace System.CommandLine
+{
+    internal static class StandardStreamWriterExtensions
+    {
+        /// <summary>
+        /// Shim for removed member from System.CommandLine.Experimental > System.CommandLine
+        /// </summary>
+        public static void WriteLine(this IStandardStreamWriter output, string value)
+        {
+            output.Write(value);
+            output.Write(Environment.NewLine);
+        }
+    }
+}

--- a/src/Tools/Common/Commands/Utils.cs
+++ b/src/Tools/Common/Commands/Utils.cs
@@ -10,7 +10,7 @@ using Microsoft.Diagnostics.NETCore.Client;
 
 namespace Microsoft.Internal.Common.Utils
 {
-    internal class CommandUtils
+    internal static class CommandUtils
     {
         // Returns processId that matches the given name.
         // It also checks whether the process has a diagnostics server port.

--- a/src/Tools/dotnet-counters/Program.cs
+++ b/src/Tools/dotnet-counters/Program.cs
@@ -11,6 +11,7 @@ using System.CommandLine;
 using System.CommandLine.Binding;
 using System.CommandLine.Builder;
 using System.CommandLine.Invocation;
+using System.CommandLine.Parsing;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -66,7 +67,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 alias: "--refresh-interval",
                 description: "The number of seconds to delay between updating the displayed counters.")
             {
-                Argument = new Argument<int>(name: "refresh-interval", defaultValue: 1)
+                Argument = new Argument<int>(name: "refresh-interval", getDefaultValue: () => 1)
             };
 
         private static Option ExportFormatOption() =>
@@ -74,7 +75,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 alias: "--format",
                 description: "The format of exported counter data.")
             {
-                Argument = new Argument<CountersExportFormat>(name: "format", defaultValue: CountersExportFormat.csv)
+                Argument = new Argument<CountersExportFormat>(name: "format", getDefaultValue: () => CountersExportFormat.csv)
             };
 
         private static Option ExportFileNameOption() =>
@@ -82,11 +83,11 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 aliases: new[] { "-o", "--output" },
                 description: "The output file name.") 
             {
-                Argument = new Argument<string>(name: "output", defaultValue: "counter")
+                Argument = new Argument<string>(name: "output", getDefaultValue: () => "counter")
             };
 
         private static Argument CounterList() =>
-            new Argument<List<string>>(name: "counter_list", defaultValue: new List<string>()) 
+            new Argument<List<string>>(name: "counter_list", getDefaultValue: () => new List<string>())
             {
                 Description = @"A space separated list of counters. Counters can be specified provider_name[:counter_name]. If the provider_name is used without a qualifying counter_name then all counters will be shown. To discover provider and counter names, use the list command.",
                 Arity = ArgumentArity.ZeroOrMore
@@ -106,7 +107,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 aliases: new[] { "-r", "--runtime-version" },
                 description: "Version of runtime. Supported runtime version: 3.0, 3.1, 5.0") 
             {
-                Argument = new Argument<string>(name: "runtimeVersion", defaultValue: "3.1")
+                Argument = new Argument<string>(name: "runtimeVersion", getDefaultValue: () => "3.1")
             };
 
         private static readonly string[] s_SupportedRuntimeVersions = new[] { "3.0", "3.1", "5.0" };

--- a/src/Tools/dotnet-counters/dotnet-counters.csproj
+++ b/src/Tools/dotnet-counters/dotnet-counters.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)..\dotnet-trace\Extensions.cs" Link="Extensions.cs" />
     <Compile Include="..\Common\CommandExtensions.cs" Link="CommandExtensions.cs" />
+    <Compile Include="..\Common\CommandLineExtensions.cs" Link="CommandLineExtensions.cs" />
     <Compile Include="..\Common\Commands\ProcessStatus.cs" Link="ProcessStatus.cs" />
     <Compile Include="..\Common\Commands\Utils.cs" Link="Utils.cs" />
   </ItemGroup>
@@ -23,7 +24,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="$(MicrosoftDiagnosticsTracingTraceEventVersion)" />
-    <PackageReference Include="System.CommandLine.Experimental" Version="$(SystemCommandLineExperimentalVersion)" />
+    <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
+    <PackageReference Include="DotNetConfig" Version="1.0.0-rc" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tools/dotnet-dump/Analyzer.cs
+++ b/src/Tools/dotnet-dump/Analyzer.cs
@@ -20,6 +20,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Diagnostic.Tools.Dump.ExtensionCommands;
 using Microsoft.Diagnostics.Runtime.DataReaders.Implementation;
+using System.CommandLine.Help;
 
 namespace Microsoft.Diagnostics.Tools.Dump
 {

--- a/src/Tools/dotnet-dump/Commands/HelpCommand.cs
+++ b/src/Tools/dotnet-dump/Commands/HelpCommand.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.Diagnostics.Repl;
 using System.CommandLine;
+using System.CommandLine.Help;
 
 namespace Microsoft.Diagnostics.Tools.Dump
 {

--- a/src/Tools/dotnet-dump/Program.cs
+++ b/src/Tools/dotnet-dump/Program.cs
@@ -4,9 +4,11 @@
 
 using Microsoft.Internal.Common.Commands;
 using Microsoft.Tools.Common;
+using System;
 using System.CommandLine;
 using System.CommandLine.Builder;
 using System.CommandLine.Invocation;
+using System.CommandLine.Parsing;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -74,7 +76,7 @@ on Linux where YYYYMMDD is Year/Month/Day and HHMMSS is Hour/Minute/Second. Othe
                 description: @"The dump type determines the kinds of information that are collected from the process. There are several types: full - The largest dump containing all memory including the module images. heap - A large and relatively comprehensive dump containing module lists, thread lists, all stacks, exception information, handle information, and all memory except for mapped 
 images. mini - A small dump containing module lists, thread lists, exception information and all stacks. If not specified 'full' is the default.")
             {
-                Argument = new Argument<Dumper.DumpTypeOption>(name: "dump_type", defaultValue: Dumper.DumpTypeOption.Full)
+                Argument = new Argument<Dumper.DumpTypeOption>(name: "dump_type", getDefaultValue: () => Dumper.DumpTypeOption.Full)
             };
 
         private static Command AnalyzeCommand() =>
@@ -101,7 +103,7 @@ images. mini - A small dump containing module lists, thread lists, exception inf
                 aliases: new[] { "-c", "--command" }, 
                 description: "Run the command on start.") 
             {
-                Argument = new Argument<string[]>(name: "command", defaultValue: System.Array.Empty<string>()) { Arity = ArgumentArity.ZeroOrMore }
+                Argument = new Argument<string[]>(name: "command", getDefaultValue: () => Array.Empty<string>()) { Arity = ArgumentArity.ZeroOrMore }
             };
     }
 }

--- a/src/Tools/dotnet-dump/dotnet-dump.csproj
+++ b/src/Tools/dotnet-dump/dotnet-dump.csproj
@@ -24,6 +24,7 @@
 
   <ItemGroup>
     <Compile Include="..\Common\CommandExtensions.cs" Link="CommandExtensions.cs" />
+    <Compile Include="..\Common\CommandLineExtensions.cs" Link="CommandLineExtensions.cs" />
     <Compile Include="..\Common\Commands\ProcessStatus.cs" Link="ProcessStatus.cs" />
     <Compile Include="..\Common\Commands\Utils.cs" Link="Utils.cs" />
   </ItemGroup>

--- a/src/Tools/dotnet-gcdump/CommandLine/CollectCommandHandler.cs
+++ b/src/Tools/dotnet-gcdump/CommandLine/CollectCommandHandler.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Diagnostics.Tools.GCDump
                 aliases: new[] { "-p", "--process-id" },
                 description: "The process id to collect the gcdump from.")
             {
-                Argument = new Argument<int>(name: "pid", defaultValue: 0),
+                Argument = new Argument<int>(name: "pid", getDefaultValue: () => 0),
             };
 
         private static Option NameOption() =>
@@ -160,7 +160,7 @@ namespace Microsoft.Diagnostics.Tools.GCDump
                 aliases: new[] { "-o", "--output" },
                 description: $@"The path where collected gcdumps should be written. Defaults to '.\YYYYMMDD_HHMMSS_<pid>.gcdump' where YYYYMMDD is Year/Month/Day and HHMMSS is Hour/Minute/Second. Otherwise, it is the full path and file name of the dump.")
             {
-                Argument = new Argument<string>(name: "gcdump-file-path", defaultValue: "")
+                Argument = new Argument<string>(name: "gcdump-file-path", getDefaultValue: () => "")
             };
 
         private static Option VerboseOption() =>
@@ -168,7 +168,7 @@ namespace Microsoft.Diagnostics.Tools.GCDump
                 aliases: new[] { "-v", "--verbose" },
                 description: "Output the log while collecting the gcdump.") 
             {
-                Argument = new Argument<bool>(name: "verbose", defaultValue: false)
+                Argument = new Argument<bool>(name: "verbose", getDefaultValue: () => false)
             };
 
         public static int DefaultTimeout = 30;
@@ -177,7 +177,7 @@ namespace Microsoft.Diagnostics.Tools.GCDump
                 aliases: new[] { "-t", "--timeout" },
                 description: $"Give up on collecting the gcdump if it takes longer than this many seconds. The default value is {DefaultTimeout}s.")
             {
-                Argument = new Argument<int>(name: "timeout", defaultValue: DefaultTimeout)
+                Argument = new Argument<int>(name: "timeout", getDefaultValue: () => DefaultTimeout)
             };
     }
 }

--- a/src/Tools/dotnet-gcdump/Program.cs
+++ b/src/Tools/dotnet-gcdump/Program.cs
@@ -5,6 +5,7 @@
 using Microsoft.Internal.Common.Commands;
 using System.CommandLine.Builder;
 using System.CommandLine.Invocation;
+using System.CommandLine.Parsing;
 using System.Threading.Tasks;
 
 namespace Microsoft.Diagnostics.Tools.GCDump

--- a/src/Tools/dotnet-gcdump/dotnet-gcdump.csproj
+++ b/src/Tools/dotnet-gcdump/dotnet-gcdump.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <RootNamespace>Microsoft.Diagnostics.Tools.GCDump</RootNamespace>
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.CommandLine.Experimental" Version="$(SystemCommandLineExperimentalVersion)" />
+    <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
     <PackageReference Include="System.CommandLine.Rendering" Version="$(SystemCommandLineRenderingVersion)" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="$(MicrosoftDiagnosticsTracingTraceEventVersion)" />
   </ItemGroup>
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <Compile Include="..\Common\CommandExtensions.cs" Link="CommandExtensions.cs" />
+    <Compile Include="..\Common\CommandLineExtensions.cs" Link="CommandLineExtensions.cs" />
     <Compile Include="..\Common\Commands\ProcessStatus.cs" Link="ProcessStatus.cs" />
     <Compile Include="..\Common\Commands\Utils.cs" Link="Utils.cs" />
   </ItemGroup>

--- a/src/Tools/dotnet-monitor/Program.cs
+++ b/src/Tools/dotnet-monitor/Program.cs
@@ -6,6 +6,7 @@ using System;
 using System.CommandLine;
 using System.CommandLine.Builder;
 using System.CommandLine.Invocation;
+using System.CommandLine.Parsing;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Diagnostics.Monitoring;
@@ -38,7 +39,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 aliases: new[] { "-u", "--urls" },
                 description: "Bindings for the REST api.")
             {
-                Argument = new Argument<string[]>(name: "urls", defaultValue: new[] { "http://localhost:52323" })
+                Argument = new Argument<string[]>(name: "urls", getDefaultValue: () => new[] { "http://localhost:52323" })
             };
 
         private static Option MetricUrls() =>
@@ -46,7 +47,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 aliases: new[] { "--metricUrls" },
                 description: "Bindings for metrics")
             {
-                Argument = new Argument<string[]>(name: "metricUrls", defaultValue: new[]{ GetDefaultMetricsEndpoint() })
+                Argument = new Argument<string[]>(name: "metricUrls", getDefaultValue: () => new[]{ GetDefaultMetricsEndpoint() })
             };
     
         private static Option ProvideMetrics() =>
@@ -54,7 +55,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 aliases: new[] { "-m", "--metrics" },
                 description: "Enable publishing of metrics")
             {
-                Argument = new Argument<bool>(name: "metrics", defaultValue: true )
+                Argument = new Argument<bool>(name: "metrics", getDefaultValue: () => true )
             };
 
         private static Option ReversedServerAddress() =>

--- a/src/Tools/dotnet-monitor/dotnet-monitor.csproj
+++ b/src/Tools/dotnet-monitor/dotnet-monitor.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.KeyPerFile" Version="$(MicrosoftExtensionsConfigurationKeyPerFileVersion)" />
-    <PackageReference Include="System.CommandLine.Experimental" Version="$(SystemCommandLineExperimentalVersion)" />
+    <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tools/dotnet-sos/Program.cs
+++ b/src/Tools/dotnet-sos/Program.cs
@@ -7,6 +7,7 @@ using SOS;
 using System.CommandLine;
 using System.CommandLine.Builder;
 using System.CommandLine.Invocation;
+using System.CommandLine.Parsing;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 

--- a/src/Tools/dotnet-sos/dotnet-sos.csproj
+++ b/src/Tools/dotnet-sos/dotnet-sos.csproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Common\CommandExtensions.cs" Link="CommandExtensions.cs" />
+    <Compile Include="..\Common\CommandLineExtensions.cs" Link="CommandLineExtensions.cs" />
   </ItemGroup>
 
   <ItemGroup>
@@ -18,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.CommandLine.Experimental" Version="$(SystemCommandLineExperimentalVersion)" />
+    <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
   </ItemGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)..\..\sos-packaging.props" />

--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
@@ -296,7 +296,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 alias: "--buffersize",
                 description: $"Sets the size of the in-memory circular buffer in megabytes. Default {DefaultCircularBufferSizeInMB} MB.")
             {
-                Argument = new Argument<uint>(name: "size", defaultValue: DefaultCircularBufferSizeInMB)
+                Argument = new Argument<uint>(name: "size", getDefaultValue: () => DefaultCircularBufferSizeInMB)
             };
 
         public static string DefaultTraceName => "trace.nettrace";
@@ -306,7 +306,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 aliases: new[] { "-o", "--output" },
                 description: $"The output path for the collected trace data. If not specified it defaults to '{DefaultTraceName}'.")
             {
-                Argument = new Argument<FileInfo>(name: "trace-file-path", defaultValue: new FileInfo(DefaultTraceName))
+                Argument = new Argument<FileInfo>(name: "trace-file-path", getDefaultValue: () => new FileInfo(DefaultTraceName))
             };
 
         private static Option ProvidersOption() =>
@@ -314,7 +314,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 alias: "--providers",
                 description: @"A list of EventPipe providers to be enabled. This is in the form 'Provider[,Provider]', where Provider is in the form: 'KnownProviderName[:Flags[:Level][:KeyValueArgs]]', and KeyValueArgs is in the form: '[key1=value1][;key2=value2]'. These providers are in addition to any providers implied by the --profile argument. If there is any discrepancy for a particular provider, the configuration here takes precedence over the implicit configuration from the profile.")
             {
-                Argument = new Argument<string>(name: "list-of-comma-separated-providers", defaultValue: "") // TODO: Can we specify an actual type?
+                Argument = new Argument<string>(name: "list-of-comma-separated-providers", getDefaultValue: () => "") // TODO: Can we specify an actual type?
             };
 
         private static Option ProfileOption() =>
@@ -322,7 +322,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 alias: "--profile",
                 description: @"A named pre-defined set of provider configurations that allows common tracing scenarios to be specified succinctly.")
             {
-                Argument = new Argument<string>(name: "profile-name", defaultValue: "")
+                Argument = new Argument<string>(name: "profile-name", getDefaultValue: () => "")
             };
 
         private static Option DurationOption() =>
@@ -330,7 +330,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 alias: "--duration",
                 description: @"When specified, will trace for the given timespan and then automatically stop the trace. Provided in the form of dd:hh:mm:ss.")
             {
-                Argument = new Argument<TimeSpan>(name: "duration-timespan", defaultValue: default)
+                Argument = new Argument<TimeSpan>(name: "duration-timespan", getDefaultValue: () => default)
             };
         
         private static Option CLREventsOption() => 
@@ -338,7 +338,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 alias: "--clrevents",
                 description: @"List of CLR runtime events to emit.")
             {
-                Argument = new Argument<string>(name: "clrevents", defaultValue: "")
+                Argument = new Argument<string>(name: "clrevents", getDefaultValue: () => "")
             };
 
         private static Option CLREventLevelOption() => 
@@ -346,7 +346,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 alias: "--clreventlevel",
                 description: @"Verbosity of CLR events to be emitted.")
             {
-                Argument = new Argument<string>(name: "clreventlevel", defaultValue: "")
+                Argument = new Argument<string>(name: "clreventlevel", getDefaultValue: () => "")
             };
     }
 }

--- a/src/Tools/dotnet-trace/CommandLine/Commands/ConvertCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/ConvertCommand.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
             };
 
         private static Argument InputFileArgument() =>
-            new Argument<FileInfo>(name: "input-filename", defaultValue: new FileInfo(CollectCommandHandler.DefaultTraceName))
+            new Argument<FileInfo>(name: "input-filename", getDefaultValue: () => new FileInfo(CollectCommandHandler.DefaultTraceName))
             {
                 Description = $"Input trace file to be converted. Defaults to '{CollectCommandHandler.DefaultTraceName}'."
             }.ExistingOnly();

--- a/src/Tools/dotnet-trace/CommandLine/Options/CommonOptions.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Options/CommonOptions.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 alias: "--format",
                 description: $"Sets the output format for the trace file.  Default is {DefaultTraceFileFormat}.")
             {
-                Argument = new Argument<TraceFileFormat>(name: "trace-file-format", defaultValue: DefaultTraceFileFormat)
+                Argument = new Argument<TraceFileFormat>(name: "trace-file-format", getDefaultValue: () => DefaultTraceFileFormat)
             };
 
         public static Option ConvertFormatOption() =>

--- a/src/Tools/dotnet-trace/Program.cs
+++ b/src/Tools/dotnet-trace/Program.cs
@@ -3,8 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Internal.Common.Commands;
+using System.CommandLine;
 using System.CommandLine.Builder;
-using System.CommandLine.Invocation;
+using System.CommandLine.Parsing;
 using System.Threading.Tasks;
 
 namespace Microsoft.Diagnostics.Tools.Trace

--- a/src/Tools/dotnet-trace/dotnet-trace.csproj
+++ b/src/Tools/dotnet-trace/dotnet-trace.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.CommandLine.Experimental" Version="$(SystemCommandLineExperimentalVersion)" />
+    <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
     <PackageReference Include="System.CommandLine.Rendering" Version="$(SystemCommandLineRenderingVersion)" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="$(MicrosoftDiagnosticsTracingTraceEventVersion)" />
   </ItemGroup>
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <Compile Include="..\Common\CommandExtensions.cs" Link="CommandExtensions.cs" />
+    <Compile Include="..\Common\CommandLineExtensions.cs" Link="CommandLineExtensions.cs" />
     <Compile Include="..\Common\Commands\ProcessStatus.cs" Link="ProcessStatus.cs" />
     <Compile Include="..\Common\Commands\Utils.cs" Link="Utils.cs" />
   </ItemGroup>


### PR DESCRIPTION
This drops the dependency on the older System.CommandLine.Experimental package and replaces it with the latest non-experimental one.

Fixes #1534