### PR TITLE
Add support for configuration of custom metrics

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/MetricsOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/MetricsOptions.cs
@@ -53,12 +53,14 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer
 
         public int MetricCount { get; set; }
 
+        public bool IncludeDefaultProviders { get; set; } = true;
+
         public List<MetricProvider> Providers { get; set; } = new List<MetricProvider>(0);
     }
 
     public class MetricProvider
     {
-        public string Provider { get; set; }
-        public List<string> Counters { get; set; } = new List<string>(0);
+        public string ProviderName { get; set; }
+        public List<string> CounterNames { get; set; } = new List<string>(0);
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/MetricsOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/MetricsOptions.cs
@@ -5,6 +5,7 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
 using System;
+using System.Collections.Generic;
 
 namespace Microsoft.Diagnostics.Monitoring.RestServer
 {
@@ -51,5 +52,13 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer
         public int UpdateIntervalSeconds { get; set; }
 
         public int MetricCount { get; set; }
+
+        public List<MetricProvider> Providers { get; set; } = new List<MetricProvider>(0);
+    }
+
+    public class MetricProvider
+    {
+        public string Provider { get; set; }
+        public List<string> Counters { get; set; } = new List<string>(0);
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/MetricsService.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/MetricsService.cs
@@ -6,7 +6,9 @@ using Microsoft.Diagnostics.Monitoring.EventPipe;
 using Microsoft.Diagnostics.NETCore.Client;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -20,53 +22,86 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer
         private EventCounterPipeline _counterPipeline;
         private readonly IDiagnosticServices _services;
         private readonly MetricsStoreService _store;
-        private readonly MetricsOptions _options;
+        private IOptionsMonitor<MetricsOptions> _optionsMonitor;
 
         public MetricsService(IDiagnosticServices services,
-            IOptions<MetricsOptions> metricsOptions,
+            IOptionsMonitor<MetricsOptions> optionsMonitor,
             MetricsStoreService metricsStore)
         {
             _store = metricsStore;
             _services = services;
-            _options = metricsOptions.Value;
+            _optionsMonitor = optionsMonitor;
         }
         
-        protected override Task ExecuteAsync(CancellationToken stoppingToken)
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
-            return Task.Run( async () =>
+            while (!stoppingToken.IsCancellationRequested)
             {
-                while (!stoppingToken.IsCancellationRequested)
+                stoppingToken.ThrowIfCancellationRequested();
+
+                try
                 {
-                    stoppingToken.ThrowIfCancellationRequested();
+                    //TODO In multi-process scenarios, how do we decide which process to choose?
+                    //One possibility is to enable metrics after a request to begin polling for metrics
+                    IProcessInfo pi = await _services.GetProcessAsync(filter: null, stoppingToken);
 
-                    try
+                    var client = new DiagnosticsClient(pi.EndpointInfo.Endpoint);
+
+                    MetricsOptions options = _optionsMonitor.CurrentValue;
+                    using var optionsTokenSource = new CancellationTokenSource();
+
+                    //If metric options change, we need to cancel the existing metrics pipeline and restart with the new settings.
+                    using IDisposable monitorListener = _optionsMonitor.OnChange((_, _) => optionsTokenSource.Cancel());
+
+                    EventPipeCounterGroup[] counterGroups = Array.Empty<EventPipeCounterGroup>();
+                    if (options.Providers.Count > 0)
                     {
-                        //TODO In multi-process scenarios, how do we decide which process to choose?
-                        //One possibility is to enable metrics after a request to begin polling for metrics
-                        IProcessInfo pi = await _services.GetProcessAsync(filter: null, stoppingToken);
-
-                        var client = new DiagnosticsClient(pi.EndpointInfo.Endpoint);
-
-                        _counterPipeline = new EventCounterPipeline(client, new EventPipeCounterPipelineSettings
+                        //In the dotnet-monitor case, custom metrics are additive to the default counters.
+                        var eventPipeCounterGroups = new List<EventPipeCounterGroup>
                         {
-                            CounterGroups = Array.Empty<EventPipeCounterGroup>(),
-                            Duration = Timeout.InfiniteTimeSpan,
-                            RefreshInterval = TimeSpan.FromSeconds(_options.UpdateIntervalSeconds)
-                        }, metricsLogger: new[] { new MetricsLogger(_store.MetricsStore) });
+                            new EventPipeCounterGroup { ProviderName = MonitoringSourceConfiguration.SystemRuntimeEventSourceName },
+                            new EventPipeCounterGroup { ProviderName = MonitoringSourceConfiguration.MicrosoftAspNetCoreHostingEventSourceName },
+                            new EventPipeCounterGroup { ProviderName = MonitoringSourceConfiguration.GrpcAspNetCoreServer }
+                        };
 
-                        await _counterPipeline.RunAsync(stoppingToken);
-                    }
-                    catch (Exception e) when (!(e is OperationCanceledException))
-                    {
-                        //Most likely we failed to resolve the pid. Attempt to do this again.
-                        if (_counterPipeline != null)
+                        foreach (MetricProvider customProvider in options.Providers)
                         {
-                            await _counterPipeline.DisposeAsync();
+                            var customCounterGroup = new EventPipeCounterGroup { ProviderName = customProvider.Provider };
+                            if (customProvider.Counters.Count > 0)
+                            {
+                                customCounterGroup.CounterNames = customProvider.Counters.ToArray();
+                            }
+                            eventPipeCounterGroups.Add(customCounterGroup);
                         }
-                        await Task.Delay(5000);
+                        counterGroups = eventPipeCounterGroups.ToArray();
                     }
+
+                    _counterPipeline = new EventCounterPipeline(client, new EventPipeCounterPipelineSettings
+                    {
+                        CounterGroups = counterGroups,
+                        Duration = Timeout.InfiniteTimeSpan,
+                        RefreshInterval = TimeSpan.FromSeconds(options.UpdateIntervalSeconds)
+                    }, metricsLogger: new[] { new MetricsLogger(_store.MetricsStore) });
+
+                    using var linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken, optionsTokenSource.Token);
+                    await _counterPipeline.RunAsync(linkedTokenSource.Token);
                 }
-            }, stoppingToken);
+                catch (Exception e)
+                {
+                    if ((e is OperationCanceledException) &&
+                       stoppingToken.IsCancellationRequested)
+                    {
+                        //We're cancelling due to shutdown, rethrow
+                        throw;
+                    }
+                    //Most likely we failed to resolve the pid or metric configuration change. Attempt to do this again.
+                    if (_counterPipeline != null)
+                    {
+                        await _counterPipeline.DisposeAsync();
+                    }
+                    await Task.Delay(5000);
+                }
+            }
         }
 
         public override async void Dispose()

