### PR TITLE
Fix dotnet-dump cross-OS arm32 issues on Windows 

### DIFF
--- a/src/SOS/SOS.NETCore/SymbolReader.cs
+++ b/src/SOS/SOS.NETCore/SymbolReader.cs
@@ -306,7 +306,7 @@ namespace SOS
                     }
                     catch (Exception ex) when (ex is BadInputFormatException || ex is InvalidVirtualAddressException || ex is TaskCanceledException)
                     {
-                        s_tracer.Error("{0}/{1:X16}: {2}", moduleFilePath, address, ex.Message);
+                        s_tracer.Error("{0} address {1:X16}: {2}", moduleFilePath, address, ex.Message);
                     }
                 }
             }

--- a/src/SOS/Strike/datatarget.cpp
+++ b/src/SOS/Strike/datatarget.cpp
@@ -167,7 +167,7 @@ DataTarget::ReadVirtual(
     HRESULT hr = g_ExtData->ReadVirtual(address, (PVOID)buffer, request, (PULONG)done);
     if (FAILED(hr)) 
     {
-        ExtDbgOut("DataTarget::ReadVirtual FAILED %08x address %p size %08x\n", hr, address, request);
+        ExtDbgOut("DataTarget::ReadVirtual FAILED %08x address %08llx size %08x\n", hr, address, request);
     }
     return hr;
 }

--- a/src/SOS/Strike/exts.h
+++ b/src/SOS/Strike/exts.h
@@ -48,17 +48,9 @@
 #define TO_TADDR(cdaddr) ((TADDR)(cdaddr))
 #define TO_CDADDR(taddr) ((CLRDATA_ADDRESS)(LONG_PTR)(taddr))
 
-// We also need a "correction" macro: there are a number of places in the DAC
-// where instead of using the CLRDATA_ADDRESS sign-extension convention
-// we 0-extend (most notably DacpGcHeapDetails)
-#define NEED_DAC_CLRDATA_ADDRESS_CORRECTION 1
-#if NEED_DAC_CLRDATA_ADDRESS_CORRECTION == 1
-    // the macro below "corrects" a CDADDR to always represent the
-    // sign-extended equivalent ULONG64 value of the original TADDR
-    #define UL64_TO_CDA(ul64) (TO_CDADDR(TO_TADDR(ul64)))
-#else
-    #define UL64_TO_CDA(ul64) (ul64)
-#endif // NEED_DAC_CLRDATA_ADDRESS_CORRECTION 1
+// the macro below "corrects" a CDADDR to always represent the
+// sign-extended equivalent ULONG64 value of the original TADDR
+#define UL64_TO_CDA(ul64) (TO_CDADDR(TO_TADDR(ul64)))
 
 // The macro below removes the sign extension, returning the  
 // equivalent ULONG64 value to the original TADDR. Useful when 

--- a/src/SOS/Strike/hostcoreclr.cpp
+++ b/src/SOS/Strike/hostcoreclr.cpp
@@ -643,7 +643,7 @@ HRESULT InitializeHosting()
 int ReadMemoryForSymbols(ULONG64 address, uint8_t *buffer, int cb)
 {
     ULONG read;
-    if (SUCCEEDED(g_ExtData->ReadVirtual(address, buffer, cb, &read)))
+    if (SafeReadMemory(TO_TADDR(address), (PVOID)buffer, cb, &read))
     {
         return read;
     }

--- a/src/SOS/Strike/hostcoreclr.cpp
+++ b/src/SOS/Strike/hostcoreclr.cpp
@@ -643,7 +643,7 @@ HRESULT InitializeHosting()
 int ReadMemoryForSymbols(ULONG64 address, uint8_t *buffer, int cb)
 {
     ULONG read;
-    if (SafeReadMemory(TO_TADDR(address), (PVOID)buffer, cb, &read))
+    if (SUCCEEDED(g_ExtData->ReadVirtual(address, buffer, cb, &read)))
     {
         return read;
     }

--- a/src/SOS/Strike/runtime.cpp
+++ b/src/SOS/Strike/runtime.cpp
@@ -554,7 +554,7 @@ HRESULT Runtime::GetCorDebugInterface(ICorDebugProcess** ppCorDebugProcess)
 \**********************************************************************/
 void Runtime::DisplayStatus()
 {
-    ExtOut("%s runtime at %p size %08llx\n", GetRuntimeConfigurationName(GetRuntimeConfiguration()), m_address, m_size);
+    ExtOut("%s runtime at %08llx size %08llx\n", GetRuntimeConfigurationName(GetRuntimeConfiguration()), m_address, m_size);
     if (m_runtimeInfo != nullptr) {
         ArrayHolder<char> szModuleName = new char[MAX_LONGPATH + 1];
         HRESULT hr = g_ExtSymbols->GetModuleNames(m_index, 0, szModuleName, MAX_LONGPATH, NULL, NULL, 0, NULL, NULL, 0, NULL);


### PR DESCRIPTION
Remove the address sign extending in memory service

Fix sosstatus display and error messages for x86/arm32