### PR TITLE
Update to test 3.1.10/3.1.24 runtimes and build with 5.0.100 SDK

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -10,22 +10,20 @@
     <!-- Latest symstore version updated by darc -->
     <MicrosoftSymbolStoreVersion>1.0.156601</MicrosoftSymbolStoreVersion>
     <!-- Runtime versions to test -->
-    <MicrosoftNETCoreApp21Version>2.1.22</MicrosoftNETCoreApp21Version>
+    <MicrosoftNETCoreApp21Version>2.1.23</MicrosoftNETCoreApp21Version>
     <MicrosoftAspNetCoreApp21Version>$(MicrosoftNETCoreApp21Version)</MicrosoftAspNetCoreApp21Version>
-    <MicrosoftNETCoreApp31Version>3.1.8</MicrosoftNETCoreApp31Version>
+    <MicrosoftNETCoreApp31Version>3.1.10</MicrosoftNETCoreApp31Version>
     <MicrosoftAspNetCoreApp31Version>$(MicrosoftNETCoreApp31Version)</MicrosoftAspNetCoreApp31Version>
-    <MicrosoftNETCoreApp50Version>
-    </MicrosoftNETCoreApp50Version>
-    <MicrosoftAspNetCoreApp50Version>
-    </MicrosoftAspNetCoreApp50Version>
+    <MicrosoftNETCoreApp50Version>5.0.0</MicrosoftNETCoreApp50Version>
+    <MicrosoftAspNetCoreApp50Version>$(MicrosoftNETCoreApp50Version)</MicrosoftAspNetCoreApp50Version>
     <!-- Latest shared runtime version updated by darc -->
     <VSRedistCommonNetCoreSharedFrameworkx6450PackageVersion>5.0.1-servicing.20566.8</VSRedistCommonNetCoreSharedFrameworkx6450PackageVersion>
     <MicrosoftNETCoreAppRuntimewinx64Version>5.0.1</MicrosoftNETCoreAppRuntimewinx64Version>
     <!-- Latest shared aspnetcore version updated by darc -->
-    <MicrosoftAspNetCoreAppRefInternalVersion>5.0.0-rc.2.20475.17</MicrosoftAspNetCoreAppRefInternalVersion>
-    <MicrosoftAspNetCoreAppRefVersion>5.0.0-rc.2.20475.17</MicrosoftAspNetCoreAppRefVersion>
+    <MicrosoftAspNetCoreAppRefInternalVersion></MicrosoftAspNetCoreAppRefInternalVersion>
+    <MicrosoftAspNetCoreAppRefVersion></MicrosoftAspNetCoreAppRefVersion>
     <!-- dotnet/installer: Testing version of the SDK. Needed for the signed & entitled host. -->
-    <MicrosoftDotnetSdkInternalVersion>5.0.100-rc.2.20480.7</MicrosoftDotnetSdkInternalVersion>
+    <MicrosoftDotnetSdkInternalVersion>5.0.100</MicrosoftDotnetSdkInternalVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Opt-in/out repo features -->

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "5.0.100-rc.2.20479.15",
+    "dotnet": "5.0.100",
     "runtimes": {
       "dotnet/x64": [
         "$(MicrosoftNETCoreApp31Version)",


### PR DESCRIPTION
Upgrade to testing on 2.1.23 runtime

Stop testing latest runtime until DARC update to 6.0