### PR TITLE
Change default binding to https. Allow partial success for missing cert.

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/ConfigurationHelper.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/ConfigurationHelper.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.Monitoring.RestServer
+{
+    internal static class ConfigurationHelper
+    {
+        public static string MakeKey(string parent, string child)
+        {
+            return FormattableString.Invariant($"{parent}:{child}");
+        }
+
+        public static string[] SplitValue(string value)
+        {
+            return value.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/MetricsOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/MetricsOptions.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer
         {
             _ports = new Lazy<int?[]>(() =>
                 {
-                    string[] endpoints = Endpoints.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+                    string[] endpoints = ConfigurationHelper.SplitValue(Endpoints);
                     int?[] ports = new int?[endpoints.Length];
                     for(int i = 0; i < endpoints.Length; i++)
                     {

--- a/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
@@ -90,8 +90,88 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 })
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
-                    webBuilder.UseUrls(urls);
-                    webBuilder.UseStartup<Startup>();
+                    webBuilder.ConfigureKestrel((context, options) =>
+                    {
+                        //Note our priorities for hosting urls don't match the default behavior.
+                        //Default Kestrel behavior priority
+                        //1) ConfigureKestrel settings
+                        //2) Command line arguments (--urls)
+                        //3) Environment variables (ASPNETCORE_URLS, then DOTNETCORE_URLS)
+
+                        //Our precedence
+                        //1) Environment variables (ASPNETCORE_URLS, DotnetMonitor_Metrics__Endpoints)
+                        //2) Command line arguments (these have defaults) --urls, --metricUrls
+                        //3) ConfigureKestrel is used for fine control of the server, but honors the first two configurations.
+
+                        string hostingUrl = context.Configuration.GetValue<string>(WebHostDefaults.ServerUrlsKey);
+                        if (!string.IsNullOrEmpty(hostingUrl))
+                        {
+                            urls = ConfigurationHelper.SplitValue(hostingUrl);
+                        }
+
+                        var metricsOptions = new MetricsOptions();
+                        context.Configuration.Bind(MetricsOptions.ConfigurationKey, metricsOptions);
+
+                        if (metricsOptions.Enabled)
+                        {
+                            string metricUrlFromConfig = metricsOptions.Endpoints;
+                            if (!string.IsNullOrEmpty(metricUrlFromConfig))
+                            {
+                                metricUrls = ConfigurationHelper.SplitValue(metricUrlFromConfig);
+                            }
+
+                            urls = urls.Concat(metricUrls).ToArray();
+                        }
+
+                        bool boundListeningPort = false;
+
+                        //Workaround for lack of default certificate. See https://github.com/dotnet/aspnetcore/issues/28120
+                        options.Configure(context.Configuration.GetSection("Kestrel")).Load();
+
+                        //By default, we bind to https for sensitive data (such as dumps and traces) and bind http for
+                        //non-sensitive data such as metrics. We may be missing a certificate for https binding. We want to continue with the
+                        //http binding in that scenario.
+                        foreach (BindingAddress url in urls.Select(BindingAddress.Parse))
+                        {
+                            Action<ListenOptions> configureListenOptions = (listenOptions) =>
+                            {
+                                if (url.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+                                {
+                                    listenOptions.UseHttps();
+                                }
+                            };
+
+                            try
+                            {
+                                if (url.Host.Equals("localhost", StringComparison.OrdinalIgnoreCase))
+                                {
+                                    options.ListenLocalhost(url.Port, configureListenOptions);
+                                }
+                                else if (IPAddress.TryParse(url.Host, out IPAddress ipAddress))
+                                {
+                                    options.Listen(ipAddress, url.Port, configureListenOptions);
+                                }
+                                else
+                                {
+                                    options.ListenAnyIP(url.Port, configureListenOptions);
+                                }
+                                boundListeningPort = true;
+                            }
+                            catch (InvalidOperationException e)
+                            {
+                                //This binding failure is typically due to missing default certificate
+                                console.Error.WriteLine($"Unable to bind to {url}. Dotnet-monitor functionality will be limited.");
+                                console.Error.WriteLine(e.Message);
+                            }
+                        }
+
+                        //If we end up not binding any ports, Kestrel defaults to port 5000. Make sure we don't attempt this.
+                        if (!boundListeningPort)
+                        {
+                            throw new InvalidOperationException("Unable to bind any urls.");
+                        }
+                    })
+                    .UseStartup<Startup>();
                 });
         }
 

--- a/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
@@ -4,6 +4,8 @@
 
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Diagnostics.Monitoring;
 using Microsoft.Diagnostics.Monitoring.RestServer;
 using Microsoft.Extensions.Configuration;
@@ -13,8 +15,10 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.CommandLine;
+using System.CommandLine.IO;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
@@ -106,7 +106,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                         string hostingUrl = context.Configuration.GetValue<string>(WebHostDefaults.ServerUrlsKey);
                         if (!string.IsNullOrEmpty(hostingUrl))
                         {
-                            urls = ConfigurationHelper.SplitValue(hostingUrl);
+                            //HACK Until our image removes the ASPNETCORE_URLS config
+                            if (BindingAddress.Parse(hostingUrl)?.Port != 80)
+                            {
+                                urls = ConfigurationHelper.SplitValue(hostingUrl);
+                            }
                         }
 
                         var metricsOptions = new MetricsOptions();

--- a/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
@@ -64,10 +64,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 {
                     //Note these are in precedence order.
                     ConfigureEndpointInfoSource(builder, diagnosticPort);
-                    if (metrics)
-                    {
-                        ConfigureMetricsEndpoint(builder, metricUrls);
-                    }
+                    ConfigureMetricsEndpoint(builder, metrics, metricUrls);
 
                     builder.AddJsonFile(UserSettingsPath, optional: true, reloadOnChange: true);
                     builder.AddJsonFile(SharedSettingsPath, optional: true, reloadOnChange: true);
@@ -83,10 +80,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                     services.AddHostedService<FilteredEndpointInfoSourceHostedService>();
                     services.AddSingleton<IDiagnosticServices, DiagnosticServices>();
                     services.ConfigureEgress(context.Configuration);
-                    if (metrics)
-                    {
-                        services.ConfigureMetrics(context.Configuration);
-                    }
+                    services.ConfigureMetrics(context.Configuration);
                     services.AddSingleton<ExperimentalToolLogger>();
                 })
                 .ConfigureLogging(builder =>
@@ -101,12 +95,12 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 });
         }
 
