### PR TITLE
Get command line, process name, os, process architecture, and process environment.

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/MetricsService.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/MetricsService.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer
                         //TODO In multi-process scenarios, how do we decide which process to choose?
                         //One possibility is to enable metrics after a request to begin polling for metrics
                         IProcessInfo pi = await _services.GetProcessAsync(filter: null, stoppingToken);
-                        await _pipeProcessor.Process(pi.Client, pi.Pid, Timeout.InfiniteTimeSpan, stoppingToken);
+                        await _pipeProcessor.Process(pi.Client, pi.ProcessId, Timeout.InfiniteTimeSpan, stoppingToken);
                     }
                     catch(Exception e) when (!(e is OperationCanceledException))
                     {

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/Models/ProcessIdentifierModel.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/Models/ProcessIdentifierModel.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace Microsoft.Diagnostics.Monitoring.RestServer.Models
+{
+    [DataContract(Name = "Process")]
+    public class ProcessIdentifierModel
+    {
+        [DataMember(Name = "pid")]
+        public int Pid { get; set; }
+
+        [DataMember(Name = "uid")]
+        public Guid Uid { get; set; }
+
+        public static ProcessIdentifierModel FromProcessInfo(IProcessInfo processInfo)
+        {
+            return new ProcessIdentifierModel()
+            {
+                Pid = processInfo.ProcessId,
+                Uid = processInfo.RuntimeInstanceCookie
+            };
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/Models/ProcessModel.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/Models/ProcessModel.cs
@@ -12,9 +12,29 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Models
         [DataMember(Name = "uid")]
         public Guid Uid { get; set; }
 
+        [DataMember(Name = "name")]
+        public string Name { get; private set; }
+
+        [DataMember(Name = "commandLine")]
+        public string CommandLine { get; private set; }
+
+        [DataMember(Name = "os")]
+        public string OperatingSystem { get; private set; }
+
+        [DataMember(Name = "architecture")]
+        public string ProcessArchitecture { get; private set; }
+
         public static ProcessModel FromProcessInfo(IProcessInfo processInfo)
         {
-            return new ProcessModel() { Pid = processInfo.Pid, Uid = processInfo.Uid };
+            return new ProcessModel()
+            {
+                CommandLine = processInfo.CommandLine,
+                Name = processInfo.ProcessName,
+                OperatingSystem = processInfo.OperatingSystem,
+                ProcessArchitecture = processInfo.ProcessArchitecture,
+                Pid = processInfo.ProcessId,
+                Uid = processInfo.RuntimeInstanceCookie
+            };
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring/CommandLineHelper.cs
+++ b/src/Microsoft.Diagnostics.Monitoring/CommandLineHelper.cs
@@ -1,0 +1,69 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text;
+
+namespace Microsoft.Diagnostics.Monitoring
+{
+    internal class CommandLineHelper
+    {
+        public static string ExtractExecutablePath(string commandLine, bool isWindows)
+        {
+            if (string.IsNullOrEmpty(commandLine))
+            {
+                return commandLine;
+            }
+
+            int commandLineLength = commandLine.Length;
+            bool isQuoted = false;
+            bool isEscaped = false;
+            int i = 0;
+            char c = commandLine[0];
+
+            // Search for the first whitespace character that is not quoted.
+            // Store character literals as it iterates the command line. Escaped
+            // characters within double quotes are unescaped for non-Windows systems.
+            // Algorithm based on INIT_FormatCommandLine behavior from
+            // https://github.com/dotnet/runtime/blob/master/src/coreclr/src/pal/src/init/pal.cpp
+            StringBuilder builder = new StringBuilder(commandLineLength);
+            do
+            {
+                if (isEscaped)
+                {
+                    builder.Append(c);
+                    isEscaped = false;
+                }
+                else if (c == '"')
+                {
+                    isQuoted = !isQuoted;
+                }
+                else if (c == '\\' && !isWindows)
+                {
+                    if (isQuoted)
+                    {
+                        isEscaped = true;
+                    }
+                    else
+                    {
+                        builder.Append(c);
+                    }
+                }
+                else
+                {
+                    builder.Append(c);
+                }
+
+                if (commandLineLength == ++i)
+                {
+                    break;
+                }
+
+                c = commandLine[i];
+            }
+            while (isQuoted || !char.IsWhiteSpace(c));
+
+            return builder.ToString();
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring/Contracts/IDiagnosticServices.cs
+++ b/src/Microsoft.Diagnostics.Monitoring/Contracts/IDiagnosticServices.cs
@@ -40,9 +40,17 @@ namespace Microsoft.Diagnostics.Monitoring
     {
         DiagnosticsClient Client { get; }
 
-        int Pid { get; }
+        string CommandLine { get; }
 
-        Guid Uid { get; }
+        public string OperatingSystem { get; }
+
+        public string ProcessArchitecture { get; }
+
+        string ProcessName { get; }
+
+        int ProcessId { get; }
+
+        Guid RuntimeInstanceCookie { get; }
     }
 
     public enum DumpType

--- a/src/Microsoft.Diagnostics.Monitoring/Contracts/IEndpointInfoSource.cs
+++ b/src/Microsoft.Diagnostics.Monitoring/Contracts/IEndpointInfoSource.cs
@@ -17,6 +17,12 @@ namespace Microsoft.Diagnostics.Monitoring
         int ProcessId { get; }
 
         Guid RuntimeInstanceCookie { get; }
+
+        string CommandLine { get; }
+
+        string OperatingSystem { get; }
+
+        string ProcessArchitecture { get; }
     }
 
     public interface IEndpointInfoSource

--- a/src/Microsoft.Diagnostics.Monitoring/EndpointInfo.cs
+++ b/src/Microsoft.Diagnostics.Monitoring/EndpointInfo.cs
@@ -1,0 +1,99 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using Microsoft.Diagnostics.NETCore.Client;
+
+namespace Microsoft.Diagnostics.Monitoring
+{
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    internal class EndpointInfo : IEndpointInfo
+    {
+        public static EndpointInfo FromProcessId(int processId)
+        {
+            var client = new DiagnosticsClient(processId);
+
+            ProcessInfo processInfo = null;
+            try
+            {
+                // Primary motivation is to get the runtime instance cookie in order to
+                // keep parity with the FromIpcEndpointInfo implementation; store the
+                // remainder of the information since it already has access to it.
+                processInfo = client.GetProcessInfo();
+
+                Debug.Assert(processId == unchecked((int)processInfo.ProcessId));
+            }
+            catch (ServerErrorException)
+            {
+                // The runtime likely doesn't understand the GetProcessInfo command.
+            }
+            catch (TimeoutException)
+            {
+                // Runtime didn't respond within client timeout.
+            }
+
+            // CONSIDER: Generate a runtime instance identifier based on the pipe name
+            // for .NET Core 3.1 e.g. pid + disambiguator in GUID form.
+            return new EndpointInfo()
+            {
+                Endpoint = new PidIpcEndpoint(processId),
+                ProcessId = processId,
+                RuntimeInstanceCookie = processInfo?.RuntimeInstanceCookie ?? Guid.Empty,
+                CommandLine = processInfo?.CommandLine,
+                OperatingSystem = processInfo?.OperatingSystem,
+                ProcessArchitecture = processInfo?.ProcessArchitecture
+            };
+        }
+
+        public static EndpointInfo FromIpcEndpointInfo(IpcEndpointInfo info)
+        {
+            var client = new DiagnosticsClient(info.Endpoint);
+
+            ProcessInfo processInfo = null;
+            try
+            {
+                // Primary motivation is to keep parity with the FromProcessId implementation,
+                // which provides the additional process information because it already has
+                // access to it.
+                processInfo = client.GetProcessInfo();
+
+                Debug.Assert(info.ProcessId == unchecked((int)processInfo.ProcessId));
+                Debug.Assert(info.RuntimeInstanceCookie == processInfo.RuntimeInstanceCookie);
+            }
+            catch (ServerErrorException)
+            {
+                // The runtime likely doesn't understand the GetProcessInfo command.
+            }
+            catch (TimeoutException)
+            {
+                // Runtime didn't respond within client timeout.
+            }
+
+            return new EndpointInfo()
+            {
+                Endpoint = info.Endpoint,
+                ProcessId = info.ProcessId,
+                RuntimeInstanceCookie = info.RuntimeInstanceCookie,
+                CommandLine = processInfo?.CommandLine,
+                OperatingSystem = processInfo?.OperatingSystem,
+                ProcessArchitecture = processInfo?.ProcessArchitecture
+            };
+        }
+
+        public IpcEndpoint Endpoint { get; private set; }
+
+        public int ProcessId { get; private set; }
+
+        public Guid RuntimeInstanceCookie { get; private set; }
+
+        public string CommandLine { get; private set; }
+
+        public string OperatingSystem { get; private set; }
+
+        public string ProcessArchitecture { get; private set; }
+
+        internal string DebuggerDisplay => FormattableString.Invariant($"PID={ProcessId}, Cookie={RuntimeInstanceCookie}");
+    }
+}

--- a/src/Microsoft.Diagnostics.NETCore.Client/ReversedServer/IpcEndpointInfo.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/ReversedServer/IpcEndpointInfo.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
     /// <summary>
     /// Represents a runtine instance connection to a reversed diagnostics server.
     /// </summary>
-    [DebuggerDisplay("PID={ProcessId}, Cookie={RuntimeInstanceCookie}")]
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     internal struct IpcEndpointInfo
     {
         internal IpcEndpointInfo(IpcEndpoint endpoint, int processId, Guid runtimeInstanceCookie)
@@ -34,5 +34,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
         /// The unique identifier of the runtime instance.
         /// </summary>
         public Guid RuntimeInstanceCookie { get; }
+
+        internal string DebuggerDisplay => FormattableString.Invariant($"PID={ProcessId}, Cookie={RuntimeInstanceCookie}");
     }
 }

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/ReversedServerHelper.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/ReversedServerHelper.cs
@@ -43,10 +43,5 @@ namespace Microsoft.Diagnostics.NETCore.Client
             runner.AddEnvVar("DOTNET_DiagnosticsMonitorAddress", transportName);
             runner.AddEnvVar("DOTNET_DiagnosticPorts", $"{transportName},nosuspend;");
         }
-
-        public static string ToTestString(this IpcEndpointInfo info)
-        {
-            return $"PID={info.ProcessId}, COOKIE={info.RuntimeInstanceCookie}";
-        }
     }
 }

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/ReversedServerTests.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/ReversedServerTests.cs
@@ -322,7 +322,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
 
             await VerifyWaitForConnection(info, useAsync, expectTimeout);
 
-            _outputHelper.WriteLine($"Connection: {info.ToTestString()}");
+            _outputHelper.WriteLine($"Connection: {info.DebuggerDisplay}");
         }
 
         private void ResumeRuntime(IpcEndpointInfo info)

--- a/src/tests/dotnet-monitor/CommandLineHelperTests.cs
+++ b/src/tests/dotnet-monitor/CommandLineHelperTests.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Monitoring;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace DotnetMonitor.UnitTests
+{
+    public class CommandLineHelperTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public CommandLineHelperTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Theory]
+        [InlineData(true, null, null)]
+        [InlineData(true, "", "")]
+        [InlineData(true, @"C:\NoArgs\test.exe", @"C:\NoArgs\test.exe")]
+        [InlineData(true, @"C:\WithArgs\test.exe arg1 arg2", @"C:\WithArgs\test.exe")]
+        [InlineData(true, @"""C:\With Space No Args\test.exe""", @"C:\With Space No Args\test.exe")]
+        [InlineData(true, @"""C:\With Space With Args\test.exe"" arg1 arg2", @"C:\With Space With Args\test.exe")]
+        [InlineData(true, @"C:\With'Quotes'No'Args\test.exe", @"C:\With'Quotes'No'Args\test.exe")]
+        [InlineData(true, @"C:\With'Quotes'With'Args\test.exe arg1 arg2", @"C:\With'Quotes'With'Args\test.exe")]
+        [InlineData(false, null, null)]
+        [InlineData(false, "", "")]
+        [InlineData(false, "/home/noargs/test", "/home/noargs/test")]
+        [InlineData(false, "/home/withargs/test arg1 arg2", "/home/withargs/test")]
+        [InlineData(false, @"""/home/with space no args/test""", "/home/with space no args/test")]
+        [InlineData(false, @"""/home/with space with args/test"" arg1 arg2", "/home/with space with args/test")]
+        [InlineData(false, @"""/home/escaped\\backslashes\\no\\args/test""", @"/home/escaped\backslashes\no\args/test")]
+        [InlineData(false, @"""/home/escaped\\backslashes\\with\\args/test"" arg1 arg2", @"/home/escaped\backslashes\with\args/test")]
+        [InlineData(false, @"""/home/escaped\""quotes\""no\""args/test""", @"/home/escaped""quotes""no""args/test")]
+        [InlineData(false, @"""/home/escaped\""quotes\""with\""args/test"" arg1 arg2", @"/home/escaped""quotes""with""args/test")]
+        public void CommandLineValidPathTest(bool isWindows, string commandLine, string expectedProcessPath)
+        {
+            Assert.Equal(expectedProcessPath, CommandLineHelper.ExtractExecutablePath(commandLine, isWindows));
+        }
+    }
+}

--- a/src/tests/dotnet-monitor/EndpointInfoSourceTests.cs
+++ b/src/tests/dotnet-monitor/EndpointInfoSourceTests.cs
@@ -121,6 +121,9 @@ namespace DotnetMonitor.UnitTests
                 endpointInfos = await GetEndpointInfoAsync(source);
 
                 var endpointInfo = Assert.Single(endpointInfos);
+                Assert.NotNull(endpointInfo.CommandLine);
+                Assert.NotNull(endpointInfo.OperatingSystem);
+                Assert.NotNull(endpointInfo.ProcessArchitecture);
                 VerifyConnection(execution1.TestRunner, endpointInfo);
 
                 _outputHelper.WriteLine("Stopping tracee.");
@@ -169,7 +172,7 @@ namespace DotnetMonitor.UnitTests
         private sealed class TestServerEndpointInfoSource : ServerEndpointInfoSource
         {
             private readonly ITestOutputHelper _outputHelper;
-            private readonly List<TaskCompletionSource<IpcEndpointInfo>> _addedEndpointInfoSources = new List<TaskCompletionSource<IpcEndpointInfo>>();
+            private readonly List<TaskCompletionSource<EndpointInfo>> _addedEndpointInfoSources = new List<TaskCompletionSource<EndpointInfo>>();
 
             public TestServerEndpointInfoSource(string transportPath, ITestOutputHelper outputHelper)
                 : base(transportPath)
@@ -177,9 +180,9 @@ namespace DotnetMonitor.UnitTests
                 _outputHelper = outputHelper;
             }
 
-            public async Task<IpcEndpointInfo> WaitForNewEndpointInfoAsync(TimeSpan timeout)
+            public async Task<EndpointInfo> WaitForNewEndpointInfoAsync(TimeSpan timeout)
             {
-                TaskCompletionSource<IpcEndpointInfo> addedEndpointInfoSource = new TaskCompletionSource<IpcEndpointInfo>(TaskCreationOptions.RunContinuationsAsynchronously);
+                TaskCompletionSource<EndpointInfo> addedEndpointInfoSource = new TaskCompletionSource<EndpointInfo>(TaskCreationOptions.RunContinuationsAsynchronously);
                 using var timeoutCancellation = new CancellationTokenSource();
                 var token = timeoutCancellation.Token;
                 using var _ = token.Register(() => addedEndpointInfoSource.TrySetCanceled(token));
@@ -191,15 +194,15 @@ namespace DotnetMonitor.UnitTests
 
                 _outputHelper.WriteLine("Waiting for new endpoint info.");
                 timeoutCancellation.CancelAfter(timeout);
-                IpcEndpointInfo endpointInfo = await addedEndpointInfoSource.Task;
+                EndpointInfo endpointInfo = await addedEndpointInfoSource.Task;
                 _outputHelper.WriteLine("Notified of new endpoint info.");
 
                 return endpointInfo;
             }
 
-            internal override void OnAddedEndpointInfo(IpcEndpointInfo info)
+            internal override void OnAddedEndpointInfo(EndpointInfo info)
             {
-                _outputHelper.WriteLine($"Added endpoint info to collection: {info.ToTestString()}");
+                _outputHelper.WriteLine($"Added endpoint info to collection: {info.DebuggerDisplay}");
                 
                 lock (_addedEndpointInfoSources)
                 {
@@ -211,9 +214,9 @@ namespace DotnetMonitor.UnitTests
                 }
             }
 
-            internal override void OnRemovedEndpointInfo(IpcEndpointInfo info)
+            internal override void OnRemovedEndpointInfo(EndpointInfo info)
             {
-                _outputHelper.WriteLine($"Removed endpoint info from collection: {info.ToTestString()}");
+                _outputHelper.WriteLine($"Removed endpoint info from collection: {info.DebuggerDisplay}");
             }
         }
     }


### PR DESCRIPTION
Summary:
- Get additional process information when collecting diagnosable processes.
- Get command line via event pipe if GetProcessInfo command failed.
- Fix getting command line via event pipe to wait for information before completing.
- Add additional process information to the /processes/{id} and the environment block to the /proceses/{id}/env endpoints.

closes #1470