### PR TITLE
Update to latest System.CommandLine (2.0.0-beta1.20467.2)

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -51,8 +51,8 @@
     <MicrosoftExtensionsLoggingConsoleVersion>2.1.1</MicrosoftExtensionsLoggingConsoleVersion>
     <!-- We use a newer version of LoggingEventSource due to a bug in an older version-->
     <MicrosoftExtensionsLoggingEventSourceVersion>3.1.4</MicrosoftExtensionsLoggingEventSourceVersion>
-    <SystemCommandLineVersion>2.0.0-beta1.20427.1</SystemCommandLineVersion>
-    <SystemCommandLineRenderingVersion>0.3.0-alpha.20427.1</SystemCommandLineRenderingVersion>
+    <SystemCommandLineVersion>2.0.0-beta1.20467.2</SystemCommandLineVersion>
+    <SystemCommandLineRenderingVersion>2.0.0-beta1.20074.1</SystemCommandLineRenderingVersion>
     <SystemMemoryVersion>4.5.4</SystemMemoryVersion>
     <SystemTextJsonVersion>4.7.1</SystemTextJsonVersion>
     <SystemThreadingChannelsVersion>4.7.0</SystemThreadingChannelsVersion>

--- a/src/Microsoft.Diagnostics.Repl/Command/CommandProcessor.cs
+++ b/src/Microsoft.Diagnostics.Repl/Command/CommandProcessor.cs
@@ -117,10 +117,6 @@ namespace Microsoft.Diagnostics.Repl
             {
                 if (baseAttribute is CommandAttribute commandAttribute && IsValidPlatform(commandAttribute))
                 {
-                    if (command != null)
-                    {
-                        rootBuilder.AddCommand(command);
-                    }
                     command = new Command(commandAttribute.Name, commandAttribute.Help);
                     var properties = new List<(PropertyInfo, Option)>();
                     var arguments = new List<(PropertyInfo, Argument)>();
@@ -168,6 +164,7 @@ namespace Microsoft.Diagnostics.Repl
                     var handler = new Handler(this, commandAttribute.AliasExpansion, arguments, properties, type);
                     _commandHandlers.Add(command.Name, handler);
                     command.Handler = handler;
+                    rootBuilder.AddCommand(command);
                 }
 
                 if (baseAttribute is CommandAliasAttribute commandAliasAttribute && IsValidPlatform(commandAliasAttribute))
@@ -178,11 +175,6 @@ namespace Microsoft.Diagnostics.Repl
                     }
                     command.AddAlias(commandAliasAttribute.Name);
                 }
-            }
-
-            if (command != null)
-            {
-                rootBuilder.AddCommand(command);
             }
         }
 


### PR DESCRIPTION
Remove workaround in command processor.

This update also fixes option aliases like "lm -v".