### PR TITLE
Dispose transport on cancellation to prevent creation of new server stream/socket on shutdown of ReversedDiagnosticsServer.

### DIFF
--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcServerTransport.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcServerTransport.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
 {
     internal abstract class IpcServerTransport : IDisposable
     {
+        private IIpcServerTransportCallbackInternal _callback;
         private bool _disposed;
 
         public static IpcServerTransport Create(string transportPath, int maxConnections)
@@ -65,6 +66,16 @@ namespace Microsoft.Diagnostics.NETCore.Client
             {
                 throw new ObjectDisposedException(this.GetType().Name);
             }
+        }
+
+        internal void SetCallback(IIpcServerTransportCallbackInternal callback)
+        {
+            _callback = callback;
+        }
+
+        protected void OnCreateNewServer()
+        {
+            _callback?.CreatedNewServer();
         }
     }
 
@@ -128,6 +139,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
                 _maxInstances,
                 PipeTransmissionMode.Byte,
                 PipeOptions.Asynchronous);
+            OnCreateNewServer();
         }
     }
 
@@ -196,6 +208,12 @@ namespace Microsoft.Diagnostics.NETCore.Client
             _socket.Bind(_path);
             _socket.Listen(_backlog);
             _socket.LingerState.Enabled = false;
+            OnCreateNewServer();
         }
+    }
+
+    internal interface IIpcServerTransportCallbackInternal
+    {
+        void CreatedNewServer();
     }
 }

--- a/src/Microsoft.Diagnostics.NETCore.Client/ReversedServer/ReversedDiagnosticsServer.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/ReversedServer/ReversedDiagnosticsServer.cs
@@ -173,6 +173,8 @@ namespace Microsoft.Diagnostics.NETCore.Client
         {
             // This disposal shuts down the transport in case an exception is thrown.
             using var transport = IpcServerTransport.Create(_transportPath, maxConnections);
+            // Set transport callback for testing purposes.
+            transport.SetCallback(TransportCallback);
             // This disposal shuts down the transport in case of cancellation; causes the transport
             // to not recreate the server stream before the AcceptAsync call observes the cancellation.
             using var _ = token.Register(() => transport.Dispose());
@@ -345,5 +347,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
         private bool IsStarted => null != _listenTask;
 
         public static int MaxAllowedConnections = IpcServerTransport.MaxAllowedConnections;
+
+        internal IIpcServerTransportCallbackInternal TransportCallback { get; set; }
     }
 }

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/ReversedServerTests.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/ReversedServerTests.cs
@@ -297,12 +297,9 @@ namespace Microsoft.Diagnostics.NETCore.Client
 
                 ResumeRuntime(info);
 
-                _outputHelper.WriteLine("Version Before VerifyWaitForConnection: {0}", await transportCallback.GetStableTransportVersion());
-
                 await VerifyWaitForConnection(info, useAsync: true);
 
                 transportVersion = await transportCallback.GetStableTransportVersion();
-                _outputHelper.WriteLine("Version After VerifyWaitForConnection: {0}", transportVersion);
 
                 // Server will be disposed
             }


### PR DESCRIPTION
@lateralusX observed an issue in the ReversedDiagnosticsServer where it will cause the underlying IpcServerTransport to recreate its stream/socket when the server is shutting down. The problem is caused by the token that is passed into ReversedDiagnosticsServer.ListenAsync is passed directly to IpcServerTransport.AcceptAsync; in both of the current implementations of IpcServerTransport.AcceptAsync, it will recreate the underlying stream/socket when the method call is cancelled. Since the IpcServerTransport is not disposed until after the call to AcceptAsync is cancelled, the IpcServerTransport implementation will create a new stream/socket and receive clients even though its about to be disposed. This leads to clients unnecessarily connecting to the server when it is shutting down.

The proposed fix is to dispose the IpcServerTransport implementation before the AcceptAsync call observes the cancellation. This allows the IpcServerTransport to call `_cancellation.Cancel()` internally, which causes AcceptAsync to cancel and NOT recreate the underlying stream/socket.

Alternative fix could be to add more state of IpcServerTransport to effectively say 'do not recreate stream/socket' which could then be exposed by a method (e.g. StopAcceptingClients). This would effectively cause the transport to become dormant. In my mind, this is the same as just disposing the IpcServerTransport since it would not be usable after setting this state, so I think just disposing it should be sufficient, especially given disposal will cancel all pending calls to AcceptAsync.

cc @lateralusX 