### PR TITLE
Use .NET Core runtime to host on Windows; fallback to desktop CLR

### DIFF
--- a/src/SOS/SOS.UnitTests/ConfigFiles/Unix/Debugger.Tests.Config.txt
+++ b/src/SOS/SOS.UnitTests/ConfigFiles/Unix/Debugger.Tests.Config.txt
@@ -64,6 +64,7 @@
     <Option Condition="'$(TestRuntime21)' == 'true'">
       <BuildProjectFramework>netcoreapp2.1</BuildProjectFramework>
       <RuntimeFrameworkVersion>$(RuntimeVersion21)</RuntimeFrameworkVersion>
+      <SetHostRuntime>$(DotNetRoot)/shared/Microsoft.NETCore.App/$(RuntimeFrameworkVersion)</SetHostRuntime>
     </Option>
     <!--
         SOS.StackAndOtherTests (cli because tested with embedded and portable PDBs)
@@ -76,6 +77,7 @@
         <Option Condition="'$(RuntimeVersionLatest)' != ''">
           <BuildProjectFramework>$(BuildProjectFrameworkLatest)</BuildProjectFramework>
           <RuntimeFrameworkVersion>$(RuntimeVersionLatest)</RuntimeFrameworkVersion>
+          <SetHostRuntime>$(DotNetRoot)/shared/Microsoft.NETCore.App/$(RuntimeFrameworkVersion)</SetHostRuntime>
         </Option>
         <Option Condition="'$(RuntimeVersion50)' != ''">
           <BuildProjectFramework>net5.0</BuildProjectFramework>
@@ -118,7 +120,6 @@
 
   <FrameworkVersion Condition="'$(FrameworkVersion)' == ''">$(RuntimeFrameworkVersion)</FrameworkVersion>
   <RuntimeSymbolsPath>$(DotNetRoot)/shared/Microsoft.NETCore.App/$(RuntimeFrameworkVersion)</RuntimeSymbolsPath>
-  <SOSHostRuntime>$(DotNetRoot)/shared/Microsoft.NETCore.App/$(RuntimeFrameworkVersion)</SOSHostRuntime>
   <LLDBHelperScript>$(ScriptRootDir)/lldbhelper.py</LLDBHelperScript>
   <HostExe>$(DotNetRoot)/dotnet</HostExe>
   <HostArgs>--fx-version $(FrameworkVersion)</HostArgs>

--- a/src/SOS/SOS.UnitTests/ConfigFiles/Windows/Debugger.Tests.Config.txt
+++ b/src/SOS/SOS.UnitTests/ConfigFiles/Windows/Debugger.Tests.Config.txt
@@ -117,8 +117,15 @@
               <BuildProjectFramework>netcoreapp2.1</BuildProjectFramework>
               <RuntimeFrameworkVersion>$(RuntimeVersion21)</RuntimeFrameworkVersion>
               <FrameworkVersion>$(AspNetCoreVersion21)</FrameworkVersion>
-              <!-- Do at least one test hosted on .NET Core. -->
-              <SOSHostRuntime>$(DotNetRoot)\shared\Microsoft.NETCore.App\$(RuntimeVersion21)</SOSHostRuntime>
+            </Option>
+          </Options>
+          <Options>
+            <!-- Test using the .NET Core and the destkop CLR framework to host the managed SOS bits -->
+            <Option>
+              <SetHostRuntime>$(DotNetRoot)\shared\Microsoft.NETCore.App\$(RuntimeVersion21)</SetHostRuntime>
+            </Option>
+            <Option>
+              <SetHostRuntime>-netfx</SetHostRuntime>
             </Option>
           </Options>
         </Option>

--- a/src/SOS/SOS.UnitTests/SOS.cs
+++ b/src/SOS/SOS.UnitTests/SOS.cs
@@ -315,6 +315,7 @@ public class SOS
 
             // Create the python script process runner
             ProcessRunner processRunner = new ProcessRunner(program, arguments.ToString()).
