### PR TITLE
Add proposal spec for dotnet-stack tool

### DIFF
--- a/documentation/design-docs/dotnet-tools.md
+++ b/documentation/design-docs/dotnet-tools.md
@@ -418,20 +418,16 @@ COMMANDS
 REPORT
 
     dotnet-stack report -p|--process-id <pid>
-                        [-t|--report-type <report-type>]
                         [-h|--help]
 
     Prints the managed stack from every thread in the target process
-
-    -t, ---report-type <report-type>
-        The way to represent the stack data.  (default: standard)
 
     -h, --help
         Show command line help
 
     Examples:
-      > dotnet-trace stack -p 1234
-      Stack for Thread (0x1):
+      > dotnet-stack report -p 1234
+      Stack for Thread (0x151c):
           [Native Frames]
           System.Private.CoreLib!System.Threading.ManualResetEventSlim.Wait(int, System.Threading.CancellationToken)
           System.Private.CoreLib!System.Threading.Tasks.Task.SpinThenBlockingWait(int, System.Threading.CancellationToken)
@@ -441,7 +437,7 @@ REPORT
           Microsoft.Extensions.Hosting.Abstractions!Microsoft.Extensions.Hosting.HostingAbstractionsHostExtensions.Run(Microsoft.Extensions.Hosting.IHost)
           testtesttest!testtesttest.Program.Main(System.String[])
 
-      Stack for Thread (0x2):
+      Stack for Thread (0x152b):
           [Native Frames]
           System.IO.FileSystem.Watcher!System.IO.FileSystemWatcher.RunningInstance.StaticWatcherRunLoopManager.WatchForFileSystemEventsThreadStart(System.Threading.ManualResetEventSlim, Microsoft.Win32.SafeHandles.SafeEventStreamHandle)
           System.IO.FileSystem.Watcher!System.IO.FileSystemWatcher.RunningInstance.StaticWatcherRunLoopManager.<>c.<ScheduleEventStream>(System.Object)
@@ -449,7 +445,7 @@ REPORT
           System.Private.CoreLib!System.Threading.ExecutionContext.RunInternal(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object)
           System.Private.CoreLib!System.Threading.ThreadHelper.ThreadStart(System.Object)
 
-      Stack for Thread (0x3):
+      Stack for Thread (0x153a):
           [Native Frames]
           System.Private.CoreLib!System.Threading.SemaphoreSlim.WaitUntilCountOrTimeout(int, uint, System.Threading.CancellationToken)
           System.Private.CoreLib!System.Threading.SemaphoreSlim.Wait(int, System.Threading.CancellationToken)
@@ -460,7 +456,7 @@ REPORT
           System.Private.CoreLib!System.Threading.ExecutionContext.RunInternal(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object)
           System.Private.CoreLib!System.Threading.ThreadHelper.ThreadStart()
 
-      Stack for Thread (0x4):
+      Stack for Thread (0x4125):
           [Native Frames]
           System.Private.CoreLib!System.Threading.Thread.Sleep(System.TimeSpan)
           Microsoft.AspNetCore.Server.Kestrel.Core!Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.Heartbeat.TimerLoop()
@@ -469,7 +465,7 @@ REPORT
           System.Private.CoreLib!System.Threading.ExecutionContext.RunInternal(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object)
           System.Private.CoreLib!System.Threading.ThreadHelper.ThreadStart(System.Object)
 
-      Stack for Thread (0x5):
+      Stack for Thread (0x5hf3):
           [Native Frames]
           System.Net.Sockets!System.Net.Sockets.SocketAsyncEngine.EventLoop()
           System.Net.Sockets!System.Net.Sockets.SocketAsyncEngine.ctor( System.Object)

--- a/documentation/design-docs/dotnet-tools.md
+++ b/documentation/design-docs/dotnet-tools.md
@@ -398,61 +398,83 @@ CONVERT
       Conversion complete
 
 
-CONVERT
+### dotnet-stack
 
-    dotnet-trace stack -p|--process-id <pid>
-                       [-h|--help]
+SYNOPSIS
 
