### PR TITLE
Add osx-arm64 to packges/CI

### DIFF
--- a/diagnostics.yml
+++ b/diagnostics.yml
@@ -157,6 +157,21 @@ stages:
                 _BuildConfig: Debug
                 _BuildArch: x64
 
+    - template: /eng/build.yml
+      parameters:
+        name: MacOS_cross
+        osGroup: MacOS_cross
+        strategy:
+          matrix:
+            Build_Release:
+              _BuildConfig: Release
+              _BuildArch: arm64
+              _PublishArtifacts: bin/OSX.arm64.Release
+            ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
+              Build_Debug:
+                _BuildConfig: Debug
+                _BuildArch: arm64
+
     - ${{ if ne(variables['System.TeamProject'], 'public') }}:
       - template: /eng/build.yml
         parameters:
@@ -310,6 +325,7 @@ stages:
             - CentOS_7
             - Alpine3_6
             - MacOS
+            - MacOS_cross
             - Linux_cross
             - Linux_cross64
             - Alpine3_6_cross64
@@ -413,6 +429,15 @@ stages:
               inputs:
                 artifactName: MacOS_x64_Release
                 targetPath: '$(Build.SourcesDirectory)/artifacts/bin/OSX.x64.Release'
+              condition: succeeded()
+
+            # MacOS arm64 download
+
+            - task: DownloadPipelineArtifact@2
+              displayName: Download MacOS arm64 Artifacts
+              inputs:
+                artifactName: MacOS_cross_arm64_Release
+                targetPath: '$(Build.SourcesDirectory)/artifacts/bin/OSX.arm64.Release'
               condition: succeeded()
 
             # Create nuget packages, sign binaries and publish to blob feed

--- a/diagnostics.yml
+++ b/diagnostics.yml
@@ -163,11 +163,10 @@ stages:
         osGroup: MacOS_cross
         strategy:
           matrix:
-            ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
-              Build_Release:
-                _BuildConfig: Release
-                _BuildArch: arm64
-                _PublishArtifacts: bin/OSX.arm64.Release
+            Build_Release:
+              _BuildConfig: Release
+              _BuildArch: arm64
+              _PublishArtifacts: bin/OSX.arm64.Release
             ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
               Build_Debug:
                 _BuildConfig: Debug

--- a/diagnostics.yml
+++ b/diagnostics.yml
@@ -163,10 +163,11 @@ stages:
         osGroup: MacOS_cross
         strategy:
           matrix:
-            Build_Release:
-              _BuildConfig: Release
-              _BuildArch: arm64
-              _PublishArtifacts: bin/OSX.arm64.Release
+            ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
+              Build_Release:
+                _BuildConfig: Release
+                _BuildArch: arm64
+                _PublishArtifacts: bin/OSX.arm64.Release
             ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
               Build_Debug:
                 _BuildConfig: Debug

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -61,6 +61,7 @@ jobs:
       # Public OSX Xcode 12 Build Pool
       ${{ if and(eq(parameters.osGroup, 'MacOS_cross'), ne(variables['System.TeamProject'], 'public')) }}:
         name: Hosted Mac Internal
+        vmImage: macOS-10.15
 
       # Official Build OSX Xcode 12 Pool
       ${{ if and(eq(parameters.osGroup, 'MacOS_cross'), eq(variables['System.TeamProject'], 'public')) }}:
@@ -167,8 +168,7 @@ jobs:
         condition: succeeded()
 
     - ${{ if eq(parameters.osGroup, 'MacOS_cross') }}:
-      - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        - script: /bin/bash -c "sudo xcode-select -s /Applications/Xcode_12.app/Contents/Developer"
+      - script: /bin/bash -c "sudo xcode-select -s /Applications/Xcode_12_beta.app/Contents/Developer"
       - script: $(Build.SourcesDirectory)/eng/cibuild.sh
           --configuration $(_BuildConfig)
           --architecture $(_BuildArch)

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -50,20 +50,19 @@ jobs:
       ${{ if and(eq(parameters.osGroup, 'FreeBSD'), ne(variables['System.TeamProject'], 'public')) }}:
         name: dnceng-freebsd-internal
 
