### PR TITLE
Implemented extended error processing for attaching to .NET Core 3.1 on macOS.

### DIFF
--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
@@ -135,7 +135,8 @@ namespace Microsoft.Diagnostics.NETCore.Client
             {
                 case DiagnosticsServerResponseId.Error:
                     uint hr = BitConverter.ToUInt32(response.Payload, 0);
-                    if (hr == (uint)DiagnosticsIpcError.UnknownCommand) {
+                    if (hr == (uint)DiagnosticsIpcError.UnknownCommand) 
+                    {
                       throw new InvalidOperationException("Unsupported profiler attach");
                     }
                     throw new ServerErrorException($"Profiler attach failed (HRESULT: 0x{hr:X8})");

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
@@ -98,8 +98,9 @@ namespace Microsoft.Diagnostics.NETCore.Client
             {
                 case DiagnosticsServerResponseId.Error:
                     uint hr = BitConverter.ToUInt32(response.Payload, 0);
-                    if (hr == (uint)DiagnosticsIpcError.UnknownCommand) {
-                        throw new PlatformNotSupportedException($"Unsupported operating system: {RuntimeInformation.OSDescription}");
+                    if (hr == (uint)DiagnosticsIpcError.UnknownCommand)
+                    {
+                        throw new UnsupportedCommandException($"Unsupported operating system: {RuntimeInformation.OSDescription}");
                     }
                     throw new ServerErrorException($"Writing dump failed (HRESULT: 0x{hr:X8})");
                 case DiagnosticsServerResponseId.OK:
@@ -135,9 +136,9 @@ namespace Microsoft.Diagnostics.NETCore.Client
             {
                 case DiagnosticsServerResponseId.Error:
                     uint hr = BitConverter.ToUInt32(response.Payload, 0);
-                    if (hr == (uint)DiagnosticsIpcError.UnknownCommand) 
+                    if (hr == (uint)DiagnosticsIpcError.UnknownCommand)
                     {
-                      throw new InvalidOperationException("The target runtime does not support profiler attach.");
+                      throw new UnsupportedCommandException("The target runtime does not support profiler attach");
                     }
                     throw new ServerErrorException($"Profiler attach failed (HRESULT: 0x{hr:X8})");
                 case DiagnosticsServerResponseId.OK:

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
@@ -134,7 +134,10 @@ namespace Microsoft.Diagnostics.NETCore.Client
             switch ((DiagnosticsServerResponseId)response.Header.CommandId)
             {
                 case DiagnosticsServerResponseId.Error:
-                    var hr = BitConverter.ToInt32(response.Payload, 0);
+                    uint hr = BitConverter.ToUInt32(response.Payload, 0);
+                    if (hr == (uint)DiagnosticsIpcError.UnknownCommand) {
+                      throw new InvalidOperationException("Unsupported profiler attach");
+                    }
                     throw new ServerErrorException($"Profiler attach failed (HRESULT: 0x{hr:X8})");
                 case DiagnosticsServerResponseId.OK:
                     return;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
                     uint hr = BitConverter.ToUInt32(response.Payload, 0);
                     if (hr == (uint)DiagnosticsIpcError.UnknownCommand) 
                     {
-                      throw new InvalidOperationException("Unsupported profiler attach");
+                      throw new InvalidOperationException("The target runtime does not support profiler attach.");
                     }
                     throw new ServerErrorException($"Profiler attach failed (HRESULT: 0x{hr:X8})");
                 case DiagnosticsServerResponseId.OK:

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClientExceptions.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClientExceptions.cs
@@ -28,4 +28,10 @@ namespace Microsoft.Diagnostics.NETCore.Client
     {
         public ServerErrorException(string msg): base(msg) {}
     }
+
+    // When the runtime doesn't support the command
+    public class UnsupportedCommandException : ServerErrorException
+    {
+        public UnsupportedCommandException(string msg): base(msg) {}
+    }
 }

--- a/src/Tools/dotnet-dump/Analyzer.cs
+++ b/src/Tools/dotnet-dump/Analyzer.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Diagnostics.NETCore.Client;
 using Microsoft.Diagnostics.DebugServices;
 using Microsoft.Diagnostics.Repl;
 using Microsoft.Diagnostics.Runtime;
@@ -103,6 +104,7 @@ namespace Microsoft.Diagnostics.Tools.Dump
                  ex is DirectoryNotFoundException || 
                  ex is UnauthorizedAccessException || 
                  ex is PlatformNotSupportedException || 
+                 ex is UnsupportedCommandException ||
                  ex is InvalidDataException ||
                  ex is InvalidOperationException ||
                  ex is NotSupportedException)

--- a/src/Tools/dotnet-dump/Dumper.cs
+++ b/src/Tools/dotnet-dump/Dumper.cs
@@ -116,6 +116,7 @@ namespace Microsoft.Diagnostics.Tools.Dump
                  ex is DirectoryNotFoundException || 
                  ex is UnauthorizedAccessException || 
                  ex is PlatformNotSupportedException || 
+                 ex is UnsupportedCommandException ||
                  ex is InvalidDataException ||
                  ex is InvalidOperationException ||
                  ex is NotSupportedException ||

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/WriteDumpTests.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/WriteDumpTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
 
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && Environment.Version.ToString().StartsWith("3"))
                 {
-                    Assert.Throws<PlatformNotSupportedException>(() => client.WriteDump(DumpType.Normal, dumpPath));
+                    Assert.Throws<UnsupportedCommandException>(() => client.WriteDump(DumpType.Normal, dumpPath));
                 }
                 else
                 {
@@ -71,10 +71,10 @@ namespace Microsoft.Diagnostics.NETCore.Client
 
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                Assert.Throws<PlatformNotSupportedException>(() => client.WriteDump(DumpType.Normal, normalDumpPath));
-                Assert.Throws<PlatformNotSupportedException>(() => client.WriteDump(DumpType.WithHeap, heapDumpPath));
-                Assert.Throws<PlatformNotSupportedException>(() => client.WriteDump(DumpType.Triage, triageDumpPath));
-                Assert.Throws<PlatformNotSupportedException>(() => client.WriteDump(DumpType.Full, fullDumpPath));
+                Assert.Throws<UnsupportedCommandException>(() => client.WriteDump(DumpType.Normal, normalDumpPath));
+                Assert.Throws<UnsupportedCommandException>(() => client.WriteDump(DumpType.WithHeap, heapDumpPath));
+                Assert.Throws<UnsupportedCommandException>(() => client.WriteDump(DumpType.Triage, triageDumpPath));
+                Assert.Throws<UnsupportedCommandException>(() => client.WriteDump(DumpType.Full, fullDumpPath));
             }
             else
             {


### PR DESCRIPTION
The library throws the unidentified error message: `Profiler attach failed (HRESULT: 0x80131385)`. It is very complicated to understand from the original message that .NET Core 3.1 on macOS doesn't support attach.