### PR TITLE
Fix testing on arm64.

### DIFF
--- a/eng/InstallRuntimes.proj
+++ b/eng/InstallRuntimes.proj
@@ -72,7 +72,7 @@
   <ItemGroup Condition="!$(InternalReleaseTesting) and !$(PrivateBuildTesting)">
     <TestVersions Include="Latest" RuntimeVersion="$(MicrosoftNETCoreAppVersion)" AspNetVersion="$(MicrosoftAspNetCoreAppRefVersion)" />
     <TestVersions Include="31" RuntimeVersion="$(MicrosoftNETCoreApp31Version)" AspNetVersion="$(MicrosoftAspNetCoreApp31Version)" />
-    <TestVersions Include="21" RuntimeVersion="$(MicrosoftNETCoreApp21Version)" AspNetVersion="$(MicrosoftAspNetCoreApp21Version)" />
+    <TestVersions Condition="'$(BuildArch)' != 'arm' and '$(BuildArch)' != 'arm64'" Include="21" RuntimeVersion="$(MicrosoftNETCoreApp21Version)" AspNetVersion="$(MicrosoftAspNetCoreApp21Version)" />
   </ItemGroup>
 
   <!-- Local private build testing -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -10,9 +10,9 @@
     <!-- Latest symstore version updated by darc -->
     <MicrosoftSymbolStoreVersion>1.0.143102</MicrosoftSymbolStoreVersion>
     <!-- Runtime versions to test -->
-    <MicrosoftNETCoreApp21Version>2.1.18</MicrosoftNETCoreApp21Version>
+    <MicrosoftNETCoreApp21Version>2.1.22</MicrosoftNETCoreApp21Version>
     <MicrosoftAspNetCoreApp21Version>$(MicrosoftNETCoreApp21Version)</MicrosoftAspNetCoreApp21Version>
-    <MicrosoftNETCoreApp31Version>3.1.5</MicrosoftNETCoreApp31Version>
+    <MicrosoftNETCoreApp31Version>3.1.8</MicrosoftNETCoreApp31Version>
     <MicrosoftAspNetCoreApp31Version>$(MicrosoftNETCoreApp31Version)</MicrosoftAspNetCoreApp31Version>
     <!-- Latest shared runtime version updated by darc -->
     <MicrosoftNETCoreAppVersion>5.0.0-rc.2.20474.8</MicrosoftNETCoreAppVersion>

--- a/src/Microsoft.Diagnostics.DebugServices/ThreadService.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/ThreadService.cs
@@ -42,25 +42,25 @@ namespace Microsoft.Diagnostics.DebugServices
                 case Architecture.Amd64:
                     // Dumps generated with newer dbgeng have bigger context buffers and clrmd requires the context size to at least be that size.
                     _contextSize = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? 0x700 : AMD64Context.Size;
-                    _contextFlags = AMD64Context.ContextControl | AMD64Context.ContextInteger | AMD64Context.ContextSegments;
+                    _contextFlags = AMD64Context.ContextControl | AMD64Context.ContextInteger | AMD64Context.ContextSegments | AMD64Context.ContextFloatingPoint;
                     contextType = typeof(AMD64Context);
                     break;
 
                 case Architecture.X86:
                     _contextSize = X86Context.Size;
-                    _contextFlags = X86Context.ContextControl | X86Context.ContextInteger | X86Context.ContextSegments;
+                    _contextFlags = X86Context.ContextControl | X86Context.ContextInteger | X86Context.ContextSegments | X86Context.ContextFloatingPoint;
                     contextType = typeof(X86Context);
                     break;
 
                 case Architecture.Arm64:
                     _contextSize = Arm64Context.Size;
-                    _contextFlags = Arm64Context.ContextControl | Arm64Context.ContextInteger;
+                    _contextFlags = Arm64Context.ContextControl | Arm64Context.ContextInteger | Arm64Context.ContextFloatingPoint;
                     contextType = typeof(Arm64Context);
                     break;
 
                 case Architecture.Arm:
                     _contextSize = ArmContext.Size;
