### PR TITLE
Fixed MacOS generated coredumps process 0 bug

### DIFF
--- a/src/SOS/SOS.Extensions/HostServices.cs
+++ b/src/SOS/SOS.Extensions/HostServices.cs
@@ -235,21 +235,14 @@ namespace SOS.Extensions
             uint processId)
         {
             Trace.TraceInformation($"HostServices.UpdateTarget {processId}");
-            if (processId == 0)
+            if (_target == null)
+            {
+                return CreateTarget(self);
+            }
+            else if (_target.ProcessId.GetValueOrDefault() != processId)
             {
                 DestroyTarget(self);
-            }
-            else
-            {
-                if (_target == null)
-                {
-                    return CreateTarget(self);
-                }
-                else if (_target.ProcessId.GetValueOrDefault() != processId)
-                {
-                    DestroyTarget(self);
-                    return CreateTarget(self);
-                }
+                return CreateTarget(self);
             }
             return HResult.S_OK;
         }

--- a/src/SOS/Strike/dbgengservices.cpp
+++ b/src/SOS/Strike/dbgengservices.cpp
@@ -503,14 +503,21 @@ HRESULT DbgEngServices::ChangeEngineState(
         if (((Argument & DEBUG_STATUS_MASK) == DEBUG_STATUS_BREAK) && ((Argument & DEBUG_STATUS_INSIDE_WAIT) == 0))
         {
             ULONG processId = 0;
-            m_system->GetCurrentProcessSystemId(&processId);
-            m_control->Output(DEBUG_OUTPUT_NORMAL, "ChangeEngineState: processId %d\n", processId);
+            if (FAILED(m_system->GetCurrentProcessSystemId(&processId)))
+            {
+                m_control->Output(DEBUG_OUTPUT_NORMAL, "ChangeEngineState: DestroyTarget\n");
+                Extensions::GetInstance()->DestroyTarget();
+            }
+            else 
+            {
+                m_control->Output(DEBUG_OUTPUT_NORMAL, "ChangeEngineState: processId %d\n", processId);
 
-            // Has the process changed since the last commmand?
-            Extensions::GetInstance()->UpdateTarget(processId);
+                // Has the process changed since the last commmand?
+                Extensions::GetInstance()->UpdateTarget(processId);
 
-            // Flush the target when the debugger target breaks
-            Extensions::GetInstance()->FlushTarget();
+                // Flush the target when the debugger target breaks
+                Extensions::GetInstance()->FlushTarget();
+            }
         }
     }
     return DEBUG_STATUS_NO_CHANGE;

--- a/src/SOS/extensions/extensions.cpp
+++ b/src/SOS/extensions/extensions.cpp
@@ -100,7 +100,11 @@ HRESULT Extensions::InitializeHostServices(
         return hr;
     }
     ULONG processId = 0;
-    m_pDebuggerServices->GetCurrentProcessSystemId(&processId);
+    if (FAILED(m_pDebuggerServices->GetCurrentProcessSystemId(&processId)))
+    {
+        m_pHostServices->DestroyTarget();
+        return S_OK;
+    }
     return m_pHostServices->UpdateTarget(processId);
 }
 

--- a/src/SOS/lldbplugin/services.cpp
+++ b/src/SOS/lldbplugin/services.cpp
@@ -2578,7 +2578,7 @@ LLDBServices::FlushCheck()
     }
     else 
     {
-        Extensions::GetInstance()->UpdateTarget(0);
+        Extensions::GetInstance()->DestroyTarget();
     }
 }
 


### PR DESCRIPTION
Removed the assumption that a process can't have a 0 id.  Because of a bug in lldb, MacOS dumps all have a process id of 0.