### PR TITLE
Fix dotnet-counters and dotnet-trace CLI arg validator

### DIFF
--- a/src/Tools/Common/Commands/Utils.cs
+++ b/src/Tools/Common/Commands/Utils.cs
@@ -53,7 +53,12 @@ namespace Microsoft.Internal.Common.Utils
         public static bool ValidateArguments(int processId, string name, string port, out int resolvedProcessId)
         {
             resolvedProcessId = -1;
-            if (processId != 0 && name != null && !string.IsNullOrEmpty(port))
+            if (processId == 0 && name == null)
+            {
+                Console.WriteLine("Must specify either --process-id, --name, or --diagnostic-port.");
+                return false;
+            }
+            else if (processId != 0 && name != null && !string.IsNullOrEmpty(port))
             {
                 Console.WriteLine("Only one of the --name, --process-id, or --diagnostic-port options may be specified.");
                 return false;

--- a/src/Tools/Common/Commands/Utils.cs
+++ b/src/Tools/Common/Commands/Utils.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Internal.Common.Utils
         public static bool ValidateArguments(int processId, string name, string port, out int resolvedProcessId)
         {
             resolvedProcessId = -1;
-            if (processId == 0 && name == null)
+            if (processId == 0 && name == null && string.IsNullOrEmpty(port))
             {
                 Console.WriteLine("Must specify either --process-id, --name, or --diagnostic-port.");
                 return false;

--- a/src/Tools/Common/Commands/Utils.cs
+++ b/src/Tools/Common/Commands/Utils.cs
@@ -58,6 +58,11 @@ namespace Microsoft.Internal.Common.Utils
                 Console.WriteLine("Must specify either --process-id, --name, or --diagnostic-port.");
                 return false;
             }
+            else if (processId < 0)
+            {
+                Console.WriteLine($"{processId} is not a valid process ID");
+                return false;
+            }
             else if (processId != 0 && name != null && !string.IsNullOrEmpty(port))
             {
                 Console.WriteLine("Only one of the --name, --process-id, or --diagnostic-port options may be specified.");


### PR DESCRIPTION
Fix #1988. 

I'm also going to follow-up with a PR that adds tests that launch the tool and check putting in invalid arguments exits with correct error messages.