### PR TITLE
Fixed %% in sosdocs and gcheapstat output

### DIFF
--- a/src/SOS/Strike/sosdocs.txt
+++ b/src/SOS/Strike/sosdocs.txt
@@ -453,7 +453,7 @@ followed by a report listing all the types found, their size and number:
     ...
 
 "Free" objects are simply regions of space the garbage collector can use later.
-If 30%% or more of the heap contains "Free" objects, the process may suffer from
+If 30% or more of the heap contains "Free" objects, the process may suffer from
 heap fragmentation. This is usually caused by pinning objects for a long time 
 combined with a high rate of allocation. Here is example output where !DumpHeap
 provides a warning about fragmentation:
@@ -2033,8 +2033,8 @@ Sample output:
     Total    337556       24           306968       8800        
 
     Free space:                                                 Percentage
-    Heap0    28           12           12           64          SOH:  0%% LOH:  0%%
-    Heap1    104          12           12           16          SOH:  0%% LOH:100%%
+    Heap0    28           12           12           64          SOH:  0% LOH:  0%
+    Heap1    104          12           12           16          SOH:  0% LOH:100%
     Total    132          24           24           80          
 
     0:002> !heapstat -inclUnrooted
@@ -2044,13 +2044,13 @@ Sample output:
     Total    337556       24           306968       8800        
 
     Free space:                                                 Percentage
-    Heap0    28           12           12           64          SOH:  0%% LOH:  0%%
-    Heap1    104          12           12           16          SOH:  0%% LOH:100%%
+    Heap0    28           12           12           64          SOH:  0% LOH:  0%
+    Heap1    104          12           12           16          SOH:  0% LOH:100%
     Total    132          24           24           80          
 
     Unrooted objects:                                           Percentage
-    Heap0    152212       0            306196       0           SOH: 94%% LOH:  0%%
-    Heap1    155704       0            0            0           SOH: 97%% LOH:  0%%
+    Heap0    152212       0            306196       0           SOH: 94% LOH:  0%
+    Heap1    155704       0            0            0           SOH: 97% LOH:  0%
     Total    307916       0            306196       0           
 
 The percentage column contains a breakout of free or unrooted bytes to total bytes.
@@ -2093,7 +2093,7 @@ is if the system is running out physical memory (+ page file if you have one) so
 GC can not commit memory it needs. You can look at these scenarios by using performance
 counters or debugger commands. For example for the former scenario the "!address 
 -summary" debugger command will show you the largest free region in the VM. For
-the latter scenario you can look at the "Memory%% Committed Bytes In Use" see
+the latter scenario you can look at the "Memory% Committed Bytes In Use" see
 if you are running low on commit space. One important thing to keep in mind is
 when you do this kind of memory analysis it could an aftereffect and doesn't 
 completely agree with what this command tells you, in which case the command should

--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -5590,9 +5590,9 @@ DECLARE_API(GCHeapStat)
             tempf = ((float)(hpUsage.genUsage[0].freed + hpUsage.genUsage[1].freed + hpUsage.genUsage[2].freed)) /
                 (hpUsage.genUsage[0].allocd + hpUsage.genUsage[1].allocd + hpUsage.genUsage[2].allocd);
             int pohFreeUsage = heapDetails.has_poh ? (int)(100*((float)hpUsage.genUsage[4].freed) / (hpUsage.genUsage[4].allocd)) : 0;
-            ExtOut("SOH:%3d%s LOH:%3d%s POH:%3d%s\n", (int)(100 * tempf), "%%",
-                (int)(100*((float)hpUsage.genUsage[3].freed) / (hpUsage.genUsage[3].allocd)), "%%",
-                pohFreeUsage, "%%");
+            ExtOut("SOH:%3d%s LOH:%3d%s POH:%3d%s\n", (int)(100 * tempf), "%",
+                (int)(100*((float)hpUsage.genUsage[3].freed) / (hpUsage.genUsage[3].allocd)), "%",
+                pohFreeUsage, "%");
 
             if (bIncUnreachable)
             {
@@ -5603,9 +5603,9 @@ DECLARE_API(GCHeapStat)
                 tempf = ((float)(hpUsage.genUsage[0].unrooted+hpUsage.genUsage[1].unrooted+hpUsage.genUsage[2].unrooted)) /
                     (hpUsage.genUsage[0].allocd+hpUsage.genUsage[1].allocd+hpUsage.genUsage[2].allocd);
                 int pohUnrootedUsage = heapDetails.has_poh ? (int)(100*((float)hpUsage.genUsage[4].unrooted) / (hpUsage.genUsage[4].allocd)) : 0;
-                ExtOut("SOH:%3d%s LOH:%3d%s POH:%3d%s\n", (int)(100 * tempf), "%%",
-                    (int)(100*((float)hpUsage.genUsage[3].unrooted) / (hpUsage.genUsage[3].allocd)), "%%",
-                    pohUnrootedUsage, "%%");
+                ExtOut("SOH:%3d%s LOH:%3d%s POH:%3d%s\n", (int)(100 * tempf), "%",
+                    (int)(100*((float)hpUsage.genUsage[3].unrooted) / (hpUsage.genUsage[3].allocd)), "%",
+                    pohUnrootedUsage, "%");
             }
             
             ExtOut("\nCommitted space:");
