### PR TITLE
Create and publish nupkg version files

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -72,6 +72,7 @@
     <PropertyGroup>
       <_BlobGroupFilePath>%(PackageFile.FullPath).blobgroup</_BlobGroupFilePath>
       <_ChecksumFilePath>%(PackageFile.FullPath).sha512</_ChecksumFilePath>
+      <_VersionFilePath>%(PackageFile.FullPath).version</_VersionFilePath>
     </PropertyGroup>
 
     <Error Condition="Exists('$(_BlobGroupFilePath)') and !Exists('$(_ChecksumFilePath)')"
@@ -99,6 +100,9 @@
         <ManifestArtifactData>@(_PackageArtifactData)</ManifestArtifactData>
       </_BlobItem>
       <_BlobItem Include="$(_ChecksumFilePath)" Condition="Exists('$(_ChecksumFilePath)')">
+        <ManifestArtifactData Condition="'@(_CommonArtifactData)' != ''">@(_CommonArtifactData)</ManifestArtifactData>
+      </_BlobItem>
+      <_BlobItem Include="$(_VersionFilePath)" Condition="Exists('$(_VersionFilePath)')">
         <ManifestArtifactData Condition="'@(_CommonArtifactData)' != ''">@(_CommonArtifactData)</ManifestArtifactData>
       </_BlobItem>
     </ItemGroup>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -47,6 +47,9 @@
     <WriteLinesToFile File="$(PackageOutputPath)\$(PackageId).$(PackageVersion).nupkg.blobgroup"
                       Lines="$(_BlobGroupName)"
                       Overwrite="true" />
+    <WriteLinesToFile File="$(PackageOutputPath)\$(PackageId).$(PackageVersion).nupkg.version"
+                      Lines="$(PackageVersion)"
+                      Overwrite="true" />
   </Target>
 
 </Project>


### PR DESCRIPTION
Create version files for nupkg that have blobgroup specification. When publishing to blob storage, these files should have an aka.ms latest link generated for them, which should allow other repositories (e.g. dotnet-docker) to more easily pick up the latest version within a versioning line. This change is to mitigate the breaking change from arcade that ignores custom categorization.