### PR TITLE
A couple fixes for the SOS support for regions

### DIFF
--- a/src/SOS/Strike/gcroot.cpp
+++ b/src/SOS/Strike/gcroot.cpp
@@ -1530,7 +1530,7 @@ void should_check_bgc_mark(const GCHeapDetails &heap,
         {
             *consider_bgc_mark_p = TRUE;
 
-            if (seg.segmentAddr == heap.saved_sweep_ephemeral_seg)
+            if ((heap.saved_sweep_ephemeral_seg != -1) && (seg.segmentAddr == heap.saved_sweep_ephemeral_seg))
             {
                 *check_saved_sweep_p = TRUE;
             }
@@ -1659,19 +1659,18 @@ BOOL FindSegment(const GCHeapDetails &heap, DacpHeapSegmentData &seg, CLRDATA_AD
                 if (addr >= TO_TADDR(seg.mem) &&
                     addr < (dwAddrSeg == heap.ephemeral_heap_segment ? heap.alloc_allocated : TO_TADDR(seg.allocated)))
                 {
-                    break;
+                    return TRUE;
                 }
                 dwAddrSeg = (DWORD_PTR)seg.next;
             }
-            if (dwAddrSeg != 0)
-                break;
         }
+        return FALSE;
     }
     else
     {
         CLRDATA_ADDRESS dwAddrSeg = heap.generation_table[GetMaxGeneration()].start_segment;
 
-        // Request the inital segment.
+        // Request the initial segment.
         if (seg.Request(g_sos, dwAddrSeg, heap.original_heap_details) != S_OK)
         {
             ExtOut("Error requesting heap segment %p.\n", SOS_PTR(dwAddrSeg));


### PR DESCRIPTION
This fixes a couple of issues I found in the SOS support for regions.

1. In the case of regions, the `saved_sweep_ephemeral_seg` value will be `-1`, while it can never be the address of real segment, it doesn't hurt to do that extra check to make sure we are not doing the wrong thing in case the heap is corrupted.
2. When we translate `FindSegment`, the code is supposed to return `FALSE` if the address does not lie in the small object heap. The segment case is doing the right thing, but the regions' case is returning `TRUE` anyway.

The begs the question - why do we restrict to the small object heap only? - this leads to https://github.com/dotnet/diagnostics/issues/2199.
