### PR TITLE
Move caret back to the end when exiting

### DIFF
--- a/src/Tools/dotnet-counters/Exporters/ConsoleWriter.cs
+++ b/src/Tools/dotnet-counters/Exporters/ConsoleWriter.cs
@@ -152,7 +152,16 @@ namespace Microsoft.Diagnostics.Tools.Counters.Exporters
 
         public void Stop()
         {
-            // Nothing to do here.
+            if (initialized)
+            {
+                var row = providers.Values.SelectMany(c => c.Counters.Values).Select(c => c.Row).DefaultIfEmpty(-1).Max();
+
+                if (row > -1)
+                {
+                    Console.SetCursorPosition(0, row);
+                    Console.WriteLine();
+                }
+            }
         }
     }
 }

--- a/src/Tools/dotnet-counters/Exporters/ConsoleWriter.cs
+++ b/src/Tools/dotnet-counters/Exporters/ConsoleWriter.cs
@@ -46,6 +46,8 @@ namespace Microsoft.Diagnostics.Tools.Counters.Exporters
         private bool paused = false;
         private bool initialized = false;
 
+        private int maxRow = -1;
+
         public void Initialize()
         {
             AssignRowsAndInitializeDisplay();
@@ -82,6 +84,8 @@ namespace Microsoft.Diagnostics.Tools.Counters.Exporters
                     counter.Row = row++;
                 }
             }
+
+            maxRow = row;
         }
 
         public void ToggleStatus(bool pauseCmdSet)
@@ -154,7 +158,7 @@ namespace Microsoft.Diagnostics.Tools.Counters.Exporters
         {
             if (initialized)
             {
-                var row = providers.Values.SelectMany(c => c.Counters.Values).Select(c => c.Row).DefaultIfEmpty(-1).Max();
+                var row = maxRow;
 
                 if (row > -1)
                 {


### PR DESCRIPTION
When exiting dotnet-counters, the caret stays at the position of the last updated counter. This causes garbage when trying to execute new commands:

![image](https://user-images.githubusercontent.com/11140081/102347432-b5a8fc00-3fa0-11eb-8480-13efff01e15d.png)

That's not a big issue in a Windows environment, since I can just execute `cls` to clear the screen. That's much more troublesome on a SSH/Linux session where no such command is available.

This PR moves the caret back to the end of the output when exiting.