### PR TITLE
Propagate timestamps for logger entries

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/EventLogsPipeline.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/EventLogsPipeline.cs
@@ -66,8 +66,12 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
                 var factoryId = (int)traceEvent.PayloadByName("FactoryID");
                 var categoryName = (string)traceEvent.PayloadByName("LoggerName");
 
-                stack.Pop();
-                logActivities.Remove(traceEvent.ActivityID);
+                //If we begin collection in the middle of a request, we can receive a stop without having a start.
+                if (stack.Count > 0)
+                {
+                    stack.Pop();
+                    logActivities.Remove(traceEvent.ActivityID);
+                }
             });
 
             eventSource.Dynamic.AddCallbackForProviderEvent(LoggingSourceConfiguration.MicrosoftExtensionsLoggingProviderName, "MessageJson", (traceEvent) =>

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/FormattedLogValues.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/FormattedLogValues.cs
@@ -1,0 +1,120 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+
+//WARNING
+//This class is sourced from https://github.com/dotnet/extensions/blob/v3.1.14/src/Logging/Logging.Abstractions/src/FormattedLogValues.cs
+//with minor modifications.
+namespace Microsoft.Diagnostics.Monitoring.EventPipe
+{
+    /// <summary>
+    /// LogValues to enable formatting options supported by <see cref="M:string.Format"/>.
+    /// This also enables using {NamedformatItem} in the format string.
+    /// </summary>
+    internal readonly struct FormattedLogValues : IReadOnlyList<KeyValuePair<string, object>>, IStateWithTimestamp
+    {
+        internal const int MaxCachedFormatters = 1024;
+        private const string NullFormat = "[null]";
+        private static int _count;
+        private static ConcurrentDictionary<string, LogValuesFormatter> _formatters = new ConcurrentDictionary<string, LogValuesFormatter>();
+        private readonly LogValuesFormatter _formatter;
+        private readonly object[] _values;
+        private readonly string _originalMessage;
+        private readonly DateTime _timestamp;
+
+        // for testing purposes
+        internal LogValuesFormatter Formatter => _formatter;
+
+        public FormattedLogValues(DateTime timestamp, string format, params object[] values)
+        {
+            _timestamp = timestamp;
+            if (values != null && values.Length != 0 && format != null)
+            {
+                if (_count >= MaxCachedFormatters)
+                {
+                    if (!_formatters.TryGetValue(format, out _formatter))
+                    {
+                        _formatter = new LogValuesFormatter(format);
+                    }
+                }
+                else
+                {
+                    _formatter = _formatters.GetOrAdd(format, f =>
+                    {
+                        Interlocked.Increment(ref _count);
+                        return new LogValuesFormatter(f);
+                    });
+                }
+            }
+            else
+            {
+                _formatter = null;
+            }
+
+            _originalMessage = format ?? NullFormat;
+            _values = values;
+        }
+
+        public KeyValuePair<string, object> this[int index]
+        {
+            get
+            {
+                if (index < 0 || index >= Count)
+                {
+                    throw new IndexOutOfRangeException(nameof(index));
+                }
+
+                if (index == Count - 1)
+                {
+                    return new KeyValuePair<string, object>("{OriginalFormat}", _originalMessage);
+                }
+
+                return _formatter.GetValue(_values, index);
+            }
+        }
+
+        public int Count
+        {
+            get
+            {
+                if (_formatter == null)
+                {
+                    return 1;
+                }
+
+                return _formatter.ValueNames.Count + 1;
+            }
+        }
+
+        public DateTime Timestamp => _timestamp;
+
+        public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
+        {
+            for (int i = 0; i < Count; ++i)
+            {
+                yield return this[i];
+            }
+        }
+
+        public override string ToString()
+        {
+            if (_formatter == null)
+            {
+                return _originalMessage;
+            }
+
+            return _formatter.Format(_values);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/IStateWithTimestamp.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/IStateWithTimestamp.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.Diagnostics.Monitoring.EventPipe
+{
+    internal interface IStateWithTimestamp
+    {
+        public DateTime Timestamp { get; }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/LogObject.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/LogObject.cs
@@ -10,7 +10,7 @@ using System.Text.Json;
 
 namespace Microsoft.Diagnostics.Monitoring.EventPipe
 {
-    public class LogObject : IReadOnlyList<KeyValuePair<string, object>>
+    public class LogObject : IReadOnlyList<KeyValuePair<string, object>>, IStateWithTimestamp
     {
         public static readonly Func<object, Exception, string> Callback = (state, exception) => ((LogObject)state).ToString();
 
@@ -53,6 +53,8 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
         public KeyValuePair<string, object> this[int index] => _items[index];
 
         public int Count => _items.Count;
+
+        public DateTime Timestamp { get; internal set; }
 
         public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
         {

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/LogValuesFormatter.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/LogValuesFormatter.cs
@@ -9,12 +9,15 @@ using System.Linq;
 using System.Globalization;
 using System.Text;
 
+//WARNING
+//This class is sourced from https://github.com/dotnet/extensions/blob/v3.1.14/src/Logging/Logging.Abstractions/src/LogValuesFormatter.cs
+//with monitor modifications.
 namespace Microsoft.Diagnostics.Monitoring.EventPipe
 {
     /// <summary>
     /// Formatter to convert the named format items like {NamedformatItem} to <see cref="M:string.Format"/> format.
     /// </summary>
-    public class LogValuesFormatter
+    internal class LogValuesFormatter
     {
         private const string NullValue = "(null)";
         private static readonly object[] EmptyArray = Array.Empty<object>();


### PR DESCRIPTION
Some other design considerations:
- We could create an extended ILogger interface with a new Log<T> method that takes a timestamp. This seems to against the spirit of the established ILogger interface, as discussed at https://github.com/aspnet/Logging/issues/483#issuecomment-320558390
- We could attach additional data to the state object's IEnumerable implementation. This can potentially confuse clients (or cause issues in the formatters since there will be unexpected data), but it saves us from having to create an extra interface to understand the timestamp data.
- It's very unlikely any other ILogger implementation would leverage this; they would likely continue to create their own timestamps for example.

Addresses https://github.com/dotnet/dotnet-monitor/issues/21

Consumed by https://github.com/dotnet/dotnet-monitor/pull/256