-    Prints the stack for every thread in the target process
+    dotnet-stack [options] [command] [<args>]
+
+OPTIONS
+
+    --version
+        Display the version of the dotnet-trace utility.
+
+    -h, --help
+        Show command line help
+
+COMMANDS
+
+    report         Displays stack traces for the target process
+
+REPORT
+
+    dotnet-stack report -p|--process-id <pid>
+                        [-t|--report-type <report-type>]
+                        [-h|--help]
+
+    Prints the managed stack from every thread in the target process
+
+    -t, ---report-type <report-type>
+        The way to represent the stack data.  (default: standard)
 
     -h, --help
         Show command line help
 
     Examples:
       > dotnet-trace stack -p 1234
-      Stack for Thread (2207382):
-          UNMANAGED_CODE_TIME
-          System.Private.CoreLib!System.Threading.ManualResetEventSlim.Wait(int32,value class System.Threading.CancellationToken)
-          System.Private.CoreLib!System.Threading.Tasks.Task.SpinThenBlockingWait(int32,value class System.Threading.CancellationToken)
-          System.Private.CoreLib!System.Threading.Tasks.Task.InternalWaitCore(int32,value class System.Threading.CancellationToken)
-          System.Private.CoreLib!System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(class System.Threading.Tasks.Task)
+      Stack for Thread (0x1):
+          [Native Frames]
+          System.Private.CoreLib!System.Threading.ManualResetEventSlim.Wait(int, System.Threading.CancellationToken)
+          System.Private.CoreLib!System.Threading.Tasks.Task.SpinThenBlockingWait(int, System.Threading.CancellationToken)
+          System.Private.CoreLib!System.Threading.Tasks.Task.InternalWaitCore(int, System.Threading.CancellationToken)
+          System.Private.CoreLib!System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task)
           System.Private.CoreLib!System.Runtime.CompilerServices.TaskAwaiter.GetResult()
-          Microsoft.Extensions.Hosting.Abstractions!Microsoft.Extensions.Hosting.HostingAbstractionsHostExtensions.Run(class Microsoft.Extensions.Hosting.IHost)
-          testtesttest!testtesttest.Program.Main(class System.String[])
+          Microsoft.Extensions.Hosting.Abstractions!Microsoft.Extensions.Hosting.HostingAbstractionsHostExtensions.Run(Microsoft.Extensions.Hosting.IHost)
+          testtesttest!testtesttest.Program.Main(System.String[])
 
-      Stack for Thread (2207415):
-          UNMANAGED_CODE_TIME
-          System.IO.FileSystem.Watcher!System.IO.FileSystemWatcher+RunningInstance+StaticWatcherRunLoopManager.WatchForFileSystemEventsThreadStart(class System.Threading.ManualResetEventSlim,class Microsoft.Win32.SafeHandles.SafeEventStreamHandle)
-          System.IO.FileSystem.Watcher!System.IO.FileSystemWatcher+RunningInstance+StaticWatcherRunLoopManager+<>c.<ScheduleEventStream>b__3_0(class System.Object)
-          System.Private.CoreLib!System.Threading.ThreadHelper.ThreadStart_Context(class System.Object)
-          System.Private.CoreLib!System.Threading.ExecutionContext.RunInternal(class System.Threading.ExecutionContext,class System.Threading.ContextCallback,class System.Object)
-          System.Private.CoreLib!System.Threading.ThreadHelper.ThreadStart(class System.Object)
+      Stack for Thread (0x2):
+          [Native Frames]
+          System.IO.FileSystem.Watcher!System.IO.FileSystemWatcher.RunningInstance.StaticWatcherRunLoopManager.WatchForFileSystemEventsThreadStart(System.Threading.ManualResetEventSlim, Microsoft.Win32.SafeHandles.SafeEventStreamHandle)
+          System.IO.FileSystem.Watcher!System.IO.FileSystemWatcher.RunningInstance.StaticWatcherRunLoopManager.<>c.<ScheduleEventStream>(System.Object)
+          System.Private.CoreLib!System.Threading.ThreadHelper.ThreadStart_Context(System.Object)
+          System.Private.CoreLib!System.Threading.ExecutionContext.RunInternal(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object)
+          System.Private.CoreLib!System.Threading.ThreadHelper.ThreadStart(System.Object)
 
