### PR TITLE
UseAppFilter for Logs pipeline

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/EventLogsPipeline.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/EventLogsPipeline.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
 
         protected override MonitoringSourceConfiguration CreateConfiguration()
         {
-            return new LoggingSourceConfiguration(Settings.LogLevel);
+            return new LoggingSourceConfiguration(Settings.LogLevel, Settings.UseAppFilters);
         }
 
         protected override Task OnEventSourceAvailable(EventPipeEventSource eventSource, Func<Task> stopSessionAsync, CancellationToken token)

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/EventLogsPipelineSettings.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/EventLogsPipelineSettings.cs
@@ -12,5 +12,8 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
     internal class EventLogsPipelineSettings : EventSourcePipelineSettings
     {
         public LogLevel LogLevel { get; set; }
+
+        //This setting will set the levels to application default.
+        public bool UseAppFilters { get; set; }
     }
 }


### PR DESCRIPTION
Enable the UseAppFilter setting for dotnet-monitor. Necessary to fix https://github.com/dotnet/dotnet-monitor/issues/15