### PR TITLE
Improve mismatched debugger message

### DIFF
--- a/src/SOS/Strike/exts.cpp
+++ b/src/SOS/Strike/exts.cpp
@@ -148,7 +148,7 @@ ArchQuery(void)
     if (targetMachine == NULL)
     {
         g_targetMachine = NULL;
-        ExtErr("SOS does not support the current target architecture 0x%08x\n", targetArchitecture);
+        ExtErr("The SOS that is loaded does not support the current target architecture '0x%04x'. A 32 bit target may require a 64 bit debugger or vice versa.\n", targetArchitecture);
         return E_FAIL;
     }
 


### PR DESCRIPTION
Relates to https://github.com/dotnet/diagnostics/issues/522

Old
```
> pe
SOS does not support the current target architecture 0x0000014c
```
New
```
> pe
The SOS that is loaded does not support the current target architecture '0x014c'. A 32 bit target may require a 64 bit debugger or vice versa.
```

If it loads SOS but can't load the DAC you have always gotten a bit more help:
```
            4) you are debugging on a platform and architecture that supports this
                the dump file. For example, an ARM dump file must be debugged
                on an X86 or an ARM machine; an AMD64 dump file must be
                debugged on an AMD64 machine.
```

The ideal here of course is that it seamlessly just works as proposed by @davidfowl in https://github.com/dotnet/diagnostics/issues/522 just as Windbg launches EngHost.exe if it needs to switch bitness. 