### PR TITLE
Document changes to reverse server in ipc protocol doc

### DIFF
--- a/documentation/design-docs/ipc-protocol.md
+++ b/documentation/design-docs/ipc-protocol.md
@@ -871,7 +871,7 @@ For example, if the Diagnostic Server finds incorrectly encoded data while parsi
 
 # DiagnosticPorts
 
-> Available since .NET 5.0 Preview 8
+> Available since .NET 5.0
 
 .NET applications can be configured with the following environment variables:
 

--- a/documentation/design-docs/ipc-protocol.md
+++ b/documentation/design-docs/ipc-protocol.md
@@ -869,7 +869,7 @@ For example, if the Diagnostic Server finds incorrectly encoded data while parsi
   </tr>
 </table>
 
-# DiagnosticPorts
+# Diagnostic Ports
 
 > Available since .NET 5.0
 
@@ -879,20 +879,20 @@ For example, if the Diagnostic Server finds incorrectly encoded data while parsi
 
 where:
 
-* `<port address>` is a NamedPipe name without \\.\pipe\ on Windows, and the full path to a Unix domain socket on other platforms
+* `<port address>` is a NamedPipe name without `\\.\pipe\` on Windows, and the full path to a Unix domain socket on other platforms
 * `tag ::= <SUSPEND_MODE> | <PORT_TYPE>`
 * `<SUSPEND_MODE> ::= suspend | nosuspend` (default value is nosuspend)`
 * `<PORT_TYPE> ::= connect` (future types such as additional listen ports could be added to this list)
 
-Any DiagnosticPorts specified in this configuration are in addition to the default port, i.e., dotnet-diagnostic-<pid>-epoch>. The suspend mode of the default port is set via the new environment variable DOTNET_DefaultDotnetPortSuspend which defaults to 0 for nosuspend.
+Any diagnostic ports specified in this configuration will be created in addition to the default port (`dotnet-diagnostic-<pid>-<epoch>`). The suspend mode of the default port is set via the new environment variable `DOTNET_DefaultDotnetPortSuspend` which defaults to 0 for `nosuspend`.
 
-Each port configuration specifies whether it is a suspend or nosuspend port. suspend induces the PauseOnStart functionality and causes the runtime to halt progress in EEStartupHelper before most usbsystems are online. Since multiple ports can individually request suspend, the resume command now needs to be sent by each suspend port connection before the event will be set and the runtime resumes execution.
+Each port configuration specifies whether it is a `suspend` or `nosuspend` port. Ports specifying `suspend` in their configuration will cause the runtime to pause early on the startup path before most systems are available. This allows any agent to receive a connection and properly setup before the application startup continues. Since multiple ports can individually request suspension, the `resume` command now needs to be sent by each suspend port connection before the event will be set and the runtime resumes execution.
 
-If a config specifies multiple tag values from a tag type, e.g., `"<path>,nosuspend,suspend,suspend,"` the first one is the only one respected.
+If a config specifies multiple tag values from a tag type, for example  `"<path>,nosuspend,suspend,suspend,"`, only the first one is respected.
 
-The port address value is required for a port config. If a config doesn't specify an address and only specifies tags, e.g., `"suspend"`, then that value will be treated as the path.
+The port address value is required for a port configuration. If a configuration doesn't specify an address and only specifies tags, then the first tag will be treated as the path. For example, a configuration `suspend,connect` would cause a port with the name `suspend` to be created, in the default `nosuspend` mode.
 
-The runtime will make a best attempt to generate a port from a port config. A bad port config won't cause an error state, but could lead to consumed resources, e.g., causing the runtime to continuously poll for a connect port that will never exist.
+The runtime will make a best attempt to generate a port from a port configuration. A bad port configuration won't cause an error state, but could lead to consumed resources. For example it could cause the runtime to continuously poll for a connect port that will never exist.
 
 When a DiagnosticPort is configured, the runtime will attempt to connect to the provided address in a retry loop while also listening on the traditional server. The retry loop has an initial timeout of 10ms with a falloff factor of 1.25x and a max timeout of 500 ms.  A successful connection will result in an infinite timeout.  The runtime is resilient to the Reverse Server transport failing, e.g., closing, not `Accepting`, etc.
 


### PR DESCRIPTION
Fix #1678. 

This reflects changes that were made via https://github.com/dotnet/runtime/pull/40499 to the diagnostics IPC protocol doc.