### PR TITLE
Logging improvements for dotnet-monitor

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/ActionContextExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/ActionContextExtensions.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Diagnostics.NETCore.Client;
+using Microsoft.Extensions.Logging;
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.Net;
@@ -14,47 +16,79 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer
 {
     internal static class ActionContextExtensions
     {
+        private const string ExceptionLogMessage = "Request failed.";
+
         public static Task ProblemAsync(this ActionContext context, Exception ex)
         {
-            ActionResult result = new BadRequestObjectResult(ex.ToProblemDetails((int)HttpStatusCode.BadRequest));
+            if (context.HttpContext.Features.Get<IHttpResponseFeature>().HasStarted)
+            {
+                // If already started writing response, do not rewrite
+                // as this will throw an InvalidOperationException.
+                return Task.CompletedTask;
+            }
+            else
+            {
+                ActionResult result = new BadRequestObjectResult(ex.ToProblemDetails((int)HttpStatusCode.BadRequest));
 
-            return result.ExecuteResultAsync(context);
+                return result.ExecuteResultAsync(context);
+            }
         }
 
-        public static async Task InvokeAsync(this ActionContext context, Func<CancellationToken, Task> action)
+        public static async Task InvokeAsync(this ActionContext context, Func<CancellationToken, Task> action, ILogger logger)
         {
+            CancellationToken token = context.HttpContext.RequestAborted;
+            // Exceptions are logged in the "when" clause in order to preview the exception
+            // from the point of where it was thrown. This allows capturing of the log scopes
+            // that were active when the exception was thrown. Waiting to log during the exception
+            // handler will miss any scopes that were added during invocation of action.
             try
             {
-                await action(context.HttpContext.RequestAborted);
+                await action(token);
             }
-            catch (ArgumentException ex)
+            catch (ArgumentException ex) when (LogError(logger, ex))
             {
                 await context.ProblemAsync(ex);
             }
-            catch (DiagnosticsClientException ex)
+            catch (DiagnosticsClientException ex) when (LogError(logger, ex))
             {
                 await context.ProblemAsync(ex);
             }
-            catch (InvalidOperationException ex)
+            catch (InvalidOperationException ex) when (LogError(logger, ex))
             {
                 await context.ProblemAsync(ex);
             }
-            catch (OperationCanceledException ex)
+            catch (OperationCanceledException ex) when (token.IsCancellationRequested && LogInformation(logger, ex))
             {
                 await context.ProblemAsync(ex);
             }
-            catch (MonitoringException ex)
+            catch (OperationCanceledException ex) when (LogError(logger, ex))
             {
                 await context.ProblemAsync(ex);
             }
-            catch (ValidationException ex)
+            catch (MonitoringException ex) when (LogError(logger, ex))
             {
                 await context.ProblemAsync(ex);
             }
-            catch (UnauthorizedAccessException ex)
+            catch (ValidationException ex) when (LogError(logger, ex))
             {
                 await context.ProblemAsync(ex);
             }
+            catch (UnauthorizedAccessException ex) when (LogError(logger, ex))
+            {
+                await context.ProblemAsync(ex);
+            }
+        }
+
+        private static bool LogError(ILogger logger, Exception ex)
+        {
+            logger.LogError(ex, ExceptionLogMessage);
+            return true;
+        }
+
+        private static bool LogInformation(ILogger logger, Exception ex)
+        {
+            logger.LogInformation(ex.Message);
+            return true;
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/ArtifactMetadataNames.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/ArtifactMetadataNames.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Diagnostics.Monitoring.RestServer
+{
+    /// <summary>
+    /// Metadata keys that represent artfiact information.
+    /// </summary>
+    internal static class ArtifactMetadataNames
+    {
+        /// <summary>
+        /// Represents the type of artifact created from the source.
+        /// </summary>
+        public const string ArtifactType = nameof(ArtifactType);
+
+        /// <summary>
+        /// Metadata keus that represent the source of an artifact.
+        /// </summary>
+        public static class ArtifactSource
+        {
+            /// <summary>
+            /// The ID of the process from which the artifact was collected.
+            /// </summary>
+            public const string ProcessId = nameof(ArtifactSource) + "_" + nameof(ProcessId);
+
+            /// <summary>
+            /// The runtime instance cookie of the process from which the artifact was collected.
+            /// </summary>
+            public const string RuntimeInstanceCookie = nameof(ArtifactSource) + "_" + nameof(RuntimeInstanceCookie);
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/Controllers/DiagController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/Controllers/DiagController.cs
@@ -28,16 +28,23 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
     [HostRestriction]
     public class DiagController : ControllerBase
     {
+        private const string ArtifactType_Dump = "dump";
+        private const string ArtifactType_GCDump = "gcdump";
+        private const string ArtifactType_Logs = "logs";
+        private const string ArtifactType_Trace = "trace";
+
         private const TraceProfile DefaultTraceProfiles = TraceProfile.Cpu | TraceProfile.Http | TraceProfile.Metrics;
         private static readonly MediaTypeHeaderValue NdJsonHeader = new MediaTypeHeaderValue(ContentTypes.ApplicationNdJson);
         private static readonly MediaTypeHeaderValue EventStreamHeader = new MediaTypeHeaderValue(ContentTypes.TextEventStream);
 
         private readonly ILogger<DiagController> _logger;
+        private readonly ILoggerFactory _loggerFactory;
         private readonly IDiagnosticServices _diagnosticServices;
 
-        public DiagController(ILogger<DiagController> logger, IServiceProvider serviceProvider)
+        public DiagController(ILoggerFactory loggerFactory, IServiceProvider serviceProvider)
         {
-            _logger = logger;
+            _logger = loggerFactory.CreateLogger<DiagController>();
+            _loggerFactory = loggerFactory;
             _diagnosticServices = serviceProvider.GetRequiredService<IDiagnosticServices>();
         }
 
@@ -52,33 +59,24 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
                     processesIdentifiers.Add(ProcessIdentifierModel.FromProcessInfo(p));
                 }
                 return new ActionResult<IEnumerable<ProcessIdentifierModel>>(processesIdentifiers);
-            });
+            }, _logger);
         }
 
         [HttpGet("processes/{processFilter}")]
         public Task<ActionResult<ProcessModel>> GetProcess(
             ProcessFilter processFilter)
         {
-            return this.InvokeService<ProcessModel>(async () =>
-            {
-                IProcessInfo processInfo = await _diagnosticServices.GetProcessAsync(
-                    processFilter,
-                    HttpContext.RequestAborted);
-
-                return ProcessModel.FromProcessInfo(processInfo);
-            });
+            return InvokeForProcess<ProcessModel>(
+                processInfo => ProcessModel.FromProcessInfo(processInfo),
+                processFilter);
         }
 
         [HttpGet("processes/{processFilter}/env")]
         public Task<ActionResult<Dictionary<string, string>>> GetProcessEnvironment(
             ProcessFilter processFilter)
         {
-            return this.InvokeService<Dictionary<string, string>>(async () =>
+            return InvokeForProcess<Dictionary<string, string>>(processInfo =>
             {
-                IProcessInfo processInfo = await _diagnosticServices.GetProcessAsync(
-                    processFilter,
-                    HttpContext.RequestAborted);
-
                 var client = new DiagnosticsClient(processInfo.EndpointInfo.Endpoint);
 
                 try
@@ -89,7 +87,8 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
                 {
                     throw new InvalidOperationException("Unable to get process environment.");
                 }
-            });
+            },
+            processFilter);
         }
 
         [HttpGet("dump/{processFilter?}")]
