### PR TITLE
Add single-file app SOS testing Part I

### DIFF
--- a/src/Microsoft.Diagnostics.TestHelpers/BaseDebuggeeCompiler.cs
+++ b/src/Microsoft.Diagnostics.TestHelpers/BaseDebuggeeCompiler.cs
@@ -151,7 +151,7 @@ namespace Microsoft.Diagnostics.TestHelpers
 
         protected virtual string GetDebuggeeBinaryDirPath(string debuggeeProjectDirPath, string framework, string runtime)
         {
-            string debuggeeBinaryDirPath = null;
+            string debuggeeBinaryDirPath;
             if (runtime != null)
             {
                 debuggeeBinaryDirPath = Path.Combine(debuggeeProjectDirPath, "bin", "Debug", framework, runtime);
@@ -163,14 +163,14 @@ namespace Microsoft.Diagnostics.TestHelpers
             return debuggeeBinaryDirPath;
         }
 
-        protected static string GetDebuggeeBinaryDllPath(string debuggeeBinaryDirPath, string debuggeeName)
+        protected static string GetDebuggeeBinaryDllPath(TestConfiguration config, string debuggeeBinaryDirPath, string debuggeeName)
         {
-            return Path.Combine(debuggeeBinaryDirPath, debuggeeName + ".dll");
+            return config.IsNETCore ? Path.Combine(debuggeeBinaryDirPath, debuggeeName + (config.PublishSingleFile ? "" : ".dll")) : null;
         }
 
-        protected static string GetDebuggeeBinaryExePath(string debuggeeBinaryDirPath, string debuggeeName)
+        protected static string GetDebuggeeBinaryExePath(TestConfiguration config, string debuggeeBinaryDirPath, string debuggeeName)
         {
-            return Path.Combine(debuggeeBinaryDirPath, debuggeeName + ".exe");
+            return config.IsDesktop ? Path.Combine(debuggeeBinaryDirPath, debuggeeName + ".exe") : null;
         }
 
         protected static string GetLogPath(TestConfiguration config, string framework, string runtime, string debuggeeName)

--- a/src/Microsoft.Diagnostics.TestHelpers/CliDebuggeeCompiler.cs
+++ b/src/Microsoft.Diagnostics.TestHelpers/CliDebuggeeCompiler.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 
 namespace Microsoft.Diagnostics.TestHelpers
@@ -32,6 +33,11 @@ namespace Microsoft.Diagnostics.TestHelpers
             if (runtimeIdentifier != null)
             {
                 buildProperties.Add("RuntimeIdentifier", runtimeIdentifier);
+            }
+            if (config.PublishSingleFile)
+            {
+                Debug.Assert(runtimeIdentifier != null);
+                buildProperties.Add("PublishSingleFile", "true");
             }
             string debugType = config.DebugType;
             if (debugType == null)
@@ -64,8 +70,8 @@ namespace Microsoft.Diagnostics.TestHelpers
             string debuggeeSolutionDirPath = GetDebuggeeSolutionDirPath(dotNetRootBuildDirPath, debuggeeName);
             string debuggeeProjectDirPath = GetDebuggeeProjectDirPath(debuggeeSolutionDirPath, initialSourceDirPath, debuggeeName);
             string debuggeeBinaryDirPath = GetDebuggeeBinaryDirPath(debuggeeProjectDirPath, framework, runtimeIdentifier);
-            string debuggeeBinaryDllPath = config.IsNETCore ? GetDebuggeeBinaryDllPath(debuggeeBinaryDirPath, debuggeeName) : null;
-            string debuggeeBinaryExePath = config.IsDesktop ? GetDebuggeeBinaryExePath(debuggeeBinaryDirPath, debuggeeName) : null;
+            string debuggeeBinaryDllPath = GetDebuggeeBinaryDllPath(config, debuggeeBinaryDirPath, debuggeeName);
+            string debuggeeBinaryExePath = GetDebuggeeBinaryExePath(config, debuggeeBinaryDirPath, debuggeeName);
             string logPath = GetLogPath(config, framework, runtimeIdentifier, debuggeeName);
             return new CsprojBuildDebuggeeTestStep(dotNetPath,
                                                initialSourceDirPath,

--- a/src/Microsoft.Diagnostics.TestHelpers/TestConfiguration.cs
+++ b/src/Microsoft.Diagnostics.TestHelpers/TestConfiguration.cs
@@ -630,6 +630,14 @@ namespace Microsoft.Diagnostics.TestHelpers
         }
 
         /// <summary>
+        /// Returns "true" if build/run this cli debuggee as a single-file app
+        /// </summary>
+        public bool PublishSingleFile
+        {
+            get { return string.Equals(GetValue("PublishSingleFile"), "true", StringComparison.InvariantCultureIgnoreCase); }
+        }
+
+        /// <summary>
         /// The version of the Microsoft.NETCore.App package to reference when running the debuggee (i.e. 
         /// using the dotnet cli --fx-version option).
         /// </summary>
@@ -711,7 +719,7 @@ namespace Microsoft.Diagnostics.TestHelpers
         /// </summary>
         public bool LogToConsole
         {
-            get { return bool.TryParse(GetValue("LogToConsole"), out bool b) && b; }
+            get { return string.Equals(GetValue("LogToConsole"), "true", StringComparison.InvariantCultureIgnoreCase); }
         }
 
         /// <summary>

--- a/src/SOS/SOS.UnitTests/ConfigFiles/Unix/Debugger.Tests.Config.txt
+++ b/src/SOS/SOS.UnitTests/ConfigFiles/Unix/Debugger.Tests.Config.txt
@@ -34,7 +34,7 @@
   <TestDotnetDumpCommandsWithRuntime21 Condition="'$(OS)' == 'Linux'">false</TestDotnetDumpCommandsWithRuntime21>
 
   <!-- Build the debuggee for this framework version but run it on latest -->
-  <BuildProjectFrameworkLatest Condition="StartsWith('$(RuntimeVersionLatest)', '6')">net5.0</BuildProjectFrameworkLatest>
+  <BuildProjectFrameworkLatest Condition="StartsWith('$(RuntimeVersionLatest)', '6')">net6.0</BuildProjectFrameworkLatest>
   <BuildProjectFrameworkLatest Condition="StartsWith('$(RuntimeVersionLatest)', '5')">net5.0</BuildProjectFrameworkLatest>
   <BuildProjectFrameworkLatest Condition="StartsWith('$(RuntimeVersionLatest)', '3.1')">netcoreapp3.1</BuildProjectFrameworkLatest>
   <BuildProjectFrameworkLatest Condition="StartsWith('$(RuntimeVersionLatest)', '2.1')">netcoreapp2.1</BuildProjectFrameworkLatest>
@@ -45,8 +45,9 @@
   <CliPath>$(DotNetRoot)/dotnet</CliPath>
 
   <NuGetPackageFeeds>
-      myget.org dotnet-core=https://dotnet.myget.org/F/dotnet-core/api/v3/index.json;
-      nuget.org=https://www.nuget.org/api/v2/
+      dotnet6=https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet6/nuget/v3/index.json;
+      dotnet-core=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
+      dotnet-public=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json
   </NuGetPackageFeeds>
 
   <Options>
@@ -73,7 +74,7 @@
       <SetHostRuntime>$(DotNetRoot)/shared/Microsoft.NETCore.App/$(RuntimeFrameworkVersion)</SetHostRuntime>
     </Option>
     <!--
-        SOS.StackAndOtherTests (cli because tested with embedded and portable PDBs)
+        SOS.StackAndOtherTests (cli because tested with embedded, portable PDBs and single-file)
       -->
     <Option>
       <DebuggeeBuildProcess>cli</DebuggeeBuildProcess>
@@ -81,8 +82,12 @@
       <TestName>SOS.StackAndOtherTests</TestName>
       <Options>
         <Option Condition="'$(RuntimeVersionLatest)' != ''">
-          <BuildProjectFramework>$(BuildProjectFrameworkLatest)</BuildProjectFramework>
-          <RuntimeFrameworkVersion>$(RuntimeVersionLatest)</RuntimeFrameworkVersion>
+          <Options>
+            <Option>
+              <BuildProjectFramework>$(BuildProjectFrameworkLatest)</BuildProjectFramework>
+              <RuntimeFrameworkVersion>$(RuntimeVersionLatest)</RuntimeFrameworkVersion>
+            </Option>
+          </Options>
         </Option>
         <Option Condition="'$(RuntimeVersion50)' != ''">
           <BuildProjectFramework>net5.0</BuildProjectFramework>
@@ -157,8 +162,10 @@
   <FrameworkVersion Condition="'$(FrameworkVersion)' == ''">$(RuntimeFrameworkVersion)</FrameworkVersion>
   <RuntimeSymbolsPath>$(DotNetRoot)/shared/Microsoft.NETCore.App/$(RuntimeFrameworkVersion)</RuntimeSymbolsPath>
   <LLDBHelperScript>$(ScriptRootDir)/lldbhelper.py</LLDBHelperScript>
-  <HostExe>$(DotNetRoot)/dotnet</HostExe>
-  <HostArgs>--fx-version $(FrameworkVersion)</HostArgs>
+
+  <!-- Single-file debuggees don't need the host -->
+  <HostExe Condition="'$(PublishSingleFile)' != 'true'">$(DotNetRoot)/dotnet</HostExe>
+  <HostArgs Condition="'$(PublishSingleFile)' != 'true'">--fx-version $(FrameworkVersion)</HostArgs>
 
   <Options>
     <Option Condition="$(OS) == Linux">

--- a/src/SOS/SOS.UnitTests/ConfigFiles/Windows/Debugger.Tests.Config.txt
+++ b/src/SOS/SOS.UnitTests/ConfigFiles/Windows/Debugger.Tests.Config.txt
@@ -36,7 +36,7 @@
   <TestDesktop Condition="'$(TargetArchitecture)' == 'arm64'">false</TestDesktop>
 
   <!-- Build the debuggee for this framework version but run it on latest -->
-  <BuildProjectFrameworkLatest Condition="StartsWith('$(RuntimeVersionLatest)', '6')">net5.0</BuildProjectFrameworkLatest>
+  <BuildProjectFrameworkLatest Condition="StartsWith('$(RuntimeVersionLatest)', '6')">net6.0</BuildProjectFrameworkLatest>
   <BuildProjectFrameworkLatest Condition="StartsWith('$(RuntimeVersionLatest)', '5')">net5.0</BuildProjectFrameworkLatest>
   <BuildProjectFrameworkLatest Condition="StartsWith('$(RuntimeVersionLatest)', '3.1')">netcoreapp3.1</BuildProjectFrameworkLatest>
   <BuildProjectFrameworkLatest Condition="StartsWith('$(RuntimeVersionLatest)', '2.1')">netcoreapp2.1</BuildProjectFrameworkLatest>
@@ -51,8 +51,9 @@
   <CliPath>$(DotNetRoot)\dotnet.exe</CliPath>
 
   <NuGetPackageFeeds>
-      myget.org dotnet-core=https://dotnet.myget.org/F/dotnet-core/api/v3/index.json;
-      nuget.org=https://www.nuget.org/api/v2/
+      dotnet6=https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet6/nuget/v3/index.json;
+      dotnet-core=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
+      dotnet-public=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json
   </NuGetPackageFeeds>
 
   <Options>

--- a/src/SOS/SOS.UnitTests/Debuggees/DesktopClrHost/CMakeLists.txt
+++ b/src/SOS/SOS.UnitTests/Debuggees/DesktopClrHost/CMakeLists.txt
@@ -34,3 +34,4 @@ target_link_libraries(DesktopClrHost ${DESKTOPCLRHOST_LIBRARY})
 
 install(TARGETS DesktopClrHost DESTINATION ${CLR_MANAGED_BINARY_DIR}/WebApp3/${CLR_BUILD_TYPE}/netcoreapp3.1)
 install(TARGETS DesktopClrHost DESTINATION ${CLR_MANAGED_BINARY_DIR}/WebApp3/${CLR_BUILD_TYPE}/net5.0)
+install(TARGETS DesktopClrHost DESTINATION ${CLR_MANAGED_BINARY_DIR}/WebApp3/${CLR_BUILD_TYPE}/net6.0)

--- a/src/SOS/SOS.UnitTests/Debuggees/Directory.Build.props
+++ b/src/SOS/SOS.UnitTests/Debuggees/Directory.Build.props
@@ -6,5 +6,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsShippingAssembly>false</IsShippingAssembly>
     <Optimize>false</Optimize>
+    <BuildTargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0;net6.0</BuildTargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/src/SOS/SOS.UnitTests/Debuggees/DivZero/DivZero.csproj
+++ b/src/SOS/SOS.UnitTests/Debuggees/DivZero/DivZero.csproj
@@ -2,6 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework Condition="'$(BuildProjectFramework)' != ''">$(BuildProjectFramework)</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildProjectFramework)' == ''">netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildProjectFramework)' == ''">$(BuildTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/src/SOS/SOS.UnitTests/Debuggees/DotnetDumpCommands/DotnetDumpCommands.csproj
+++ b/src/SOS/SOS.UnitTests/Debuggees/DotnetDumpCommands/DotnetDumpCommands.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-	<OutputType>Exe</OutputType>
-	<TargetFramework Condition="'$(BuildProjectFramework)' != ''">$(BuildProjectFramework)</TargetFramework>
-	<TargetFrameworks Condition="'$(BuildProjectFramework)' == ''">netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <TargetFramework Condition="'$(BuildProjectFramework)' != ''">$(BuildProjectFramework)</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildProjectFramework)' == ''">$(BuildTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/src/SOS/SOS.UnitTests/Debuggees/GCPOH/GCPOH.csproj
+++ b/src/SOS/SOS.UnitTests/Debuggees/GCPOH/GCPOH.csproj
@@ -2,6 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework Condition="'$(BuildProjectFramework)' != ''">$(BuildProjectFramework)</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildProjectFramework)' == ''">netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildProjectFramework)' == ''">$(BuildTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/src/SOS/SOS.UnitTests/Debuggees/GCWhere/GCWhere.csproj
+++ b/src/SOS/SOS.UnitTests/Debuggees/GCWhere/GCWhere.csproj
@@ -2,6 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework Condition="'$(BuildProjectFramework)' != ''">$(BuildProjectFramework)</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildProjectFramework)' == ''">netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildProjectFramework)' == ''">$(BuildTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/src/SOS/SOS.UnitTests/Debuggees/LineNums/LineNums.csproj
+++ b/src/SOS/SOS.UnitTests/Debuggees/LineNums/LineNums.csproj
@@ -3,6 +3,6 @@
     <OutputType>Exe</OutputType>
     <Optimize>true</Optimize>
     <TargetFramework Condition="'$(BuildProjectFramework)' != ''">$(BuildProjectFramework)</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildProjectFramework)' == ''">netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildProjectFramework)' == ''">$(BuildTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/src/SOS/SOS.UnitTests/Debuggees/NestedExceptionTest/NestedExceptionTest.csproj
