### PR TITLE
Add authentication to dotnet-monitor

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -38,6 +38,7 @@
     <!-- Other libs -->
     <AzureStorageBlobsVersion>12.6.0</AzureStorageBlobsVersion>
     <MicrosoftAspNetCoreVersion>2.1.7</MicrosoftAspNetCoreVersion>
+    <MicrosoftAspNetCoreAuthenticationNegotiateVersion>3.1.10</MicrosoftAspNetCoreAuthenticationNegotiateVersion>
     <MicrosoftAspNetCoreHttpsPolicyVersion>2.1.1</MicrosoftAspNetCoreHttpsPolicyVersion>
     <MicrosoftAspNetCoreMvcVersion>2.1.3</MicrosoftAspNetCoreMvcVersion>
     <MicrosoftAspNetCoreResponseCompressionVersion>2.1.1</MicrosoftAspNetCoreResponseCompressionVersion>
@@ -49,7 +50,7 @@
     <MicrosoftDiaSymReaderNativePackageVersion>1.7.0</MicrosoftDiaSymReaderNativePackageVersion>
     <MicrosoftDiagnosticsTracingTraceEventVersion>2.0.64</MicrosoftDiagnosticsTracingTraceEventVersion>
     <MicrosoftExtensionsConfigurationJsonVersion>2.1.1</MicrosoftExtensionsConfigurationJsonVersion>
-    <MicrosoftExtensionsConfigurationKeyPerFileVersion>2.1.1</MicrosoftExtensionsConfigurationKeyPerFileVersion>
+    <MicrosoftExtensionsConfigurationKeyPerFileVersion>5.0.2</MicrosoftExtensionsConfigurationKeyPerFileVersion>
     <MicrosoftExtensionsDependencyInjectionVersion>2.1.1</MicrosoftExtensionsDependencyInjectionVersion>
     <MicrosoftExtensionsHostingAbstractionsVersion>2.1.1</MicrosoftExtensionsHostingAbstractionsVersion>
     <MicrosoftExtensionsLoggingVersion>2.1.1</MicrosoftExtensionsLoggingVersion>

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/MonitoringSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/MonitoringSourceConfiguration.cs
@@ -18,6 +18,8 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
         public const string SampleProfilerProviderName = "Microsoft-DotNETCore-SampleProfiler";
         public const string EventPipeProviderName = "Microsoft-DotNETCore-EventPipe";
 