@@ -98,10 +97,8 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
             [FromQuery] DumpType type = DumpType.WithHeap,
             [FromQuery] string egressProvider = null)
         {
-            return this.InvokeService(async () =>
+            return InvokeForProcess(async processInfo =>
             {
-                IProcessInfo processInfo = await _diagnosticServices.GetProcessAsync(processFilter, HttpContext.RequestAborted);
-
                 string dumpFileName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
                     FormattableString.Invariant($"dump_{GetFileNameTimeStampUtcNow()}.dmp") :
                     FormattableString.Invariant($"core_{GetFileNameTimeStampUtcNow()}");
@@ -116,14 +113,19 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
                 }
                 else
                 {
+                    KeyValueLogScope scope = new KeyValueLogScope();
+                    scope.AddArtifactType(ArtifactType_Dump);
+                    scope.AddEndpointInfo(processInfo.EndpointInfo);
+
                     return new EgressStreamResult(
                         token => _diagnosticServices.GetDump(processInfo, type, token),
                         egressProvider,
                         dumpFileName,
                         processInfo.EndpointInfo,
-                        ContentTypes.ApplicationOctectStream);
+                        ContentTypes.ApplicationOctectStream,
+                        scope);
                 }
-            });
+            }, processFilter, ArtifactType_Dump);
         }
 
         [HttpGet("gcdump/{processFilter?}")]
@@ -131,10 +133,8 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
             ProcessFilter? processFilter,
             [FromQuery] string egressProvider = null)
         {
-            return this.InvokeService(async () =>
+            return InvokeForProcess(processInfo =>
             {
-                IProcessInfo processInfo = await _diagnosticServices.GetProcessAsync(processFilter, HttpContext.RequestAborted);
-
                 string fileName = FormattableString.Invariant($"{GetFileNameTimeStampUtcNow()}_{processInfo.EndpointInfo.ProcessId}.gcdump");
 
                 Func<CancellationToken, Task<IFastSerializable>> action = async (token) => {
@@ -157,12 +157,13 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
                 };
 
                 return Result(
+                    ArtifactType_GCDump,
                     egressProvider,
                     ConvertFastSerializeAction(action),
                     fileName,
                     ContentTypes.ApplicationOctectStream,
                     processInfo.EndpointInfo);
-            });
+            }, processFilter, ArtifactType_GCDump);
         }
 
         [HttpGet("trace/{processFilter?}")]
@@ -173,10 +174,10 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
             [FromQuery][Range(1, int.MaxValue)] int metricsIntervalSeconds = 1,
             [FromQuery] string egressProvider = null)
         {
-            TimeSpan duration = ConvertSecondsToTimeSpan(durationSeconds);
-
-            return this.InvokeService(async () =>
+            return InvokeForProcess(processInfo =>
             {
+                TimeSpan duration = ConvertSecondsToTimeSpan(durationSeconds);
+
                 var configurations = new List<MonitoringSourceConfiguration>();
                 if (profile.HasFlag(TraceProfile.Cpu))
                 {
@@ -197,8 +198,8 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
 
                 var aggregateConfiguration = new AggregateSourceConfiguration(configurations.ToArray());
 
-                return await StartTrace(processFilter, aggregateConfiguration, duration, egressProvider);
-            });
+                return StartTrace(processInfo, aggregateConfiguration, duration, egressProvider);
+            }, processFilter, ArtifactType_Trace);
         }
 
         [HttpPost("trace/{processFilter?}")]
@@ -208,10 +209,10 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
             [FromQuery][Range(-1, int.MaxValue)] int durationSeconds = 30,
             [FromQuery] string egressProvider = null)
         {
-            TimeSpan duration = ConvertSecondsToTimeSpan(durationSeconds);
-
-            return this.InvokeService(async () =>
+            return InvokeForProcess(processInfo =>
             {
+                TimeSpan duration = ConvertSecondsToTimeSpan(durationSeconds);
+
                 var providers = new List<EventPipeProvider>();
 
                 foreach (EventPipeProviderModel providerModel in configuration.Providers)
@@ -234,8 +235,8 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
                     requestRundown: configuration.RequestRundown,
                     bufferSizeInMB: configuration.BufferSizeInMB);
 
-                return await StartTrace(processFilter, traceConfiguration, duration, egressProvider);
-            });
+                return StartTrace(processInfo, traceConfiguration, duration, egressProvider);
+            }, processFilter, ArtifactType_Trace);
         }
 
         [HttpGet("logs/{processFilter?}")]
