### PR TITLE
Add ProfilerAlreadyActiveException in DiagnosticsClient.AttachProfiler()

### DIFF
--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
@@ -140,6 +140,10 @@ namespace Microsoft.Diagnostics.NETCore.Client
                     {
                       throw new UnsupportedCommandException("The target runtime does not support profiler attach");
                     }
+                    if (hr == (uint)DiagnosticsIpcError.ProfilerAlreadyActive)
+                    {
+                        throw new ProfilerAlreadyActiveException("The request to attach a profiler was denied because a profiler is already loaded");
+                    }
                     throw new ServerErrorException($"Profiler attach failed (HRESULT: 0x{hr:X8})");
                 case DiagnosticsServerResponseId.OK:
                     return;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClientExceptions.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClientExceptions.cs
@@ -34,4 +34,10 @@ namespace Microsoft.Diagnostics.NETCore.Client
     {
         public UnsupportedCommandException(string msg): base(msg) {}
     }
+
+    // When the runtime already has loaded profiler
+    public class ProfilerAlreadyActiveException : ServerErrorException
+    {
+        public ProfilerAlreadyActiveException(string msg): base(msg) {}
+    }
 }

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcMessage.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcMessage.cs
@@ -15,10 +15,11 @@ namespace Microsoft.Diagnostics.NETCore.Client
     /// </summary>
     internal enum DiagnosticsIpcError : uint
     {
-        BadEncoding     = 0x80131384,
-        UnknownCommand  = 0x80131385,
-        UnknownMagic    = 0x80131386,
-        UnknownError    = 0x80131387
+        ProfilerAlreadyActive = 0x8013136A,
+        BadEncoding           = 0x80131384,
+        UnknownCommand        = 0x80131385,
+        UnknownMagic          = 0x80131386,
+        UnknownError          = 0x80131387
     }
 
     /// <summary>


### PR DESCRIPTION
Added the clear message without hex error code.