### PR TITLE
Fixes for some vendors issues for the stable release (#1785)

### DIFF
--- a/eng/CreateVersionFile.csproj
+++ b/eng/CreateVersionFile.csproj
@@ -73,8 +73,8 @@
     </PropertyGroup>
 
     <PropertyGroup>
-      <NativeVersionLines>
       <!-- SOS (strike.cpp) has a dependency on this variable being public and that it begins with the @(#)Version prefix -->
+      <NativeVersionLines>
 <![CDATA[
 char sccsid[] __attribute__((used)) = "@(#)Version $(InformationalVersion)$(BuiltByString)";
  ]]>

--- a/eng/CreateVersionFile.csproj
+++ b/eng/CreateVersionFile.csproj
@@ -74,6 +74,7 @@
 
     <PropertyGroup>
       <NativeVersionLines>
+      <!-- SOS (strike.cpp) has a dependency on this variable being public and that it begins with the @(#)Version prefix -->
 <![CDATA[
 char sccsid[] __attribute__((used)) = "@(#)Version $(InformationalVersion)$(BuiltByString)";
  ]]>

--- a/src/SOS/SOS.NETCore/CMakeLists.txt
+++ b/src/SOS/SOS.NETCore/CMakeLists.txt
@@ -2,13 +2,8 @@ project(SOS.NETCore)
 
 if(NOT ${CLR_MANAGED_BINARY_DIR} STREQUAL "")
     set(MANAGED_BINDIR ${CLR_MANAGED_BINARY_DIR}/SOS.NETCore/${CLR_BUILD_TYPE}/netstandard2.0/publish)
-
-    install(FILES ${MANAGED_BINDIR}/SOS.NETCore.dll DESTINATION . )
-    install(FILES ${MANAGED_BINDIR}/SOS.NETCore.pdb DESTINATION . )
-    install(FILES ${MANAGED_BINDIR}/Microsoft.FileFormats.dll DESTINATION . )
-    install(FILES ${MANAGED_BINDIR}/Microsoft.SymbolStore.dll DESTINATION . )
-    install(FILES ${MANAGED_BINDIR}/System.Reflection.Metadata.dll DESTINATION . )
-    install(FILES ${MANAGED_BINDIR}/System.Collections.Immutable.dll DESTINATION . )
+    file(GLOB installfiles ${MANAGED_BINDIR}/*.dll ${MANAGED_BINDIR}/*.pdb)
+    install(FILES ${installfiles} DESTINATION . )
 endif()
 
 if(NOT ${NUGET_PACKAGES} STREQUAL "")

--- a/src/SOS/SOS.UnitTests/ConfigFiles/Unix/Debugger.Tests.Config.txt
+++ b/src/SOS/SOS.UnitTests/ConfigFiles/Unix/Debugger.Tests.Config.txt
@@ -52,6 +52,7 @@
     <Option Condition="'$(RuntimeVersionLatest)' != ''">
       <BuildProjectFramework>$(BuildProjectFrameworkLatest)</BuildProjectFramework>
       <RuntimeFrameworkVersion>$(RuntimeVersionLatest)</RuntimeFrameworkVersion>
+      <SetHostRuntime>$(DotNetRoot)/shared/Microsoft.NETCore.App/$(RuntimeFrameworkVersion)</SetHostRuntime>
     </Option>
     <Option Condition="'$(RuntimeVersion50)' != ''">
       <BuildProjectFramework>net5.0</BuildProjectFramework>
@@ -60,6 +61,7 @@
     <Option Condition="'$(RuntimeVersion31)' != ''">
       <BuildProjectFramework>netcoreapp3.1</BuildProjectFramework>
       <RuntimeFrameworkVersion>$(RuntimeVersion31)</RuntimeFrameworkVersion>
+      <SetHostRuntime>$(DotNetRoot)/shared/Microsoft.NETCore.App/$(RuntimeFrameworkVersion)</SetHostRuntime>
     </Option>
     <Option Condition="'$(TestRuntime21)' == 'true'">
       <BuildProjectFramework>netcoreapp2.1</BuildProjectFramework>
@@ -77,7 +79,6 @@
         <Option Condition="'$(RuntimeVersionLatest)' != ''">
           <BuildProjectFramework>$(BuildProjectFrameworkLatest)</BuildProjectFramework>
           <RuntimeFrameworkVersion>$(RuntimeVersionLatest)</RuntimeFrameworkVersion>
-          <SetHostRuntime>$(DotNetRoot)/shared/Microsoft.NETCore.App/$(RuntimeFrameworkVersion)</SetHostRuntime>
         </Option>
         <Option Condition="'$(RuntimeVersion50)' != ''">
           <BuildProjectFramework>net5.0</BuildProjectFramework>

--- a/src/SOS/SOS.UnitTests/ConfigFiles/Windows/Debugger.Tests.Config.txt
+++ b/src/SOS/SOS.UnitTests/ConfigFiles/Windows/Debugger.Tests.Config.txt
@@ -68,6 +68,7 @@
         <Option Condition="'$(RuntimeVersionLatest)' != ''">
           <BuildProjectFramework>$(BuildProjectFrameworkLatest)</BuildProjectFramework>
           <RuntimeFrameworkVersion>$(RuntimeVersionLatest)</RuntimeFrameworkVersion>
+          <SetHostRuntime>$(DotNetRoot)/shared/Microsoft.NETCore.App/$(RuntimeFrameworkVersion)</SetHostRuntime>
         </Option>
         <Option Condition="'$(RuntimeVersion50)' != ''">
           <BuildProjectFramework>net5.0</BuildProjectFramework>
@@ -76,10 +77,12 @@
         <Option Condition="'$(RuntimeVersion31)' != ''">
           <BuildProjectFramework>netcoreapp3.1</BuildProjectFramework>
           <RuntimeFrameworkVersion>$(RuntimeVersion31)</RuntimeFrameworkVersion>
+          <SetHostRuntime>$(DotNetRoot)/shared/Microsoft.NETCore.App/$(RuntimeFrameworkVersion)</SetHostRuntime>
         </Option>
         <Option Condition="'$(RuntimeVersion21)' != ''">
           <BuildProjectFramework>netcoreapp2.1</BuildProjectFramework>
           <RuntimeFrameworkVersion>$(RuntimeVersion21)</RuntimeFrameworkVersion>
+          <SetHostRuntime>$(DotNetRoot)/shared/Microsoft.NETCore.App/$(RuntimeFrameworkVersion)</SetHostRuntime>
         </Option>
         <!--
             SOS.StackAndOtherTests (cli because tested with full, embedded and portable PDBs)
@@ -186,6 +189,7 @@
       <BuildProjectRuntime>win-$(TargetArchitecture)</BuildProjectRuntime>
       <DebugType>full</DebugType>
       <RuntimeSymbolsPath>$(DesktopFrameworkPath)</RuntimeSymbolsPath>
+      <SetHostRuntime>-netfx</SetHostRuntime>
     </Option>
   </Options>
 

--- a/src/SOS/Strike/hostcoreclr.cpp
+++ b/src/SOS/Strike/hostcoreclr.cpp
@@ -63,6 +63,15 @@ SOSNetCoreCallbacks g_SOSNetCoreCallbacks;
 HMODULE g_hmoduleSymBinder = nullptr;
 ISymUnmanagedBinder3 *g_pSymBinder = nullptr;
 #endif
+
+static void AddFileToTpaList(const char* directory, const char* filename, std::string & tpaList)
+{
+    tpaList.append(directory);
+    tpaList.append(DIRECTORY_SEPARATOR_STR_A);
+    tpaList.append(filename);
+    tpaList.append(TPALIST_SEPARATOR_STR_A);
+}
+
 //
 // Build the TPA list of assemblies for the runtime hosting api.
 //
@@ -106,11 +115,7 @@ static void AddFilesFromDirectoryToTpaList(const char* directory, std::string& t
                     if (addedAssemblies.find(filenameWithoutExt) == addedAssemblies.end())
                     {
                         addedAssemblies.insert(filenameWithoutExt);
-
-                        tpaList.append(directory);
-                        tpaList.append(DIRECTORY_SEPARATOR_STR_A);
-                        tpaList.append(filename);
-                        tpaList.append(TPALIST_SEPARATOR_STR_A);
+                        AddFileToTpaList(directory, filename.c_str(), tpaList);
                     }
                 }
             } 
@@ -612,7 +617,11 @@ static HRESULT InitializeNetCoreHost()
 
     // Trust The SOS managed and dependent assemblies from the sos directory
     std::string tpaList;
-    AddFilesFromDirectoryToTpaList(sosModuleDirectory.c_str(), tpaList);
+    const char* directory = sosModuleDirectory.c_str();
+    AddFileToTpaList(directory, "System.Reflection.Metadata.dll", tpaList);
+    AddFileToTpaList(directory, "System.Collections.Immutable.dll", tpaList);
+    AddFileToTpaList(directory, "Microsoft.FileFormats.dll", tpaList);
+    AddFileToTpaList(directory, "Microsoft.SymbolStore.dll", tpaList);
 
     // Trust the runtime assemblies
     AddFilesFromDirectoryToTpaList(hostRuntimeDirectory.c_str(), tpaList);

--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -10895,7 +10895,7 @@ DECLARE_API(EEVersion)
 
     // Print SOS version
 #ifdef FEATURE_PAL
-    ExtOut("SOS Version: %s\n", sccsid);
+    ExtOut("SOS Version: %s\n", sccsid + sizeof("@(#)Version"));
 #else
     VS_FIXEDFILEINFO sosVersion;
     if (GetSOSVersion(&sosVersion))

--- a/src/Tools/dotnet-dump/Analyzer.cs
+++ b/src/Tools/dotnet-dump/Analyzer.cs
@@ -63,8 +63,10 @@ namespace Microsoft.Diagnostics.Tools.Dump
                     // Add all the services needed by commands and other services
                     AddServices(target);
 
-                    // Set the default symbol cache to match Visual Studio's
-                    SymbolReader.DefaultSymbolCache = Path.Combine(Path.GetTempPath(), "SymbolCache");
+                    // Set the default symbol cache to match Visual Studio's when running on Windows
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+                        SymbolReader.DefaultSymbolCache = Path.Combine(Path.GetTempPath(), "SymbolCache");
+                    }
 
                     // Automatically enable symbol server support
                     SymbolReader.InitializeSymbolStore(

--- a/src/Tools/dotnet-dump/Program.cs
+++ b/src/Tools/dotnet-dump/Program.cs
@@ -73,8 +73,7 @@ on Linux where YYYYMMDD is Year/Month/Day and HHMMSS is Hour/Minute/Second. Othe
         private static Option TypeOption() =>
             new Option(
                 alias: "--type",
-                description: @"The dump type determines the kinds of information that are collected from the process. There are several types: full - The largest dump containing all memory including the module images. heap - A large and relatively comprehensive dump containing module lists, thread lists, all stacks, exception information, handle information, and all memory except for mapped 
-images. mini - A small dump containing module lists, thread lists, exception information and all stacks. If not specified 'full' is the default.")
+                description: @"The dump type determines the kinds of information that are collected from the process. There are several types: Full - The largest dump containing all memory including the module images. Heap - A large and relatively comprehensive dump containing module lists, thread lists, all stacks, exception information, handle information, and all memory except for mapped images. Mini - A small dump containing module lists, thread lists, exception information and all stacks.")
             {
                 Argument = new Argument<Dumper.DumpTypeOption>(name: "dump_type", getDefaultValue: () => Dumper.DumpTypeOption.Full)
             };


### PR DESCRIPTION
* Fixes for some vendors issues for the stable release

1) Stop printing the "@(#)Version" prefix of the SOS version on Linux.
2) Change the default symbol cache for dotnet-dump on Windows to VS's.
3) Fix eeversion unhandled exception on Linux when hosted on 5.0.0.
4) Fix `dotnet-dump collect --help` ArgumentOutOfRangeException by reformatting the --type option description.

* Fix eeversion unhandled exception on Linux hosted on 5.0.0

This turned out to be that the dotnet-sos installed included runtime binaries
like System.Memory, System.Buffer, etc. that were wrong version for hosting on
5.0.0. This didn't get catch by the normal testing because only certain project
references were copied to the bin directory.

The main part of this fix was to be very explicit in which assemblies are added to
the TPA that are in the SOS directory instead of adding all of them.

Changed the SOS managed installed to copy all the managed assemblies in SOS.NETCore
to better match the dotnet-sos install layout.

Changed the SOS tests to explicitly test across all the host runtimes (2.1.x,
3.1.x, 5.0.x and desktop).

* Fix `dotnet-dump collect --help` ArgumentOutOfRangeException by reformatting the --type option description.