-        private static void ConfigureMetricsEndpoint(IConfigurationBuilder builder, string[] metricEndpoints)
+        private static void ConfigureMetricsEndpoint(IConfigurationBuilder builder, bool enableMetrics, string[] metricEndpoints)
         {
             builder.AddInMemoryCollection(new Dictionary<string, string>
             {
                 {ConfigurationHelper.MakeKey(MetricsOptions.ConfigurationKey, nameof(MetricsOptions.Endpoints)), string.Join(';', metricEndpoints)},
-                {ConfigurationHelper.MakeKey(MetricsOptions.ConfigurationKey, nameof(MetricsOptions.Enabled)), true.ToString()},
+                {ConfigurationHelper.MakeKey(MetricsOptions.ConfigurationKey, nameof(MetricsOptions.Enabled)), enableMetrics.ToString()},
                 {ConfigurationHelper.MakeKey(MetricsOptions.ConfigurationKey, nameof(MetricsOptions.UpdateIntervalSeconds)), 10.ToString()},
                 {ConfigurationHelper.MakeKey(MetricsOptions.ConfigurationKey, nameof(MetricsOptions.MetricCount)), 3.ToString()}
             });

--- a/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
@@ -59,11 +59,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         public IHostBuilder CreateHostBuilder(IConsole console, string[] urls, string[] metricUrls, bool metrics, string diagnosticPort)
         {
-            if (metrics)
-            {
-                urls = urls.Concat(metricUrls).ToArray();
-            }
-
             return Host.CreateDefaultBuilder()
                 .ConfigureAppConfiguration((IConfigurationBuilder builder) =>
                 {
@@ -110,10 +105,10 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         {
             builder.AddInMemoryCollection(new Dictionary<string, string>
             {
-                {MakeKey(MetricsOptions.ConfigurationKey, nameof(MetricsOptions.Endpoints)), string.Join(';', metricEndpoints)},
-                {MakeKey(MetricsOptions.ConfigurationKey, nameof(MetricsOptions.Enabled)), true.ToString()},
-                {MakeKey(MetricsOptions.ConfigurationKey, nameof(MetricsOptions.UpdateIntervalSeconds)), 10.ToString()},
-                {MakeKey(MetricsOptions.ConfigurationKey, nameof(MetricsOptions.MetricCount)), 3.ToString()}
+                {ConfigurationHelper.MakeKey(MetricsOptions.ConfigurationKey, nameof(MetricsOptions.Endpoints)), string.Join(';', metricEndpoints)},
+                {ConfigurationHelper.MakeKey(MetricsOptions.ConfigurationKey, nameof(MetricsOptions.Enabled)), true.ToString()},
+                {ConfigurationHelper.MakeKey(MetricsOptions.ConfigurationKey, nameof(MetricsOptions.UpdateIntervalSeconds)), 10.ToString()},
+                {ConfigurationHelper.MakeKey(MetricsOptions.ConfigurationKey, nameof(MetricsOptions.MetricCount)), 3.ToString()}
             });
         }
 
@@ -122,14 +117,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             DiagnosticPortConnectionMode connectionMode = string.IsNullOrEmpty(diagnosticPort) ? DiagnosticPortConnectionMode.Connect : DiagnosticPortConnectionMode.Listen;
             builder.AddInMemoryCollection(new Dictionary<string, string>
             {
-                {MakeKey(DiagnosticPortOptions.ConfigurationKey, nameof(DiagnosticPortOptions.ConnectionMode)), connectionMode.ToString()},
-                {MakeKey(DiagnosticPortOptions.ConfigurationKey, nameof(DiagnosticPortOptions.EndpointName)), diagnosticPort}
+                {ConfigurationHelper.MakeKey(DiagnosticPortOptions.ConfigurationKey, nameof(DiagnosticPortOptions.ConnectionMode)), connectionMode.ToString()},
+                {ConfigurationHelper.MakeKey(DiagnosticPortOptions.ConfigurationKey, nameof(DiagnosticPortOptions.EndpointName)), diagnosticPort}
             });
-        }
-
-        private static string MakeKey(string parent, string child)
-        {
-            return FormattableString.Invariant($"{parent}:{child}");
         }
     }
 }

--- a/src/Tools/dotnet-monitor/Program.cs
+++ b/src/Tools/dotnet-monitor/Program.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 aliases: new[] { "-u", "--urls" },
                 description: "Bindings for the REST api.")
             {
-                Argument = new Argument<string[]>(name: "urls", getDefaultValue: () => new[] { "http://localhost:52323" })
+                Argument = new Argument<string[]>(name: "urls", getDefaultValue: () => new[] { "https://localhost:52323" })
             };
 
         private static Option MetricUrls() =>


