### PR TITLE
Rename reversed-server-address arg to diagnostic-port.

### DIFF
--- a/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
@@ -22,15 +22,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         private const string ConfigPrefix = "DotnetMonitor_";
         private const string ConfigPath = "/etc/dotnet-monitor";
 
-        public async Task<int> Start(CancellationToken token, IConsole console, string[] urls, string[] metricUrls, bool metrics, string reversedServerAddress)
+        public async Task<int> Start(CancellationToken token, IConsole console, string[] urls, string[] metricUrls, bool metrics, string diagnosticPort)
         {
             //CONSIDER The console logger uses the standard AddConsole, and therefore disregards IConsole.
-            using IWebHost host = CreateWebHostBuilder(console, urls, metricUrls, metrics, reversedServerAddress).Build();
+            using IWebHost host = CreateWebHostBuilder(console, urls, metricUrls, metrics, diagnosticPort).Build();
             await host.RunAsync(token);
             return 0;
         }
 
-        public IWebHostBuilder CreateWebHostBuilder(IConsole console, string[] urls, string[] metricUrls, bool metrics, string reversedServerAddress)
+        public IWebHostBuilder CreateWebHostBuilder(IConsole console, string[] urls, string[] metricUrls, bool metrics, string diagnosticPort)
         {
             if (metrics)
             {
@@ -40,7 +40,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             IWebHostBuilder builder = WebHost.CreateDefaultBuilder()
                 .ConfigureAppConfiguration((IConfigurationBuilder builder) =>
                 {
-                    ConfigureEndpointInfoSource(builder, reversedServerAddress);
+                    ConfigureEndpointInfoSource(builder, diagnosticPort);
                     if (metrics)
                     {
                         //Note these are in precedence order.

--- a/src/Tools/dotnet-monitor/Program.cs
+++ b/src/Tools/dotnet-monitor/Program.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         private static Option DiagnosticPort() =>
             new Option(
                 alias: "--diagnostic-port",
-                description: "A fully qualified path and filename of the listening diagnostic port to which runtime instances can connect.")
+                description: "The fully qualified path and filename of the diagnostic port to which runtime instances can connect.")
             {
                 Argument = new Argument<string>(name: "diagnosticPort")
             };

--- a/src/Tools/dotnet-monitor/Program.cs
+++ b/src/Tools/dotnet-monitor/Program.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
               {
                 // Handler
                 CommandHandler.Create<CancellationToken, IConsole, string[], string[], bool, string>(new DiagnosticsMonitorCommandHandler().Start),
-                Urls(), MetricUrls(), ProvideMetrics(), ReversedServerAddress()
+                Urls(), MetricUrls(), ProvideMetrics(), DiagnosticPort()
               };
 
         private static Option Urls() =>
@@ -58,12 +58,12 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 Argument = new Argument<bool>(name: "metrics", getDefaultValue: () => true )
             };
 
-        private static Option ReversedServerAddress() =>
+        private static Option DiagnosticPort() =>
             new Option(
-                alias: "--reversed-server-address",
-                description: "A fully qualified path and filename for the OS transport to communicate over.")
+                alias: "--diagnostic-port",
+                description: "A fully qualified path and filename of the listening diagnostic port to which runtime instances can connect.")
             {
-                Argument = new Argument<string>(name: "reversedServerAddress")
+                Argument = new Argument<string>(name: "diagnosticPort")
             };
 
         private static string GetDefaultMetricsEndpoint()


### PR DESCRIPTION
Rename the reversed server transport argument for dotnet-monitor to make it consistent with the diagnostic port terminology.