+++ b/src/SOS/SOS.UnitTests/Debuggees/NestedExceptionTest/NestedExceptionTest.csproj
@@ -2,6 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework Condition="'$(BuildProjectFramework)' != ''">$(BuildProjectFramework)</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildProjectFramework)' == ''">netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildProjectFramework)' == ''">$(BuildTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/src/SOS/SOS.UnitTests/Debuggees/Overflow/Overflow.csproj
+++ b/src/SOS/SOS.UnitTests/Debuggees/Overflow/Overflow.csproj
@@ -2,6 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework Condition="'$(BuildProjectFramework)' != ''">$(BuildProjectFramework)</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildProjectFramework)' == ''">netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildProjectFramework)' == ''">$(BuildTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/src/SOS/SOS.UnitTests/Debuggees/ReflectionTest/ReflectionTest.csproj
+++ b/src/SOS/SOS.UnitTests/Debuggees/ReflectionTest/ReflectionTest.csproj
@@ -2,6 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework Condition="'$(BuildProjectFramework)' != ''">$(BuildProjectFramework)</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildProjectFramework)' == ''">netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildProjectFramework)' == ''">$(BuildTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/src/SOS/SOS.UnitTests/Debuggees/SimpleThrow/SimpleThrow.csproj
+++ b/src/SOS/SOS.UnitTests/Debuggees/SimpleThrow/SimpleThrow.csproj
@@ -2,6 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework Condition="'$(BuildProjectFramework)' != ''">$(BuildProjectFramework)</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildProjectFramework)' == ''">netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildProjectFramework)' == ''">$(BuildTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/src/SOS/SOS.UnitTests/Debuggees/SymbolTestApp/SymbolTestApp/SymbolTestApp.csproj
+++ b/src/SOS/SOS.UnitTests/Debuggees/SymbolTestApp/SymbolTestApp/SymbolTestApp.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework Condition="'$(BuildProjectFramework)' != ''">$(BuildProjectFramework)</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildProjectFramework)' == ''">netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildProjectFramework)' == ''">$(BuildTargetFrameworks)</TargetFrameworks>
     <DefineConstants Condition="'$(TargetFramework)' == 'net462'">$(DefineConstants);FULL_CLR</DefineConstants>
   </PropertyGroup>
 

