### PR TITLE
Fix printing exception upon graceful exit

### DIFF
--- a/src/Tools/dotnet-counters/CounterMonitor.cs
+++ b/src/Tools/dotnet-counters/CounterMonitor.cs
@@ -356,7 +356,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.ToString()}");
+                    Debug.WriteLine($"[ERROR] {ex.ToString()}");
                 }
                 finally
                 {


### PR DESCRIPTION
Fix #2135. 

This is a regression from https://github.com/dotnet/diagnostics/pull/1635