### PR TITLE
Disable createdump dump logging for stack overflow tests

### DIFF
--- a/src/SOS/SOS.UnitTests/SOS.cs
+++ b/src/SOS/SOS.UnitTests/SOS.cs
@@ -147,6 +147,8 @@ public class SOS
         await RunTest("Overflow.script", information: new SOSRunner.TestInformation {
             TestConfiguration = config,
             DebuggeeName = "Overflow",
+            // Generating the logging for overflow test causes so much output from createdump that it hangs/timesout the test run
+            DumpDiagnostics = false,
             DumpGenerator = config.StackOverflowCreatesDump ? SOSRunner.DumpGenerator.CreateDump : SOSRunner.DumpGenerator.NativeDebugger
         });
     }


### PR DESCRIPTION
The logging causes the tests to timeout because of the excessive stack overflow logging.