### PR TITLE
Hide counter argument and update --counters option description

### DIFF
--- a/src/Tools/dotnet-counters/Program.cs
+++ b/src/Tools/dotnet-counters/Program.cs
@@ -90,16 +90,17 @@ namespace Microsoft.Diagnostics.Tools.Counters
         private static Option CounterOption() =>
             new Option(
                 alias: "--counters",
-                description: "List of counter providers.")
+                description: "A space separated list of counter providers. Counter providers can be specified provider_name[:counter_name]. If the provider_name is used without a qualifying counter_name then all counters will be shown. To discover provider and counter names, use the list command.")
             {
                 Argument = new Argument<string>(name: "counters", getDefaultValue: () => "System.Runtime")
             };
 
         private static Argument CounterList() =>
-            new Argument<List<string>>(name: "counter_list", getDefaultValue: () => new List<string>() ) 
+            new Argument<List<string>>(name: "counter_list", getDefaultValue: () => new List<string>())
             {
                 Description = @"A space separated list of counters. Counters can be specified provider_name[:counter_name]. If the provider_name is used without a qualifying counter_name then all counters will be shown. To discover provider and counter names, use the list command.",
-                Arity = ArgumentArity.ZeroOrMore
+                Arity = ArgumentArity.ZeroOrMore,
+                IsHidden = true
             };
 
         private static Command ListCommand() =>

--- a/src/Tools/dotnet-counters/Program.cs
+++ b/src/Tools/dotnet-counters/Program.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
         private static Option CounterOption() =>
             new Option(
                 alias: "--counters",
-                description: "A space separated list of counter providers. Counter providers can be specified provider_name[:counter_name]. If the provider_name is used without a qualifying counter_name then all counters will be shown. To discover provider and counter names, use the list command.")
+                description: "A comma-separated list of counter providers. Counter providers can be specified provider_name[:counter_name]. If the provider_name is used without a qualifying counter_name then all counters will be shown. To discover provider and counter names, use the list command.")
             {
                 Argument = new Argument<string>(name: "counters", getDefaultValue: () => "System.Runtime")
             };

--- a/src/Tools/dotnet-counters/Program.cs
+++ b/src/Tools/dotnet-counters/Program.cs
@@ -99,7 +99,6 @@ namespace Microsoft.Diagnostics.Tools.Counters
             new Argument<List<string>>(name: "counter_list", getDefaultValue: () => new List<string>())
             {
                 Description = @"A space separated list of counters. Counters can be specified provider_name[:counter_name]. If the provider_name is used without a qualifying counter_name then all counters will be shown. To discover provider and counter names, use the list command.",
-                Arity = ArgumentArity.ZeroOrMore,
                 IsHidden = true
             };
 


### PR DESCRIPTION
Related issue: #1754 

The underlying cause in the issue is System.CommandLine simply calling .ToString() on the default argument. This *can* be fixed by defining a CounterList class and overriding the ToString() (very hacky, yes...), but will be addressed in a different PR, if at all.

I think the best way to address it instead is to deprecate this argument because we now have the `--counters` option which is the preferred way to specify the counters.

This also updates the description for the `--counters` argument.

