### PR TITLE
Make Tracee run for correct amount of time

### DIFF
--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/TestRunner.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/TestRunner.cs
@@ -67,6 +67,13 @@ namespace Microsoft.Diagnostics.NETCore.Client
 
         public void Start(int timeoutInMSPipeCreation=15_000, int testProcessTimeout=30_000)
         {
+            // If test process timeout was specified to be longer than 30 seconds, make the tracee run 5 seconds longer than 
+            // the test process timeout + pipe creation timeout. 
+            if (testProcessTimeout > 30_000)
+            {
+                startInfo.Arguments = (((timeoutInMSPipeCreation + testProcessTimeout) / 1_000) + 5).ToString();
+            }
+
             if (outputHelper != null)
                 outputHelper.WriteLine($"[{DateTime.Now.ToString()}] Launching test: " + startInfo.FileName + " " + startInfo.Arguments);
 

--- a/src/tests/Tracee/Program.cs
+++ b/src/tests/Tracee/Program.cs
@@ -9,10 +9,15 @@ namespace Tracee
 {
     class Program
     {
-        private const int LoopCount = 30;
+        private static int LoopCount = 30;
 
         static void Main(string[] args)
         {
+            if (args.Length > 0)
+            {
+                LoopCount = Int32.Parse(args[1]);
+            }
+
             Console.WriteLine("Sleep in loop for {0} seconds.", LoopCount);
 
             // Runs for max of 30 sec


### PR DESCRIPTION
The tracee launched by TestRunner for Microsoft.Diagnostics.NETCore.Client tests are fixed to run for only 30 seconds. This fixes the Tracee to take in an optional command line argument to make it run for longer than 30 seconds if specified, and fixes TestRunner to pass the argument properly to the process startInfo.

