### PR TITLE
Fix clru

### DIFF
--- a/src/SOS/Strike/sildasm.cpp
+++ b/src/SOS/Strike/sildasm.cpp
@@ -358,7 +358,7 @@ ULONG GetILSize(DWORD_PTR ilAddr)
     // workaround: read enough bytes at ilAddr to presumably get the entire header.
     // Could be error prone.
 
-    static BYTE headerArray[1024];
+    alignas(COR_ILMETHOD) static BYTE headerArray[1024];
     HRESULT Status = g_ExtData->ReadVirtual(TO_CDADDR(ilAddr), headerArray, sizeof(headerArray), NULL);    
     if (SUCCEEDED(Status))
     {            

--- a/src/inc/corhlpr.cpp
+++ b/src/inc/corhlpr.cpp
@@ -46,11 +46,7 @@ void __stdcall DecoderInit(void *pThis, COR_ILMETHOD *header)
     }
     if (header->Fat.IsFat())
     {
-#ifdef _WIN64
-        if((((size_t) header) & 3) == 0)        // header is aligned
-#else
-        _ASSERTE((((size_t) header) & 3) == 0);        // header is aligned
-#endif
+        _ASSERTE((((size_t) header) & (alignof(COR_ILMETHOD) - 1)) == 0);        // header is aligned
         {
             *((COR_ILMETHOD_FAT *)decoder) = header->Fat;
             decoder->Code = header->Fat.GetCode();


### PR DESCRIPTION
`clru` was sometimes not working

```
(lldb) clru -gcinfo -o 0000000280de61ac
Normal JIT generated code
Rotate.App+Node.rotateTree(Rotate.Weight ByRef, Rotate.Weight ByRef)
ilAddr is 00000001001AC3B0 pImport is 000000010DA18E00
error decoding IL
```

The error was tracked down to an error in the `GetILSize()` implementation.  The `COR_ILMETHOD *header` needed to be aligned, but the implementation was not guaranteeing its alignment.

/cc @janvorli 