### PR TITLE
Fix the default message written to console when no --counters is specified

### DIFF
--- a/src/Tools/dotnet-counters/CounterMonitor.cs
+++ b/src/Tools/dotnet-counters/CounterMonitor.cs
@@ -260,7 +260,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
             if (_counterList.Count == 0)
             {
                 CounterProvider defaultProvider = null;
-                _console.Out.WriteLine($"counter_list is unspecified. Monitoring all counters by default.");
+                _console.Out.WriteLine($"--counters is unspecified. Monitoring System.Runtime counters by default.");
 
                 // Enable the default profile if nothing is specified
                 if (!KnownData.TryGetProvider("System.Runtime", out defaultProvider))


### PR DESCRIPTION
Currently if user doesn't specify the counter list, then this message is printed:

`counter_list is unspecified. Monitoring all counters by default`

Technically this is incorrect because it only monitors "System.Runtime" counters. This message is a remnant from all the way to 3.0 when System.Runtime was the only set of counters published by .NET but it's end of 2020 and we have a lot of counters now : ) 

This PR changes this message to:

`--counters is unspecified. Monitoring System.Runtime counters by default`