### PR TITLE
Use sccsid version.cpp variable to display SOS version on xplat

### DIFF
--- a/eng/Build-Native.cmd
+++ b/eng/Build-Native.cmd
@@ -304,10 +304,10 @@ mkdir %__dotnet_sos%\win-%__BuildArch%
 mkdir %__dotnet_sos%\publish\win-%__BuildArch%
 mkdir %__dotnet_dump%\win-%__BuildArch%
 mkdir %__dotnet_dump%\publish\win-%__BuildArch%
-xcopy /y /f /i %__BinDir% %__dotnet_sos%\win-%__BuildArch%
-xcopy /y /f /i %__BinDir% %__dotnet_sos%\publish\win-%__BuildArch%
-xcopy /y /f /i %__BinDir% %__dotnet_dump%\win-%__BuildArch%
-xcopy /y /f /i %__BinDir% %__dotnet_dump%\publish\win-%__BuildArch%
+xcopy /y /q /i %__BinDir% %__dotnet_sos%\win-%__BuildArch%
+xcopy /y /q /i %__BinDir% %__dotnet_sos%\publish\win-%__BuildArch%
+xcopy /y /q /i %__BinDir% %__dotnet_dump%\win-%__BuildArch%
+xcopy /y /q /i %__BinDir% %__dotnet_dump%\publish\win-%__BuildArch%
 
 REM =========================================================================================
 REM ===

--- a/eng/CreateVersionFile.csproj
+++ b/eng/CreateVersionFile.csproj
@@ -75,7 +75,7 @@
     <PropertyGroup>
       <NativeVersionLines>
 <![CDATA[
-static char sccsid[] __attribute__((used)) = "@(#)Version $(InformationalVersion)$(BuiltByString)";
+char sccsid[] __attribute__((used)) = "@(#)Version $(InformationalVersion)$(BuiltByString)";
  ]]>
       </NativeVersionLines>
     </PropertyGroup>

--- a/src/SOS/SOS.NETCore/SymbolReader.cs
+++ b/src/SOS/SOS.NETCore/SymbolReader.cs
@@ -375,7 +375,7 @@ namespace SOS
                 if (symbolCachePath == null)
                 {
                     if (msdl || symweb || symbolServerPath != null) {
-                        symbolCachePath = GetDefaultSymbolCache();
+                        symbolCachePath = DefaultSymbolCache;
                     }
                 }
                 // Build the symbol stores using the other parameters
@@ -1311,7 +1311,7 @@ namespace SOS
                             { 
                                 case 1:
                                     msdl = true;
-                                    symbolCachePath = GetDefaultSymbolCache();
+                                    symbolCachePath = DefaultSymbolCache;
                                     break;
                                 case 2:
                                     symbolServerPath = parts[1];
@@ -1329,7 +1329,7 @@ namespace SOS
                             switch (parts.Length)
                             { 
                                 case 1:
-                                    symbolCachePath = GetDefaultSymbolCache();
+                                    symbolCachePath = DefaultSymbolCache;
                                     break;
                                 case 2:
                                     symbolCachePath = parts[1];
@@ -1470,16 +1470,33 @@ namespace SOS
             return false;
         }
 
-        private static string GetDefaultSymbolCache()
+        private static string s_defaultSymbolCache;
+
+        /// <summary>
+        /// The default symbol cache path:
+        /// 
+        /// * On Windows use the dbgeng symbol cache path: %PROGRAMDATA%\dbg\sym
+        /// * dotnet-dump on Windows sets it to use the VS symbol cache path: %TEMPDIR%\SymbolCache
+        /// * dotnet-dump/lldb on Linux/MacOS uses: $HOME/.dotnet/symbolcache
+        /// </summary>
+        public static string DefaultSymbolCache
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            get
             {
-                return Path.Combine(Path.GetTempPath(), "SymbolCache");
+                if (s_defaultSymbolCache == null)
+                {
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                    {
+                        s_defaultSymbolCache = Path.Combine(Environment.GetEnvironmentVariable("PROGRAMDATA"), "dbg", "sym");
+                    }
+                    else
+                    {
+                        s_defaultSymbolCache = Path.Combine(Environment.GetEnvironmentVariable("HOME"), ".dotnet", "symbolcache");
+                    }
+                }
+                return s_defaultSymbolCache;
             }
-            else
-            {
-                return Path.Combine(Environment.GetEnvironmentVariable("HOME"), ".dotnet", "symbolcache");
-            }
+            set { s_defaultSymbolCache = value; }
         }
 
         /// <summary>

--- a/src/SOS/Strike/util.cpp
+++ b/src/SOS/Strike/util.cpp
@@ -3432,6 +3432,11 @@ BOOL GetEEVersion(VS_FIXEDFILEINFO* pFileInfo, char* fileVersionBuffer, int file
 
     HRESULT hr = g_ExtSymbols2->GetModuleVersionInformation(g_pRuntime->GetModuleIndex(), 0, "\\", pFileInfo, sizeof(VS_FIXEDFILEINFO), NULL);
 
+    // 0.0.0.0 is not a valid version. This is sometime returned by windbg for Linux core dumps
+    if (SUCCEEDED(hr) && (pFileInfo->dwFileVersionMS == (DWORD)-1 || (pFileInfo->dwFileVersionLS == 0 && pFileInfo->dwFileVersionMS == 0))) {
+        return FALSE;
+    }
+
     // Attempt to get the the FileVersion string that contains version and the "built by" and commit id info
     if (fileVersionBuffer != nullptr)
     {
@@ -3568,6 +3573,9 @@ BOOL GetSOSVersion(VS_FIXEDFILEINFO *pFileInfo)
                 UINT uLen = 0;
                 if (VerQueryValue(pVersionInfo, "\\", (LPVOID *) &pTmpFileInfo, &uLen))
                 {
+                    if (pFileInfo->dwFileVersionMS == (DWORD)-1) {
+                        return FALSE;
+                    }
                     *pFileInfo = *pTmpFileInfo; // Copy the info
                     return TRUE;
                 }

--- a/src/Tools/dotnet-dump/Analyzer.cs
+++ b/src/Tools/dotnet-dump/Analyzer.cs
@@ -63,6 +63,9 @@ namespace Microsoft.Diagnostics.Tools.Dump
                     // Add all the services needed by commands and other services
                     AddServices(target);
 
+                    // Set the default symbol cache to match Visual Studio's
+                    SymbolReader.DefaultSymbolCache = Path.Combine(Path.GetTempPath(), "SymbolCache");
+
                     // Automatically enable symbol server support
                     SymbolReader.InitializeSymbolStore(
                         logging: false, 


### PR DESCRIPTION
Update to test 3.1.10/3.1.24 runtimes and build with 5.0.100 SDK

Upgrade to testing on 2.1.23 runtime

Stop testing latest runtime until DARC update to 6.0