### PR TITLE
Increase timeout for dotnet monitor tests to a minute

### DIFF
--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/RemoteTestExecution.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/RemoteTestExecution.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Diagnostics.NETCore.Client.UnitTests
             {
                 runner.AddReversedServer(reversedServerTransportName);
             }
-            runner.Start();
+            runner.Start(testProcessTimeout: 60_000);
 
             Task readingTask = ReadAllOutput(runner.StandardOutput, runner.StandardError, outputHelper);
 


### PR DESCRIPTION
Increase the process timeout for process launched by RemoteTestExecution because these tests take a bit longer than the other Microsoft.Diagnostics.NETCore.Client tests. 