### PR TITLE
Add warning message to dotnet-monitor

### DIFF
--- a/src/Tools/dotnet-monitor/Program.cs
+++ b/src/Tools/dotnet-monitor/Program.cs
@@ -79,6 +79,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         public static Task<int> Main(string[] args)
         {
+            // FUTURE: This log message should be removed when dotnet-monitor is no longer an experimental tool
+            Console.WriteLine("WARNING: dotnet-monitor is experimental and is not intended for production environments yet.");
             var parser = new CommandLineBuilder()
                             .AddCommand(CollectCommand())
                             .UseDefaults()


### PR DESCRIPTION
closes #1639 

Adds a simple warning message that always prints when running dotnet-monitor.

I'm opening this in draft mode so we can discuss the phrasing of the message.  Currently, it will be the first thing printed _always_.

CC @tommcdon 