-      Stack for Thread (2207469):
-          UNMANAGED_CODE_TIME
-          System.Private.CoreLib!System.Threading.SemaphoreSlim.WaitUntilCountOrTimeout(int32,unsigned int32,value class System.Threading.CancellationToken)
-          System.Private.CoreLib!System.Threading.SemaphoreSlim.Wait(int32,value class System.Threading.CancellationToken)
-          System.Collections.Concurrent!System.Collections.Concurrent.BlockingCollection`1[Microsoft.Extensions.Logging.Console.LogMessageEntry].TryTakeWithNoTimeValidation(!0&,int32,value class System.Threading.CancellationToken,class System.Threading.CancellationTokenSource)
-          System.Collections.Concurrent!System.Collections.Concurrent.BlockingCollection`1+<GetConsumingEnumerable>d__68[Microsoft.Extensions.Logging.Console.LogMessageEntry].MoveNext()
+      Stack for Thread (0x3):
+          [Native Frames]
+          System.Private.CoreLib!System.Threading.SemaphoreSlim.WaitUntilCountOrTimeout(int, uint, System.Threading.CancellationToken)
+          System.Private.CoreLib!System.Threading.SemaphoreSlim.Wait(int, System.Threading.CancellationToken)
+          System.Collections.Concurrent!System.Collections.Concurrent.BlockingCollection<Microsoft.Extensions.Logging.Console.LogMessageEntry>.TryTakeWithNoTimeValidation(int, System.Threading.CancellationToken, System.Threading.CancellationTokenSource)
+          System.Collections.Concurrent!System.Collections.Concurrent.BlockingCollection<Microsoft.Extensions.Logging.Console.LogMessageEntry>.GetConsumingEnumerable().MoveNext()
           Microsoft.Extensions.Logging.Console!Microsoft.Extensions.Logging.Console.ConsoleLoggerProcessor.ProcessLogQueue()
-          System.Private.CoreLib!System.Threading.ThreadHelper.ThreadStart_Context(class System.Object)
-          System.Private.CoreLib!System.Threading.ExecutionContext.RunInternal(class System.Threading.ExecutionContext,class System.Threading.ContextCallback,class System.Object)
+          System.Private.CoreLib!System.Threading.ThreadHelper.ThreadStart_Context(System.Object)
+          System.Private.CoreLib!System.Threading.ExecutionContext.RunInternal(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object)
           System.Private.CoreLib!System.Threading.ThreadHelper.ThreadStart()
 
-      Stack for Thread (2207474):
-          UNMANAGED_CODE_TIME
-          System.Private.CoreLib!System.Threading.Thread.Sleep(value class System.TimeSpan)
+      Stack for Thread (0x4):
+          [Native Frames]
+          System.Private.CoreLib!System.Threading.Thread.Sleep(System.TimeSpan)
           Microsoft.AspNetCore.Server.Kestrel.Core!Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.Heartbeat.TimerLoop()
-          Microsoft.AspNetCore.Server.Kestrel.Core!Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.Heartbeat+<>c.<.ctor>b__8_0(class System.Object)
-          System.Private.CoreLib!System.Threading.ThreadHelper.ThreadStart_Context(class System.Object)
-          System.Private.CoreLib!System.Threading.ExecutionContext.RunInternal(class System.Threading.ExecutionContext,class System.Threading.ContextCallback,class System.Object)
-          System.Private.CoreLib!System.Threading.ThreadHelper.ThreadStart(class System.Object)
+          Microsoft.AspNetCore.Server.Kestrel.Core!Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.Heartbeat.ctor(System.Object)
+          System.Private.CoreLib!System.Threading.ThreadHelper.ThreadStart_Context(System.Object)
+          System.Private.CoreLib!System.Threading.ExecutionContext.RunInternal(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object)
+          System.Private.CoreLib!System.Threading.ThreadHelper.ThreadStart(System.Object)
 
-      Stack for Thread (2207860):
-          UNMANAGED_CODE_TIME
+      Stack for Thread (0x5):
+          [Native Frames]
           System.Net.Sockets!System.Net.Sockets.SocketAsyncEngine.EventLoop()
