### PR TITLE
Fix race condition when pruning processes and add test.

### DIFF
--- a/src/tests/Microsoft.Diagnostics.Monitoring/EndpointInfoSourceTests.cs
+++ b/src/tests/Microsoft.Diagnostics.Monitoring/EndpointInfoSourceTests.cs
@@ -138,8 +138,8 @@ namespace Microsoft.Diagnostics.Monitoring.UnitTests
         }
 
         /// <summary>
-        /// Tests that the server endpoint info source can properly enumerate endpoint infos when a single
-        /// target connects to it and "disconnects" from it.
+        /// Tests that the server endpoint info source can properly enumerate endpoint infos when multiple
+        /// targets connect to it and "disconnect" from it.
         /// </summary>
         [Fact]
         public async Task ServerSourceAddRemoveMultipleConnectionTest()


### PR DESCRIPTION
The ServerEndpointInfoSource caches endpoints and implicitly prunes them upon demand via the GetEndpointInfoAsync method. This existing logic has an issue where if two or more processes are no longer active, then there is a race condition when trying to remove the endpoints from the _endpointInfos field. Access to the field is not synchronized thus if two pruning tasks attempt to modify the field at the same time, an exception is likely to be thrown:

```
Message: 
    System.ArgumentOutOfRangeException : Index was out of range. Must be non-negative and less than the size of the collection. (Parameter 'index')
  Stack Trace: 
    List`1.RemoveAt(Int32 index)
    List`1.Remove(T item)
    ServerEndpointInfoSource.PruneIfNotViable(EndpointInfo info, CancellationToken token) line 161
    ServerEndpointInfoSource.GetEndpointInfoAsync(CancellationToken token) line 134
    EndpointInfoSourceTests.GetEndpointInfoAsync(ServerEndpointInfoSource source) line 228
    EndpointInfoSourceTests.ServerSourceAddRemoveMultipleConnectionTest() line 205
    EndpointInfoSourceTests.ServerSourceAddRemoveMultipleConnectionTest() line 207
    --- End of stack trace from previous location ---
```

This change fixes the logic to only have the tasks check if the the endpoints are still viable, wait for all of the tasks, and then synchronously remove all of the inviable endpoints.