### PR TITLE
Increase IpcClient connect timeout for resource constrained environments

### DIFF
--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcClient.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcClient.cs
@@ -11,7 +11,8 @@ namespace Microsoft.Diagnostics.NETCore.Client
     internal class IpcClient
     {
         // The amount of time to wait for a stream to be available for consumption by the Connect method.
-        private static readonly TimeSpan ConnectTimeout = TimeSpan.FromSeconds(3);
+        // Normally expect the runtime to respond quickly but resource constrained machines may take longer.
+        private static readonly TimeSpan ConnectTimeout = TimeSpan.FromSeconds(30);
 
         /// <summary>
         /// Sends a single DiagnosticsIpc Message to the dotnet process with PID processId.


### PR DESCRIPTION
The ServerSourceAddRemoveSingleConnectionTest fails very often when checking that the CommandLine, OperatingSystem, and ProcessArchitecture fields are not null. These fields are filled by issuing a GetProcessInfo command and may be null if the runtime doesn't respond within the timeout period (currently 3 seconds) or if the runtime doesn't understand the command. It's likely that the runtime isn't responding to the command in a timely manner given that this test is failing against the .NET 5.0 RC2 runtime. I've increased the timeout in IpcClient to be even longer to accommodate resource constrained environments.

closes #1609 