-          System.Net.Sockets!System.Net.Sockets.SocketAsyncEngine+<>c.<.ctor>b__14_0(class System.Object)
-          System.Private.CoreLib!System.Threading.ThreadHelper.ThreadStart(class System.Object)
+          System.Net.Sockets!System.Net.Sockets.SocketAsyncEngine.ctor( System.Object)
+          System.Private.CoreLib!System.Threading.ThreadHelper.ThreadStart(System.Object)
 
 ### dotnet-dump
 

--- a/documentation/design-docs/dotnet-tools.md
+++ b/documentation/design-docs/dotnet-tools.md
@@ -301,7 +301,6 @@ COMMANDS
     ps              Lists dotnet processes that can be attached to.
     list-profiles   Lists pre-built tracing profiles with a description of what providers and filters are in each profile.
     convert         Converts traces to alternate formats for use with alternate trace analysis tools
-    stack           Print the stack trace for every thread in teh target process
 
 COLLECT
 

--- a/documentation/design-docs/dotnet-tools.md
+++ b/documentation/design-docs/dotnet-tools.md
@@ -396,81 +396,6 @@ CONVERT
       Writing:       ./trace.speedscope.json
       Conversion complete
 
-
-### dotnet-stack
-
-SYNOPSIS
-
-    dotnet-stack [options] [command] [<args>]
-
-OPTIONS
-
-    --version
-        Display the version of the dotnet-trace utility.
-
-    -h, --help
-        Show command line help
-
-COMMANDS
-
-    report         Displays stack traces for the target process
-
-REPORT
-
-    dotnet-stack report -p|--process-id <pid>
-                        [-h|--help]
-
-    Prints the managed stack from every thread in the target process
-
-    -h, --help
-        Show command line help
-
-    Examples:
-      > dotnet-stack report -p 1234
-      Stack for Thread (0x151c):
-          [Native Frames]
-          System.Private.CoreLib!System.Threading.ManualResetEventSlim.Wait(int, System.Threading.CancellationToken)
-          System.Private.CoreLib!System.Threading.Tasks.Task.SpinThenBlockingWait(int, System.Threading.CancellationToken)
-          System.Private.CoreLib!System.Threading.Tasks.Task.InternalWaitCore(int, System.Threading.CancellationToken)
-          System.Private.CoreLib!System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task)
-          System.Private.CoreLib!System.Runtime.CompilerServices.TaskAwaiter.GetResult()
-          Microsoft.Extensions.Hosting.Abstractions!Microsoft.Extensions.Hosting.HostingAbstractionsHostExtensions.Run(Microsoft.Extensions.Hosting.IHost)
-          testtesttest!testtesttest.Program.Main(System.String[])
-
-      Stack for Thread (0x152b):
-          [Native Frames]
-          System.IO.FileSystem.Watcher!System.IO.FileSystemWatcher.RunningInstance.StaticWatcherRunLoopManager.WatchForFileSystemEventsThreadStart(System.Threading.ManualResetEventSlim, Microsoft.Win32.SafeHandles.SafeEventStreamHandle)
-          System.IO.FileSystem.Watcher!System.IO.FileSystemWatcher.RunningInstance.StaticWatcherRunLoopManager.<>c.<ScheduleEventStream>(System.Object)
-          System.Private.CoreLib!System.Threading.ThreadHelper.ThreadStart_Context(System.Object)
-          System.Private.CoreLib!System.Threading.ExecutionContext.RunInternal(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object)
-          System.Private.CoreLib!System.Threading.ThreadHelper.ThreadStart(System.Object)
-
-      Stack for Thread (0x153a):
-          [Native Frames]
-          System.Private.CoreLib!System.Threading.SemaphoreSlim.WaitUntilCountOrTimeout(int, uint, System.Threading.CancellationToken)
-          System.Private.CoreLib!System.Threading.SemaphoreSlim.Wait(int, System.Threading.CancellationToken)
-          System.Collections.Concurrent!System.Collections.Concurrent.BlockingCollection<Microsoft.Extensions.Logging.Console.LogMessageEntry>.TryTakeWithNoTimeValidation(int, System.Threading.CancellationToken, System.Threading.CancellationTokenSource)
-          System.Collections.Concurrent!System.Collections.Concurrent.BlockingCollection<Microsoft.Extensions.Logging.Console.LogMessageEntry>.GetConsumingEnumerable().MoveNext()
-          Microsoft.Extensions.Logging.Console!Microsoft.Extensions.Logging.Console.ConsoleLoggerProcessor.ProcessLogQueue()
-          System.Private.CoreLib!System.Threading.ThreadHelper.ThreadStart_Context(System.Object)
-          System.Private.CoreLib!System.Threading.ExecutionContext.RunInternal(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object)
-          System.Private.CoreLib!System.Threading.ThreadHelper.ThreadStart()
-
-      Stack for Thread (0x4125):
-          [Native Frames]
-          System.Private.CoreLib!System.Threading.Thread.Sleep(System.TimeSpan)
-          Microsoft.AspNetCore.Server.Kestrel.Core!Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.Heartbeat.TimerLoop()
-          Microsoft.AspNetCore.Server.Kestrel.Core!Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.Heartbeat.ctor(System.Object)
-          System.Private.CoreLib!System.Threading.ThreadHelper.ThreadStart_Context(System.Object)
-          System.Private.CoreLib!System.Threading.ExecutionContext.RunInternal(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object)
-          System.Private.CoreLib!System.Threading.ThreadHelper.ThreadStart(System.Object)
-
-      Stack for Thread (0x5hf3):
-          [Native Frames]
-          System.Net.Sockets!System.Net.Sockets.SocketAsyncEngine.EventLoop()
-          System.Net.Sockets!System.Net.Sockets.SocketAsyncEngine.ctor( System.Object)
-          System.Private.CoreLib!System.Threading.ThreadHelper.ThreadStart(System.Object)
-
 ### dotnet-dump
 
 SYNOPSIS
