### PR TITLE
"ps" command handler fix 

### DIFF
--- a/src/Tools/Common/Commands/ProcessStatus.cs
+++ b/src/Tools/Common/Commands/ProcessStatus.cs
@@ -48,13 +48,12 @@ namespace Microsoft.Internal.Common.Commands
                     {
                         sb.Append($"{process.Id, 10} {process.ProcessName, -10} {process.MainModule.FileName}\n");
                     }
-                    catch (InvalidOperationException)
+                    catch (Exception ex)
                     {
-                        sb.Append($"{process.Id, 10} {process.ProcessName, -10} [Elevated process - cannot determine path]\n");
-                    }
-                    catch (NullReferenceException)
-                    {
-                        sb.Append($"{process.Id, 10} {process.ProcessName, -10} [Elevated process - cannot determine path]\n");
+                        if (ex is InvalidOperationException || ex is System.ComponentModel.Win32Exception || ex is NullReferenceException)
+                        {
+                            sb.Append($"{process.Id, 10} {process.ProcessName, -10} [Elevated process - cannot determine path]\n");
+                        }
                     }
                 }
                 console.Out.WriteLine(sb.ToString());

--- a/src/Tools/Common/Commands/ProcessStatus.cs
+++ b/src/Tools/Common/Commands/ProcessStatus.cs
@@ -7,6 +7,7 @@ using System;
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.CommandLine.IO;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using Process = System.Diagnostics.Process;
@@ -53,6 +54,10 @@ namespace Microsoft.Internal.Common.Commands
                         if (ex is System.ComponentModel.Win32Exception || ex is NullReferenceException)
                         {
                             sb.Append($"{process.Id, 10} {process.ProcessName, -10} [Elevated process - cannot determine path]\n");
+                        }
+                        else
+                        {
+                            Debug.WriteLine($"[PrintProcessStatus] {ex.ToString()}");
                         }
                     }
                 }

--- a/src/Tools/Common/Commands/ProcessStatus.cs
+++ b/src/Tools/Common/Commands/ProcessStatus.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Internal.Common.Commands
                     }
                     catch (Exception ex)
                     {
-                        if (ex is InvalidOperationException || ex is System.ComponentModel.Win32Exception || ex is NullReferenceException)
+                        if (ex is System.ComponentModel.Win32Exception || ex is NullReferenceException)
                         {
                             sb.Append($"{process.Id, 10} {process.ProcessName, -10} [Elevated process - cannot determine path]\n");
                         }


### PR DESCRIPTION
The ps command will fail with a Win32Exception. 

This fixes the ps command handler to look for Win32Exception and NullReferenceException (for Linux/macOS) and make it log if it fails with any other error instead of just crashing.