+        public static IEnumerable<string> DefaultMetricProviders => new[] { SystemRuntimeEventSourceName, MicrosoftAspNetCoreHostingEventSourceName, GrpcAspNetCoreServer };
+
         public abstract IList<EventPipeProvider> GetProviders();
 
         public virtual bool RequestRundown => true;

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/Auth/ApiKeyConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/Auth/ApiKeyConfiguration.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Diagnostics.Monitoring.RestServer
+{
+    internal sealed class ApiAuthenticationOptions
+    {
+        public const string ConfigurationKey = "ApiAuthentication";
+
+        public string ApiKeyHash { get; set; }
+        public string ApiKeyHashType { get; set; }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/Auth/AuthConstants.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/Auth/AuthConstants.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.Monitoring.RestServer
+{
+    internal static class AuthConstants
+    {
+        public const string PolicyName = "AuthorizedUserPolicy";
+        public const string NegotiateSchema = "Negotiate";
+        public const string NtlmSchema = "NTLM";
+        public const string KerberosSchema = "Kerberos";
+        public const string ApiKeySchema = "MonitorApiKey";
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/Auth/AuthOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/Auth/AuthOptions.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.Monitoring.RestServer
+{
+    internal sealed class AuthOptions : IAuthOptions
+    {
+        public bool EnableNegotiate => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+        public KeyAuthenticationMode KeyAuthenticationMode { get; }
+
+        public bool EnableKeyAuth => (KeyAuthenticationMode == KeyAuthenticationMode.StoredKey) ||
+                                     (KeyAuthenticationMode == KeyAuthenticationMode.TemporaryKey);
+
+        public AuthOptions(KeyAuthenticationMode mode)
+        {
+            KeyAuthenticationMode = mode;
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/Auth/IAuthOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/Auth/IAuthOptions.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.Monitoring.RestServer
+{
+    internal enum KeyAuthenticationMode
+    {
+        StoredKey,
+        TemporaryKey,
+        NoAuth,
+    }
+
+    internal interface IAuthOptions
+    {
+        bool EnableNegotiate { get; }
+        KeyAuthenticationMode KeyAuthenticationMode { get; }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/ConfigurationHelper.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/ConfigurationHelper.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.Monitoring.RestServer
+{
+    internal static class ConfigurationHelper
+    {
+        public static string MakeKey(string parent, string child)
+        {
+            return FormattableString.Invariant($"{parent}:{child}");
+        }
+
+        public static string[] SplitValue(string value)
+        {
+            return value.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/ConfigurationHelper.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/ConfigurationHelper.cs
@@ -11,6 +11,10 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer
 {
     internal static class ConfigurationHelper
     {
+        private const char ValueSeparator = ';';
+        private static readonly char[] ValueSeparatorArray = new char[] { ValueSeparator };
+        private static readonly string ValueSeparatorString = ValueSeparator.ToString();
+
         public static string MakeKey(string parent, string child)
         {
             return FormattableString.Invariant($"{parent}:{child}");
@@ -18,7 +22,12 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer
 
         public static string[] SplitValue(string value)
         {
-            return value.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+            return value.Split(ValueSeparatorArray, StringSplitOptions.RemoveEmptyEntries);
+        }
+
+        public static string JoinValue(string[] values)
+        {
+            return string.Join(ValueSeparatorString, values);
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/Controllers/DiagController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/Controllers/DiagController.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using FastSerialization;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Diagnostics.Monitoring.EventPipe;
@@ -26,6 +27,7 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
     [Route("")] // Root
     [ApiController]
     [HostRestriction]
+    [Authorize(Policy = AuthConstants.PolicyName)]
     public class DiagController : ControllerBase
     {
         private const string ArtifactType_Dump = "dump";

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/MetricsOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/MetricsOptions.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer
         {
             _ports = new Lazy<int?[]>(() =>
                 {
-                    string[] endpoints = Endpoints.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+                    string[] endpoints = ConfigurationHelper.SplitValue(Endpoints);
                     int?[] ports = new int?[endpoints.Length];
                     for(int i = 0; i < endpoints.Length; i++)
                     {

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/MetricsOptions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/MetricsOptions.cs
@@ -55,6 +55,8 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer
 
         public bool IncludeDefaultProviders { get; set; } = true;
 
+        public bool AllowInsecureChannelForCustomMetrics { get; set; } = false;
+
         public List<MetricProvider> Providers { get; set; } = new List<MetricProvider>(0);
     }
 

--- a/src/Microsoft.Diagnostics.Monitoring/ClientEndpointInfoSource.cs
+++ b/src/Microsoft.Diagnostics.Monitoring/ClientEndpointInfoSource.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -19,12 +20,24 @@ namespace Microsoft.Diagnostics.Monitoring
             // a GetProcessInfo command to the runtime instance to get additional information.
             foreach (int pid in DiagnosticsClient.GetPublishedProcesses())
             {
-                endpointInfoTasks.Add(Task.Run(() => EndpointInfo.FromProcessId(pid)));
+                endpointInfoTasks.Add(Task.Run(() =>
+                {
+                    try
+                    {
+                        return EndpointInfo.FromProcessId(pid);
+                    }
+                    //Catch when the application is running a more privilaged socket than dotnet-monitor. For example, running a web app as administrator
+                    //while running dotnet-monitor without elevation.
+                    catch (UnauthorizedAccessException)
+                    {
+                        return null;
+                    }
+                }, token));
             }
 
             await Task.WhenAll(endpointInfoTasks);
 
-            return endpointInfoTasks.Select(t => t.Result);
+            return endpointInfoTasks.Where(t => t.Result != null).Select(t => t.Result);
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring/RuntimeInfo.cs
+++ b/src/Microsoft.Diagnostics.Monitoring/RuntimeInfo.cs
@@ -36,5 +36,7 @@ namespace Microsoft.Diagnostics.Monitoring
                 return false;
             }
         }
+
+        public static bool IsInKubernetes => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("KUBERNETES_SERVICE_HOST"));
     }
 }

--- a/src/Tools/dotnet-monitor/Auth/ApiKeyAuthenticationHandler.cs
+++ b/src/Tools/dotnet-monitor/Auth/ApiKeyAuthenticationHandler.cs
@@ -1,0 +1,124 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Diagnostics.Monitoring.RestServer;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+using Microsoft.Net.Http.Headers;
+using System;
+using System.Buffers.Text;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.Tools.Monitor
+{
+    /// <summary>
+    /// Authenticates against the ApiKey stored on the server.
+    /// </summary>
+    internal sealed class ApiKeyAuthenticationHandler : AuthenticationHandler<ApiKeyAuthenticationHandlerOptions>
+    {
+        private static readonly string[] DisallowedHashAlgorithms = new string[]
+        {
+            "SHA", "SHA1", "System.Security.Cryptography.SHA1", "System.Security.Cryptography.HashAlgorithm", "MD5", "System.Security.Cryptography.MD5"
+        };
+
+        public ApiKeyAuthenticationHandler(IOptionsMonitor<ApiKeyAuthenticationHandlerOptions> options, ILoggerFactory loggerFactory, UrlEncoder encoder, ISystemClock clock)
+            : base(options, loggerFactory, encoder, clock)
+        {
+        }
+
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            //We are expecting a header such as Authorization: <Schema> <key>
+            //If this is not present, we will return NoResult and move on to the next authentication handler.
+            if (!Request.Headers.TryGetValue(HeaderNames.Authorization, out StringValues values) ||
+                !values.Any())
+            {
+                return Task.FromResult(AuthenticateResult.NoResult());
+            }
+
+            if (!AuthenticationHeaderValue.TryParse(values.First(), out AuthenticationHeaderValue authHeader))
+            {
+                return Task.FromResult(AuthenticateResult.Fail("Invalid authentication header"));
+            }
+
+            if (!string.Equals(authHeader.Scheme, Scheme.Name, StringComparison.OrdinalIgnoreCase))
+            {
+                return Task.FromResult(AuthenticateResult.NoResult());
+            }
+
+            //The user is passing a base 64-encoded version of the secret
+            //We will be hash this and compare it to the secret in our configuration.
+            byte[] secret = new byte[32];
+            Span<byte> span = new Span<byte>(secret);
+            if (!Convert.TryFromBase64String(authHeader.Parameter, span, out int bytesWritten) || bytesWritten < 32)
+            {
+                return Task.FromResult(AuthenticateResult.Fail("Invalid Api Key format"));
+            }
+
+            //HACK IOptionsMonitor and similiar do not properly update here even though the underlying
+            //configuration is updated. We get the value directly from IConfiguration.
+
+            var authenticationOptions = new ApiAuthenticationOptions();
+            IConfiguration configService = Context.RequestServices.GetRequiredService<IConfiguration>();
+            configService.Bind(ApiAuthenticationOptions.ConfigurationKey, authenticationOptions);
+            string apiKeyHash = authenticationOptions.ApiKeyHash;
+            if (apiKeyHash == null)
+            {
+                return Task.FromResult(AuthenticateResult.Fail("Server does not contain Api Key"));
+            }
+            if (string.IsNullOrEmpty(authenticationOptions.ApiKeyHashType))
+            {
+                return Task.FromResult(AuthenticateResult.Fail("Missing hash algorithm"));
+            }
+            if (DisallowedHashAlgorithms.Contains(authenticationOptions.ApiKeyHashType, StringComparer.OrdinalIgnoreCase))
+            {
+                return Task.FromResult(AuthenticateResult.Fail($"Disallowed hash algorithm {authenticationOptions.ApiKeyHashType}"));
+            }
+
+            using HashAlgorithm algorithm = HashAlgorithm.Create(authenticationOptions.ApiKeyHashType);
+            if (algorithm == null)
+            {
+                return Task.FromResult(AuthenticateResult.Fail($"Invalid hash algorithm {authenticationOptions.ApiKeyHashType}"));
+            }
+
+            byte[] hashedSecret = algorithm.ComputeHash(secret);
+
+            //ApiKeyHash is represented as a hex string. e.g. AABBCCDDEEFF
+            byte[] apiKeyHashBytes = new byte[apiKeyHash.Length / 2];
+            for (int i = 0; i < apiKeyHash.Length; i += 2)
+            {
+                if (!byte.TryParse(apiKeyHash.AsSpan(i, 2), NumberStyles.HexNumber, provider: NumberFormatInfo.InvariantInfo, result: out byte resultByte))
+                {
+                    return Task.FromResult(AuthenticateResult.Fail("Invalid Api Key hash"));
+                }
+                apiKeyHashBytes[i / 2] = resultByte;
+            }
+
+            if (hashedSecret.SequenceEqual(apiKeyHashBytes))
+            {
+                return Task.FromResult(AuthenticateResult.Success(
+                    new AuthenticationTicket(
+                        new ClaimsPrincipal(new[] { new ClaimsIdentity(AuthConstants.ApiKeySchema) }),
+                        AuthConstants.ApiKeySchema)));
+
+            }
+            else
+            {
+                return Task.FromResult(AuthenticateResult.Fail("Invalid Api Key"));
+            }
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/Auth/ApiKeyAuthenticationHandlerOptions.cs
+++ b/src/Tools/dotnet-monitor/Auth/ApiKeyAuthenticationHandlerOptions.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.AspNetCore.Authentication;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Diagnostics.Tools.Monitor
+{
+    internal sealed class ApiKeyAuthenticationHandlerOptions : AuthenticationSchemeOptions
+    {
+    }
+}

--- a/src/Tools/dotnet-monitor/Auth/AuthorizedUserRequirement.cs
+++ b/src/Tools/dotnet-monitor/Auth/AuthorizedUserRequirement.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.AspNetCore.Authorization;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Diagnostics.Tools.Monitor
+{
+    internal sealed class AuthorizedUserRequirement : IAuthorizationRequirement
+    {
+    }
+}

--- a/src/Tools/dotnet-monitor/Auth/UserAuthorizationHandler.cs
+++ b/src/Tools/dotnet-monitor/Auth/UserAuthorizationHandler.cs
@@ -1,0 +1,57 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.AspNetCore.Authentication.Negotiate;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Diagnostics.Monitoring.RestServer;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Security.Principal;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.Tools.Monitor
+{
+    /// <summary>
+    /// Handles authorization for both Negotiate and ApiKey authentication.
+    /// </summary>
+    internal sealed class UserAuthorizationHandler : AuthorizationHandler<AuthorizedUserRequirement>
+    {
+        protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, AuthorizedUserRequirement requirement)
+        {
+            // If the schema type is ApiKey, we do not need further authorization.
+            if (context.User.Identity.AuthenticationType == AuthConstants.ApiKeySchema)
+            {
+                context.Succeed(requirement);
+            }
+            else if ((context.User.Identity.AuthenticationType == AuthConstants.NtlmSchema) ||
+                    (context.User.Identity.AuthenticationType == AuthConstants.KerberosSchema) ||
+                    (context.User.Identity.AuthenticationType == AuthConstants.NegotiateSchema))
+            {
+                //Negotiate, Kerberos, or NTLM.
+                //CONSIDER In the future, we may want to have configuration around a dotnet-monitor group sid instead.
+                //We cannot check the user against BUILTIN\Administrators group membership, since the browser user
+                //has a deny claim on Administrator group.
+                //Validate that the user that logged in matches the user that is running dotnet-monitor
+                //Do not allow at all if running as Administrator.
+                WindowsIdentity currentUser = WindowsIdentity.GetCurrent();
+                WindowsPrincipal principal = new WindowsPrincipal(currentUser);
+                if (principal.IsInRole(WindowsBuiltInRole.Administrator))
+                {
+                    return Task.CompletedTask;
+                }
+
+                Claim currentUserClaim = currentUser.Claims.FirstOrDefault(claim => string.Equals(claim.Type, ClaimTypes.PrimarySid));
+                if ((currentUserClaim != null) && context.User.HasClaim(currentUserClaim.Type, currentUserClaim.Value))
+                {
+                    context.Succeed(requirement);
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
@@ -4,6 +4,8 @@
 
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Diagnostics.Monitoring;
 using Microsoft.Diagnostics.Monitoring.RestServer;
 using Microsoft.Extensions.Configuration;
@@ -13,8 +15,10 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.CommandLine;
+using System.CommandLine.IO;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -55,21 +59,13 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         public IHostBuilder CreateHostBuilder(IConsole console, string[] urls, string[] metricUrls, bool metrics, string diagnosticPort)
         {
-            if (metrics)
-            {
-                urls = urls.Concat(metricUrls).ToArray();
-            }
-
             return Host.CreateDefaultBuilder()
                 .UseContentRoot(AppContext.BaseDirectory) // Use the application root instead of the current directory
                 .ConfigureAppConfiguration((IConfigurationBuilder builder) =>
                 {
                     //Note these are in precedence order.
                     ConfigureEndpointInfoSource(builder, diagnosticPort);
-                    if (metrics)
-                    {
-                        ConfigureMetricsEndpoint(builder, metricUrls);
-                    }
+                    ConfigureMetricsEndpoint(builder, metrics, metricUrls);
 
                     builder.AddJsonFile(UserSettingsPath, optional: true, reloadOnChange: true);
                     builder.AddJsonFile(SharedSettingsPath, optional: true, reloadOnChange: true);
@@ -85,10 +81,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                     services.AddHostedService<FilteredEndpointInfoSourceHostedService>();
                     services.AddSingleton<IDiagnosticServices, DiagnosticServices>();
                     services.ConfigureEgress(context.Configuration);
-                    if (metrics)
-                    {
-                        services.ConfigureMetrics(context.Configuration);
-                    }
+                    services.ConfigureMetrics(context.Configuration);
                     services.AddSingleton<ExperimentalToolLogger>();
                 })
                 .ConfigureLogging(builder =>
@@ -98,19 +91,99 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 })
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
-                    webBuilder.UseUrls(urls);
-                    webBuilder.UseStartup<Startup>();
+                    webBuilder.ConfigureKestrel((context, options) =>
+                    {
+                        //Note our priorities for hosting urls don't match the default behavior.
+                        //Default Kestrel behavior priority
+                        //1) ConfigureKestrel settings
+                        //2) Command line arguments (--urls)
+                        //3) Environment variables (ASPNETCORE_URLS, then DOTNETCORE_URLS)
+
+                        //Our precedence
+                        //1) Environment variables (ASPNETCORE_URLS, DotnetMonitor_Metrics__Endpoints)
+                        //2) Command line arguments (these have defaults) --urls, --metricUrls
+                        //3) ConfigureKestrel is used for fine control of the server, but honors the first two configurations.
+
+                        string hostingUrl = context.Configuration.GetValue<string>(WebHostDefaults.ServerUrlsKey);
+                        if (!string.IsNullOrEmpty(hostingUrl))
+                        {
+                            urls = ConfigurationHelper.SplitValue(hostingUrl);
+                        }
+
+                        var metricsOptions = new MetricsOptions();
+                        context.Configuration.Bind(MetricsOptions.ConfigurationKey, metricsOptions);
+
+                        if (metricsOptions.Enabled)
+                        {
+                            string metricUrlFromConfig = metricsOptions.Endpoints;
+                            if (!string.IsNullOrEmpty(metricUrlFromConfig))
+                            {
+                                metricUrls = ConfigurationHelper.SplitValue(metricUrlFromConfig);
+                            }
+
+                            urls = urls.Concat(metricUrls).ToArray();
+                        }
+
+                        bool boundListeningPort = false;
+
+                        //Workaround for lack of default certificate. See https://github.com/dotnet/aspnetcore/issues/28120
+                        options.Configure(context.Configuration.GetSection("Kestrel")).Load();
+
+                        //By default, we bind to https for sensitive data (such as dumps and traces) and bind http for
+                        //non-sensitive data such as metrics. We may be missing a certificate for https binding. We want to continue with the
+                        //http binding in that scenario.
+                        foreach (BindingAddress url in urls.Select(BindingAddress.Parse))
+                        {
+                            Action<ListenOptions> configureListenOptions = (listenOptions) =>
+                            {
+                                if (url.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+                                {
+                                    listenOptions.UseHttps();
+                                }
+                            };
+
+                            try
+                            {
+                                if (url.Host.Equals("localhost", StringComparison.OrdinalIgnoreCase))
+                                {
+                                    options.ListenLocalhost(url.Port, configureListenOptions);
+                                }
+                                else if (IPAddress.TryParse(url.Host, out IPAddress ipAddress))
+                                {
+                                    options.Listen(ipAddress, url.Port, configureListenOptions);
+                                }
+                                else
+                                {
+                                    options.ListenAnyIP(url.Port, configureListenOptions);
+                                }
+                                boundListeningPort = true;
+                            }
+                            catch (InvalidOperationException e)
+                            {
+                                //This binding failure is typically due to missing default certificate
+                                console.Error.WriteLine($"Unable to bind to {url}. Dotnet-monitor functionality will be limited.");
+                                console.Error.WriteLine(e.Message);
+                            }
+                        }
+
+                        //If we end up not binding any ports, Kestrel defaults to port 5000. Make sure we don't attempt this.
+                        if (!boundListeningPort)
+                        {
+                            throw new InvalidOperationException("Unable to bind any urls.");
+                        }
+                    })
+                    .UseStartup<Startup>();
                 });
         }
 
-        private static void ConfigureMetricsEndpoint(IConfigurationBuilder builder, string[] metricEndpoints)
+        private static void ConfigureMetricsEndpoint(IConfigurationBuilder builder, bool enableMetrics, string[] metricEndpoints)
         {
             builder.AddInMemoryCollection(new Dictionary<string, string>
             {
-                {MakeKey(MetricsOptions.ConfigurationKey, nameof(MetricsOptions.Endpoints)), string.Join(';', metricEndpoints)},
-                {MakeKey(MetricsOptions.ConfigurationKey, nameof(MetricsOptions.Enabled)), true.ToString()},
-                {MakeKey(MetricsOptions.ConfigurationKey, nameof(MetricsOptions.UpdateIntervalSeconds)), 10.ToString()},
-                {MakeKey(MetricsOptions.ConfigurationKey, nameof(MetricsOptions.MetricCount)), 3.ToString()}
+                {ConfigurationHelper.MakeKey(MetricsOptions.ConfigurationKey, nameof(MetricsOptions.Endpoints)), string.Join(';', metricEndpoints)},
+                {ConfigurationHelper.MakeKey(MetricsOptions.ConfigurationKey, nameof(MetricsOptions.Enabled)), enableMetrics.ToString()},
+                {ConfigurationHelper.MakeKey(MetricsOptions.ConfigurationKey, nameof(MetricsOptions.UpdateIntervalSeconds)), 10.ToString()},
+                {ConfigurationHelper.MakeKey(MetricsOptions.ConfigurationKey, nameof(MetricsOptions.MetricCount)), 3.ToString()}
             });
         }
 
@@ -119,14 +192,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             DiagnosticPortConnectionMode connectionMode = string.IsNullOrEmpty(diagnosticPort) ? DiagnosticPortConnectionMode.Connect : DiagnosticPortConnectionMode.Listen;
             builder.AddInMemoryCollection(new Dictionary<string, string>
             {
-                {MakeKey(DiagnosticPortOptions.ConfigurationKey, nameof(DiagnosticPortOptions.ConnectionMode)), connectionMode.ToString()},
-                {MakeKey(DiagnosticPortOptions.ConfigurationKey, nameof(DiagnosticPortOptions.EndpointName)), diagnosticPort}
+                {ConfigurationHelper.MakeKey(DiagnosticPortOptions.ConfigurationKey, nameof(DiagnosticPortOptions.ConnectionMode)), connectionMode.ToString()},
+                {ConfigurationHelper.MakeKey(DiagnosticPortOptions.ConfigurationKey, nameof(DiagnosticPortOptions.EndpointName)), diagnosticPort}
             });
-        }
-
-        private static string MakeKey(string parent, string child)
-        {
-            return FormattableString.Invariant($"{parent}:{child}");
         }
     }
 }

--- a/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
@@ -3,6 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Negotiate;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
@@ -20,6 +23,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Runtime.InteropServices;
+using System.Security.Principal;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -49,15 +53,15 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         private static readonly string UserSettingsPath = Path.Combine(UserConfigDirectoryPath, SettingsFileName);
 
-        public async Task<int> Start(CancellationToken token, IConsole console, string[] urls, string[] metricUrls, bool metrics, string diagnosticPort)
+        public async Task<int> Start(CancellationToken token, IConsole console, string[] urls, string[] metricUrls, bool metrics, string diagnosticPort, bool noAuth)
         {
             //CONSIDER The console logger uses the standard AddConsole, and therefore disregards IConsole.
-            using IHost host = CreateHostBuilder(console, urls, metricUrls, metrics, diagnosticPort).Build();
+            using IHost host = CreateHostBuilder(console, urls, metricUrls, metrics, diagnosticPort, noAuth).Build();
             await host.RunAsync(token);
             return 0;
         }
 
-        public IHostBuilder CreateHostBuilder(IConsole console, string[] urls, string[] metricUrls, bool metrics, string diagnosticPort)
+        public IHostBuilder CreateHostBuilder(IConsole console, string[] urls, string[] metricUrls, bool metrics, string diagnosticPort, bool noAuth)
         {
             return Host.CreateDefaultBuilder()
                 .UseContentRoot(AppContext.BaseDirectory) // Use the application root instead of the current directory
@@ -66,16 +70,87 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                     //Note these are in precedence order.
                     ConfigureEndpointInfoSource(builder, diagnosticPort);
                     ConfigureMetricsEndpoint(builder, metrics, metricUrls);
+                    builder.AddCommandLine(new[] { "--urls", ConfigurationHelper.JoinValue(urls) });
 
                     builder.AddJsonFile(UserSettingsPath, optional: true, reloadOnChange: true);
                     builder.AddJsonFile(SharedSettingsPath, optional: true, reloadOnChange: true);
 
-                    builder.AddKeyPerFile(SharedConfigDirectoryPath, optional: true);
+                    //HACK Workaround for https://github.com/dotnet/runtime/issues/36091
+                    //KeyPerFile provider uses a file system watcher to trigger changes.
+                    //The watcher does not follow symlinks inside the watched directory, such as mounted files
+                    //in Kubernetes.
+                    //We get around this by watching the target folder of the symlink instead.
+                    //See https://github.com/kubernetes/kubernetes/master/pkg/volume/util/atomic_writer.go
+                    string path = SharedConfigDirectoryPath;
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && RuntimeInfo.IsInKubernetes)
+                    {
+                        string symlinkTarget = Path.Combine(SharedConfigDirectoryPath, "..data");
+                        if (Directory.Exists(symlinkTarget))
+                        {
+                            path = symlinkTarget;
+                        }
+                    }
+
+                    builder.AddKeyPerFile(path, optional: true, reloadOnChange: true);
                     builder.AddEnvironmentVariables(ConfigPrefix);
                 })
                 .ConfigureServices((HostBuilderContext context, IServiceCollection services) =>
                 {
                     //TODO Many of these service additions should be done through extension methods
+
+                    AuthOptions authenticationOptions = new AuthOptions(noAuth ? KeyAuthenticationMode.NoAuth : KeyAuthenticationMode.StoredKey);
+                    services.AddSingleton<IAuthOptions>(authenticationOptions);
+
+                    List<string> authSchemas = null;
+                    if (authenticationOptions.EnableKeyAuth)
+                    {
+                        //Add support for Authentication and Authorization.
+                        AuthenticationBuilder authBuilder = services.AddAuthentication(options =>
+                        {
+                            options.DefaultAuthenticateScheme = AuthConstants.ApiKeySchema;
+                            options.DefaultChallengeScheme = AuthConstants.ApiKeySchema;
+                        })
+                        .AddScheme<ApiKeyAuthenticationHandlerOptions, ApiKeyAuthenticationHandler>(AuthConstants.ApiKeySchema, _ => { });
+
+                        authSchemas = new List<string> { AuthConstants.ApiKeySchema };
+
+                        if (authenticationOptions.EnableNegotiate)
+                        {
+                            //On Windows add Negotiate package. This will use NTLM to perform Windows Authentication.
+                            authBuilder.AddNegotiate();
+                            authSchemas.Add(AuthConstants.NegotiateSchema);
+                        }
+                    }
+
+                    //Apply Authorization Policy for NTLM. Without Authorization, any user with a valid login/password will be authorized. We only
+                    //want to authorize the same user that is running dotnet-monitor, at least for now.
+                    //Note this policy applies to both Authorization schemas.
+                    services.AddAuthorization(authOptions =>
+                    {
+                        if (authenticationOptions.EnableKeyAuth)
+                        {
+                            authOptions.AddPolicy(AuthConstants.PolicyName, (builder) =>
+                            {
+                                builder.AddRequirements(new AuthorizedUserRequirement());
+                                builder.RequireAuthenticatedUser();
+                                builder.AddAuthenticationSchemes(authSchemas.ToArray());
+
+                            });
+                        }
+                        else
+                        {
+                            authOptions.AddPolicy(AuthConstants.PolicyName, (builder) =>
+                            {
+                                builder.RequireAssertion((_) => true);
+                            });
+                        }
+                    });
+
+                    if (authenticationOptions.EnableKeyAuth)
+                    {
+                        services.AddSingleton<IAuthorizationHandler, UserAuthorizationHandler>();
+                    }
+
                     services.Configure<DiagnosticPortOptions>(context.Configuration.GetSection(DiagnosticPortOptions.ConfigurationKey));
                     services.AddSingleton<IEndpointInfoSource, FilteredEndpointInfoSource>();
                     services.AddHostedService<FilteredEndpointInfoSourceHostedService>();
@@ -105,22 +180,14 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                         //3) ConfigureKestrel is used for fine control of the server, but honors the first two configurations.
 
                         string hostingUrl = context.Configuration.GetValue<string>(WebHostDefaults.ServerUrlsKey);
-                        if (!string.IsNullOrEmpty(hostingUrl))
-                        {
-                            urls = ConfigurationHelper.SplitValue(hostingUrl);
-                        }
+                        urls = ConfigurationHelper.SplitValue(hostingUrl);
 
                         var metricsOptions = new MetricsOptions();
                         context.Configuration.Bind(MetricsOptions.ConfigurationKey, metricsOptions);
 
                         if (metricsOptions.Enabled)
                         {
-                            string metricUrlFromConfig = metricsOptions.Endpoints;
-                            if (!string.IsNullOrEmpty(metricUrlFromConfig))
-                            {
-                                metricUrls = ConfigurationHelper.SplitValue(metricUrlFromConfig);
-                            }
-
+                            metricUrls = ProcessMetricUrls(metricUrls, metricsOptions);
                             urls = urls.Concat(metricUrls).ToArray();
                         }
 
@@ -174,6 +241,42 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                     })
                     .UseStartup<Startup>();
                 });
+        }
+
+        private static string[] ProcessMetricUrls(string[] metricUrls, MetricsOptions metricsOptions)
+        {
+            string metricUrlFromConfig = metricsOptions.Endpoints;
+            if (!string.IsNullOrEmpty(metricUrlFromConfig))
+            {
+                metricUrls = ConfigurationHelper.SplitValue(metricUrlFromConfig);
+            }
+
+            //If we have custom metrics we want to upgrade the metrics transport channel to https, but
+            //also respect the user's configuration to leave it insecure.
+            if ((metricsOptions.Providers.Count > 0) &&
+                (!metricsOptions.AllowInsecureChannelForCustomMetrics) &&
+                (metricsOptions.Providers.Any(provider =>
+                    !Monitoring.EventPipe.MonitoringSourceConfiguration.DefaultMetricProviders.Contains(provider.ProviderName, StringComparer.OrdinalIgnoreCase))))
+            {
+                for (int i = 0; i < metricUrls.Length; i++)
+                {
+                    BindingAddress metricUrl = BindingAddress.Parse(metricUrls[i]);
+
+                    //Upgrade http to https by default.
+                    if (metricUrl.Scheme.Equals(Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase))
+                    {
+                        //Based on BindAddress.ToString
+                        metricUrls[i] = string.Concat(Uri.UriSchemeHttps.ToLowerInvariant(),
+                            Uri.SchemeDelimiter,
+                            metricUrl.Host.ToLowerInvariant(),
+                            ":",
+                            metricUrl.Port.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                            metricUrl.PathBase);
+                    }
+                }
+            }
+
+            return metricUrls;
         }
 
         private static void ConfigureMetricsEndpoint(IConfigurationBuilder builder, bool enableMetrics, string[] metricEndpoints)

--- a/src/Tools/dotnet-monitor/ExperimentalToolLogger.cs
+++ b/src/Tools/dotnet-monitor/ExperimentalToolLogger.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Diagnostics.Tools.Monitor
     internal class ExperimentalToolLogger
     {
         private const string ExperimentMessage = "WARNING: dotnet-monitor is experimental and is not intended for production environments yet.";
+        private const string NoAuthMessage = "WARNING: Authentication has been disabled. This can pose a security risk and is not intended for production environments.";
+        private const string InsecureAuthMessage = "WARNING: Authentication is enabled over insecure http transport. This can pose a security risk and is not intended for production environments.";
 
         private readonly ILogger<ExperimentalToolLogger> _logger;
 
@@ -21,6 +23,16 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         public void LogExperimentMessage()
         {
             _logger.LogWarning(ExperimentMessage);
+        }
+
+        public void LogNoAuthMessage()
+        {
+            _logger.LogWarning(NoAuthMessage);
+        }
+
+        public void LogInsecureAuthMessage()
+        {
+            _logger.LogWarning(InsecureAuthMessage);
         }
 
         public static void AddLogFilter(ILoggingBuilder builder)

--- a/src/Tools/dotnet-monitor/GenerateApiKeyCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/GenerateApiKeyCommandHandler.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.IO;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.Tools.Monitor
+{
+    /// <summary>
+    /// Used to generate Api Key for authentication. The first output is
+    /// part of the Authorization header, and is the Base64 encoded key.
+    /// The second output is a hex encoded string of the hash of the secret.
+    /// </summary>
+    internal sealed class GenerateApiKeyCommandHandler
+    {
+        public Task<int> GenerateApiKey(CancellationToken token, IConsole console)
+        {
+            using RandomNumberGenerator rng = RandomNumberGenerator.Create();
+            using HashAlgorithm hashAlgorithm = SHA256.Create();
+
+            byte[] secret = new byte[32];
+            rng.GetBytes(secret);
+
+            byte[] hash = hashAlgorithm.ComputeHash(secret);
+
+            Console.Out.WriteLine(FormattableString.Invariant($"Authorization: {Monitoring.RestServer.AuthConstants.ApiKeySchema} {Convert.ToBase64String(secret)}"));
+            Console.Out.Write("HashedSecret ");
+            foreach (byte b in hash)
+            {
+                console.Out.Write(b.ToString("X2"));
+            }
+            console.Out.WriteLine();
+
+            return Task.FromResult(0);
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/Program.cs
+++ b/src/Tools/dotnet-monitor/Program.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                 aliases: new[] { "-u", "--urls" },
                 description: "Bindings for the REST api.")
             {
-                Argument = new Argument<string[]>(name: "urls", getDefaultValue: () => new[] { "http://localhost:52323" })
+                Argument = new Argument<string[]>(name: "urls", getDefaultValue: () => new[] { "https://localhost:52323" })
             };
 
         private static Option MetricUrls() =>

--- a/src/Tools/dotnet-monitor/ServiceCollectionExtensions.cs
+++ b/src/Tools/dotnet-monitor/ServiceCollectionExtensions.cs
@@ -15,7 +15,17 @@ namespace Microsoft.Diagnostics.Tools.Monitor
     {
         public static IServiceCollection ConfigureMetrics(this IServiceCollection services, IConfiguration configuration)
         {
-            return services.Configure<MetricsOptions>(configuration.GetSection(MetricsOptions.ConfigurationKey));
+            return ConfigureOptions<MetricsOptions>(services, configuration, MetricsOptions.ConfigurationKey);
+        }
+
+        public static IServiceCollection ConfigureApiKeyConfiguration(this IServiceCollection services, IConfiguration configuration)
+        {
+            return ConfigureOptions<ApiAuthenticationOptions>(services, configuration, ApiAuthenticationOptions.ConfigurationKey);
+        }
+
+        private static IServiceCollection ConfigureOptions<T>(IServiceCollection services, IConfiguration configuration, string key) where T : class
+        {
+            return services.Configure<T>(configuration.GetSection(key));
         }
 
         public static IServiceCollection ConfigureEgress(this IServiceCollection services, IConfiguration configuration)

--- a/src/Tools/dotnet-monitor/dotnet-monitor.csproj
+++ b/src/Tools/dotnet-monitor/dotnet-monitor.csproj
@@ -17,7 +17,7 @@
     <!-- Version information -->
     <VersionPrefix>5.0.0</VersionPrefix>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
-    <PreReleaseVersionIteration>3</PreReleaseVersionIteration>
+    <PreReleaseVersionIteration>4</PreReleaseVersionIteration>
   </PropertyGroup>
 
   <ItemGroup>
@@ -30,6 +30,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.KeyPerFile" Version="$(MicrosoftExtensionsConfigurationKeyPerFileVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingConsoleVersion)" />
     <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="$(MicrosoftAspNetCoreAuthenticationNegotiateVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Support for ApiKey based authentication
- On Windows, add support for Negotiate
- Change default binding to https. Allow partial success for missing cert.

Note for Windows, Negotiate falls back to NTLM. 

Example message if no cert is available:
```
Unable to bind to https://localhost:52323. Dotnet-monitor functionality will be limited.
System.InvalidOperationException: Unable to configure HTTPS endpoint. No server certificate was specified, and the default developer certificate could not be found or is out of date.
To generate a developer certificate run 'dotnet dev-certs https'. To trust the certificate (Windows and macOS only) run 'dotnet dev-certs https --trust'.
For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.
   at Microsoft.AspNetCore.Hosting.ListenOptionsHttpsExtensions.UseHttps(ListenOptions listenOptions, Action`1 configureOptions)
   at Microsoft.AspNetCore.Hosting.ListenOptionsHttpsExtensions.UseHttps(ListenOptions listenOptions)
   at Microsoft.Diagnostics.Tools.Monitor.DiagnosticsMonitorCommandHandler.<>c__DisplayClass8_1.<CreateWebHostBuilder>b__3(ListenOptions listenOptions) in D:\dd\Github\diagnostics\src\Tools\dotnet-monitor\DiagnosticsMonitorCommandHandler.cs:line 113
   at Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.ListenLocalhost(Int32 port, Action`1 configure)
   at Microsoft.Diagnostics.Tools.Monitor.DiagnosticsMonitorCommandHandler.<>c__DisplayClass8_0.<CreateWebHostBuilder>b__2(WebHostBuilderContext context, KestrelServerOptions options) in D:\dd\Github\diagnostics\src\Tools\dotnet-monitor\DiagnosticsMonitorCommandHandler.cs:line 119
←[40m←[1m←[33mwarn←[39m←[22m←[49m: Microsoft.AspNetCore.DataProtection.Repositories.FileSystemXmlRepository[60]
      Storing keys in a directory '/root/.aspnet/DataProtection-Keys' that may not be persisted outside of the container. Protected data will be unavailable when container is destroyed.
←[40m←[1m←[33mwarn←[39m←[22m←[49m: Microsoft.AspNetCore.DataProtection.KeyManagement.XmlKeyManager[35]
      No XML encryptor configured. Key {9f89641f-3014-4be2-bc65-8009fbe9ab42} may be persisted to storage in unencrypted form.
←[40m←[1m←[33mwarn←[39m←[22m←[49m: Microsoft.AspNetCore.Server.Kestrel[0]
      Overriding address(es) 'http://+:80'. Binding to endpoints defined in UseKestrel() instead.
Hosting environment: Production
Content root path: /localagent
Now listening on: http://[::]:52325
```