### PR TITLE
Set monitoring library versions to 5.0.X

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Microsoft.Diagnostics.Monitoring.EventPipe.csproj
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Microsoft.Diagnostics.Monitoring.EventPipe.csproj
@@ -13,6 +13,8 @@
     <!-- Do not ship this package until ready to be consumed. -->
     <IsShipping>false</IsShipping>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- Version information -->
+    <VersionPrefix>5.0.0</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/Microsoft.Diagnostics.Monitoring.RestServer.csproj
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/Microsoft.Diagnostics.Monitoring.RestServer.csproj
@@ -13,6 +13,8 @@
     <!-- Do not ship this package until ready to be consumed. -->
     <IsShipping>false</IsShipping>
     <OutputType>Library</OutputType>
+    <!-- Version information -->
+    <VersionPrefix>5.0.0</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/src/Microsoft.Diagnostics.Monitoring/Microsoft.Diagnostics.Monitoring.csproj
+++ b/src/Microsoft.Diagnostics.Monitoring/Microsoft.Diagnostics.Monitoring.csproj
@@ -13,6 +13,8 @@
     <!-- Do not ship this package until ready to be consumed. -->
     <IsShipping>false</IsShipping>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- Version information -->
+    <VersionPrefix>5.0.0</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fix the monitoring library versions to the 5.0.X range before they are implicitly incremented out of the range. This allows us to reserve the decision to later increment the version manually or to change back to keep versioning in sync with other diagnostic tools.