### PR TITLE
Update outdated known counter descriptions

### DIFF
--- a/src/Tools/dotnet-counters/KnownData.cs
+++ b/src/Tools/dotnet-counters/KnownData.cs
@@ -31,21 +31,21 @@ namespace Microsoft.Diagnostics.Tools.Counters
                     new CounterProfile{ Name="cpu-usage", Description="Percentage of time the process has utilized the CPU (%)", SupportedVersions=new[] { net30, net31, net50 } },
                     new CounterProfile{ Name="working-set", Description="Amount of working set used by the process (MB)", SupportedVersions=new[] { net30, net31, net50 } },
                     new CounterProfile{ Name="gc-heap-size", Description="Total heap size reported by the GC (MB)", SupportedVersions=new[] { net30, net31, net50 } },
-                    new CounterProfile{ Name="gen-0-gc-count", Description="Number of Gen 0 GCs / min", SupportedVersions=new[] { net30, net31, net50 } },
-                    new CounterProfile{ Name="gen-1-gc-count", Description="Number of Gen 1 GCs / min", SupportedVersions=new[] { net30, net31, net50 } },
-                    new CounterProfile{ Name="gen-2-gc-count", Description="Number of Gen 2 GCs / min", SupportedVersions=new[] { net30, net31, net50 } },
+                    new CounterProfile{ Name="gen-0-gc-count", Description="Number of Gen 0 GCs between interval", SupportedVersions=new[] { net30, net31, net50 } },
+                    new CounterProfile{ Name="gen-1-gc-count", Description="Number of Gen 1 GCs between interval", SupportedVersions=new[] { net30, net31, net50 } },
+                    new CounterProfile{ Name="gen-2-gc-count", Description="Number of Gen 2 GCs between interval", SupportedVersions=new[] { net30, net31, net50 } },
                     new CounterProfile{ Name="time-in-gc", Description="% time in GC since the last GC", SupportedVersions=new[] { net30, net31, net50 } },
                     new CounterProfile{ Name="gen-0-size", Description="Gen 0 Heap Size", SupportedVersions=new[] { net30, net31, net50 } },
                     new CounterProfile{ Name="gen-1-size", Description="Gen 1 Heap Size", SupportedVersions=new[] { net30, net31, net50 } },
                     new CounterProfile{ Name="gen-2-size", Description="Gen 2 Heap Size", SupportedVersions=new[] { net30, net31, net50 } },
                     new CounterProfile{ Name="loh-size", Description="LOH Size", SupportedVersions=new[] { net30, net31, net50 } },
                     new CounterProfile{ Name="poh-size", Description="POH (Pinned Object Heap) Size", SupportedVersions=new[] { net50 } },
-                    new CounterProfile{ Name="alloc-rate", Description="Number of bytes allocated in the managed heap per second", SupportedVersions=new[] { net30, net31, net50 } },
+                    new CounterProfile{ Name="alloc-rate", Description="Number of bytes allocated in the managed heap between interval", SupportedVersions=new[] { net30, net31, net50 } },
                     new CounterProfile{ Name="gc-fragmentation", Description="GC Heap Fragmentation", SupportedVersions=new[] { net50 } },
                     new CounterProfile{ Name="assembly-count", Description="Number of Assemblies Loaded", SupportedVersions=new[] { net30, net31, net50 } },
                     new CounterProfile{ Name="exception-count", Description="Number of Exceptions / sec", SupportedVersions=new[] { net30, net31, net50 } },
                     new CounterProfile{ Name="threadpool-thread-count", Description="Number of ThreadPool Threads", SupportedVersions=new[] { net30, net31, net50 } },
