### PR TITLE
Changes for doubly linked freelists in the 64-bit GC

### DIFF
--- a/src/SOS/Strike/eeheap.cpp
+++ b/src/SOS/Strike/eeheap.cpp
@@ -970,7 +970,7 @@ DWORD GetNumComponents(TADDR obj)
 static MethodTableInfo* GetMethodTableInfo(DWORD_PTR dwAddrMethTable)
 {
     // Remove lower bits in case we are in mark phase
-    dwAddrMethTable = dwAddrMethTable & ~3;
+    dwAddrMethTable = dwAddrMethTable & ~sos::Object::METHODTABLE_PTR_LOW_BITMASK;
     MethodTableInfo* info = g_special_mtCache.Lookup(dwAddrMethTable);
     if (!info->IsInitialized())        // An uninitialized entry
     {
@@ -1214,7 +1214,7 @@ BOOL GCHeapTraverse(const GCHeapDetails &heap, AllocInfo* pallocInfo, VISITGCHEA
             return FALSE;
         }
 
-        dwAddrMethTable = dwAddrMethTable & ~3;
+        dwAddrMethTable = dwAddrMethTable & ~sos::Object::METHODTABLE_PTR_LOW_BITMASK;
         if (dwAddrMethTable == 0)
         {
             // Is this the beginning of an allocation context?
@@ -1338,7 +1338,7 @@ BOOL GCHeapTraverse(const GCHeapDetails &heap, AllocInfo* pallocInfo, VISITGCHEA
             return FALSE;
         }
 
-        dwAddrMethTable = dwAddrMethTable & ~3;
+        dwAddrMethTable = dwAddrMethTable & ~sos::Object::METHODTABLE_PTR_LOW_BITMASK;
         BOOL bContainsPointers;
         BOOL bMTOk = GetSizeEfficient(dwAddrCurrObj, dwAddrMethTable, TRUE, s, bContainsPointers);
         if (verify && bMTOk)

--- a/src/SOS/Strike/sos.cpp
+++ b/src/SOS/Strike/sos.cpp
@@ -119,7 +119,7 @@ namespace sos
             if (temp == NULL)
                 sos::Throw<HeapCorruption>("Object %s has an invalid method table.", DMLListNearObj(mAddress));
 
-            mMT = temp & ~3;
+            mMT = temp & ~METHODTABLE_PTR_LOW_BITMASK;
         }
 
         return mMT;
@@ -135,7 +135,7 @@ namespace sos
             sos::Throw<DataRead>("Failed to request object data for %s.", DMLListNearObj(mAddress));
 
         if (mMT == NULL)
-            mMT = TO_TADDR(objData.MethodTable) & ~3;
+            mMT = TO_TADDR(objData.MethodTable) & ~METHODTABLE_PTR_LOW_BITMASK;
 
         return TO_TADDR(objData.ElementTypeHandle);
     }

--- a/src/SOS/Strike/sos.h
+++ b/src/SOS/Strike/sos.h
@@ -262,6 +262,15 @@ namespace sos
 #endif
         }
 
+        // GC uses the low bits of the method table ptr in objects to store information
+        // it uses one more bit in the 64-bit implementations for the doubly linked free lists
+        static const size_t METHODTABLE_PTR_LOW_BITMASK =
+#ifdef _TARGET_WIN64_
+            7;
+#else
+            3;
+#endif
+
     public:
         /* Constructor.  Use Object(TADDR, TADDR) instead if you know the method table.
          * Parameters:

--- a/src/inc/sospriv.idl
+++ b/src/inc/sospriv.idl
@@ -413,7 +413,7 @@ interface ISOSDacInterface8 : IUnknown
 // Increment anytime there is a change in the data structures that SOS depends on like
 // stress log structs (StressMsg, StressLogChunck, ThreadStressLog, etc), exception
 // stack traces (StackTraceElement), the PredefinedTlsSlots enums, etc.
-cpp_quote("#define SOS_BREAKING_CHANGE_VERSION 1")
+cpp_quote("#define SOS_BREAKING_CHANGE_VERSION 2")
 
 [
     object,

--- a/src/pal/prebuilt/inc/sospriv.h
+++ b/src/pal/prebuilt/inc/sospriv.h
@@ -2675,7 +2675,7 @@ EXTERN_C const IID IID_ISOSDacInterface8;
 /* interface __MIDL_itf_sospriv_0000_0012 */
 /* [local] */ 
 
-#define SOS_BREAKING_CHANGE_VERSION 1
+#define SOS_BREAKING_CHANGE_VERSION 2
 
 
 extern RPC_IF_HANDLE __MIDL_itf_sospriv_0000_0012_v0_0_c_ifspec;


### PR DESCRIPTION
The 64-bit implementation of GC now uses one more bit in the methodtable pointer, so SOS needs to mask out one more bit as well.