@@ -785,6 +710,80 @@ Examples:
 ## Future suggestions
 
 Work described in here captures potential future directions these tools could take given time and customer interest. Some of these might come relatively soon, others feel quite speculative or duplicative with existing technology. Regardless, understanding potential future options helps to ensure that we don't unknowingly paint ourselves into a corner or build an incoherent offering.
+
+### dotnet-stack
+
+SYNOPSIS
+
+    dotnet-stack [options] [command] [<args>]
+
+OPTIONS
+
+    --version
+        Display the version of the dotnet-trace utility.
+
+    -h, --help
+        Show command line help
+
+COMMANDS
+
+    report         Displays stack traces for the target process
+
+REPORT
+
+    dotnet-stack report -p|--process-id <pid>
+                        [-h|--help]
+
+    Prints the managed stack from every thread in the target process
+
+    -h, --help
+        Show command line help
+
+    Examples:
+      > dotnet-stack report -p 1234
+      Thread (0x151c):
+          [Native Frames]
+          System.Private.CoreLib!System.Threading.ManualResetEventSlim.Wait(int, System.Threading.CancellationToken)
+          System.Private.CoreLib!System.Threading.Tasks.Task.SpinThenBlockingWait(int, System.Threading.CancellationToken)
+          System.Private.CoreLib!System.Threading.Tasks.Task.InternalWaitCore(int, System.Threading.CancellationToken)
+          System.Private.CoreLib!System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task)
+          System.Private.CoreLib!System.Runtime.CompilerServices.TaskAwaiter.GetResult()
+          Microsoft.Extensions.Hosting.Abstractions!Microsoft.Extensions.Hosting.HostingAbstractionsHostExtensions.Run(Microsoft.Extensions.Hosting.IHost)
+          testtesttest!testtesttest.Program.Main(System.String[])
+
+      Thread (0x152b):
+          [Native Frames]
+          System.IO.FileSystem.Watcher!System.IO.FileSystemWatcher.RunningInstance.StaticWatcherRunLoopManager.WatchForFileSystemEventsThreadStart(System.Threading.ManualResetEventSlim, Microsoft.Win32.SafeHandles.SafeEventStreamHandle)
+          System.IO.FileSystem.Watcher!System.IO.FileSystemWatcher.RunningInstance.StaticWatcherRunLoopManager.<>c.<ScheduleEventStream>(System.Object)
+          System.Private.CoreLib!System.Threading.ThreadHelper.ThreadStart_Context(System.Object)
+          System.Private.CoreLib!System.Threading.ExecutionContext.RunInternal(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object)
+          System.Private.CoreLib!System.Threading.ThreadHelper.ThreadStart(System.Object)
+
+      Thread (0x153a):
+          [Native Frames]
+          System.Private.CoreLib!System.Threading.SemaphoreSlim.WaitUntilCountOrTimeout(int, uint, System.Threading.CancellationToken)
+          System.Private.CoreLib!System.Threading.SemaphoreSlim.Wait(int, System.Threading.CancellationToken)
+          System.Collections.Concurrent!System.Collections.Concurrent.BlockingCollection<Microsoft.Extensions.Logging.Console.LogMessageEntry>.TryTakeWithNoTimeValidation(int, System.Threading.CancellationToken, System.Threading.CancellationTokenSource)
+          System.Collections.Concurrent!System.Collections.Concurrent.BlockingCollection<Microsoft.Extensions.Logging.Console.LogMessageEntry>.GetConsumingEnumerable().MoveNext()
+          Microsoft.Extensions.Logging.Console!Microsoft.Extensions.Logging.Console.ConsoleLoggerProcessor.ProcessLogQueue()
+          System.Private.CoreLib!System.Threading.ThreadHelper.ThreadStart_Context(System.Object)
+          System.Private.CoreLib!System.Threading.ExecutionContext.RunInternal(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object)
+          System.Private.CoreLib!System.Threading.ThreadHelper.ThreadStart()
+
+      Thread (0x4125):
+          [Native Frames]
+          System.Private.CoreLib!System.Threading.Thread.Sleep(System.TimeSpan)
+          Microsoft.AspNetCore.Server.Kestrel.Core!Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.Heartbeat.TimerLoop()
+          Microsoft.AspNetCore.Server.Kestrel.Core!Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.Heartbeat.ctor(System.Object)
+          System.Private.CoreLib!System.Threading.ThreadHelper.ThreadStart_Context(System.Object)
+          System.Private.CoreLib!System.Threading.ExecutionContext.RunInternal(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object)
+          System.Private.CoreLib!System.Threading.ThreadHelper.ThreadStart(System.Object)
+
+      Thread (0x5hf3):
+          [Native Frames]
+          System.Net.Sockets!System.Net.Sockets.SocketAsyncEngine.EventLoop()
+          System.Net.Sockets!System.Net.Sockets.SocketAsyncEngine.ctor( System.Object)
+          System.Private.CoreLib!System.Threading.ThreadHelper.ThreadStart(System.Object)
 
 ### dotnet-counters
 