-                    new CounterProfile{ Name="monitor-lock-contention-count", Description="Number of times there were contention when trying to take the monitor lock per second", SupportedVersions=new[] { net30, net31, net50 } },
+                    new CounterProfile{ Name="monitor-lock-contention-count", Description="Number of times there were contention when trying to take the monitor lock between interval", SupportedVersions=new[] { net30, net31, net50 } },
                     new CounterProfile{ Name="threadpool-queue-length", Description="ThreadPool Work Items Queue Length", SupportedVersions=new[] { net30, net31, net50 } },
                     new CounterProfile{ Name="threadpool-completed-items-count", Description="ThreadPool Completed Work Items Count", SupportedVersions=new[] { net30, net31, net50 } },
                     new CounterProfile{ Name="active-timer-count", Description="Number of timers that are currently active", SupportedVersions=new[] { net30, net31, net50 } },
@@ -60,7 +60,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 "0x0", // Keywords
                 "4", // Level 
                 new[] { // Counters
-                    new CounterProfile{ Name="requests-per-second", Description="Request rate", SupportedVersions=new[] { net30, net31, net50 } },
+                    new CounterProfile{ Name="requests-per-second", Description="Number of requests per interval", SupportedVersions=new[] { net30, net31, net50 } },
                     new CounterProfile{ Name="total-requests", Description="Total number of requests", SupportedVersions=new[] { net30, net31, net50 } },
                     new CounterProfile{ Name="current-requests", Description="Current number of requests", SupportedVersions=new[] { net30, net31, net50 } },
                     new CounterProfile{ Name="failed-requests", Description="Failed number of requests", SupportedVersions=new[] { net30, net31, net50 } },
@@ -73,9 +73,9 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 "0x0", // Keywords
                 "4", // Level
                 new[] {
-                    new CounterProfile{ Name="connections-per-second", Description="Connection Rate", SupportedVersions=new[] { net50 } },
+                    new CounterProfile{ Name="connections-per-second", Description="Number of connections between interval", SupportedVersions=new[] { net50 } },
                     new CounterProfile{ Name="total-connections", Description="Total Connections", SupportedVersions=new[] { net50 } },
-                    new CounterProfile{ Name="tls-handshakes-per-second", Description="Rate at which TLS Handshakes are made", SupportedVersions=new[] { net50 } },
+                    new CounterProfile{ Name="tls-handshakes-per-second", Description="Number of TLS Handshakes made between interval", SupportedVersions=new[] { net50 } },
                     new CounterProfile{ Name="total-tls-handshakes", Description="Total number of TLS handshakes made", SupportedVersions=new[] { net50 } },
                     new CounterProfile{ Name="current-tls-handshakes", Description="Number of currently active TLS handshakes", SupportedVersions=new[] { net50 } },
                     new CounterProfile{ Name="failed-tls-handshakes", Description="Total number of failed TLS handshakes", SupportedVersions=new[] { net50 } },
@@ -91,10 +91,10 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 "0x0", // Keywords
                 "4", // Level
                 new[] {
-                    new CounterProfile{ Name="requests-started", Description="Requests Started", SupportedVersions=new[] { net50 } },
-                    new CounterProfile{ Name="requests-started-rate", Description="Requests Started Rate", SupportedVersions=new[] { net50 } },
-                    new CounterProfile{ Name="requests-aborted", Description="Requests Aborted", SupportedVersions=new[] { net50 } },
-                    new CounterProfile{ Name="requests-aborted-rate", Description="Requests Aborted Rate", SupportedVersions=new[] { net50 } },
+                    new CounterProfile{ Name="requests-started", Description="Total Requests Started", SupportedVersions=new[] { net50 } },
+                    new CounterProfile{ Name="requests-started-rate", Description="Number of Requests Started between interval", SupportedVersions=new[] { net50 } },
+                    new CounterProfile{ Name="requests-aborted", Description="Total Requests Aborted", SupportedVersions=new[] { net50 } },
+                    new CounterProfile{ Name="requests-aborted-rate", Description="Number of Requests Aborted between interval", SupportedVersions=new[] { net50 } },
                     new CounterProfile{ Name="current-requests", Description="Current Requests", SupportedVersions=new[] { net50 } }
                 },
                 runtimeVersion

--- a/src/Tools/dotnet-counters/KnownData.cs
+++ b/src/Tools/dotnet-counters/KnownData.cs
@@ -31,21 +31,21 @@ namespace Microsoft.Diagnostics.Tools.Counters
                     new CounterProfile{ Name="cpu-usage", Description="Percentage of time the process has utilized the CPU (%)", SupportedVersions=new[] { net30, net31, net50 } },
                     new CounterProfile{ Name="working-set", Description="Amount of working set used by the process (MB)", SupportedVersions=new[] { net30, net31, net50 } },
                     new CounterProfile{ Name="gc-heap-size", Description="Total heap size reported by the GC (MB)", SupportedVersions=new[] { net30, net31, net50 } },
-                    new CounterProfile{ Name="gen-0-gc-count", Description="Number of Gen 0 GCs between interval", SupportedVersions=new[] { net30, net31, net50 } },
-                    new CounterProfile{ Name="gen-1-gc-count", Description="Number of Gen 1 GCs between interval", SupportedVersions=new[] { net30, net31, net50 } },
-                    new CounterProfile{ Name="gen-2-gc-count", Description="Number of Gen 2 GCs between interval", SupportedVersions=new[] { net30, net31, net50 } },
+                    new CounterProfile{ Name="gen-0-gc-count", Description="Number of Gen 0 GCs between update intervals", SupportedVersions=new[] { net30, net31, net50 } },
+                    new CounterProfile{ Name="gen-1-gc-count", Description="Number of Gen 1 GCs between update intervals", SupportedVersions=new[] { net30, net31, net50 } },
+                    new CounterProfile{ Name="gen-2-gc-count", Description="Number of Gen 2 GCs between update intervals", SupportedVersions=new[] { net30, net31, net50 } },
                     new CounterProfile{ Name="time-in-gc", Description="% time in GC since the last GC", SupportedVersions=new[] { net30, net31, net50 } },
                     new CounterProfile{ Name="gen-0-size", Description="Gen 0 Heap Size", SupportedVersions=new[] { net30, net31, net50 } },
                     new CounterProfile{ Name="gen-1-size", Description="Gen 1 Heap Size", SupportedVersions=new[] { net30, net31, net50 } },
                     new CounterProfile{ Name="gen-2-size", Description="Gen 2 Heap Size", SupportedVersions=new[] { net30, net31, net50 } },
                     new CounterProfile{ Name="loh-size", Description="LOH Size", SupportedVersions=new[] { net30, net31, net50 } },
                     new CounterProfile{ Name="poh-size", Description="POH (Pinned Object Heap) Size", SupportedVersions=new[] { net50 } },
-                    new CounterProfile{ Name="alloc-rate", Description="Number of bytes allocated in the managed heap between interval", SupportedVersions=new[] { net30, net31, net50 } },
+                    new CounterProfile{ Name="alloc-rate", Description="Number of bytes allocated in the managed heap between update intervals", SupportedVersions=new[] { net30, net31, net50 } },
                     new CounterProfile{ Name="gc-fragmentation", Description="GC Heap Fragmentation", SupportedVersions=new[] { net50 } },
                     new CounterProfile{ Name="assembly-count", Description="Number of Assemblies Loaded", SupportedVersions=new[] { net30, net31, net50 } },
                     new CounterProfile{ Name="exception-count", Description="Number of Exceptions / sec", SupportedVersions=new[] { net30, net31, net50 } },
                     new CounterProfile{ Name="threadpool-thread-count", Description="Number of ThreadPool Threads", SupportedVersions=new[] { net30, net31, net50 } },
-                    new CounterProfile{ Name="monitor-lock-contention-count", Description="Number of times there were contention when trying to take the monitor lock between interval", SupportedVersions=new[] { net30, net31, net50 } },
+                    new CounterProfile{ Name="monitor-lock-contention-count", Description="Number of times there were contention when trying to take the monitor lock between update intervals", SupportedVersions=new[] { net30, net31, net50 } },
                     new CounterProfile{ Name="threadpool-queue-length", Description="ThreadPool Work Items Queue Length", SupportedVersions=new[] { net30, net31, net50 } },
                     new CounterProfile{ Name="threadpool-completed-items-count", Description="ThreadPool Completed Work Items Count", SupportedVersions=new[] { net30, net31, net50 } },
                     new CounterProfile{ Name="active-timer-count", Description="Number of timers that are currently active", SupportedVersions=new[] { net30, net31, net50 } },
@@ -60,7 +60,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 "0x0", // Keywords
                 "4", // Level 
                 new[] { // Counters
-                    new CounterProfile{ Name="requests-per-second", Description="Number of requests per interval", SupportedVersions=new[] { net30, net31, net50 } },
+                    new CounterProfile{ Name="requests-per-second", Description="Number of requests between update intervals", SupportedVersions=new[] { net30, net31, net50 } },
                     new CounterProfile{ Name="total-requests", Description="Total number of requests", SupportedVersions=new[] { net30, net31, net50 } },
                     new CounterProfile{ Name="current-requests", Description="Current number of requests", SupportedVersions=new[] { net30, net31, net50 } },
                     new CounterProfile{ Name="failed-requests", Description="Failed number of requests", SupportedVersions=new[] { net30, net31, net50 } },
@@ -73,9 +73,9 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 "0x0", // Keywords
                 "4", // Level
                 new[] {
-                    new CounterProfile{ Name="connections-per-second", Description="Number of connections between interval", SupportedVersions=new[] { net50 } },
+                    new CounterProfile{ Name="connections-per-second", Description="Number of connections between update intervals", SupportedVersions=new[] { net50 } },
                     new CounterProfile{ Name="total-connections", Description="Total Connections", SupportedVersions=new[] { net50 } },
-                    new CounterProfile{ Name="tls-handshakes-per-second", Description="Number of TLS Handshakes made between interval", SupportedVersions=new[] { net50 } },
+                    new CounterProfile{ Name="tls-handshakes-per-second", Description="Number of TLS Handshakes made between update intervals", SupportedVersions=new[] { net50 } },
                     new CounterProfile{ Name="total-tls-handshakes", Description="Total number of TLS handshakes made", SupportedVersions=new[] { net50 } },
                     new CounterProfile{ Name="current-tls-handshakes", Description="Number of currently active TLS handshakes", SupportedVersions=new[] { net50 } },
                     new CounterProfile{ Name="failed-tls-handshakes", Description="Total number of failed TLS handshakes", SupportedVersions=new[] { net50 } },
@@ -92,9 +92,9 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 "4", // Level
                 new[] {
                     new CounterProfile{ Name="requests-started", Description="Total Requests Started", SupportedVersions=new[] { net50 } },
-                    new CounterProfile{ Name="requests-started-rate", Description="Number of Requests Started between interval", SupportedVersions=new[] { net50 } },
+                    new CounterProfile{ Name="requests-started-rate", Description="Number of Requests Started between update intervals", SupportedVersions=new[] { net50 } },
                     new CounterProfile{ Name="requests-aborted", Description="Total Requests Aborted", SupportedVersions=new[] { net50 } },
-                    new CounterProfile{ Name="requests-aborted-rate", Description="Number of Requests Aborted between interval", SupportedVersions=new[] { net50 } },
+                    new CounterProfile{ Name="requests-aborted-rate", Description="Number of Requests Aborted between update intervals", SupportedVersions=new[] { net50 } },
                     new CounterProfile{ Name="current-requests", Description="Current Requests", SupportedVersions=new[] { net50 } }
                 },
                 runtimeVersion


### PR DESCRIPTION
The counter description for "/sec" or "/min" is outdated because we decided that it was confusing since it can change depending on the report interval. This updates the descriptions that will show up in the `dotnet-counters list` command to "some-value between interval" instead of "some-value/sec". 

Fix #1813. 