### PR TITLE
Update console logger and set content root.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -53,7 +53,7 @@
     <MicrosoftExtensionsDependencyInjectionVersion>2.1.1</MicrosoftExtensionsDependencyInjectionVersion>
     <MicrosoftExtensionsHostingAbstractionsVersion>2.1.1</MicrosoftExtensionsHostingAbstractionsVersion>
     <MicrosoftExtensionsLoggingVersion>2.1.1</MicrosoftExtensionsLoggingVersion>
-    <MicrosoftExtensionsLoggingConsoleVersion>2.1.1</MicrosoftExtensionsLoggingConsoleVersion>
+    <MicrosoftExtensionsLoggingConsoleVersion>5.0.0</MicrosoftExtensionsLoggingConsoleVersion>
     <!-- We use a newer version of LoggingEventSource due to a bug in an older version-->
     <MicrosoftExtensionsLoggingEventSourceVersion>3.1.4</MicrosoftExtensionsLoggingEventSourceVersion>
     <SystemCommandLineVersion>2.0.0-beta1.20468.1</SystemCommandLineVersion>

--- a/src/Microsoft.Diagnostics.Monitoring.RestServer/appsettings.json
+++ b/src/Microsoft.Diagnostics.Monitoring.RestServer/appsettings.json
@@ -6,8 +6,11 @@
       "Microsoft.Hosting.Lifetime": "Information"
     },
     "Console": {
-      "IncludeScopes": true,
-      "TimestampFormat": "HH:mm:ss "
+      "FormatterName": "simple",
+      "FormatterOptions": {
+        "IncludeScopes": true,
+        "TimestampFormat": "HH:mm:ss "
+      }
     },
     "EventLog": {
       "LogLevel": {

--- a/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
+++ b/src/Tools/dotnet-monitor/DiagnosticsMonitorCommandHandler.cs
@@ -61,6 +61,7 @@ namespace Microsoft.Diagnostics.Tools.Monitor
             }
 
             return Host.CreateDefaultBuilder()
+                .UseContentRoot(AppContext.BaseDirectory) // Use the application root instead of the current directory
                 .ConfigureAppConfiguration((IConfigurationBuilder builder) =>
                 {
                     //Note these are in precedence order.

--- a/src/Tools/dotnet-monitor/dotnet-monitor.csproj
+++ b/src/Tools/dotnet-monitor/dotnet-monitor.csproj
@@ -23,7 +23,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" Version="$(AzureStorageBlobsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.KeyPerFile" Version="$(MicrosoftExtensionsConfigurationKeyPerFileVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingConsoleVersion)" />
     <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
   </ItemGroup>
 

--- a/src/Tools/dotnet-monitor/dotnet-monitor.csproj
+++ b/src/Tools/dotnet-monitor/dotnet-monitor.csproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" Version="$(AzureStorageBlobsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.KeyPerFile" Version="$(MicrosoftExtensionsConfigurationKeyPerFileVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
     <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
   </ItemGroup>
 


### PR DESCRIPTION
These changes update the console logger to 5.0.0 which allow for JSON formatted console output. However, I've kept the default to be the simple console logger so that typical ad-hoc usage is still easily human readable. I will add environment variables to the Docker file to switch the tool to use the JSON formatter with UTC timestamps and sortable/parseable timestamp format.

The following is an example of it running in the Docker container with the described environment variables set:
```
{"Timestamp":"2021-01-13T19:23:42.6108693\u002B00:00","EventId":60,"LogLevel":"Warning","Category":"Microsoft.AspNetCore.DataProtection.Repositories.FileSystemXmlRepository","Message":"Storing keys in a directory \u0027/root/.aspnet/DataProtection-Keys\u0027 that may not be persisted outside of the container. Protected data will be unavailable when container is destroyed.","State":{"Message":"Storing keys in a directory \u0027/root/.aspnet/DataProtection-Keys\u0027 that may not be persisted outside of the container. Protected data will be unavailable when container is destroyed.","path":"/root/.aspnet/DataProtection-Keys","{OriginalFormat}":"Storing keys in a directory \u0027{path}\u0027 that may not be persisted outside of the container. Protected data will be unavailable when container is destroyed."},"Scopes":[]}
{"Timestamp":"2021-01-13T19:23:43.7134981\u002B00:00","EventId":35,"LogLevel":"Warning","Category":"Microsoft.AspNetCore.DataProtection.KeyManagement.XmlKeyManager","Message":"No XML encryptor configured. Key {b80b6505-b208-4694-badf-f62399bee04d} may be persisted to storage in unencrypted form.","State":{"Message":"No XML encryptor configured. Key {b80b6505-b208-4694-badf-f62399bee04d} may be persisted to storage in unencrypted form.","KeyId":"b80b6505-b208-4694-badf-f62399bee04d","{OriginalFormat}":"No XML encryptor configured. Key {KeyId:B} may be persisted to storage in unencrypted form."},"Scopes":[]}
{"Timestamp":"2021-01-13T19:23:44.8176476\u002B00:00","EventId":0,"LogLevel":"Warning","Category":"Microsoft.Diagnostics.Tools.Monitor.ExperimentalToolLogger","Message":"WARNING: dotnet-monitor is experimental and is not intended for production environments yet.","State":{"Message":"WARNING: dotnet-monitor is experimental and is not intended for production environments yet.","{OriginalFormat}":"WARNING: dotnet-monitor is experimental and is not intended for production environments yet."},"Scopes":[]}
{"Timestamp":"2021-01-13T19:23:45.9103413\u002B00:00","EventId":0,"LogLevel":"Warning","Category":"Microsoft.AspNetCore.Server.Kestrel","Message":"Unable to bind to http://localhost:52323 on the IPv6 loopback interface: \u0027Address not available\u0027.","State":{"Message":"Unable to bind to http://localhost:52323 on the IPv6 loopback interface: \u0027Address not available\u0027.","address":"http://localhost:52323","interfaceName":"IPv6 loopback","error":"Address not available","{OriginalFormat}":"Unable to bind to {address} on the {interfaceName} interface: \u0027{error}\u0027."},"Scopes":[]}
{"Timestamp":"2021-01-13T19:23:45.9141671\u002B00:00","EventId":0,"LogLevel":"Information","Category":"Microsoft.Hosting.Lifetime","Message":"Now listening on: http://localhost:52323","State":{"Message":"Now listening on: http://localhost:52323","address":"http://localhost:52323","{OriginalFormat}":"Now listening on: {address}"},"Scopes":[]}
{"Timestamp":"2021-01-13T19:23:45.9142050\u002B00:00","EventId":0,"LogLevel":"Information","Category":"Microsoft.Hosting.Lifetime","Message":"Now listening on: http://[::]:52325","State":{"Message":"Now listening on: http://[::]:52325","address":"http://[::]:52325","{OriginalFormat}":"Now listening on: {address}"},"Scopes":[]}
{"Timestamp":"2021-01-13T19:23:45.9143103\u002B00:00","EventId":0,"LogLevel":"Information","Category":"Microsoft.Hosting.Lifetime","Message":"Application started. Press Ctrl\u002BC to shut down.","State":{"Message":"Application started. Press Ctrl\u002BC to shut down.","{OriginalFormat}":"Application started. Press Ctrl\u002BC to shut down."},"Scopes":[]}
{"Timestamp":"2021-01-13T19:23:45.9143407\u002B00:00","EventId":0,"LogLevel":"Information","Category":"Microsoft.Hosting.Lifetime","Message":"Hosting environment: Production","State":{"Message":"Hosting environment: Production","envName":"Production","{OriginalFormat}":"Hosting environment: {envName}"},"Scopes":[]}
{"Timestamp":"2021-01-13T19:23:45.9143642\u002B00:00","EventId":0,"LogLevel":"Information","Category":"Microsoft.Hosting.Lifetime","Message":"Content root path: /app/.store/dotnet-monitor/5.0.0-dev.21063.1/dotnet-monitor/5.0.0-dev.21063.1/tools/netcoreapp3.1/any/","State":{"Message":"Content root path: /app/.store/dotnet-monitor/5.0.0-dev.21063.1/dotnet-monitor/5.0.0-dev.21063.1/tools/netcoreapp3.1/any/","contentRoot":"/app/.store/dotnet-monitor/5.0.0-dev.21063.1/dotnet-monitor/5.0.0-dev.21063.1/tools/netcoreapp3.1/any/","{OriginalFormat}":"Content root path: {contentRoot}"},"Scopes":[]}
```

This change includes an additional fix to set the content root to the root of the application rather than to the current directory. This is needed in order to load the application settings correctly.

closes #1467 