### PR TITLE
Change default trace name to app name + timestamp

### DIFF
--- a/documentation/dotnet-trace-instructions.md
+++ b/documentation/dotnet-trace-instructions.md
@@ -30,7 +30,7 @@ You may also use the command `dotnet-trace ps` command to find out what .NET Cor
 - Then, run the following command:
 
 ```cmd
-dotnet-trace collect --process-id <PID> --providers Microsoft-Windows-DotNETRuntime
+dotnet-trace collect --process-id <PID> --providers Microsoft-Windows-DotNETRuntime --output trace.nettrace
 
 Press <Enter> to exit...
 Connecting to process: <Full-Path-To-Process-Being-Profiled>/dotnet.exe
@@ -64,7 +64,7 @@ Sometimes it may be useful to collect a trace of a process from its startup. For
 This will launch `hello.exe` with `arg1` and `arg2` as its command line arguments and collect a trace from its runtime startup:
 
 ```console
-dotnet-trace collect -- hello.exe arg1 arg2
+dotnet-trace collect --output trace.nettrace -- hello.exe arg1 arg2
 ```
 
 The preceding command generates output similar to the following:
@@ -209,7 +209,7 @@ Options:
     The name of the process to collect the trace from.
 
   -o, --output <trace-file-path>
-    The output path for the collected trace data. If not specified it defaults to 'trace.nettrace'
+    The output path for the collected trace data. If not specified it defaults to '<appname>_<yyyyMMdd>_<HHmmss>.nettrace', e.g., 'myapp_20210315_111514.nettrace'.
 
   --profile
       A named pre-defined set of provider configurations that allows common tracing scenarios to be specified

--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
@@ -192,9 +192,11 @@ namespace Microsoft.Diagnostics.Tools.Trace
                         }
                     }
 
-                    if (output.Name.Equals(DefaultTraceName))
+                    if (String.Equals(output.Name, DefaultTraceName, StringComparison.OrdinalIgnoreCase))
                     {
-                        output = new FileInfo($"{processMainModuleFileName}_{DateTime.Now:yyyyMMddHHmmss}.nettrace");
+                        DateTime now = DateTime.Now;
+                        var processMainModuleFileInfo = new FileInfo(processMainModuleFileName);
+                        output = new FileInfo($"{processMainModuleFileInfo.Name}_{now:yyyyMMdd}_{now:HHmmss}.nettrace");
                     }
 
                     var shouldStopAfterDuration = duration != default(TimeSpan);
@@ -415,7 +417,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
         private static Option OutputPathOption() =>
             new Option(
                 aliases: new[] { "-o", "--output" },
-                description: $"The output path for the collected trace data. If not specified it defaults to '{DefaultTraceName}'.")
+                description: $"The output path for the collected trace data. If not specified it defaults to '<appname>_<yyyyMMdd>_<HHmmss>.nettrace', e.g., 'myapp_20210315_111514.nettrace'.")
             {
                 Argument = new Argument<FileInfo>(name: "trace-file-path", getDefaultValue: () => new FileInfo(DefaultTraceName))
             };

--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
@@ -192,6 +192,11 @@ namespace Microsoft.Diagnostics.Tools.Trace
                         }
                     }
 
+                    if (output.Name.Equals(DefaultTraceName))
+                    {
+                        output = new FileInfo($"{processMainModuleFileName}_{DateTime.Now:yyyyMMddHHmmss}.nettrace");
+                    }
+
                     var shouldStopAfterDuration = duration != default(TimeSpan);
                     var rundownRequested = false;
                     System.Timers.Timer durationTimer = null;
@@ -405,7 +410,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 Argument = new Argument<uint>(name: "size", getDefaultValue: DefaultCircularBufferSizeInMB)
             };
 
-        public static string DefaultTraceName => "trace.nettrace";
+        public static string DefaultTraceName => "default";
 
         private static Option OutputPathOption() =>
             new Option(


### PR DESCRIPTION
fixes #560 

Example filename after patch: `dotnet_20210317_173254.nettrace`

This could be considered a breaking change for users with existing scripts/workflows that expect the old `trace.nettrace` filename by default.