### PR TITLE
Cleanup metadata mapping memory service

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -8,11 +8,11 @@
       <Uri>https://github.com/dotnet/symstore</Uri>
       <Sha>3ed87724fe4e98c7ecc77617720591783ee2e676</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Diagnostics.Runtime" Version="2.0.156101">
+    <Dependency Name="Microsoft.Diagnostics.Runtime" Version="2.0.216202">
       <Uri>https://github.com/Microsoft/clrmd</Uri>
       <Sha>8b1eadaa0dd50fdd05419764f5606914da56ac9e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Diagnostics.Runtime.Utilities" Version="2.0.156101">
+    <Dependency Name="Microsoft.Diagnostics.Runtime.Utilities" Version="2.0.216202">
       <Uri>https://github.com/Microsoft/clrmd</Uri>
       <Sha>8b1eadaa0dd50fdd05419764f5606914da56ac9e</Sha>
     </Dependency>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <RepositoryUrl>https://github.com/dotnet/diagnostics</RepositoryUrl>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
-    <VersionPrefix>5.0.0</VersionPrefix>
+    <VersionPrefix>6.0.0</VersionPrefix>
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>
     <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
   </PropertyGroup>
@@ -36,8 +36,8 @@
     <MicrosoftWin32PrimitivesVersion>4.3.0</MicrosoftWin32PrimitivesVersion>
     <!-- Other libs -->
     <MicrosoftBclAsyncInterfacesVersion>1.1.0</MicrosoftBclAsyncInterfacesVersion>
-    <MicrosoftDiagnosticsRuntimeVersion>2.0.161401</MicrosoftDiagnosticsRuntimeVersion>
-    <MicrosoftDiagnosticsRuntimeUtilitiesVersion>2.0.156101</MicrosoftDiagnosticsRuntimeUtilitiesVersion>
+    <MicrosoftDiagnosticsRuntimeVersion>2.0.216202</MicrosoftDiagnosticsRuntimeVersion>
+    <MicrosoftDiagnosticsRuntimeUtilitiesVersion>2.0.216202</MicrosoftDiagnosticsRuntimeUtilitiesVersion>
     <ParallelStacksRuntimeVersion>2.0.1</ParallelStacksRuntimeVersion>
     <MicrosoftDiaSymReaderNativePackageVersion>1.7.0</MicrosoftDiaSymReaderNativePackageVersion>
     <MicrosoftDiagnosticsTracingTraceEventVersion>2.0.64</MicrosoftDiagnosticsTracingTraceEventVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <RepositoryUrl>https://github.com/dotnet/diagnostics</RepositoryUrl>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
