### PR TITLE
Link the official documentation in the dev versions of the docs for all CLI tools

### DIFF
--- a/documentation/dotnet-counters-instructions.md
+++ b/documentation/dotnet-counters-instructions.md
@@ -1,5 +1,6 @@
 # dotnet-counters
 
+NOTE: This documentation page may contain information on some features that are still work-in-progress. For most up-to-date documentation on released version of `dotnet-counters`, please refer to [its official documentation](https://docs.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-counters) page.
 
 ## Intro
 

--- a/documentation/dotnet-dump-instructions.md
+++ b/documentation/dotnet-dump-instructions.md
@@ -1,6 +1,10 @@
 Dump collection and analysis utility (dotnet-dump)
 ==================================================
 
+NOTE: This documentation page may contain information on some features that are still work-in-progress. For most up-to-date documentation on released version of `dotnet-dump`, please refer to [its official documentation](https://docs.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-dump) page.
+
+## Intro
+
 The dotnet-dump CLI global tool is way to collect and analyze the managed data structures in Windows and Linux dumps all without any native debugger involved. This makes creating a managed dump easier, and on some platforms like Alpine Linux or Linux ARM32/ARM64 (where a fully working lldb isn't available) it makes creating a managed dump possible. The dotnet-dump tool will allow you to run SOS commands to analyze crashes and the GC, but it isn't a native debugger so things like displaying the native stack frames aren't supported.
 
 Here's a table showing how dotnet-dump fits into your dump debugging options:

--- a/documentation/dotnet-gcdump-instructions.md
+++ b/documentation/dotnet-gcdump-instructions.md
@@ -1,5 +1,9 @@
 # Heap Analysis Tool (dotnet-gcdump)
 
+NOTE: This documentation page may contain information on some features that are still work-in-progress. For most up-to-date documentation on released version of `dotnet-gcdump`, please refer to [its official documentation](https://docs.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-gcdump) page.
+
+## Intro
+
 The dotnet-gcdump tool is a cross-platform CLI tool that collects gcdumps of live .NET processes. It is built using the EventPipe technology which is a cross-platform alternative to ETW on Windows. Gcdumps are created by triggering a GC
 in the target process, turning on special events, and regenerating the graph of object roots from the event stream. This allows for gcdumps to be collected while the process is running with minimal overhead. These dumps are useful for
 several scenarios:

--- a/documentation/dotnet-trace-instructions.md
+++ b/documentation/dotnet-trace-instructions.md
@@ -1,5 +1,9 @@
 # Trace for performance analysis utility (dotnet-trace)
 
+NOTE: This documentation page may contain information on some features that are still work-in-progress. For most up-to-date documentation on released version of `dotnet-trace`, please refer to [its official documentation](https://docs.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-trace) page.
+
+## Intro
+
 The dotnet-trace tool is a cross-platform CLI global tool that enables the collection of .NET Core traces of a running process without any native profiler involved. It is built around the EventPipe technology of the .NET Core runtime as a cross-platform alternative to ETW on Windows and LTTng on Linux, which only work on a single platform. With EventPipe/dotnet-trace, we are trying to deliver the same experience on Windows, Linux, or macOS. dotnet-trace can be used on any .NET Core applications using versions .NET Core 3.0 Preview 5 or later.
 
 ## Installing dotnet-trace


### PR DESCRIPTION
We have duplicate documentation in this repo that may divert over time. Until we can fully migrate to the official docs and remove the duplicate in this repo, linking these docs to the official docs allows us to: 
1. keep the official docs up-to-date with the latest shipped features
2. still check in docs on WIP features while spec'ing 

