### PR TITLE
Fix GetDefaultValue func

### DIFF
--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
@@ -330,7 +330,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 alias: "--duration",
                 description: @"When specified, will trace for the given timespan and then automatically stop the trace. Provided in the form of dd:hh:mm:ss.")
             {
-                Argument = new Argument<TimeSpan>(name: "duration-timespan", getDefaultValue: default)
+                Argument = new Argument<TimeSpan>(name: "duration-timespan", getDefaultValue: () => default)
             };
         
         private static Option CLREventsOption() => 


### PR DESCRIPTION
Fixes #1577

The upgrade of S.CommandLine changed the `T defaultValue` on arguments to `Func<T> getDefaultValue`.  `default` for a `Func<T>` is `null`, so we nullrefed when it tried to build the command line parser.