-    <VersionPrefix>6.0.0</VersionPrefix>
+    <VersionPrefix>5.0.0</VersionPrefix>
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>
     <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
   </PropertyGroup>

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/BinaryLocator.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/BinaryLocator.cs
@@ -39,12 +39,12 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
                 }
                 else
                 {
-                    Trace.TraceInformation($"DownloadFile: {fileName}: key not generated");
+                    Trace.TraceInformation($"FindBinary: {fileName}: key not generated");
                 }
             }
             else
             {
-                Trace.TraceInformation($"DownLoadFile: {fileName}: symbol store not enabled");
+                Trace.TraceInformation($"FindBinary: {fileName}: symbol store not enabled");
             }
 
             return null;

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/ImageMappingMemoryService.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/ImageMappingMemoryService.cs
@@ -2,34 +2,44 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.FileFormats;
+using Microsoft.FileFormats.ELF;
+using Microsoft.FileFormats.MachO;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.Diagnostics.DebugServices.Implementation
 {
     /// <summary>
     /// Memory service wrapper that maps and fixes up PE module on read memory errors.
     /// </summary>
-    internal class PEImageMappingMemoryService : IMemoryService
+    internal class ImageMappingMemoryService : IMemoryService
     {
         private readonly IMemoryService _memoryService;
         private readonly IModuleService _moduleService;
         private readonly MemoryCache _memoryCache;
+        private readonly HashSet<ulong> _recursionProtection;
 
         /// <summary>
-        /// Memory service constructor
+        /// The PE and ELF image mapping memory service. This service assumes that the managed PE 
+        /// assemblies are in the module service's list. This is true for dbgeng, dotnet-dump but not
+        /// true for lldb (only native modules are provided).
         /// </summary>
-        /// <param name="target"></param>
+        /// <param name="target">target instance</param>
         /// <param name="memoryService">memory service to wrap</param>
-        internal PEImageMappingMemoryService(ITarget target, IMemoryService memoryService)
+        internal ImageMappingMemoryService(ITarget target, IMemoryService memoryService)
         {
             _memoryService = memoryService;
             _moduleService = target.Services.GetService<IModuleService>();
             _memoryCache = new MemoryCache(ReadMemoryFromModule);
+            _recursionProtection = new HashSet<ulong>();
             target.OnFlushEvent.Register(_memoryCache.FlushCache);
+            target.DisposeOnClose(target.Services.GetService<ISymbolService>()?.OnChangeEvent.Register(_memoryCache.FlushCache));
         }
 
         #region IMemoryService
@@ -92,41 +102,102 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
             if (module != null)
             {
                 Trace.TraceInformation("ReadMemory: address {0:X16} size {1:X8} found module {2}", address, bytesRequested, module.FileName);
-
-                // We found a module that contains the memory requested. Now find or download the PE image.
-                PEReader reader = module.Services.GetService<PEReader>();
-                if (reader != null)
+                if (!_recursionProtection.Contains(module.ImageBase))
                 {
-                    // Read the memory from the PE image.
-                    int rva = (int)(address - module.ImageBase);
-                    Debug.Assert(rva >= 0);
+                    _recursionProtection.Add(module.ImageBase);
                     try
                     {
-                        byte[] data = null;
-
-                        int sizeOfHeaders = reader.PEHeaders.PEHeader.SizeOfHeaders;
-                        if (rva < sizeOfHeaders)
+                        // We found a module that contains the memory requested. Now find or download the PE image.
+                        PEReader reader = module.Services.GetService<PEReader>();
+                        if (reader != null)
                         {
-                            // If the address isn't contained in one of the sections, assume that SOS is reading the PE headers directly.
-                            Trace.TraceInformation("ReadMemory: rva {0:X8} size {1:X8} in PE Header", rva, bytesRequested);
-                            data = reader.GetEntireImage().GetReader(rva, bytesRequested).ReadBytes(bytesRequested);
-                        }
-                        else
-                        {
-                            PEMemoryBlock block = reader.GetSectionData(rva);
-                            if (block.Length > 0)
+                            // Read the memory from the PE image.
+                            int rva = (int)(address - module.ImageBase);
+                            Debug.Assert(rva >= 0);
+                            try
                             {
-                                int size = Math.Min(block.Length, bytesRequested);
-                                data = block.GetReader().ReadBytes(size);
-                                ApplyRelocations(module, reader, rva, data);
+                                byte[] data = null;
+
+                                int sizeOfHeaders = reader.PEHeaders.PEHeader.SizeOfHeaders;
+                                if (rva < sizeOfHeaders)
+                                {
+                                    // If the address isn't contained in one of the sections, assume that SOS is reading the PE headers directly.
+                                    Trace.TraceInformation("ReadMemory: rva {0:X8} size {1:X8} in PE Header", rva, bytesRequested);
+                                    data = reader.GetEntireImage().GetReader(rva, bytesRequested).ReadBytes(bytesRequested);
+                                }
+                                else
+                                {
+                                    PEMemoryBlock block = reader.GetSectionData(rva);
+                                    if (block.Length > 0)
+                                    {
+                                        int size = Math.Min(block.Length, bytesRequested);
+                                        data = block.GetReader().ReadBytes(size);
+                                        ApplyRelocations(module, reader, rva, data);
+                                    }
+                                }
+
+                                return data;
+                            }
+                            catch (Exception ex) when (ex is BadImageFormatException || ex is InvalidOperationException || ex is IOException)
+                            {
+                                Trace.TraceError($"ReadMemory: exception {ex.Message}");
+                                return null;
                             }
                         }
 
-                        return data;
+                        // Now find or download the ELF image, if one.
+                        ELFFile elfFile = module.Services.GetService<ELFFile>();
+                        if (elfFile != null)
+                        {
+                            // Read the memory from the ELF image.
+                            ulong rva = address - module.ImageBase;
+                            Debug.Assert(rva >= 0);
+                            try
+                            {
+                                Trace.TraceInformation("ReadMemory: rva {0:X16} size {1:X8} in ELF file", rva, bytesRequested);
+                                byte[] data = new byte[bytesRequested];
+                                uint read = elfFile.VirtualAddressReader.Read(rva, data, 0, (uint)bytesRequested);
+                                if (read == 0)
+                                {
+                                    data = null;
+                                }
+                                return data;
+                            }
+                            catch (Exception ex) when (ex is BadInputFormatException || ex is InvalidVirtualAddressException)
+                            {
+                                Trace.TraceError($"ReadMemory: exception {ex.Message}");
+                                return null;
+                            }
+                        }
+
+                        // Now find or download the MachO image, if one.
+                        MachOFile machoFile = module.Services.GetService<MachOFile>();
+                        if (machoFile != null)
+                        {
+                            // Read the memory from the MachO image.
+                            ulong rva = address - module.ImageBase;
+                            Debug.Assert(rva >= 0);
+                            try
+                            {
+                                Trace.TraceInformation("ReadMemory: rva {0:X16} size {1:X8} in MachO file", rva, bytesRequested);
+                                byte[] data = new byte[bytesRequested];
+                                uint read = machoFile.VirtualAddressReader.Read(rva, data, 0, (uint)bytesRequested);
+                                if (read == 0)
+                                {
+                                    data = null;
+                                }
+                                return data;
+                            }
+                            catch (Exception ex) when (ex is BadInputFormatException || ex is InvalidVirtualAddressException)
+                            {
+                                Trace.TraceError($"ReadMemory: exception {ex.Message}");
+                                return null;
+                            }
+                        }
                     }
-                    catch (Exception ex) when (ex is BadImageFormatException || ex is InvalidOperationException || ex is IOException)
+                    finally
                     {
-                        Trace.TraceError($"ReadMemory: exception {ex.Message}");
+                        _recursionProtection.Remove(module.ImageBase);
                     }
                 }
             }

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/MemoryCache.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/MemoryCache.cs
@@ -28,6 +28,11 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
             private readonly byte[] _data;
 
             /// <summary>
+            /// Length of cluster data
+            /// </summary>
+            internal int Length => _data.Length;
+
+            /// <summary>
             /// Creates a cluster for some data.
             /// If the buffer is shorter than a page, it build a validity bitmap for it.
             /// </summary>
@@ -163,18 +168,12 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
                 // There are 3 things that can happen here:
                 // 1) Normal full size cluster read (== Cluster.Size). The full block memory is cached.
                 // 2) Partial cluster read (< Cluster.Size). The partial memory block is cached and the memory after it is invalid.
-                // 3) Data == null. Read failure. Failure is not cached.
+                // 3) Data == null. Read failure. Failure is cached.
                 byte[] data = _readMemory(baseAddress, Cluster.Size);
-                if (data == null)
-                {
-                    cluster = Cluster.Empty;
-                }
-                else
-                { 
-                    cluster = new Cluster(data);
-                    CacheSize += data.Length;
-                    _map[baseAddress] = cluster;
-                }
+
+                cluster = data == null ? Cluster.Empty : new Cluster(data);
+                CacheSize += cluster.Length;
+                _map[baseAddress] = cluster;
             }
 
             return cluster;

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/ModuleServiceFromDataReader.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/ModuleServiceFromDataReader.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
             private string _versionString;
 
             public ModuleFromDataReader(ModuleServiceFromDataReader moduleService, int moduleIndex, ModuleInfo moduleInfo, ulong imageSize)
+                : base(moduleService.Target)
             {
                 _moduleService = moduleService;
                 _moduleInfo = moduleInfo;

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/Runtime.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/Runtime.cs
@@ -216,7 +216,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
                     }
                     else
                     {
-                        Trace.TraceError($"DownloadFile: {fileName}: key not generated - no build id");
+                        Trace.TraceError($"DownloadFile: {fileName}: key not generated - no index timestamp/filesize");
                     }
                 }
                 else
