### PR TITLE
Add database and aspnet-requests profiles to dotnet-trace

### DIFF
--- a/src/Tools/dotnet-trace/CommandLine/Commands/ListProfilesCommandHandler.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/ListProfilesCommandHandler.cs
@@ -15,18 +15,6 @@ namespace Microsoft.Diagnostics.Tools.Trace
 {
     internal sealed class ListProfilesCommandHandler
     {
-        /// <summary>
-        /// Indicates diagnostics messages from DiagnosticSourceEventSource should be included.
-        /// </summary>
-        /// <remarks>See: https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs</remarks>
-        private const long DiagnosticSourceKeywords_Messages = 0x1;
-          
-        /// <summary>
-        /// Indicates that all events from all diagnostic sources should be forwarded to the EventSource using the 'Event' event.
-        /// </summary>
-        /// <remarks>See: https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs</remarks>
-        private const long DiagnosticSourceKeywords_Events = 0x2;
-
         public static async Task<int> GetProfiles(IConsole console)
         {
             try
@@ -83,50 +71,18 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 },
                 "Tracks GC collections only at very low overhead."),
             new Profile(
-                "aspnet-requests",
-                new EventPipeProvider[] {
-                    new EventPipeProvider(
-                        name: "System.Threading.Tasks.TplEventSource",
-                        eventLevel: EventLevel.Verbose,
-                        keywords:   (long)TplEtwProviderTraceEventParser.Keywords.Tasktransfer |
-                                    (long)TplEtwProviderTraceEventParser.Keywords.Tasks |
-                                    (long)TplEtwProviderTraceEventParser.Keywords.Taskstops |
-                                    (long)TplEtwProviderTraceEventParser.Keywords.TasksFlowActivityIds |
-                                    (long)TplEtwProviderTraceEventParser.Keywords.Asynccausalityoperation | 
-                                    (long)TplEtwProviderTraceEventParser.Keywords.Asynccausalityrelation
-                    ),
-                    new EventPipeProvider(
-                        name: "Microsoft-Diagnostics-DiagnosticSource",
-                        eventLevel: EventLevel.Verbose,
-                        keywords: DiagnosticSourceKeywords_Messages |
-                                  DiagnosticSourceKeywords_Events,
-                        arguments: new Dictionary<string, string> {
-                            { 
-                                "FilterAndPayloadSpecs",
-                                    "Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.HttpRequestIn.Start@Activity1Start:-TraceIdentifier;Request.Method;Request.Host;Request.Path;Request.QueryString\r\n" + 
-                                    "Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.HttpRequestIn.Stop@Activity1Stop:-TraceIdentifier;Response.StatusCode"
-                            }
-                        }
-                    )
-                },
-                "Captures ASP.NET requests"
-            ),
-            new Profile(
                 "database",
                 new EventPipeProvider[] {
                     new EventPipeProvider(
                         name: "System.Threading.Tasks.TplEventSource",
-                        eventLevel: EventLevel.Verbose,
-                        keywords:   (long)TplEtwProviderTraceEventParser.Keywords.Tasktransfer |
-                                    (long)TplEtwProviderTraceEventParser.Keywords.Tasks |
-                                    (long)TplEtwProviderTraceEventParser.Keywords.Taskstops |
-                                    (long)TplEtwProviderTraceEventParser.Keywords.TasksFlowActivityIds
+                        eventLevel: EventLevel.Informational,
+                        keywords: (long)TplEtwProviderTraceEventParser.Keywords.TasksFlowActivityIds
                     ),
                     new EventPipeProvider(
                         name: "Microsoft-Diagnostics-DiagnosticSource",
                         eventLevel: EventLevel.Verbose,
-                        keywords: DiagnosticSourceKeywords_Messages |
-                                  DiagnosticSourceKeywords_Events,
+                        keywords:   (long)DiagnosticSourceKeywords.Messages |
+                                    (long)DiagnosticSourceKeywords.Events,
                         arguments: new Dictionary<string, string> {
                             {
                                 "FilterAndPayloadSpecs",
@@ -140,5 +96,18 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 },
                 "Captures ADO.NET and Entity Framework database commands")
         };
+
+        /// <summary>
+        /// Keywords for DiagnosticSourceEventSource provider
+        /// </summary>
+        /// <remarks>See https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs</remarks>
+        private enum DiagnosticSourceKeywords : long
+        {
+            Messages = 0x1,
+            Events = 0x2,
+            IgnoreShortCutKeywords = 0x0800,
+            AspNetCoreHosting = 0x1000,
+            EntityFrameworkCoreCommands = 0x2000
+        }
     }
 }


### PR DESCRIPTION
- Add database profile to dotnet-trace that captures ADO.NET and
EntityFramework events through DiagnosticSourceEventSource. Resulting
file can be viewed in Visual Studio with the PerformanceProfiler
- Add aspnet-requests profile to dotnet-trace that captures ASP.NET
requests and TPL events through DiagnosticSourceEventSource. Resulting
file can be viewed in Visual Studio with the PerformanceProfiler