### PR TITLE
[Test PR] Stabilize CIs 

### DIFF
--- a/src/SOS/SOS.UnitTests/Scripts/lldbhelper.py
+++ b/src/SOS/SOS.UnitTests/Scripts/lldbhelper.py
@@ -1,7 +1,12 @@
 import lldb
 
 def __lldb_init_module(debugger, internal_dict):    
-    debugger.HandleCommand('command script add -f lldbhelper.runcommand runcommand')
+    try:
+        debugger.HandleCommand('command script add -f lldbhelper.runcommand runcommand')
+    except ImportError:
+        print("Failed to initialize the python lldb module - ImportError")
+        import os
+        os._exit(1)
     print("<END_COMMAND_OUTPUT>")
 
 def runcommand(debugger, command, result, internal_dict):

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/EventPipeSessionTests.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/EventPipeSessionTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
         public void BasicEventPipeSessionTest()
         {
             using TestRunner runner = new TestRunner(CommonHelper.GetTraceePathWithArgs(), output);
-            runner.Start(3000);
+            runner.Start(timeoutInMSPipeCreation: 3000);
             DiagnosticsClient client = new DiagnosticsClient(runner.Pid);
             using (var session = client.StartEventPipeSession(new List<EventPipeProvider>()
             {
@@ -55,7 +55,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
         public void EventPipeSessionStreamTest()
         {
             TestRunner runner = new TestRunner(CommonHelper.GetTraceePathWithArgs(), output);
-            runner.Start(3000);
+            runner.Start(timeoutInMSPipeCreation: 3000);
             DiagnosticsClient client = new DiagnosticsClient(runner.Pid);
             runner.PrintStatus();
             output.WriteLine($"[{DateTime.Now.ToString()}] Trying to start an EventPipe session on process {runner.Pid}");
@@ -120,7 +120,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
         public void StartEventPipeSessionWithSingleProviderTest()
         {
             using TestRunner runner = new TestRunner(CommonHelper.GetTraceePathWithArgs(), output);
-            runner.Start(3000);
+            runner.Start(timeoutInMSPipeCreation: 3000);
             DiagnosticsClient client = new DiagnosticsClient(runner.Pid);
             using (var session = client.StartEventPipeSession(new EventPipeProvider("Microsoft-Windows-DotNETRuntime", EventLevel.Informational)))
             {

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/GetProcessEnvironmentTests.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/GetProcessEnvironmentTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
             string testKey = "FOO";
             string testVal = "BAR";
             runner.AddEnvVar(testKey, testVal);
-            runner.Start(3000);
+            runner.Start(timeoutInMSPipeCreation: 3000);
             DiagnosticsClient client = new DiagnosticsClient(runner.Pid);
             Dictionary<string,string> env = client.GetProcessEnvironment();
 

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/GetPublishedProcessesTests.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/GetPublishedProcessesTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
         public void PublishedProcessTest1()
         {
             using TestRunner runner = new TestRunner(CommonHelper.GetTraceePathWithArgs(), output);
-            runner.Start(3000);
+            runner.Start(timeoutInMSPipeCreation: 3000);
             // On Windows, runner.Start will not wait for named pipe creation since for other tests, NamedPipeClientStream will
             // just wait until the named pipe is created.
             // For these tests, we need to sleep an arbitrary time before pipe is created.
@@ -83,7 +83,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
         public async Task WaitForConnectionTest()
         {
             using TestRunner runner = new TestRunner(CommonHelper.GetTraceePathWithArgs(), output);
-            runner.Start(3000);
+            runner.Start(timeoutInMSPipeCreation: 3000);
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 Thread.Sleep(5000);

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/TestRunner.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/TestRunner.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
         private ITestOutputHelper outputHelper;
 
         private CancellationTokenRegistration ctsRegistration;
+        private CancellationTokenSource cts;
 
         public TestRunner(string testExePath, ITestOutputHelper _outputHelper = null,
             bool redirectError = false, bool redirectInput = false)
@@ -55,6 +56,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
             }
 
             ctsRegistration.Unregister();
+            cts.Dispose();
         }
 
         public void AddEnvVar(string key, string value)
@@ -85,7 +87,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
                 outputHelper.WriteLine($"Process " + startInfo.FileName + " came back as exited");
             }
 
-            CancellationTokenSource cts = new CancellationTokenSource(testProcessTimeout);
+            cts = new CancellationTokenSource(testProcessTimeout);
             ctsRegistration = cts.Token.Register(() => testProcess.Kill());
 
             if (outputHelper != null)

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/TestRunner.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/TestRunner.cs
@@ -19,8 +19,6 @@ namespace Microsoft.Diagnostics.NETCore.Client
         private Process testProcess;
         private ProcessStartInfo startInfo;
         private ITestOutputHelper outputHelper;
-
-        private CancellationTokenRegistration ctsRegistration;
         private CancellationTokenSource cts;
 
         public TestRunner(string testExePath, ITestOutputHelper _outputHelper = null,
@@ -55,7 +53,6 @@ namespace Microsoft.Diagnostics.NETCore.Client
                 testProcess?.Dispose();
             }
 
-            ctsRegistration.Unregister();
             cts.Dispose();
         }
 
@@ -68,7 +65,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
         public StreamReader StandardOutput => testProcess.StandardOutput;
         public StreamReader StandardError => testProcess.StandardError;
 
-        public void Start(int timeoutInMSPipeCreation=15000, int testProcessTimeout=30_000)
+        public void Start(int timeoutInMSPipeCreation=15_000, int testProcessTimeout=30_000)
         {
             if (outputHelper != null)
                 outputHelper.WriteLine($"[{DateTime.Now.ToString()}] Launching test: " + startInfo.FileName + " " + startInfo.Arguments);
@@ -88,7 +85,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
             }
 
             cts = new CancellationTokenSource(testProcessTimeout);
-            ctsRegistration = cts.Token.Register(() => testProcess.Kill());
+            cts.Token.Register(() => testProcess.Kill());
 
             if (outputHelper != null)
             {

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/WriteDumpTests.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/WriteDumpTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
             {
                 var dumpPath = "./myDump.dmp";
                 using TestRunner runner = new TestRunner(CommonHelper.GetTraceePathWithArgs(), output);
-                runner.Start(3000);
+                runner.Start(timeoutInMSPipeCreation: 3000);
                 DiagnosticsClient client = new DiagnosticsClient(runner.Pid);
 
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && Environment.Version.ToString().StartsWith("3"))
@@ -66,7 +66,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
             var triageDumpPath = "./myDump-triage.dmp";
             var fullDumpPath = "./myDump-full.dmp";
             using TestRunner runner = new TestRunner(CommonHelper.GetTraceePathWithArgs(), output);
-            runner.Start(3000);
+            runner.Start(timeoutInMSPipeCreation: 3000);
             DiagnosticsClient client = new DiagnosticsClient(runner.Pid);
 
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))


### PR DESCRIPTION
Fixes:
* TestRunner used by Microsoft.Diganostics.NETCore.Client tests - Introduce timeout to tracee process

* lldbhelper script that hangs forever when an ImportError is thrown.