--- a/documentation/design-docs/dotnet-tools.md
+++ b/documentation/design-docs/dotnet-tools.md
@@ -301,6 +301,7 @@ COMMANDS
     ps              Lists dotnet processes that can be attached to.
     list-profiles   Lists pre-built tracing profiles with a description of what providers and filters are in each profile.
     convert         Converts traces to alternate formats for use with alternate trace analysis tools
+    stack           Print the stack trace for every thread in teh target process
 
 COLLECT
 
@@ -395,6 +396,63 @@ CONVERT
       > dotnet-trace convert trace.nettrace -f speedscope
       Writing:       ./trace.speedscope.json
       Conversion complete
+
+
+CONVERT
+
+    dotnet-trace stack -p|--process-id <pid>
+                       [-h|--help]
+
+    Prints the stack for every thread in the target process
+
+    -h, --help
+        Show command line help
+
+    Examples:
+      > dotnet-trace stack -p 1234
+      Stack for Thread (2207382):
+          UNMANAGED_CODE_TIME
+          System.Private.CoreLib!System.Threading.ManualResetEventSlim.Wait(int32,value class System.Threading.CancellationToken)
+          System.Private.CoreLib!System.Threading.Tasks.Task.SpinThenBlockingWait(int32,value class System.Threading.CancellationToken)
+          System.Private.CoreLib!System.Threading.Tasks.Task.InternalWaitCore(int32,value class System.Threading.CancellationToken)
+          System.Private.CoreLib!System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(class System.Threading.Tasks.Task)
+          System.Private.CoreLib!System.Runtime.CompilerServices.TaskAwaiter.GetResult()
+          Microsoft.Extensions.Hosting.Abstractions!Microsoft.Extensions.Hosting.HostingAbstractionsHostExtensions.Run(class Microsoft.Extensions.Hosting.IHost)
+          testtesttest!testtesttest.Program.Main(class System.String[])
+
+      Stack for Thread (2207415):
+          UNMANAGED_CODE_TIME
+          System.IO.FileSystem.Watcher!System.IO.FileSystemWatcher+RunningInstance+StaticWatcherRunLoopManager.WatchForFileSystemEventsThreadStart(class System.Threading.ManualResetEventSlim,class Microsoft.Win32.SafeHandles.SafeEventStreamHandle)
+          System.IO.FileSystem.Watcher!System.IO.FileSystemWatcher+RunningInstance+StaticWatcherRunLoopManager+<>c.<ScheduleEventStream>b__3_0(class System.Object)
+          System.Private.CoreLib!System.Threading.ThreadHelper.ThreadStart_Context(class System.Object)
+          System.Private.CoreLib!System.Threading.ExecutionContext.RunInternal(class System.Threading.ExecutionContext,class System.Threading.ContextCallback,class System.Object)
+          System.Private.CoreLib!System.Threading.ThreadHelper.ThreadStart(class System.Object)
+
+      Stack for Thread (2207469):
+          UNMANAGED_CODE_TIME
+          System.Private.CoreLib!System.Threading.SemaphoreSlim.WaitUntilCountOrTimeout(int32,unsigned int32,value class System.Threading.CancellationToken)
+          System.Private.CoreLib!System.Threading.SemaphoreSlim.Wait(int32,value class System.Threading.CancellationToken)
+          System.Collections.Concurrent!System.Collections.Concurrent.BlockingCollection`1[Microsoft.Extensions.Logging.Console.LogMessageEntry].TryTakeWithNoTimeValidation(!0&,int32,value class System.Threading.CancellationToken,class System.Threading.CancellationTokenSource)
+          System.Collections.Concurrent!System.Collections.Concurrent.BlockingCollection`1+<GetConsumingEnumerable>d__68[Microsoft.Extensions.Logging.Console.LogMessageEntry].MoveNext()
+          Microsoft.Extensions.Logging.Console!Microsoft.Extensions.Logging.Console.ConsoleLoggerProcessor.ProcessLogQueue()
+          System.Private.CoreLib!System.Threading.ThreadHelper.ThreadStart_Context(class System.Object)
+          System.Private.CoreLib!System.Threading.ExecutionContext.RunInternal(class System.Threading.ExecutionContext,class System.Threading.ContextCallback,class System.Object)
+          System.Private.CoreLib!System.Threading.ThreadHelper.ThreadStart()
+
+      Stack for Thread (2207474):
+          UNMANAGED_CODE_TIME
+          System.Private.CoreLib!System.Threading.Thread.Sleep(value class System.TimeSpan)
+          Microsoft.AspNetCore.Server.Kestrel.Core!Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.Heartbeat.TimerLoop()
+          Microsoft.AspNetCore.Server.Kestrel.Core!Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.Heartbeat+<>c.<.ctor>b__8_0(class System.Object)
+          System.Private.CoreLib!System.Threading.ThreadHelper.ThreadStart_Context(class System.Object)
+          System.Private.CoreLib!System.Threading.ExecutionContext.RunInternal(class System.Threading.ExecutionContext,class System.Threading.ContextCallback,class System.Object)
+          System.Private.CoreLib!System.Threading.ThreadHelper.ThreadStart(class System.Object)
+
+      Stack for Thread (2207860):
+          UNMANAGED_CODE_TIME
+          System.Net.Sockets!System.Net.Sockets.SocketAsyncEngine.EventLoop()
+          System.Net.Sockets!System.Net.Sockets.SocketAsyncEngine+<>c.<.ctor>b__14_0(class System.Object)
+          System.Private.CoreLib!System.Threading.ThreadHelper.ThreadStart(class System.Object)
 
 ### dotnet-dump
 


### PR DESCRIPTION
We've had customer requests for a mechanism to get a single set of stack traces from a target process (#1660).  This proposal is to add a `dotnet-stack` tool that would do just that.  I have most of the code for this already implemented in [josalem/DotStack](https://github.com/josalem/DotStack), so implementation shouldn't be too involved.

CC @tommcdon