### PR TITLE
Update symstore to fix forward slash escape download bug

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -8,9 +8,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>72b28b7e023d4c3fffa0a0b9748a7d4e8cc799be</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.SymbolStore" Version="1.0.156601">
+    <Dependency Name="Microsoft.SymbolStore" Version="1.0.215101">
       <Uri>https://github.com/dotnet/symstore</Uri>
-      <Sha>74f738706c921aa1e3ea79ea5c69369e8f2f827b</Sha>
+      <Sha>3ed87724fe4e98c7ecc77617720591783ee2e676</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Diagnostics.Runtime" Version="2.0.156101">
       <Uri>https://github.com/Microsoft/clrmd</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Latest symstore version updated by darc -->
-    <MicrosoftSymbolStoreVersion>1.0.156601</MicrosoftSymbolStoreVersion>
+    <MicrosoftSymbolStoreVersion>1.0.215101</MicrosoftSymbolStoreVersion>
     <!-- Runtime versions to test -->
     <MicrosoftNETCoreApp21Version>2.1.23</MicrosoftNETCoreApp21Version>
     <MicrosoftAspNetCoreApp21Version>$(MicrosoftNETCoreApp21Version)</MicrosoftAspNetCoreApp21Version>


### PR DESCRIPTION
Update to version 1.0.215101 symstore that has the fix/workaround for the slash (/) fix in the downloader.