### PR TITLE
Remove file-dedup workaround

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -11,22 +11,6 @@
     <EmbeddedFiles Include="$(GeneratedAssemblyInfoFile)"/>
   </ItemGroup>
 
-  <!-- This is an ugly workaround needed to be able to do r2r/single file on packages that reference TraceEvent as the package's props inject a double
-  write to the same relative path. This is related to https://github.com/microsoft/perfview/issues/1002 -->
-  <Target Name="RemoveDupeAssemblies"
-          Condition="'$(PublishSingleFile)' == 'true'"
-          AfterTargets="ComputeResolvedFilesToPublishList"
-          BeforeTargets="CopyFilesToPublishDirectory">
-      
-    <PropertyGroup>
-      <ExcludedTraceEventPath>$([MSBuild]::NormalizeDirectory($(PkgMicrosoft_Diagnostics_Tracing_TraceEvent), 'lib/netstandard1.6'))</ExcludedTraceEventPath>
-    </PropertyGroup>
-    <ItemGroup>
-      <ResolvedFileToPublish Condition="$([MSBuild]::NormalizePath(%(ResolvedFileToPublish.Identity)).StartsWith($(ExcludedTraceEventPath)))"
-                             ExcludeFromSingleFile="true"/>
-    </ItemGroup>
-  </Target>
-
   <!-- We need this for the binplacing for testing assets.
   This should be removed at some point as it's brittle (harcodes versions and creates native-managed coupling). -->
   <Target Name="_PublishPackageReferences"

--- a/src/Tools/Directory.Build.targets
+++ b/src/Tools/Directory.Build.targets
@@ -36,18 +36,4 @@
     </ItemGroup>
     <Message Importance="Low" Text="@(FilesInBundleToSign)"/>
   </Target>
-
-  <Target Name="PrepareForBundling"
-          BeforeTargets="GenerateSingleFileBundle"
-          AfterTargets="_ComputeFilesToBundle"
-          DependsOnTargets="RemoveDupeAssemblies" />
-
-  <!-- Workaround for https://github.com/microsoft/perfview/issues/1002 -->
-  <Target Name="RemoveDupeAssemblies">
-    <ItemGroup>
-      <_FilesToBundle Remove="$(PkgMicrosoft_Diagnostics_Tracing_TraceEvent)\lib\netstandard1.6\Dia2Lib.dll" />
-      <_FilesToBundle Remove="$(PkgMicrosoft_Diagnostics_Tracing_TraceEvent)\lib\netstandard1.6\OSExtensions.dll" />
-      <_FilesToBundle Remove="$(PkgMicrosoft_Diagnostics_Tracing_TraceEvent)\lib\netstandard1.6\TraceReloggerLib.dll" />
-    </ItemGroup>
-  </Target>
 </Project>


### PR DESCRIPTION
Fixes #2206

The new SDKs have resolution conflict logic that will prevent the file dupe. This also introduced a bug as the assets are chosen arbitrarily for traceevent as the file versions are the same. 