@@ -236,7 +236,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
                         }
                         else
                         {
-                            Trace.TraceError($"DownloadFile: {fileName}: platform not support - {platform}");
+                            Trace.TraceError($"DownloadFile: {fileName}: platform not supported - {platform}");
                         }
 
                         key = keys?.SingleOrDefault((k) => Path.GetFileName(k.FullPathName) == fileName);

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/RuntimeService.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/RuntimeService.cs
@@ -285,41 +285,11 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
             return _runtimes;
         }
 
-        private IModuleService ModuleService
-        {
-            get
-            {
-                if (_moduleService == null)
-                {
-                    _moduleService = _target.Services.GetService<IModuleService>();
-                }
-                return _moduleService;
-            }
-        }
+        private IModuleService ModuleService => _moduleService ??= _target.Services.GetService<IModuleService>();
 
-        private IMemoryService MemoryService
-        {
-            get
-            {
-                if (_memoryService == null)
-                {
-                    _memoryService = _currentRuntime?.Services.GetService<IMemoryService>() ?? _target.Services.GetService<IMemoryService>();
-                }
-                return _memoryService;
-            }
-        }
+        private IMemoryService MemoryService => _memoryService ??= _target.Services.GetService<IMemoryService>();
 
-        private IThreadService ThreadService
-        {
-            get
-            {
-                if (_threadService == null)
-                {
-                    _threadService = _target.Services.GetService<IThreadService>();
-                }
-                return _threadService;
-            }
-        }
+        private IThreadService ThreadService => _threadService ??= _target.Services.GetService<IThreadService>();
 
         public override string ToString()
         {

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/Target.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/Target.cs
@@ -112,10 +112,13 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
         /// <summary>
         /// Registers an object to be disposed when ITarget.Close() is called.
         /// </summary>
-        /// <param name="disposable">object to be disposed on Close()</param>
+        /// <param name="disposable">object to be disposed on Close() or null</param>
         public void DisposeOnClose(IDisposable disposable)
         {
-            _disposables.Add(disposable);
+            if (disposable != null)
+            {
+                _disposables.Add(disposable);
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/TargetFromDataReader.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/TargetFromDataReader.cs
@@ -3,11 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Runtime;
-using Microsoft.Diagnostics.Runtime.DataReaders.Implementation;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
 using System.Runtime.InteropServices;
 using Architecture = System.Runtime.InteropServices.Architecture;
 
@@ -54,8 +50,9 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
             ServiceProvider.AddServiceFactory<IModuleService>(() => new ModuleServiceFromDataReader(this, _dataReader));
             ServiceProvider.AddServiceFactory<IMemoryService>(() => {
                 IMemoryService memoryService = new MemoryServiceFromDataReader(_dataReader);
-                if (Host.HostType == HostType.DotnetDump && OperatingSystem == OSPlatform.Windows) {
-                    memoryService = new PEImageMappingMemoryService(this, memoryService);
+                if (IsDump && Host.HostType == HostType.DotnetDump)
+                {
+                    memoryService = new ImageMappingMemoryService(this, memoryService);
                 }
                 return memoryService;
             });

--- a/src/Microsoft.Diagnostics.DebugServices/ITarget.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/ITarget.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Diagnostics.DebugServices
         /// <summary>
         /// Registers an object to be disposed when ITarget.Close() is called.
         /// </summary>
-        /// <param name="disposable">object to be disposed on Close()</param>
+        /// <param name="disposable">object to be disposed on Close() or null</param>
         void DisposeOnClose(IDisposable disposable);
 
         /// <summary>

--- a/src/Microsoft.Diagnostics.DebugServices/MemoryServiceExtensions.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/MemoryServiceExtensions.cs
@@ -105,41 +105,6 @@ namespace Microsoft.Diagnostics.DebugServices
         }
 
         /// <summary>
-        /// Creates a key generator for the runtime module pointed to by the address/size.
-        /// </summary>
-        /// <param name="memoryService">memory service instance</param>
-        /// <param name="config">Target configuration: Windows, Linux or OSX</param>
-        /// <param name="moduleFilePath">module path</param>
-        /// <param name="address">module base address</param>
-        /// <param name="size">module size</param>
-        /// <returns>KeyGenerator or null if error</returns>
-        public static KeyGenerator GetKeyGenerator(this IMemoryService memoryService, OSPlatform config, string moduleFilePath, ulong address, ulong size)
-        {
-            Stream stream = memoryService.CreateMemoryStream(address, size);
-            KeyGenerator generator = null;
-            if (config == OSPlatform.Linux)
-            {
-                var elfFile = new ELFFile(new StreamAddressSpace(stream), 0, true);
-                generator = new ELFFileKeyGenerator(Tracer.Instance, elfFile, moduleFilePath);
-            }
-            else if (config == OSPlatform.OSX)
-            {
-                var machOFile = new MachOFile(new StreamAddressSpace(stream), 0, true);
-                generator = new MachOFileKeyGenerator(Tracer.Instance, machOFile, moduleFilePath);
-            }
-            else if (config == OSPlatform.Windows)
-            {
-                var peFile = new PEFile(new StreamAddressSpace(stream), true);
-                generator = new PEFileKeyGenerator(Tracer.Instance, peFile, moduleFilePath);
-            }
-            else
-            {
-                Trace.TraceError("GetKeyGenerator: unsupported platform {0}", config);
-            }
-            return generator;
-        }
-
-        /// <summary>
         /// Create a stream for the address range.
         /// </summary>
         /// <param name="memoryService">memory service instance</param>

--- a/src/SOS/SOS.Extensions/ModuleServiceFromDebuggerServices.cs
+++ b/src/SOS/SOS.Extensions/ModuleServiceFromDebuggerServices.cs
@@ -35,7 +35,8 @@ namespace SOS.Extensions
                 ulong imageBase,
                 ulong imageSize,
                 uint indexFileSize,
-                uint indexTimeStamp)
+                uint indexTimeStamp) 
+                    : base(moduleService.Target)
             {
                 _moduleService = moduleService;
                 ModuleIndex = moduleIndex;

--- a/src/SOS/SOS.Extensions/TargetFromFromDebuggerServices.cs
+++ b/src/SOS/SOS.Extensions/TargetFromFromDebuggerServices.cs
@@ -21,7 +21,7 @@ namespace SOS.Extensions
         /// <summary>
         /// Create a target instance from IDataReader
         /// </summary>
-        internal TargetFromDebuggerServices(DebuggerServices debuggerServices, IHost host) 
+        internal TargetFromDebuggerServices(DebuggerServices debuggerServices, IHost host)
             : base(host, dumpPath: null)
         {
             Debug.Assert(debuggerServices != null);
@@ -74,7 +74,19 @@ namespace SOS.Extensions
             // Add the thread, memory, and module services
             ServiceProvider.AddServiceFactory<IModuleService>(() => new ModuleServiceFromDebuggerServices(this, debuggerServices));
             ServiceProvider.AddServiceFactory<IThreadService>(() => new ThreadServiceFromDebuggerServices(this, debuggerServices));
-            ServiceProvider.AddServiceFactory<IMemoryService>(() => new MemoryServiceFromDebuggerServices(this, debuggerServices));
+            ServiceProvider.AddServiceFactory<IMemoryService>(() => {
+                IMemoryService memoryService = new MemoryServiceFromDebuggerServices(this, debuggerServices);
+                Debug.Assert(Host.HostType != HostType.DotnetDump);
+                if (IsDump && Host.HostType == HostType.Lldb)
+                {
+                    // This is a special memory service that maps the managed assemblies' metadata into the address 
+                    // space. The lldb debugger returns zero's (instead of failing the memory read) for missing pages
+                    // in core dumps that older (< 5.0) createdumps generate so it needs this special metadata mapping 
+                    // memory service. dotnet-dump needs this logic for clrstack -i (uses ICorDebug data targets).
+                    memoryService = new MetadataMappingMemoryService(this, memoryService);
+                }
+                return memoryService;
+            });
         }
     }
 }