@@ -246,10 +247,9 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
             [FromQuery] LogLevel level = LogLevel.Debug,
             [FromQuery] string egressProvider = null)
         {
-            TimeSpan duration = ConvertSecondsToTimeSpan(durationSeconds);
-            return this.InvokeService(async () =>
+            return InvokeForProcess(processInfo =>
             {
-                IProcessInfo processInfo = await _diagnosticServices.GetProcessAsync(processFilter, HttpContext.RequestAborted);
+                TimeSpan duration = ConvertSecondsToTimeSpan(durationSeconds);
 
                 LogFormat format = ComputeLogFormat(Request.GetTypedHeaders().Accept);
                 if (format == LogFormat.None)
@@ -279,23 +279,22 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
                 };
 
                 return Result(
+                    ArtifactType_Logs,
                     egressProvider,
                     action,
                     fileName,
                     contentType,
                     processInfo.EndpointInfo,
                     format != LogFormat.EventStream);
-            });
+            }, processFilter, ArtifactType_Logs);
         }
 
-        private async Task<ActionResult> StartTrace(
-            ProcessFilter? processFilter,
+        private ActionResult StartTrace(
+            IProcessInfo processInfo,
             MonitoringSourceConfiguration configuration,
             TimeSpan duration,
             string egressProvider)
         {
-            IProcessInfo processInfo = await _diagnosticServices.GetProcessAsync(processFilter, HttpContext.RequestAborted);
-
             string fileName = FormattableString.Invariant($"{GetFileNameTimeStampUtcNow()}_{processInfo.EndpointInfo.ProcessId}.nettrace");
 
             Func<Stream, CancellationToken, Task> action = async (outputStream, token) =>
@@ -319,6 +318,7 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
             };
 
             return Result(
+                ArtifactType_Trace,
                 egressProvider,
                 action,
                 fileName,
@@ -364,7 +364,8 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
             return LogFormat.None;
         }
 
-        private static ActionResult Result(
+        private ActionResult Result(
+            string artifactType,
             string providerName,
             Func<Stream, CancellationToken, Task> action,
             string fileName,
@@ -372,12 +373,17 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
             IEndpointInfo endpointInfo,
             bool asAttachment = true)
         {
+            KeyValueLogScope scope = new KeyValueLogScope();
+            scope.AddArtifactType(artifactType);
+            scope.AddEndpointInfo(endpointInfo);
+
             if (string.IsNullOrEmpty(providerName))
             {
                 return new OutputStreamResult(
                     action,
                     contentType,
-                    asAttachment ? fileName : null);
+                    asAttachment ? fileName : null,
+                    scope);
             }
             else
             {
@@ -386,7 +392,8 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
                     providerName,
                     fileName,
                     endpointInfo,
-                    contentType);
+                    contentType,
+                    scope);
             }
         }
 
@@ -428,6 +435,57 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
                     serializer.Close();
                 }
             };