--- a/src/SOS/SOS.UnitTests/Debuggees/SymbolTestApp/SymbolTestDll/SymbolTestDll.csproj
+++ b/src/SOS/SOS.UnitTests/Debuggees/SymbolTestApp/SymbolTestDll/SymbolTestDll.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework Condition="'$(BuildProjectFramework)' != ''">$(BuildProjectFramework)</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildProjectFramework)' == '' and '$(OS)' != 'Windows_NT'">netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(BuildProjectFramework)' == '' and '$(OS)' == 'Windows_NT'">net462;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildProjectFramework)' == '' and '$(OS)' != 'Windows_NT'">$(BuildTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildProjectFramework)' == '' and '$(OS)' == 'Windows_NT'">net462;$(BuildTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/src/SOS/SOS.UnitTests/Debuggees/TaskNestedException/RandomUserLibrary/RandomUserLibrary.csproj
+++ b/src/SOS/SOS.UnitTests/Debuggees/TaskNestedException/RandomUserLibrary/RandomUserLibrary.csproj
@@ -2,6 +2,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework Condition="'$(BuildProjectFramework)' != ''">$(BuildProjectFramework)</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildProjectFramework)' == ''">netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildProjectFramework)' == ''">$(BuildTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/src/SOS/SOS.UnitTests/Debuggees/TaskNestedException/TaskNestedException/TaskNestedException.csproj
+++ b/src/SOS/SOS.UnitTests/Debuggees/TaskNestedException/TaskNestedException/TaskNestedException.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework Condition="'$(BuildProjectFramework)' != ''">$(BuildProjectFramework)</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildProjectFramework)' == ''">netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildProjectFramework)' == ''">$(BuildTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SOS/SOS.UnitTests/Debuggees/WebApp3/WebApp3.csproj
+++ b/src/SOS/SOS.UnitTests/Debuggees/WebApp3/WebApp3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR gets ready for single-file app testing, but doesn't add the app yet
because the current SDK can't build them and the new SDKs break building
the cli built debuggees.

Also works around that the DAC GetPEFileName()/GetAssemblyName() APIs don't return
the module or assembly name.