### PR DESCRIPTION
Example message if no cert is available:

```
Unable to bind to https://localhost:52323. Dotnet-monitor functionality will be limited.
System.InvalidOperationException: Unable to configure HTTPS endpoint. No server certificate was specified, and the default developer certificate could not be found or is out of date.
To generate a developer certificate run 'dotnet dev-certs https'. To trust the certificate (Windows and macOS only) run 'dotnet dev-certs https --trust'.
For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.
   at Microsoft.AspNetCore.Hosting.ListenOptionsHttpsExtensions.UseHttps(ListenOptions listenOptions, Action`1 configureOptions)
   at Microsoft.AspNetCore.Hosting.ListenOptionsHttpsExtensions.UseHttps(ListenOptions listenOptions)
   at Microsoft.Diagnostics.Tools.Monitor.DiagnosticsMonitorCommandHandler.<>c__DisplayClass8_1.<CreateWebHostBuilder>b__3(ListenOptions listenOptions) in D:\dd\Github\diagnostics\src\Tools\dotnet-monitor\DiagnosticsMonitorCommandHandler.cs:line 113
   at Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.ListenLocalhost(Int32 port, Action`1 configure)
   at Microsoft.Diagnostics.Tools.Monitor.DiagnosticsMonitorCommandHandler.<>c__DisplayClass8_0.<CreateWebHostBuilder>b__2(WebHostBuilderContext context, KestrelServerOptions options) in D:\dd\Github\diagnostics\src\Tools\dotnet-monitor\DiagnosticsMonitorCommandHandler.cs:line 119
←[40m←[1m←[33mwarn←[39m←[22m←[49m: Microsoft.AspNetCore.DataProtection.Repositories.FileSystemXmlRepository[60]
      Storing keys in a directory '/root/.aspnet/DataProtection-Keys' that may not be persisted outside of the container. Protected data will be unavailable when container is destroyed.
←[40m←[1m←[33mwarn←[39m←[22m←[49m: Microsoft.AspNetCore.DataProtection.KeyManagement.XmlKeyManager[35]
      No XML encryptor configured. Key {9f89641f-3014-4be2-bc65-8009fbe9ab42} may be persisted to storage in unencrypted form.
←[40m←[1m←[33mwarn←[39m←[22m←[49m: Microsoft.AspNetCore.Server.Kestrel[0]
      Overriding address(es) 'http://+:80'. Binding to endpoints defined in UseKestrel() instead.
Hosting environment: Production
Content root path: /localagent
Now listening on: http://[::]:52325
```