-                    _contextFlags = ArmContext.ContextControl | ArmContext.ContextInteger;
+                    _contextFlags = ArmContext.ContextControl | ArmContext.ContextInteger | ArmContext.ContextFloatingPoint;
                     contextType = typeof(ArmContext);
                     break;
 

--- a/src/SOS/SOS.UnitTests/ConfigFiles/Unix/Debugger.Tests.Config.txt
+++ b/src/SOS/SOS.UnitTests/ConfigFiles/Unix/Debugger.Tests.Config.txt
@@ -28,6 +28,11 @@
   <TestWebApp3>true</TestWebApp3>
   <TestWebApp3 Condition="'$(InternalReleaseTesting)' == 'true'">false</TestWebApp3>
 
+  <TestRuntime21>true</TestRuntime21>
+  <TestRuntime21 Condition="'$(TestLatestOnly)' == 'true'">false</TestRuntime21>
+  <TestRuntime21 Condition="'$(TargetArchitecture)' == 'arm'">false</TestRuntime21>
+  <TestRuntime21 Condition="'$(TargetArchitecture)' == 'arm64'">false</TestRuntime21>
+
   <!-- Build the debuggee for this framework version but run it on latest -->
   <BuildProjectFrameworkLatest Condition="StartsWith('$(RuntimeVersionLatest)', '6')">net5.0</BuildProjectFrameworkLatest>
   <BuildProjectFrameworkLatest Condition="StartsWith('$(RuntimeVersionLatest)', '5')">net5.0</BuildProjectFrameworkLatest>
@@ -56,7 +61,7 @@
       <BuildProjectFramework>netcoreapp3.1</BuildProjectFramework>
       <RuntimeFrameworkVersion>$(RuntimeVersion31)</RuntimeFrameworkVersion>
     </Option>
-    <Option Condition="'$(TestLatestOnly)' != 'true'">
+    <Option Condition="'$(TestRuntime21)' == 'true'">
       <BuildProjectFramework>netcoreapp2.1</BuildProjectFramework>
       <RuntimeFrameworkVersion>$(RuntimeVersion21)</RuntimeFrameworkVersion>
     </Option>
@@ -76,7 +81,7 @@
           <BuildProjectFramework>netcoreapp3.1</BuildProjectFramework>
           <RuntimeFrameworkVersion>$(RuntimeVersion31)</RuntimeFrameworkVersion>
         </Option>
-        <Option Condition="'$(TestLatestOnly)' != 'true'">
+        <Option Condition="'$(TestRuntime21)' == 'true'">
           <BuildProjectFramework>netcoreapp2.1</BuildProjectFramework>
           <RuntimeFrameworkVersion>$(RuntimeVersion21)</RuntimeFrameworkVersion>
         </Option>