+                WithEnvironmentVariable("DOTNET_ROOT", config.DotNetRoot()).
                 WithLog(new TestRunner.TestLogger(outputHelper.IndentedOutput)).
                 WithTimeout(TimeSpan.FromMinutes(10)).
                 WithExpectedExitCode(0).

--- a/src/SOS/SOS.UnitTests/SOSRunner.cs
+++ b/src/SOS/SOS.UnitTests/SOSRunner.cs
@@ -578,6 +578,7 @@ public class SOSRunner : IDisposable
 
             // Create the native debugger process running
             ProcessRunner processRunner = new ProcessRunner(debuggerPath, ReplaceVariables(variables, arguments.ToString())).
+                WithEnvironmentVariable("DOTNET_ROOT", config.DotNetRoot()).
                 WithLog(scriptLogger).
                 WithTimeout(TimeSpan.FromMinutes(10));
 
@@ -751,10 +752,24 @@ public class SOSRunner : IDisposable
 
     public async Task LoadSosExtension()
     {
-        string sosHostRuntime = _config.SOSHostRuntime();
+        string setHostRuntime = _config.SetHostRuntime();
         string sosPath = _config.SOSPath();
         List<string> commands = new List<string>();
 
+        if (!string.IsNullOrEmpty(setHostRuntime))
+        {
+            switch (setHostRuntime)
+            {
+                case "-netfx":
+                case "-netcore":
+                case "-none":
+                case "-clear":
+                    break;
+                default:
+                    setHostRuntime = TestConfiguration.MakeCanonicalPath(setHostRuntime);
+                    break;
+            }
+        }
         switch (Debugger)
         {
             case NativeDebugger.Cdb:
@@ -767,16 +782,16 @@ public class SOSRunner : IDisposable
                 commands.Add($".load {sosPath}");
                 commands.Add(".reload");
                 commands.Add(".chain");
-                if (sosHostRuntime != null)
+                if (!string.IsNullOrEmpty(setHostRuntime))
                 {
-                    commands.Add($"!SetHostRuntime {sosHostRuntime}");
+                    commands.Add($"!SetHostRuntime {setHostRuntime}");
                 }
                 break;
             case NativeDebugger.Lldb:
                 commands.Add($"plugin load {sosPath}");
-                if (sosHostRuntime != null)
+                if (!string.IsNullOrEmpty(setHostRuntime))
                 {
-                    commands.Add($"sos SetHostRuntime {sosHostRuntime}");
+                    commands.Add($"sos SetHostRuntime {setHostRuntime}");
                 }
                 SwitchToExceptionThread();
                 break;
@@ -1400,6 +1415,12 @@ public static class TestConfigurationExtensions
         return TestConfiguration.MakeCanonicalPath(gdbPath);
     }
 
+    public static string DotNetRoot(this TestConfiguration config)
+    {
+        string dotnetRoot = config.GetValue("DotNetRoot");
+        return TestConfiguration.MakeCanonicalPath(dotnetRoot);
+    }
+
     public static string DotNetDumpHost(this TestConfiguration config)
     {
         string dotnetDumpHost = config.GetValue("DotNetDumpHost");
@@ -1417,9 +1438,9 @@ public static class TestConfigurationExtensions
         return TestConfiguration.MakeCanonicalPath(config.GetValue("SOSPath"));
     }
 
-    public static string SOSHostRuntime(this TestConfiguration config)
+    public static string SetHostRuntime(this TestConfiguration config)
     {
-        return TestConfiguration.MakeCanonicalPath(config.GetValue("SOSHostRuntime"));
+        return config.GetValue("SetHostRuntime");
     }
 
     public static string DesktopRuntimePath(this TestConfiguration config)

--- a/src/SOS/Strike/hostcoreclr.cpp
+++ b/src/SOS/Strike/hostcoreclr.cpp
@@ -685,7 +685,7 @@ HRESULT InitializeHosting()
     {
         return S_OK;
     }
-    HRESULT hr;
+    HRESULT hr = S_OK;
     if (!g_useDesktopClrHost)
     {
         hr = InitializeNetCoreHost();


### PR DESCRIPTION
Changes the order on Windows from desktop first then netcore to netcore then desktop CLR.