### PR TITLE
Clarify installation vs usage in docs

### DIFF
--- a/documentation/dotnet-counters-instructions.md
+++ b/documentation/dotnet-counters-instructions.md
@@ -5,6 +5,8 @@
 
 dotnet-counters is a performance monitoring tool for ad-hoc health monitoring or 1st level performance investigation. It can observe performance counter values that are published via `EventCounter` API (https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.tracing.eventcounter). For example, you can quickly monitor things like the CPU usage or the rate of exceptions being thrown in your .NET Core application to see if there is anything suspiscious before diving into more serious performance investigation using PerfView or dotnet-trace.
 
+`dotnet-counters` can be used on Linux, Mac, and Windows with runtime versions 3.0 or newer.
+
 
 ## Install dotnet-counters
 

--- a/documentation/dotnet-dump-instructions.md
+++ b/documentation/dotnet-dump-instructions.md
@@ -17,7 +17,7 @@ Here's a table showing how dotnet-dump fits into your dump debugging options:
 
 ## Installing dotnet-dump
 
-The first step is to install the dotnet-dump CLI global tool. This requires at least the 2.1 or greater .NET Core SDK to be installed. If you see the error message `Tool 'dotnet-dump' is already installed`, you will need to uninstall the global tool (see below). 
+The first step is to install the dotnet-dump CLI global tool. Installing `dotnet-dump` requires at least the 2.1 or greater .NET Core SDK to be installed.  Note, that _collecting_ a dump on non-Windows platforms requires the target application to run on a 3.0 or newer .NET Runtime. If you see the error message `Tool 'dotnet-dump' is already installed`, you will need to uninstall the global tool (see below). 
 
     $ dotnet tool install -g dotnet-dump
     You can invoke the tool using the following command: dotnet-dump

--- a/documentation/dotnet-gcdump-instructions.md
+++ b/documentation/dotnet-gcdump-instructions.md
@@ -8,7 +8,7 @@ several scenarios:
 * analyzing roots of objects (answering questions like, "what still has a reference to this type?")
 * collecting general statistics about the counts of objects on the heap.
 
-dotnet-gcdump can be used on Linux, Mac, and Windows with runtime versions 3.1 or newer.
+`dotnet-gcdump` can be used on Linux, Mac, and Windows with runtime versions 3.1 or newer.
 
 ## Installing dotnet-gcdump
 

--- a/documentation/dotnet-trace-instructions.md
+++ b/documentation/dotnet-trace-instructions.md
@@ -1,6 +1,8 @@
 # Trace for performance analysis utility (dotnet-trace)
 
-The dotnet-trace tool is a cross-platform CLI global tool that enables the collection of .NET Core traces of a running process without any native profiler involved. It is built around the EventPipe technology of the .NET Core runtime as a cross-platform alternative to ETW on Windows and LTTng on Linux, which only work on a single platform. With EventPipe/dotnet-trace, we are trying to deliver the same experience on Windows, Linux, or macOS. dotnet-trace can be used on any .NET Core applications using versions .NET Core 3.0 Preview 5 or later.
+The dotnet-trace tool is a cross-platform CLI global tool that enables the collection of .NET Core traces of a running process without any native profiler involved. It is built around the EventPipe technology of the .NET Core runtime as a cross-platform alternative to ETW on Windows and LTTng on Linux, which only work on a single platform. With EventPipe/dotnet-trace, we are trying to deliver the same experience on Windows, Linux, or macOS. 
+
+`dotnet-trace` can be used on Linux, Mac, and Windows with runtime versions 3.0 or newer.
 
 ## Installing dotnet-trace
 

--- a/documentation/installing-sos-instructions.md
+++ b/documentation/installing-sos-instructions.md
@@ -1,7 +1,7 @@
 Installing SOS on Linux and MacOS
 =================================
 
-The first step is to install the dotnet-sos CLI global tool. This requires at least the 2.1 or greater .NET Core SDK to be installed. If you see the error message `Tool 'dotnet-sos' is already installed`, you will need to uninstall the global tool (see below). 
+The first step is to install the dotnet-sos CLI global tool. Installing the `dotnet-sos` requires at least the 2.1 or greater .NET Core SDK to be installed. If you see the error message `Tool 'dotnet-sos' is already installed`, you will need to uninstall the global tool (see below). 
 
     $ dotnet tool install -g dotnet-sos
     You can invoke the tool using the following command: dotnet-sos


### PR DESCRIPTION
resolves #1632

This patch attempts to make the documentation a little clearer about what versions of the SDK and Runtime are required for installation of the tools themselves vs using them.  Right now, it isn't immediately clear in some of the docs that the target application needs to be running at least 3.0 for most scenarios.  The installation instructions come first for some of the docs and they only mention 2.1 since that is all that is required for the tools themselves to run.