-      # Public OSX Build Pool
+      # Official Build OSX Pool
       ${{ if and(eq(parameters.osGroup, 'MacOS'), ne(variables['System.TeamProject'], 'public')) }}:
         name: Hosted Mac Internal
 
-      # Official Build OSX Pool
+      # Public OSX Build Pool
       ${{ if and(eq(parameters.osGroup, 'MacOS'), eq(variables['System.TeamProject'], 'public')) }}:
         vmImage: macOS-10.14
 
-      # Public OSX Xcode 12 Build Pool
-      ${{ if and(eq(parameters.osGroup, 'MacOS_cross'), ne(variables['System.TeamProject'], 'public')) }}:
-        name: Hosted Mac Internal
-        vmImage: macOS-10.15
-
       # Official Build OSX Xcode 12 Pool
+      ${{ if and(eq(parameters.osGroup, 'MacOS_cross'), ne(variables['System.TeamProject'], 'public')) }}:
+        vmImage: macos-10.15
+
+      # Public OSX Xcode 12 Build Pool
       ${{ if and(eq(parameters.osGroup, 'MacOS_cross'), eq(variables['System.TeamProject'], 'public')) }}:
         vmImage: macOS-10.15
 
@@ -168,7 +167,7 @@ jobs:
         condition: succeeded()
 
     - ${{ if eq(parameters.osGroup, 'MacOS_cross') }}:
-      - script: /bin/bash -c "sudo xcode-select -s /Applications/Xcode_12_beta.app/Contents/Developer"
+      - script: /bin/bash -c "sudo xcode-select -s /Applications/Xcode_12.2.app/Contents/Developer"
       - script: $(Build.SourcesDirectory)/eng/build.sh
           --restore
           --ci

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -60,11 +60,11 @@ jobs:
 
       # Public OSX Xcode 12 Build Pool
       ${{ if and(eq(parameters.osGroup, 'MacOS_cross'), ne(variables['System.TeamProject'], 'public')) }}:
-        queue: OSX.1100.Amd64.Public
+        name: Hosted Mac Internal
 
       # Official Build OSX Xcode 12 Pool
       ${{ if and(eq(parameters.osGroup, 'MacOS_cross'), eq(variables['System.TeamProject'], 'public')) }}:
-        queue: OSX.1100.Amd64
+        vmImage: macOS-10.15
 
       # Official Build Windows Pool
       ${{ if and(eq(parameters.osGroup, 'Windows_NT'), ne(variables['System.TeamProject'], 'public')) }}:
@@ -167,6 +167,8 @@ jobs:
         condition: succeeded()
 
     - ${{ if eq(parameters.osGroup, 'MacOS_cross') }}:
+      - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        - script: /bin/bash -c "sudo xcode-select -s /Applications/Xcode_12.app/Contents/Developer"
       - script: $(Build.SourcesDirectory)/eng/cibuild.sh
           --configuration $(_BuildConfig)
           --architecture $(_BuildArch)

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -166,7 +166,7 @@ jobs:
         displayName: Build / Test
         condition: succeeded()
 
-     - ${{ if eq(parameters.osGroup, 'MacOS_cross') }}:
+    - ${{ if eq(parameters.osGroup, 'MacOS_cross') }}:
       - script: $(Build.SourcesDirectory)/eng/cibuild.sh
           --configuration $(_BuildConfig)
           --architecture $(_BuildArch)

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -169,7 +169,10 @@ jobs:
 
     - ${{ if eq(parameters.osGroup, 'MacOS_cross') }}:
       - script: /bin/bash -c "sudo xcode-select -s /Applications/Xcode_12_beta.app/Contents/Developer"
-      - script: $(Build.SourcesDirectory)/eng/cibuild.sh
+      - script: $(Build.SourcesDirectory)/eng/build.sh
+          --restore
+          --ci
+          --stripsymbols
           --configuration $(_BuildConfig)
           --architecture $(_BuildArch)
           --prepareMachine

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -58,6 +58,14 @@ jobs:
       ${{ if and(eq(parameters.osGroup, 'MacOS'), eq(variables['System.TeamProject'], 'public')) }}:
         vmImage: macOS-10.14
 
