### PR TITLE
dotnet-dump analyze allows redirecting stdout

### DIFF
--- a/src/Microsoft.Diagnostics.Repl/Console/ConsoleProvider.cs
+++ b/src/Microsoft.Diagnostics.Repl/Console/ConsoleProvider.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Diagnostics.Repl
 
         private string m_clearLine;
         private bool m_interactiveConsole;
+        private bool m_outputRedirected;
         private bool m_refreshingLine;
         private StringBuilder m_activeLine;
 
@@ -74,6 +75,7 @@ namespace Microsoft.Diagnostics.Repl
         {
             m_lastCommandLine = null;
             m_interactiveConsole = !Console.IsInputRedirected;
+            m_outputRedirected = Console.IsOutputRedirected;
             RefreshLine();
 
             // The special prompts for the test runner are built into this
@@ -269,7 +271,10 @@ namespace Microsoft.Diagnostics.Repl
             }
 
             Console.Write(m_clearLine);
-            Console.CursorLeft = 0;
+
+            if (!m_outputRedirected) {
+                Console.CursorLeft = 0;
+            }
         }
 
         private void PrintActiveLine()
@@ -312,7 +317,10 @@ namespace Microsoft.Diagnostics.Repl
             string text = m_activeLine.ToString(m_scrollPosition, max);
 
             Console.Write("{0}{1}", prompt, text);
-            Console.CursorLeft = prompt.Length + (m_cursorPosition - m_scrollPosition);
+
+            if (!m_outputRedirected) {
+                Console.CursorLeft = prompt.Length + (m_cursorPosition - m_scrollPosition);
+            }
         }
 
         private void RefreshLine()

--- a/src/Tools/dotnet-dump/Analyzer.cs
+++ b/src/Tools/dotnet-dump/Analyzer.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Diagnostics.Tools.Dump
                         }
                     }
                 }
-                if (!_consoleProvider.Shutdown)
+                if (!_consoleProvider.Shutdown && !Console.IsOutputRedirected)
                 {
                     // Start interactive command line processing
                     _consoleProvider.WriteLine("Ready to process analysis commands. Type 'help' to list available commands or 'help [command]' to get detailed help on a command.");

--- a/src/Tools/dotnet-dump/Analyzer.cs
+++ b/src/Tools/dotnet-dump/Analyzer.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Diagnostics.Tools.Dump
                         }
                     }
                 }
-                if (!_consoleProvider.Shutdown && !Console.IsOutputRedirected)
+                if (!_consoleProvider.Shutdown && (!Console.IsOutputRedirected || Console.IsInputRedirected))
                 {
                     // Start interactive command line processing
                     _consoleProvider.WriteLine("Ready to process analysis commands. Type 'help' to list available commands or 'help [command]' to get detailed help on a command.");


### PR DESCRIPTION
Fixes https://github.com/dotnet/diagnostics/issues/2169

With this change iif the console output is redirected
* `Console.CursorLeft` isn't set, as there is no handle which would crash the process
* REPL isn't started for `dump analyze`, just the given commands are executed

/cc: @mikem8361 