+        }
+
+        private Task<ActionResult> InvokeForProcess(Func<IProcessInfo, ActionResult> func, ProcessFilter? filter, string artifactType = null)
+        {
+            Func<IProcessInfo, Task<ActionResult>> asyncFunc =
+                processInfo => Task.FromResult(func(processInfo));
+
+            return InvokeForProcess(asyncFunc, filter, artifactType);
+        }
+
+        private async Task<ActionResult> InvokeForProcess(Func<IProcessInfo, Task<ActionResult>> func, ProcessFilter? filter, string artifactType)
+        {
+            ActionResult<object> result = await InvokeForProcess<object>(async processInfo => await func(processInfo), filter, artifactType);
+
+            return result.Result;
+        }
+
+        private Task<ActionResult<T>> InvokeForProcess<T>(Func<IProcessInfo, ActionResult<T>> func, ProcessFilter? filter, string artifactType = null)
+        {
+            return InvokeForProcess(processInfo => Task.FromResult(func(processInfo)), filter, artifactType);
+        }
+
+        private async Task<ActionResult<T>> InvokeForProcess<T>(Func<IProcessInfo, Task<ActionResult<T>>> func, ProcessFilter? filter, string artifactType = null)
+        {
+            IDisposable artifactTypeRegistration = null;
+            if (!string.IsNullOrEmpty(artifactType))
+            {
+                KeyValueLogScope artifactTypeScope = new KeyValueLogScope();
+                artifactTypeScope.AddArtifactType(artifactType);
+                artifactTypeRegistration = _logger.BeginScope(artifactTypeScope);
+            }
+
+            try
+            {
+                return await this.InvokeService(async () =>
+                {
+                    IProcessInfo processInfo = await _diagnosticServices.GetProcessAsync(filter, HttpContext.RequestAborted);
+
+                    KeyValueLogScope processInfoScope = new KeyValueLogScope();
+                    processInfoScope.AddEndpointInfo(processInfo.EndpointInfo);
+                    using var _ = _logger.BeginScope(processInfoScope);
+
+                    _logger.LogDebug("Resolved target process.");
+
+                    return await func(processInfo);
+                }, _logger);
+            }
+            finally
+            {
+                artifactTypeRegistration?.Dispose();
+            }
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/Controllers/DiagController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/Controllers/DiagController.cs
@@ -38,13 +38,11 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
         private static readonly MediaTypeHeaderValue EventStreamHeader = new MediaTypeHeaderValue(ContentTypes.TextEventStream);
 
         private readonly ILogger<DiagController> _logger;
-        private readonly ILoggerFactory _loggerFactory;
         private readonly IDiagnosticServices _diagnosticServices;
 
-        public DiagController(ILoggerFactory loggerFactory, IServiceProvider serviceProvider)
+        public DiagController(ILogger<DiagController> logger, IServiceProvider serviceProvider)
         {
-            _logger = loggerFactory.CreateLogger<DiagController>();
-            _loggerFactory = loggerFactory;
+            _logger = logger;
             _diagnosticServices = serviceProvider.GetRequiredService<IDiagnosticServices>();
         }
 

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/Controllers/DiagControllerExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/Controllers/DiagControllerExtensions.cs
@@ -4,9 +4,11 @@
 
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Diagnostics.NETCore.Client;
+using Microsoft.Extensions.Logging;
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 
 // For more information on enabling MVC for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
@@ -15,60 +17,71 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
 {
     internal static class DiagControllerExtensions
     {
+        private const string ExceptionLogMessage = "Request failed.";
+
         public static ActionResult NotAcceptable(this ControllerBase controller)
         {
             return new StatusCodeResult((int)HttpStatusCode.NotAcceptable);
         }
 
-        public static ActionResult InvokeService(this ControllerBase controller, Func<ActionResult> serviceCall)
+        public static ActionResult InvokeService(this ControllerBase controller, Func<ActionResult> serviceCall, ILogger logger)
         {
             //We can convert ActionResult to ActionResult<T>
             //and then safely convert back.
-            return controller.InvokeService<object>(() => serviceCall()).Result;
+            return controller.InvokeService<object>(() => serviceCall(), logger).Result;
         }
 
-        public static ActionResult<T> InvokeService<T>(this ControllerBase controller, Func<ActionResult<T>> serviceCall)
+        public static ActionResult<T> InvokeService<T>(this ControllerBase controller, Func<ActionResult<T>> serviceCall, ILogger logger)
         {
             //Convert from ActionResult<T> to Task<ActionResult<T>>
             //and safely convert back.
-            return controller.InvokeService(() => Task.FromResult(serviceCall())).Result;
+            return controller.InvokeService(() => Task.FromResult(serviceCall()), logger).Result;
         }
 
-        public static async Task<ActionResult> InvokeService(this ControllerBase controller, Func<Task<ActionResult>> serviceCall)
+        public static async Task<ActionResult> InvokeService(this ControllerBase controller, Func<Task<ActionResult>> serviceCall, ILogger logger)
         {
             //Task<ActionResult> -> Task<ActionResult<T>>
             //Then unwrap the result back to ActionResult
-            ActionResult<object> result = await controller.InvokeService<object>(async () => await serviceCall());
+            ActionResult<object> result = await controller.InvokeService<object>(async () => await serviceCall(), logger);
             return result.Result;
         }
 
-        public static async Task<ActionResult<T>> InvokeService<T>(this ControllerBase controller, Func<Task<ActionResult<T>>> serviceCall)
+        public static async Task<ActionResult<T>> InvokeService<T>(this ControllerBase controller, Func<Task<ActionResult<T>>> serviceCall, ILogger logger)
         {
+            CancellationToken token = controller.HttpContext.RequestAborted;
+            // Exceptions are logged in the "when" clause in order to preview the exception
+            // from the point of where it was thrown. This allows capturing of the log scopes
+            // that were active when the exception was thrown. Waiting to log during the exception
+            // handler will miss any scopes that were added during invocation of serviceCall.
             try
             {
                 return await serviceCall();
             }
-            catch (ArgumentException e)
+            catch (ArgumentException e) when (LogError(logger, e))
             {
                 return controller.Problem(e);
             }
-            catch (DiagnosticsClientException e)
+            catch (DiagnosticsClientException e) when (LogError(logger, e))
             {
                 return controller.Problem(e);
             }
-            catch (InvalidOperationException e)
+            catch (InvalidOperationException e) when (LogError(logger, e))
             {
                 return controller.Problem(e);
             }
-            catch (OperationCanceledException e)
+            catch (OperationCanceledException e) when (token.IsCancellationRequested && LogInformation(logger, e))
             {
                 return controller.Problem(e);
             }
-            catch (MonitoringException e)
+            catch (OperationCanceledException e) when (LogError(logger, e))
             {
                 return controller.Problem(e);
             }
-            catch (ValidationException e)
+            catch (MonitoringException e) when (LogError(logger, e))
+            {
+                return controller.Problem(e);
+            }
+            catch (ValidationException e) when (LogError(logger, e))
             {
                 return controller.Problem(e);
             }
@@ -77,6 +90,18 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
         public static ObjectResult Problem(this ControllerBase controller, Exception ex)
         {
             return controller.BadRequest(ex.ToProblemDetails((int)HttpStatusCode.BadRequest));
+        }
+
+        private static bool LogError(ILogger logger, Exception ex)
+        {
+            logger.LogError(ex, ExceptionLogMessage);
+            return true;
+        }
+
+        private static bool LogInformation(ILogger logger, Exception ex)
+        {
+            logger.LogInformation(ex.Message);
+            return true;
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/Controllers/MetricsController.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/Controllers/MetricsController.cs
@@ -14,6 +14,8 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
     [ApiController]
     public class MetricsController : ControllerBase
     {
+        private const string ArtifactType_Metrics = "metrics";
+
         private readonly ILogger<MetricsController> _logger;
         private readonly MetricsStoreService _metricsStore;
         private readonly MetricsOptions _metricsOptions;
@@ -37,11 +39,17 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer.Controllers
                     throw new InvalidOperationException("Metrics was not enabled");
                 }
 
+                KeyValueLogScope scope = new KeyValueLogScope();
+                scope.AddArtifactType(ArtifactType_Metrics);
+
                 return new OutputStreamResult(async (outputStream, token) =>
-                {
-                    await _metricsStore.MetricsStore.SnapshotMetrics(outputStream, token);
-                }, "text/plain; version=0.0.4");
-            });
+                    {
+                        await _metricsStore.MetricsStore.SnapshotMetrics(outputStream, token);
+                    },
+                    "text/plain; version=0.0.4",
+                    null,
+                    scope);
+            }, _logger);
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/KeyValueLogScope.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/KeyValueLogScope.cs
@@ -1,0 +1,48 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Diagnostics.Monitoring.RestServer
+{
+    // Logger implementations have different ways of serializing log scopes. This class helps those loggers
+    // serialize the scope information in the best way possible for each of the implementations. For example,
+    // the console logger will only call ToString on the scope data, thus the data needs to be formatted appropriately
+    // in the ToString method. Another example, the event log logger will check if the scope data impelements
+    // IEnumerable<KeyValuePair<string, object>> and then formats each value from the enumeration; it will fallback
+    // calling the ToString method otherwise.
+    internal class KeyValueLogScope : IEnumerable<KeyValuePair<string, object>>
+    {
+        public IDictionary<string, object> Values =
+            new Dictionary<string, object>();
+
+        IEnumerator<KeyValuePair<string, object>> IEnumerable<KeyValuePair<string, object>>.GetEnumerator()
+        {
+            return Values.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return ((IEnumerable)Values).GetEnumerator();
+        }
+
+        public override string ToString()
+        {
+            StringBuilder builder = new StringBuilder();
+            foreach (var kvp in Values)
+            {
+                if (builder.Length > 0)
+                {
+                    builder.Append(" ");
+                }
+                builder.Append(kvp.Key);
+                builder.Append(":");
+                builder.Append(kvp.Value);
+            }
+            return builder.ToString();
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/KeyValueLogScopeExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/KeyValueLogScopeExtensions.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Globalization;
+
 namespace Microsoft.Diagnostics.Monitoring.RestServer
 {
     internal static class KeyValueLogScopeExtensions
@@ -13,8 +15,12 @@ namespace Microsoft.Diagnostics.Monitoring.RestServer
 
         public static void AddEndpointInfo(this KeyValueLogScope scope, IEndpointInfo endpointInfo)
         {
-            scope.Values.Add("TargetProcessId", endpointInfo.ProcessId);
-            scope.Values.Add("TargetRuntimeInstanceCookie", endpointInfo.RuntimeInstanceCookie);
+            scope.Values.Add(
+                ArtifactMetadataNames.ArtifactSource.ProcessId,
+                endpointInfo.ProcessId.ToString(CultureInfo.InvariantCulture));
+            scope.Values.Add(
+                ArtifactMetadataNames.ArtifactSource.RuntimeInstanceCookie,
+                endpointInfo.RuntimeInstanceCookie.ToString("N"));
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/KeyValueLogScopeExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/KeyValueLogScopeExtensions.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Diagnostics.Monitoring.RestServer
+{
+    internal static class KeyValueLogScopeExtensions
+    {
+        public static void AddArtifactType(this KeyValueLogScope scope, string artifactType)
+        {
+            scope.Values.Add("ArtifactType", artifactType);
+        }
+
+        public static void AddEndpointInfo(this KeyValueLogScope scope, IEndpointInfo endpointInfo)
+        {
+            scope.Values.Add("TargetProcessId", endpointInfo.ProcessId);
+            scope.Values.Add("TargetRuntimeInstanceCookie", endpointInfo.RuntimeInstanceCookie);
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/appsettings.json
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/appsettings.json
@@ -1,7 +1,20 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Warning"
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    },
+    "Console": {
+      "IncludeScopes": true,
+      "TimestampFormat": "HH:mm:ss "
+    },
+    "EventLog": {
+      "LogLevel": {
+        "Default": "Information",
+        "Microsoft": "Warning",
+        "Microsoft.Hosting.Lifetime": "Information"
+      }
     }
   },
   "AllowedHosts": "*"

--- a/src/Tools/dotnet-monitor/ActivityExtensions.cs
+++ b/src/Tools/dotnet-monitor/ActivityExtensions.cs
@@ -1,0 +1,47 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+
+namespace Microsoft.Diagnostics.Tools.Monitor
+{
+    internal static class ActivityExtensions
+    {
+        public static string GetSpanId(this Activity activity)
+        {
+            switch (activity.IdFormat)
+            {
+                case ActivityIdFormat.Hierarchical:
+                    return activity.Id;
+                case ActivityIdFormat.W3C:
+                    return activity.SpanId.ToHexString();
+            }
+            return string.Empty;
+        }
+
+        public static string GetParentId(this Activity activity)
+        {
+            switch (activity.IdFormat)
+            {
+                case ActivityIdFormat.Hierarchical:
+                    return activity.ParentId;
+                case ActivityIdFormat.W3C:
+                    return activity.ParentSpanId.ToHexString();
+            }
+            return string.Empty;
+        }
+
+        public static string GetTraceId(this Activity activity)
+        {
+            switch (activity.IdFormat)
+            {
+                case ActivityIdFormat.Hierarchical:
+                    return activity.RootId;
+                case ActivityIdFormat.W3C:
+                    return activity.TraceId.ToHexString();
+            }
+            return string.Empty;
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/ActivityMetadataNames.cs
+++ b/src/Tools/dotnet-monitor/ActivityMetadataNames.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Diagnostics.Tools.Monitor
+{
+    /// <summary>
+    /// Metadata keys that correspond to <see cref="System.Diagnostics.Activity"/> properties.
+    /// </summary>
+    internal static class ActivityMetadataNames
+    {
+        /// <summary>
+        /// Represents the ID of the parent activity.
+        /// </summary>
+        /// <remarks>
+        /// This name is the same as logged by the ActivityLogScope.
+        /// </remarks>
+        public const string ParentId = nameof(ParentId);
+
+        /// <summary>
+        /// Represents the ID of the current activity.
+        /// </summary>
+        /// <remarks>
+        /// This name is the same as logged by the ActivityLogScope.
+        /// </remarks>
+        public const string SpanId = nameof(SpanId);
+
+        /// <summary>
+        /// Represents the trace ID of the activity.
+        /// </summary>
+        /// <remarks>
+        /// This name is the same as logged by the ActivityLogScope.
+        /// </remarks>
+        public const string TraceId = nameof(TraceId);
+    }
+}

--- a/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
@@ -8,6 +8,8 @@ using Microsoft.Diagnostics.Monitoring;
 using Microsoft.Diagnostics.Monitoring.RestServer;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.CommandLine;
@@ -46,19 +48,19 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         public async Task<int> Start(CancellationToken token, IConsole console, string[] urls, string[] metricUrls, bool metrics, string diagnosticPort)
         {
             //CONSIDER The console logger uses the standard AddConsole, and therefore disregards IConsole.
-            using IWebHost host = CreateWebHostBuilder(console, urls, metricUrls, metrics, diagnosticPort).Build();
+            using IHost host = CreateHostBuilder(console, urls, metricUrls, metrics, diagnosticPort).Build();
             await host.RunAsync(token);
             return 0;
         }
 
-        public IWebHostBuilder CreateWebHostBuilder(IConsole console, string[] urls, string[] metricUrls, bool metrics, string diagnosticPort)
+        public IHostBuilder CreateHostBuilder(IConsole console, string[] urls, string[] metricUrls, bool metrics, string diagnosticPort)
         {
             if (metrics)
             {
                 urls = urls.Concat(metricUrls).ToArray();
             }
 
-            IWebHostBuilder builder = WebHost.CreateDefaultBuilder()
+            return Host.CreateDefaultBuilder()
                 .ConfigureAppConfiguration((IConfigurationBuilder builder) =>
                 {
                     //Note these are in precedence order.
@@ -74,7 +76,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                     builder.AddKeyPerFile(SharedConfigDirectoryPath, optional: true);
                     builder.AddEnvironmentVariables(ConfigPrefix);
                 })
-                .ConfigureServices((WebHostBuilderContext context, IServiceCollection services) =>
+                .ConfigureServices((HostBuilderContext context, IServiceCollection services) =>
                 {
                     //TODO Many of these service additions should be done through extension methods
                     services.Configure<DiagnosticPortOptions>(context.Configuration.GetSection(DiagnosticPortOptions.ConfigurationKey));
@@ -87,10 +89,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                         services.ConfigureMetrics(context.Configuration);
                     }
                 })
-                .UseUrls(urls)
-                .UseStartup<Startup>();
-
-            return builder;
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseUrls(urls);
+                    webBuilder.UseStartup<Startup>();
+                });
         }
 
         private static void ConfigureMetricsEndpoint(IConfigurationBuilder builder, string[] metricEndpoints)

--- a/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
@@ -88,6 +88,12 @@ namespace Microsoft.Diagnostics.Tools.Monitor
                     {
                         services.ConfigureMetrics(context.Configuration);
                     }
+                    services.AddSingleton<ExperimentalToolLogger>();
+                })
+                .ConfigureLogging(builder =>
+                {
+                    // Always allow the experimental tool message to be logged
+                    ExperimentalToolLogger.AddLogFilter(builder);
                 })
                 .ConfigureWebHostDefaults(webBuilder =>
                 {

--- a/src/Tools/dotnet-monitor/Egress/AzureBlob/AzureBlobEgressProvider.cs
+++ b/src/Tools/dotnet-monitor/Egress/AzureBlob/AzureBlobEgressProvider.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress.AzureStorage
                 Logger?.LogDebug("End uploading to storage with headers and metadata.");
 
                 string blobUriString = GetBlobUri(blobClient);
-                Logger?.LogInformation("Uploaded stream to {0}", blobUriString);
+                Logger?.LogDebug("Uploaded stream to {0}", blobUriString);
                 return blobUriString;
             }
             catch (AggregateException ex) when (ex.InnerException is RequestFailedException innerException)
@@ -101,7 +101,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress.AzureStorage
                 Logger?.LogDebug("End writing metadata.");
 
                 string blobUriString = GetBlobUri(blobClient);
-                Logger?.LogInformation("Uploaded stream to {0}", blobUriString);
+                Logger?.LogDebug("Uploaded stream to {0}", blobUriString);
                 return blobUriString;
             }
             catch (AggregateException ex) when (ex.InnerException is RequestFailedException innerException)

--- a/src/Tools/dotnet-monitor/Egress/AzureBlobEgressFactory.cs
+++ b/src/Tools/dotnet-monitor/Egress/AzureBlobEgressFactory.cs
@@ -9,6 +9,8 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -94,9 +96,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress
                 IEndpointInfo source,
                 CancellationToken token)
             {
-                // TODO: Add metadata based on source
                 var streamOptions = new AzureBlobEgressStreamOptions();
                 streamOptions.ContentType = contentType;
+                FillBlobMetadata(streamOptions.Metadata, source);
 
                 string blobUri = await _provider.EgressAsync(action, fileName, streamOptions, token);
 
@@ -110,13 +112,35 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress
                 IEndpointInfo source,
                 CancellationToken token)
             {
-                // TODO: Add metadata based on source
                 var streamOptions = new AzureBlobEgressStreamOptions();
                 streamOptions.ContentType = contentType;
+                FillBlobMetadata(streamOptions.Metadata, source);
 
                 string blobUri = await _provider.EgressAsync(action, fileName, streamOptions, token);
 
                 return new EgressResult("uri", blobUri);
+            }
+
+            private static void FillBlobMetadata(IDictionary<string, string> metadata, IEndpointInfo source)
+            {
+                // Activity metadata
+                metadata.Add(
+                    ActivityMetadataNames.ParentId,
+                    Activity.Current.GetParentId());
+                metadata.Add(
+                    ActivityMetadataNames.SpanId,
+                    Activity.Current.GetSpanId());
+                metadata.Add(
+                    ActivityMetadataNames.TraceId,
+                    Activity.Current.GetTraceId());
+
+                // Artifact metadata
+                metadata.Add(
+                    ArtifactMetadataNames.ArtifactSource.ProcessId,
+                    source.ProcessId.ToString(CultureInfo.InvariantCulture));
+                metadata.Add(
+                    ArtifactMetadataNames.ArtifactSource.RuntimeInstanceCookie,
+                    source.RuntimeInstanceCookie.ToString("N"));
             }
         }
 

--- a/src/Tools/dotnet-monitor/Egress/AzureBlobEgressFactory.cs
+++ b/src/Tools/dotnet-monitor/Egress/AzureBlobEgressFactory.cs
@@ -124,15 +124,19 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress
             private static void FillBlobMetadata(IDictionary<string, string> metadata, IEndpointInfo source)
             {
                 // Activity metadata
-                metadata.Add(
-                    ActivityMetadataNames.ParentId,
-                    Activity.Current.GetParentId());
-                metadata.Add(
-                    ActivityMetadataNames.SpanId,
-                    Activity.Current.GetSpanId());
-                metadata.Add(
-                    ActivityMetadataNames.TraceId,
-                    Activity.Current.GetTraceId());
+                Activity activity = Activity.Current;
+                if (null != activity)
+                {
+                    metadata.Add(
+                        ActivityMetadataNames.ParentId,
+                        activity.GetParentId());
+                    metadata.Add(
+                        ActivityMetadataNames.SpanId,
+                        activity.GetSpanId());
+                    metadata.Add(
+                        ActivityMetadataNames.TraceId,
+                        activity.GetTraceId());
+                }
 
                 // Artifact metadata
                 metadata.Add(

--- a/src/Tools/dotnet-monitor/Egress/Configuration/EgressConfigureOptions.cs
+++ b/src/Tools/dotnet-monitor/Egress/Configuration/EgressConfigureOptions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Diagnostics.Monitoring.RestServer;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -64,7 +65,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress.Configuration
             {
                 string providerName = providerSection.Key;
 
-                using var providerNameScope = _logger.BeginScope(new Dictionary<string, string>() { { "ProviderName", providerName } });
+                KeyValueLogScope providerNameScope = new KeyValueLogScope();
+                providerNameScope.Values.Add("EgressProviderName", providerName);
+                using var providerNameRegistration = _logger.BeginScope(providerNameScope);
 
                 CommonEgressProviderOptions commonOptions = new CommonEgressProviderOptions();
                 providerSection.Bind(commonOptions);
@@ -76,7 +79,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress.Configuration
                 }
 
                 string providerType = commonOptions.Type;
-                using var providerTypeScope = _logger.BeginScope(new Dictionary<string, string>() { { "ProviderType", providerType } });
+                KeyValueLogScope providerTypeScope = new KeyValueLogScope();
+                providerTypeScope.Values.Add("EgressProviderType", providerType);
+                using var providerTypeRegistration = _logger.BeginScope(providerTypeScope);
 
                 if (!_factories.TryGetValue(providerType, out EgressFactory factory))
                 {
@@ -92,7 +97,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress.Configuration
 
                 options.Providers.Add(providerName, provider);
 
-                _logger.LogInformation("Added egress provider '{0}'.", providerName);
+                _logger.LogDebug("Added egress provider '{0}'.", providerName);
             }
             _logger.LogDebug("End loading egress providers.");
         }

--- a/src/Tools/dotnet-monitor/Egress/FileSystem/FileSystemEgressProvider.cs
+++ b/src/Tools/dotnet-monitor/Egress/FileSystem/FileSystemEgressProvider.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor.Egress.FileSystem
                 await WriteFileAsync(action, targetPath, token);
             }
 
-            Logger?.LogInformation("Saved stream to '{0}.", targetPath);
+            Logger?.LogDebug("Saved stream to '{0}.", targetPath);
             return targetPath;
         }
 

--- a/src/Tools/dotnet-monitor/ExperimentalToolLogger.cs
+++ b/src/Tools/dotnet-monitor/ExperimentalToolLogger.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Diagnostics.Tools.Monitor
+{
+    // FUTURE: This log message should be removed when dotnet-monitor is no longer an experimental tool
+    internal class ExperimentalToolLogger
+    {
+        private const string ExperimentMessage = "WARNING: dotnet-monitor is experimental and is not intended for production environments yet.";
+
+        private readonly ILogger<ExperimentalToolLogger> _logger;
+
+        public ExperimentalToolLogger(ILogger<ExperimentalToolLogger> logger)
+        {
+            _logger = logger;
+        }
+
+        public void LogExperimentMessage()
+        {
+            _logger.LogWarning(ExperimentMessage);
+        }
+
+        public static void AddLogFilter(ILoggingBuilder builder)
+        {
+            builder.AddFilter(typeof(ExperimentalToolLogger).FullName, LogLevel.Warning);
+        }
+    }
+}

--- a/src/Tools/dotnet-monitor/Program.cs
+++ b/src/Tools/dotnet-monitor/Program.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Tools.Common;
 using System;
 using System.CommandLine;
@@ -24,6 +26,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
     class Program
     {
+        // FUTURE: This log message should be removed when dotnet-monitor is no longer an experimental tool
+        private const string ExperimentMessage = "WARNING: dotnet-monitor is experimental and is not intended for production environments yet.";
+
         private static Command CollectCommand() =>
               new Command(
                   name: "collect",
@@ -79,13 +84,18 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         public static Task<int> Main(string[] args)
         {
-            // FUTURE: This log message should be removed when dotnet-monitor is no longer an experimental tool
-            Console.WriteLine("WARNING: dotnet-monitor is experimental and is not intended for production environments yet.");
+            // Write directly to console so that message is always written regardless of logging level.
+            Console.WriteLine(ExperimentMessage);
             var parser = new CommandLineBuilder()
                             .AddCommand(CollectCommand())
                             .UseDefaults()
                             .Build();
             return parser.InvokeAsync(args);
+        }
+
+        public static void LogExperimentalWarning(ILogger logger)
+        {
+            logger.Log(LogLevel.Warning, ExperimentMessage);
         }
     }
 }

--- a/src/Tools/dotnet-monitor/Program.cs
+++ b/src/Tools/dotnet-monitor/Program.cs
@@ -4,7 +4,6 @@
 
 using Microsoft.Diagnostics.Monitoring;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Microsoft.Tools.Common;
 using System;
 using System.CommandLine;
@@ -26,9 +25,6 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
     class Program
     {
-        // FUTURE: This log message should be removed when dotnet-monitor is no longer an experimental tool
-        private const string ExperimentMessage = "WARNING: dotnet-monitor is experimental and is not intended for production environments yet.";
-
         private static Command CollectCommand() =>
               new Command(
                   name: "collect",
@@ -84,18 +80,11 @@ namespace Microsoft.Diagnostics.Tools.Monitor
 
         public static Task<int> Main(string[] args)
         {
-            // Write directly to console so that message is always written regardless of logging level.
-            Console.WriteLine(ExperimentMessage);
             var parser = new CommandLineBuilder()
-                            .AddCommand(CollectCommand())
-                            .UseDefaults()
-                            .Build();
+                .AddCommand(CollectCommand())
+                .UseDefaults()
+                .Build();
             return parser.InvokeAsync(args);
-        }
-
-        public static void LogExperimentalWarning(ILogger logger)
-        {
-            logger.Log(LogLevel.Warning, ExperimentMessage);
         }
     }
 }

--- a/src/Tools/dotnet-monitor/Startup.cs
+++ b/src/Tools/dotnet-monitor/Startup.cs
@@ -12,10 +12,11 @@ using Microsoft.Diagnostics.Monitoring.RestServer.Controllers;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using System.IO.Compression;
 
-namespace Microsoft.Diagnostics.Monitoring
+namespace Microsoft.Diagnostics.Tools.Monitor
 {
     internal class Startup
     {
@@ -77,8 +78,13 @@ namespace Microsoft.Diagnostics.Monitoring
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        public void Configure(
+            IApplicationBuilder app,
+            IWebHostEnvironment env,
+            ILogger<Startup> logger)
         {
+            Program.LogExperimentalWarning(logger);
+
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();

--- a/src/Tools/dotnet-monitor/Startup.cs
+++ b/src/Tools/dotnet-monitor/Startup.cs
@@ -81,9 +81,9 @@ namespace Microsoft.Diagnostics.Tools.Monitor
         public void Configure(
             IApplicationBuilder app,
             IWebHostEnvironment env,
-            ILogger<Startup> logger)
+            ExperimentalToolLogger logger)
         {
-            Program.LogExperimentalWarning(logger);
+            logger.LogExperimentMessage();
 
             if (env.IsDevelopment())
             {


### PR DESCRIPTION
This is the initial set of changes to improve the logging information for the dotnet-monitor diagnostic tool.

Overview of changes:
- Log exceptions from controller actions and action context executions. Cancellations from an aborted HTTP request are logged at the Information level.
- Add artifact type and endpoint information as logging scopes to the diagnostics and metrics controllers.
- Add additional configuration for console and event log loggers.
- Refactor host builder to route lifetime events through logging and to include console logger by default.
- Write experiment warning message through logging.

TODO:
- [X] Add correlation ID to azure blob metadata so that it can be correlated with logs.

Example log output when attempting to capture a trace and write out to non-existent egress provider:
```
10:15:35 warn: Microsoft.Diagnostics.Tools.Monitor.ExperimentalToolLogger[0]
      WARNING: dotnet-monitor is experimental and is not intended for production environments yet.
10:15:35 info: Microsoft.Hosting.Lifetime[0]
      Now listening on: http://localhost:52323
10:15:35 info: Microsoft.Hosting.Lifetime[0]
      Now listening on: http://localhost:52325
10:15:35 info: Microsoft.Hosting.Lifetime[0]
      Application started. Press Ctrl+C to shut down.
10:15:35 info: Microsoft.Hosting.Lifetime[0]
      Hosting environment: Production
10:15:35 info: Microsoft.Hosting.Lifetime[0]
      Content root path: D:\src\dotnet\diagnostics\artifacts\bin\dotnet-monitor\Debug\netcoreapp3.1
10:18:27 fail: Microsoft.Diagnostics.Monitoring.RestServer.EgressStreamResult[0]
      => ConnectionId:0HM5K06V3H2BM => RequestPath:/trace RequestId:0HM5K06V3H2BM:00000003, SpanId:|e2f2fff9-45dcecf20fb5f4f5., TraceId:e2f2fff9-45dcecf20fb5f4f5, ParentId: => Microsoft.Diagnostics.Monitoring.RestServer.Controllers.DiagController.Trace (Microsoft.Diagnostics.Monitoring.RestServer) => ArtifactType:trace ArtifactSource_ProcessId:16576 ArtifactSource_RuntimeInstanceCookie:b94f8d6a671d414daad3f2a347440b8b
      Request failed.
Microsoft.Diagnostics.Tools.Monitor.Egress.EgressException: Egress provider 'noprovider' does not exist.
   at Microsoft.Diagnostics.Tools.Monitor.Egress.EgressService.EgressAsync(String providerName, Func`3 action, String fileName, String contentType, IEndpointInfo source, CancellationToken token) in D:\src\dotnet\diagnostics\src\Tools\dotnet-monitor\Egress\EgressService.cs:line 44
   at Microsoft.Diagnostics.Monitoring.RestServer.EgressStreamResult.<>c__DisplayClass3_0.<.ctor>b__0(IEgressService service, CancellationToken token) in D:\src\dotnet\diagnostics\src\Microsoft.Diagnostics.Monitoring.RestServer\EgressStreamResult.cs:line 29
   at Microsoft.Diagnostics.Monitoring.RestServer.EgressStreamResult.<>c__DisplayClass4_0.<<ExecuteResultAsync>b__0>d.MoveNext() in D:\src\dotnet\diagnostics\src\Microsoft.Diagnostics.Monitoring.RestServer\EgressStreamResult.cs:line 46
--- End of stack trace from previous location where exception was thrown ---
   at Microsoft.Diagnostics.Monitoring.RestServer.ActionContextExtensions.InvokeAsync(ActionContext context, Func`2 action, ILogger logger) in D:\src\dotnet\diagnostics\src\Microsoft.Diagnostics.Monitoring.RestServer\ActionContextExtensions.cs:line 46
```

In a subsequent change (not part of this PR), I will:
- Update console logger to newer version to allow for different logging format based on environment. For example, may want to use systemd or json logging for the dotnet-monitor docker image.
- Add dedicated logging category for audit logging that is set to the Information level by default.
- Use well-defined EventIds when logging.

closes #1469, #1832, #1833, #1468