--- a/src/SOS/SOS.Hosting/CorDebugDataTargetWrapper.cs
+++ b/src/SOS/SOS.Hosting/CorDebugDataTargetWrapper.cs
@@ -31,7 +31,7 @@ namespace SOS.Hosting
             Debug.Assert(target != null);
             Debug.Assert(runtime != null);
             _target = target;
-            _memoryService = runtime.Services.GetService<IMemoryService>() ?? target.Services.GetService<IMemoryService>();
+            _memoryService = target.Services.GetService<IMemoryService>();
             _threadService = target.Services.GetService<IThreadService>();
             _threadUnwindService = target.Services.GetService<IThreadUnwindService>();
             _symbolServiceWrapper = new SymbolServiceWrapper(target.Host);

--- a/src/SOS/SOS.Hosting/DataTargetWrapper.cs
+++ b/src/SOS/SOS.Hosting/DataTargetWrapper.cs
@@ -41,7 +41,7 @@ namespace SOS.Hosting
             Debug.Assert(runtime != null);
             _target = target;
             _runtimeBaseAddress = runtime.RuntimeModule.ImageBase;
-            _memoryService = runtime.Services.GetService<IMemoryService>() ?? target.Services.GetService<IMemoryService>();
+            _memoryService = target.Services.GetService<IMemoryService>();
             _threadService = target.Services.GetService<IThreadService>();
             _threadUnwindService = target.Services.GetService<IThreadUnwindService>();
             _moduleService = target.Services.GetService<IModuleService>();

--- a/src/Tools/dotnet-dump/Analyzer.cs
+++ b/src/Tools/dotnet-dump/Analyzer.cs
@@ -15,6 +15,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.Diagnostics.Tools.Dump
 {
@@ -54,7 +55,7 @@ namespace Microsoft.Diagnostics.Tools.Dump
                 using DataTarget dataTarget = DataTarget.LoadDump(dump_path.FullName);
 
                 OSPlatform targetPlatform = dataTarget.DataReader.TargetPlatform;
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) || dataTarget.DataReader.EnumerateModules().Any((module) => Path.GetExtension(module.FileName) == ".dylib")) {
                     targetPlatform = OSPlatform.OSX;
                 }
                 _target = new TargetFromDataReader(dataTarget.DataReader, targetPlatform, this, dump_path.FullName);


### PR DESCRIPTION
Add ELF file module memory mapping

Rename PEImageMappingMemoryService to ImageMappingMemoryService .

Cache failures in MemoryCache used by image memory mapping service

Handled recursion in image mapping

Add MachO mapping support

Cleanup key generation in symbol service wrapper. Removed extension function.

Fixes issue: https://github.com/dotnet/diagnostics/issues/2043