--- a/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                     services.ConfigureEgress(context.Configuration);
                     if (metrics)
                     {
-                        services.Configure<MetricsOptions>(context.Configuration.GetSection(MetricsOptions.ConfigurationKey));
+                        services.ConfigureMetrics(context.Configuration);
                     }
                 })
                 .UseUrls(urls)

--- a/src/Tools/dotnet-monitor/ServiceCollectionExtensions.cs
+++ b/src/Tools/dotnet-monitor/ServiceCollectionExtensions.cs
@@ -15,10 +15,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
     {
         public static IServiceCollection ConfigureMetrics(this IServiceCollection services, IConfiguration configuration)
         {
-            services.AddSingleton((IOptionsChangeTokenSource<MetricsOptions>)new ConfigurationChangeTokenSource<MetricsOptions>(configuration.GetSection(MetricsOptions.ConfigurationKey)));
-
-            services.Configure<MetricsOptions>(configuration.GetSection(MetricsOptions.ConfigurationKey));
-            return services;
+            return services.Configure<MetricsOptions>(configuration.GetSection(MetricsOptions.ConfigurationKey));
         }
 
         public static IServiceCollection ConfigureEgress(this IServiceCollection services, IConfiguration configuration)

--- a/src/Tools/dotnet-monitor/ServiceCollectionExtensions.cs
+++ b/src/Tools/dotnet-monitor/ServiceCollectionExtensions.cs
@@ -13,6 +13,14 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 {
     internal static class ServiceCollectionExtensions
     {
+        public static IServiceCollection ConfigureMetrics(this IServiceCollection services, IConfiguration configuration)
+        {
+            services.AddSingleton((IOptionsChangeTokenSource<MetricsOptions>)new ConfigurationChangeTokenSource<MetricsOptions>(configuration.GetSection(MetricsOptions.ConfigurationKey)));
+
+            services.Configure<MetricsOptions>(configuration.GetSection(MetricsOptions.ConfigurationKey));
+            return services;
+        }
+
         public static IServiceCollection ConfigureEgress(this IServiceCollection services, IConfiguration configuration)
         {
             // Register change token for EgressOptions binding


### PR DESCRIPTION
Custom metrics example. 
```
{
    "Metrics":
    {
        "Providers":[
            {
                "Provider": "TestEventSource",
                "Counters": [
                    "TestCounterName",
                    "TestCounterName2"
                ]
            }
        ] 
    }
}
```