--- a/src/SOS/SOS.UnitTests/Scripts/DivZero.script
+++ b/src/SOS/SOS.UnitTests/Scripts/DivZero.script
@@ -37,7 +37,7 @@ VERIFY:\[.*[\\|/]Debuggees[\\|/](dotnet.+[\\|/])?DivZero[\\|/]DivZero\.cs @ 21\s
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+[Dd]iv[Zz]ero.*!C\.F2(\(.*\))?\+0x<HEXVAL>\s+
 VERIFY:\[.*[\\|/]Debuggees[\\|/](dotnet.+[\\|/])?DivZero[\\|/]DivZero\.cs @ 33\s*\]\s*
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+[Dd]iv[Zz]ero.*!C\.Main(\(.*\))?\+0x<HEXVAL>\s+
-VERIFY:\[.*[\\|/]Debuggees[\\|/](dotnet.+[\\|/])?DivZero[\\|/]DivZero\.cs @ 54\s*\]\s*
+VERIFY:\[.*[\\|/]Debuggees[\\|/](dotnet.+[\\|/])?DivZero[\\|/]DivZero\.cs @ (54|53)\s*\]\s*
 
 # Verify that Threads (clrthreads) works
 IFDEF:DOTNETDUMP
@@ -62,4 +62,4 @@ VERIFY:\s+Child\s+SP\s+IP\s+Call Site\s+
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+(\*\*\* WARNING: Unable to verify checksum for DivZero.exe\s*)?C\.DivideByZero(\(.*\))?\s+\[(?i:.*[\\|/]DivZero\.cs) @ 12\s*\]\s+
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+C\.F3(\(.*\))?\s+\[(?i:.*[\\|/]DivZero\.cs) @ 21\s*\]\s+
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+C\.F2(\(.*\))?\s+\[(?i:.*[\\|/]DivZero\.cs) @ 33\s*\]\s+
-VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+C\.Main(\(.*\))?\s+\[(?i:.*[\\|/]DivZero\.cs) @ 54\s*\]\s+
+VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+C\.Main(\(.*\))?\s+\[(?i:.*[\\|/]DivZero\.cs) @ (54|53)\s*\]\s+

--- a/src/SOS/SOS.UnitTests/Scripts/StackAndOtherTests.script
+++ b/src/SOS/SOS.UnitTests/Scripts/StackAndOtherTests.script
@@ -113,7 +113,7 @@ ENDIF:ARM
 IFDEF:ARM64
 VERIFY:\s+x0=<HEXVAL>\s+x1=<HEXVAL>\s+x2=<HEXVAL>\s+
 ENDIF:ARM64
-VERIFY:\s+([r|e]sp|sp)=<HEXVAL>\s+([r|e]bp|lr)=<HEXVAL>\s+([r|e]ip|pc)=<HEXVAL>\s+
+VERIFY:\s+([r|e]sp|sp|lr)=<HEXVAL>\s+([r|e]bp|lr|sp)=<HEXVAL>\s+([r|e]ip|pc)=<HEXVAL>\s+
 IFDEF:X64
 VERIFY:\s+rax=<HEXVAL>\s+rbx=<HEXVAL>\s+rcx=<HEXVAL>\s+
 ENDIF:X64
@@ -128,7 +128,7 @@ ENDIF:ARM
 IFDEF:ARM64
 VERIFY:\s+x0=<HEXVAL>\s+x1=<HEXVAL>\s+x2=<HEXVAL>\s+
 ENDIF:ARM64
-VERIFY:\s+([r|e]sp|sp)=<HEXVAL>\s+([r|e]bp|lr)=<HEXVAL>\s+([r|e]ip|pc)=<HEXVAL>\s+
+VERIFY:\s+([r|e]sp|sp|lr)=<HEXVAL>\s+([r|e]bp|lr|sp)=<HEXVAL>\s+([r|e]ip|pc)=<HEXVAL>\s+
 IFDEF:X64
 VERIFY:\s+rax=<HEXVAL>\s+rbx=<HEXVAL>\s+rcx=<HEXVAL>\s+
 ENDIF:X64

--- a/src/SOS/SOS.UnitTests/Scripts/StackTests.script
+++ b/src/SOS/SOS.UnitTests/Scripts/StackTests.script
@@ -65,7 +65,7 @@ ENDIF:ARM
 IFDEF:ARM64
 VERIFY:\s+x0=<HEXVAL>\s+x1=<HEXVAL>\s+x2=<HEXVAL>\s+
 ENDIF:ARM64
-VERIFY:\s+([r|e]sp|sp)=<HEXVAL>\s+([r|e]bp|lr)=<HEXVAL>\s+([r|e]ip|pc)=<HEXVAL>\s+
+VERIFY:\s+([r|e]sp|sp|lr)=<HEXVAL>\s+([r|e]bp|lr|sp)=<HEXVAL>\s+([r|e]ip|pc)=<HEXVAL>\s+
 IFDEF:X64
 VERIFY:\s+rax=<HEXVAL>\s+rbx=<HEXVAL>\s+rcx=<HEXVAL>\s+
 ENDIF:X64
@@ -81,7 +81,7 @@ ENDIF:ARM
 IFDEF:ARM64
 VERIFY:\s+x0=<HEXVAL>\s+x1=<HEXVAL>\s+x2=<HEXVAL>\s+
 ENDIF:ARM64
-VERIFY:\s+([r|e]sp|sp)=<HEXVAL>\s+([r|e]bp|lr)=<HEXVAL>\s+([r|e]ip|pc)=<HEXVAL>\s+
+VERIFY:\s+([r|e]sp|sp|lr)=<HEXVAL>\s+([r|e]bp|lr|sp)=<HEXVAL>\s+([r|e]ip|pc)=<HEXVAL>\s+
 IFDEF:X64
 VERIFY:\s+rax=<HEXVAL>\s+rbx=<HEXVAL>\s+rcx=<HEXVAL>\s+
 ENDIF:X64

--- a/src/SOS/SOS.UnitTests/Scripts/WebApp.script
+++ b/src/SOS/SOS.UnitTests/Scripts/WebApp.script
@@ -55,7 +55,7 @@ ENDIF:ARM
 IFDEF:ARM64
 VERIFY:\s+x0=<HEXVAL>\s+x1=<HEXVAL>\s+x2=<HEXVAL>\s+
 ENDIF:ARM64
-VERIFY:\s+([r|e]sp|sp)=<HEXVAL>\s+([r|e]bp|lr)=<HEXVAL>\s+([r|e]ip|pc)=<HEXVAL>\s+
+VERIFY:\s+([r|e]sp|sp|lr)=<HEXVAL>\s+([r|e]bp|lr|sp)=<HEXVAL>\s+([r|e]ip|pc)=<HEXVAL>\s+
 IFDEF:X64
 VERIFY:\s+rax=<HEXVAL>\s+rbx=<HEXVAL>\s+rcx=<HEXVAL>\s+
 ENDIF:X64
@@ -71,7 +71,7 @@ ENDIF:ARM
 IFDEF:ARM64
 VERIFY:\s+x0=<HEXVAL>\s+x1=<HEXVAL>\s+x2=<HEXVAL>\s+
 ENDIF:ARM64
-VERIFY:\s+([r|e]sp|sp)=<HEXVAL>\s+([r|e]bp|lr)=<HEXVAL>\s+([r|e]ip|pc)=<HEXVAL>\s+
+VERIFY:\s+([r|e]sp|sp|lr)=<HEXVAL>\s+([r|e]bp|lr|sp)=<HEXVAL>\s+([r|e]ip|pc)=<HEXVAL>\s+
 IFDEF:X64
 VERIFY:\s+rax=<HEXVAL>\s+rbx=<HEXVAL>\s+rcx=<HEXVAL>\s+
 ENDIF:X64

--- a/src/SOS/Strike/ExpressionNode.cpp
+++ b/src/SOS/Strike/ExpressionNode.cpp
@@ -1797,7 +1797,7 @@ HRESULT ExpressionNode::EnumerateFrames(FrameEnumCallback pCallback, VOID* pUser
         CROSS_PLATFORM_CONTEXT context;
         ULONG32 cbContextActual;
         if ((Status=pStackWalk->GetContext(
-            DT_CONTEXT_FULL, 
+            g_targetMachine->GetFullContextFlags(), 
             sizeof(context),
             &cbContextActual,
             (BYTE *)&context))!=S_OK)

--- a/src/SOS/Strike/cordebugdatatarget.h
+++ b/src/SOS/Strike/cordebugdatatarget.h
@@ -144,16 +144,16 @@ public:
         ULONG32 contextSize,
         BYTE * context)
     {
+        HRESULT hr;
 #ifdef FEATURE_PAL
         if (g_ExtServices == NULL)
         {
             return E_UNEXPECTED;
         }
-        return g_ExtServices->GetThreadContextById(dwThreadOSID, contextFlags, contextSize, context);
+        hr = g_ExtServices->GetThreadContextById(dwThreadOSID, contextFlags, contextSize, context);
 #else
         ULONG ulThreadIDOrig;
         ULONG ulThreadIDRequested;
-        HRESULT hr;
 
         hr = g_ExtSystem->GetCurrentThreadId(&ulThreadIDOrig);
         if (FAILED(hr))
@@ -175,20 +175,20 @@ public:
 
         // Prepare context structure
         ZeroMemory(context, contextSize);
-        ((CONTEXT*)context)->ContextFlags = contextFlags;
+        g_targetMachine->SetContextFlags(context, contextFlags);
 
         // Ok, do it!
         hr = g_ExtAdvanced->GetThreadContext((LPVOID) context, contextSize);
 
-        // GetThreadContext clears ContextFlags but DBI needs it set to know what registers to copy
-        ((CONTEXT*)context)->ContextFlags = contextFlags;
-
         // This is cleanup; failure here doesn't mean GetThreadContext should fail
         // (that's determined by hr).
         g_ExtSystem->SetCurrentThreadId(ulThreadIDOrig);
+#endif // FEATURE_PAL
+
+        // GetThreadContext clears ContextFlags or sets them incorrectly and DBI needs it set to know what registers to copy
+        g_targetMachine->SetContextFlags(context, contextFlags);
 
         return hr;
-#endif // FEATURE_PAL
     }
 
     //

--- a/src/SOS/Strike/datatarget.cpp
+++ b/src/SOS/Strike/datatarget.cpp
@@ -222,12 +222,13 @@ DataTarget::GetThreadContext(
     /* [in] */ ULONG32 contextSize,
     /* [out, size_is(contextSize)] */ PBYTE context)
 {
+    HRESULT hr;
 #ifdef FEATURE_PAL
     if (g_ExtServices == NULL)
     {
         return E_UNEXPECTED;
     }
-    return g_ExtServices->GetThreadContextById(threadID, contextFlags, contextSize, context);
+    hr = g_ExtServices->GetThreadContextById(threadID, contextFlags, contextSize, context);
 #else
     if (g_ExtSystem == NULL || g_ExtAdvanced == NULL)
     {
@@ -235,7 +236,6 @@ DataTarget::GetThreadContext(
     }
     ULONG ulThreadIDOrig;
     ULONG ulThreadIDRequested;
-    HRESULT hr;
 
     hr = g_ExtSystem->GetCurrentThreadId(&ulThreadIDOrig);
     if (FAILED(hr))
@@ -257,20 +257,20 @@ DataTarget::GetThreadContext(
 
     // Prepare context structure
     ZeroMemory(context, contextSize);
-    ((CONTEXT*) context)->ContextFlags = contextFlags;
+    g_targetMachine->SetContextFlags(context, contextFlags);
 
     // Ok, do it!
     hr = g_ExtAdvanced->GetThreadContext((LPVOID) context, contextSize);
 
-    // GetThreadContext clears ContextFlags
-    ((CONTEXT*)context)->ContextFlags = contextFlags;
-
     // This is cleanup; failure here doesn't mean GetThreadContext should fail
     // (that's determined by hr).
     g_ExtSystem->SetCurrentThreadId(ulThreadIDOrig);
+#endif
+
+    // GetThreadContext clears ContextFlags or sets them incorrectly and DBI needs it set to know what registers to copy
+    g_targetMachine->SetContextFlags(context, contextFlags);
 
     return hr;
-#endif
 }
 
 HRESULT STDMETHODCALLTYPE

--- a/src/SOS/Strike/disasm.h
+++ b/src/SOS/Strike/disasm.h
@@ -139,6 +139,9 @@ public:
 
     ULONG GetPlatform()             const { return IMAGE_FILE_MACHINE_I386; }
     ULONG GetContextSize()          const { return sizeof(X86_CONTEXT); }
+    ULONG GetFullContextFlags()     const { return 0x0001000BL; }
+    void SetContextFlags(BYTE* context, ULONG32 contextFlags)   { ((X86_CONTEXT*)context)->ContextFlags = contextFlags; };
+
     virtual void Unassembly(
                 TADDR IPBegin, 
                 TADDR IPEnd, 
@@ -207,6 +210,9 @@ public:
 
     ULONG GetPlatform()             const { return IMAGE_FILE_MACHINE_ARMNT; }
     ULONG GetContextSize()          const { return sizeof(ARM_CONTEXT); }
+    ULONG GetFullContextFlags()     const { return 0x00200007L; }
+    void SetContextFlags(BYTE* context, ULONG32 contextFlags)   { ((ARM_CONTEXT*)context)->ContextFlags = contextFlags; };
+
     virtual void Unassembly(
                 TADDR IPBegin, 
                 TADDR IPEnd, 
@@ -276,6 +282,8 @@ public:
 
     ULONG GetPlatform()             const { return IMAGE_FILE_MACHINE_AMD64; }
     ULONG GetContextSize()          const { return sizeof(AMD64_CONTEXT); }
+    ULONG GetFullContextFlags()     const { return 0x0010000BL; }
+    void SetContextFlags(BYTE* context, ULONG32 contextFlags)   { ((AMD64_CONTEXT*)context)->ContextFlags = contextFlags; };
 
     virtual void Unassembly(
                 TADDR IPBegin, 
@@ -346,6 +354,9 @@ public:
 
     ULONG GetPlatform()             const { return IMAGE_FILE_MACHINE_ARM64; }
     ULONG GetContextSize()          const { return sizeof(ARM64_CONTEXT); }
+    ULONG GetFullContextFlags()     const { return 0x00400007L; }
+    void SetContextFlags(BYTE* context, ULONG32 contextFlags)   { ((ARM64_CONTEXT*)context)->ContextFlags = contextFlags; };
+
     virtual void Unassembly(
                 TADDR IPBegin, 
                 TADDR IPEnd, 

--- a/src/SOS/Strike/disasmARM.cpp
+++ b/src/SOS/Strike/disasmARM.cpp
@@ -595,7 +595,7 @@ BOOL ARMMachine::GetExceptionContext (TADDR stack, TADDR PC, TADDR *cxrAddr, CRO
         return FALSE;
     *cxrAddr = stack;
 
-    if (FAILED (g_ExtData->ReadVirtual(TO_CDADDR(stack), cxr, sizeof(DT_CONTEXT), NULL))) {
+    if (FAILED (g_ExtData->ReadVirtual(TO_CDADDR(stack), cxr, GetContextSize(), NULL))) {
         return FALSE;
     }
 

--- a/src/SOS/Strike/disasmX86.cpp
+++ b/src/SOS/Strike/disasmX86.cpp
@@ -392,8 +392,7 @@ void HandleCall(TADDR callee, Register *reg)
     // A jump thunk?
 
     CONTEXT ctx = {0};
-
-    ctx.ContextFlags = (CONTEXT_AMD64 | CONTEXT_CONTROL | CONTEXT_INTEGER);
+    ctx.ContextFlags = (DT_CONTEXT_AMD64 | DT_CONTEXT_CONTROL | DT_CONTEXT_INTEGER);
 
     for (unsigned ireg = 0; ireg < 16; ireg++)
     {
@@ -826,7 +825,7 @@ eTargetType GetFinalTarget(TADDR callee, TADDR* finalMDorIP)
     // A jump thunk?
 
     CONTEXT ctx = {0};
-    ctx.ContextFlags = (CONTEXT_AMD64 | CONTEXT_CONTROL | CONTEXT_INTEGER);
+    ctx.ContextFlags = (DT_CONTEXT_AMD64 | DT_CONTEXT_CONTROL | DT_CONTEXT_INTEGER);
     ctx.Rip = callee;
 
     CLRDATA_ADDRESS ip = 0, md = 0;
@@ -930,11 +929,10 @@ BOOL
 #ifndef FEATURE_PAL
 #ifdef SOS_TARGET_X86
     X86_CONTEXT * cxr = &pcxr->X86Context;
-    size_t contextSize = offsetof(CONTEXT, ExtendedRegisters);
 #elif defined(SOS_TARGET_AMD64)
     AMD64_CONTEXT * cxr = &pcxr->Amd64Context;
-    size_t contextSize = offsetof(CONTEXT, FltSave);
 #endif
+    size_t contextSize = GetContextSize();
 
     static TADDR IPRetAddr[4] = {0, 0, 0, 0};
 

--- a/src/SOS/Strike/exts.h
+++ b/src/SOS/Strike/exts.h
@@ -349,8 +349,15 @@ class IMachine
 public:
     // Returns the IMAGE_FILE_MACHINE_*** constant corresponding to the target machine
     virtual ULONG GetPlatform() const = 0;
+
     // Returns the size of the CONTEXT for the target machine
     virtual ULONG GetContextSize() const = 0;
+
+    // Returns the architecture's DT_CONTEXT_FULL flags 
+    virtual ULONG GetFullContextFlags() const = 0;
+
+    // Sets the context flags in the context
+    virtual void SetContextFlags(BYTE* context, ULONG32 contextFlags) = 0;
 
     // Disassembles a managed method specified by the IPBegin-IPEnd range
     virtual void Unassembly(

--- a/src/SOS/Strike/util.cpp
+++ b/src/SOS/Strike/util.cpp
@@ -4054,8 +4054,10 @@ BOOL GetGcStructuresValid()
     // We don't want to use the cached HeapData, because this can change
     // each time the program runs for a while.
     DacpGcHeapData heapData;
-    if (heapData.Request(g_sos) != S_OK)
+    HRESULT hr;
+    if ((hr = heapData.Request(g_sos)) != S_OK)
     {
+        ExtOut("GetGcStructuresValid: request heap data FAILED %08x\n", hr);
         return FALSE;
     }
 

--- a/src/inc/dbgtargetcontext.h
+++ b/src/inc/dbgtargetcontext.h
@@ -26,11 +26,8 @@
 // ByteSwapContext.
 //
 
-// For now, the only cross-platform CONTEXTs we support are x86/PAL and ARM/Win. Look in
-// rotor/pal/inc/rotor_pal.h for the original PAL definitions.
-
 //
-// **** NOTE: Keep these in sync with rotor/pal/inc/rotor_pal.h ****
+// **** NOTE: Keep these in sync with pal/inc/pal.h ****
 //
 
 // This odd define pattern is needed because in DBI we set _TARGET_ to match the host and


### PR DESCRIPTION
Disabled installing and running on 2.1.x when arm/arm64.

Fix the test scripts for arm64 registers.

Upgraded to testing on 3.1.8 and 2.1.23.

Add IMachine::SetContextFlags() and IMachine::GetFullContextFlags() to better support
cross-architecture/cross-OS. Had to use a hard coded context flags for each architecture
because the normal DT_CONTEXT_FULL define only exists for the currently building arch.

The main reason `clrstack -i -a` was failing because the architecture bits in the context
flags were being passed into the DAC/DBI were wrong so the context wasn't being copied.

DAC/DBI context copy helper function that is very sensitive to the dst/src context flags
(at the architecture specific bit) matching.

```
void CORDbgCopyThreadContext(DT_CONTEXT* pDst, const DT_CONTEXT* pSrc)
{
    DWORD dstFlags = pDst->ContextFlags;
    DWORD srcFlags = pSrc->ContextFlags;
    LOG((LF_CORDB, LL_INFO1000000,
         "CP::CTC: pDst=0x%08x dstFlags=0x%x, pSrc=0x%08x srcFlags=0x%x\n",
         pDst, dstFlags, pSrc, srcFlags));

    if ((dstFlags & srcFlags & DT_CONTEXT_CONTROL) == DT_CONTEXT_CONTROL)
    {
        CopyContextChunk(&(pDst->Fp), &(pSrc->Fp), &(pDst->V),
                         DT_CONTEXT_CONTROL);
        CopyContextChunk(&(pDst->Cpsr), &(pSrc->Cpsr), &(pDst->X),
                         DT_CONTEXT_CONTROL);
    }

    if ((dstFlags & srcFlags & DT_CONTEXT_INTEGER) == DT_CONTEXT_INTEGER)
        CopyContextChunk(&(pDst->X[0]), &(pSrc->X[0]), &(pDst->Fp),
                         DT_CONTEXT_INTEGER);
```

Remove arm32/arm64 installs from global because they don't work on MacOS