+      # Public OSX Xcode 12 Build Pool
+      ${{ if and(eq(parameters.osGroup, 'MacOS_cross'), ne(variables['System.TeamProject'], 'public')) }}:
+        queue: OSX.1100.Amd64.Public
+
+      # Official Build OSX Xcode 12 Pool
+      ${{ if and(eq(parameters.osGroup, 'MacOS_cross'), eq(variables['System.TeamProject'], 'public')) }}:
+        queue: OSX.1100.Amd64
+
       # Official Build Windows Pool
       ${{ if and(eq(parameters.osGroup, 'Windows_NT'), ne(variables['System.TeamProject'], 'public')) }}:
         name: NetCoreInternal-Pool
@@ -157,7 +165,17 @@ jobs:
           $(_InternalInstallArgs)
         displayName: Build / Test
         condition: succeeded()
- 
+
+     - ${{ if eq(parameters.osGroup, 'MacOS_cross') }}:
+      - script: $(Build.SourcesDirectory)/eng/cibuild.sh
+          --configuration $(_BuildConfig)
+          --architecture $(_BuildArch)
+          --prepareMachine
+          /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+          $(_InternalInstallArgs)
+        displayName: Build / Test
+        condition: succeeded()
+
     - ${{ if ne(variables['System.TeamProject'], 'public') }}:
       - task: PublishBuildArtifacts@1
         displayName: Publish Build Artifacts

--- a/src/SOS/SOS.Package/SOS.Symbol.Package.csproj
+++ b/src/SOS/SOS.Package/SOS.Symbol.Package.csproj
@@ -71,6 +71,13 @@
     <None Include="$(ArtifactsBinDir)\OSX.x64.$(Configuration)\libsos.dylib.dwarf" Pack="true" Visible="false">
       <PackagePath>$(SOSPackagePathPrefix)/osx-x64</PackagePath>
     </None>
+
+    <None Include="$(ArtifactsBinDir)\OSX.arm64.$(Configuration)\libsosplugin.dylib.dwarf" Pack="true" Visible="false">
+      <PackagePath>$(SOSPackagePathPrefix)/osx-arm64</PackagePath>
+    </None>
+    <None Include="$(ArtifactsBinDir)\OSX.arm64.$(Configuration)\libsos.dylib.dwarf" Pack="true" Visible="false">
+      <PackagePath>$(SOSPackagePathPrefix)/osx-arm64</PackagePath>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/src/sos-packaging.props
+++ b/src/sos-packaging.props
@@ -55,6 +55,11 @@
     <SosRequiredBinaries Include="$(ArtifactsBinDir)\OSX.x64.$(Configuration)\libsosplugin.dylib" TargetRid="osx-x64" />
     <SosRequiredBinaries Include="$(ArtifactsBinDir)\OSX.x64.$(Configuration)\libsos.dylib" TargetRid="osx-x64" />
     <SosRequiredBinaries Include="$(ArtifactsBinDir)\OSX.x64.$(Configuration)\sosdocsunix.txt" TargetRid="osx-x64" />
+
+    <SosRequiredBinaries Include="$(SOSNETCoreBinaries)" TargetRid="osx-arm64" />
+    <SosRequiredBinaries Include="$(ArtifactsBinDir)\OSX.arm64.$(Configuration)\libsosplugin.dylib" TargetRid="osx-arm64" />
+    <SosRequiredBinaries Include="$(ArtifactsBinDir)\OSX.arm64.$(Configuration)\libsos.dylib" TargetRid="osx-arm64" />
+    <SosRequiredBinaries Include="$(ArtifactsBinDir)\OSX.arm64.$(Configuration)\sosdocsunix.txt" TargetRid="osx-arm64" />
   </ItemGroup>
 
   <!-- What and where to pack SOS assets in the final packages. -->


### PR DESCRIPTION
This is roughly what I think should work...

+ I Hijacked the osGroup usage a bit adding MacOS_cross, but it seemed simplest for now.  Probably will eventually need to be cleaned up.  Possibly when we move all the builds to using the XCode12 tool chain.
+ I am not sure exactly about pool configuration/queue names.
+ I am not sure whether prepare machine might need extra work...