### PR TITLE
Enable dumping of hung tests + transition to dotnet test

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -25,8 +25,9 @@
     <!-- Opt-in/out repo features -->
     <UsingToolXliff>false</UsingToolXliff>
     <UsingToolNetFrameworkReferenceAssemblies>true</UsingToolNetFrameworkReferenceAssemblies>
-    <!-- Build tools -->
-    <MicrosoftNetCompilersVersion>3.0.0</MicrosoftNetCompilersVersion>
+    <!-- Use `dotnet test` to have the ability to collect dumps on hanging tests.  -->
+    <UseVSTestRunner>true</UseVSTestRunner>
+    <MicrosoftTestPlatformVersion>16.8.0-preview-20200921-01</MicrosoftTestPlatformVersion>
     <!-- CoreFX -->
     <SystemReflectionMetadataVersion>1.8.1</SystemReflectionMetadataVersion>
     <SystemCollectionsImmutableVersion>1.7.1</SystemCollectionsImmutableVersion>

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -214,7 +214,7 @@ jobs:
     # Publish test results to Azure Pipelines
     - task: PublishTestResults@2
       inputs:
-        testResultsFormat: xUnit
+        testResultsFormat: VSTest
         testResultsFiles: '**/*UnitTests*.xml' 
         searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults'
         failTaskOnFailedTests: true

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,6 +15,10 @@
     <CheckForOverflowUnderflow>false</CheckForOverflowUnderflow>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(ContinuousIntegrationBuild)' == 'true'">
+    <TestRunnerAdditionalArguments>--blame "CollectHangDump;TestTimeout=5m"</TestRunnerAdditionalArguments>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <CheckForOverflowUnderflow>false</CheckForOverflowUnderflow>
   </PropertyGroup>

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/EventPipeSessionTests.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/EventPipeSessionTests.cs
@@ -56,6 +56,8 @@ namespace Microsoft.Diagnostics.NETCore.Client
         {
             TestRunner runner = new TestRunner(CommonHelper.GetTraceePathWithArgs(), output);
             runner.Start(3000);
+            output.WriteLine($"[{DateTime.Now.ToString()}] TEST");
+            Thread.Sleep(10_000_000);
             DiagnosticsClient client = new DiagnosticsClient(runner.Pid);
             runner.PrintStatus();
             output.WriteLine($"[{DateTime.Now.ToString()}] Trying to start an EventPipe session on process {runner.Pid}");


### PR DESCRIPTION
- Enable test dumping with a timeout of 5 min
- Use dotnet test (vstest) instead of XUnit Console Runner
- Dumps (process trees included) will be taken on Windows and Linux, but not macOS.