@@ -5698,9 +5698,9 @@ DECLARE_API(GCHeapStat)
             tempf = ((float)(hpUsage[n].genUsage[0].freed + hpUsage[n].genUsage[1].freed + hpUsage[n].genUsage[2].freed)) /
                 (hpUsage[n].genUsage[0].allocd + hpUsage[n].genUsage[1].allocd + hpUsage[n].genUsage[2].allocd);
             int pohFreeUsage = hasPoh ? (int)(100*((float)hpUsage[n].genUsage[4].freed) / (hpUsage[n].genUsage[4].allocd)) : 0;
-            ExtOut("SOH:%3d%s LOH:%3d%s POH:%3d%s\n", (int)(100 * tempf), "%%",
-                (int)(100*((float)hpUsage[n].genUsage[3].freed) / (hpUsage[n].genUsage[3].allocd)), "%%",
-                pohFreeUsage, "%%");
+            ExtOut("SOH:%3d%s LOH:%3d%s POH:%3d%s\n", (int)(100 * tempf), "%",
+                (int)(100*((float)hpUsage[n].genUsage[3].freed) / (hpUsage[n].genUsage[3].allocd)), "%",
+                pohFreeUsage, "%");
         }
         ExtOut("Total    %12" POINTERSIZE_TYPE "u %12" POINTERSIZE_TYPE "u %12" POINTERSIZE_TYPE "u %12" POINTERSIZE_TYPE "u %12" POINTERSIZE_TYPE "u\n",
             genUsageStat[0].freed, genUsageStat[1].freed,
@@ -5720,9 +5720,9 @@ DECLARE_API(GCHeapStat)
                 tempf = ((float)(hpUsage[n].genUsage[0].unrooted + hpUsage[n].genUsage[1].unrooted + hpUsage[n].genUsage[2].unrooted)) /
                     (hpUsage[n].genUsage[0].allocd + hpUsage[n].genUsage[1].allocd + hpUsage[n].genUsage[2].allocd);
                 int pohUnrootedUsage = hasPoh ? (int)(100*((float)hpUsage[n].genUsage[4].unrooted) / (hpUsage[n].genUsage[4].allocd)) : 0;
-                ExtOut("SOH:%3d%s LOH:%3d%s POH:%3d%s\n", (int)(100 * tempf), "%%",
-                    (int)(100*((float)hpUsage[n].genUsage[3].unrooted) / (hpUsage[n].genUsage[3].allocd)), "%%",
-                    pohUnrootedUsage, "%%");
+                ExtOut("SOH:%3d%s LOH:%3d%s POH:%3d%s\n", (int)(100 * tempf), "%",
+                    (int)(100*((float)hpUsage[n].genUsage[3].unrooted) / (hpUsage[n].genUsage[3].allocd)), "%",
+                    pohUnrootedUsage, "%");
             }
             ExtOut("Total    %12" POINTERSIZE_TYPE "u %12" POINTERSIZE_TYPE "u %12" POINTERSIZE_TYPE "u %12" POINTERSIZE_TYPE "u %12" POINTERSIZE_TYPE "u\n",
                 genUsageStat[0].unrooted, genUsageStat[1].unrooted,
@@ -8840,7 +8840,7 @@ DECLARE_API(ThreadPool)
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-        ExtOut ("CPU utilization: %d %s\n", threadpool.cpuUtilization, "%%");
+    ExtOut ("CPU utilization: %d %s\n", threadpool.cpuUtilization, "%");
     ExtOut ("Worker Thread:");
     ExtOut (" Total: %d", threadpool.NumWorkingWorkerThreads + threadpool.NumIdleWorkerThreads + threadpool.NumRetiredWorkerThreads);
     ExtOut (" Running: %d", threadpool.NumWorkingWorkerThreads);


### PR DESCRIPTION
The `%%` looks a bit strange, it should be just `%`.

`help dumpheap`:
![grafik](https://user-images.githubusercontent.com/5755834/114316908-ec81bf80-9b05-11eb-94f1-93513b772f36.png)

`gcheapstat` output:
![grafik](https://user-images.githubusercontent.com/5755834/114316848-b3e1e600-9b05-11eb-9ab9-67f1ee8efca4.png)
