### PR TITLE
Add sourcebuild leg

### DIFF
--- a/diagnostics.yml
+++ b/diagnostics.yml
@@ -77,6 +77,18 @@ stages:
 
     ############################
     #                          #
+    #    Source Build legs     #
+    #                          #
+    ############################
+
+    - template: /eng/common/templates/job/source-build.yml
+      parameters:
+        platform:
+          name: Complete
+          buildScript: ./eng/common/build.sh
+
+    ############################
+    #                          #
     #        Build legs        #
     #                          #
     ############################


### PR DESCRIPTION
Fixes #2059.

This leg only builds `Microsoft.Diagnostics.NetCore.Client` as it is the only prodcon asset in this repo. It does so in the default Linux container in a portable manner. 

Test internal run: https://dnceng.visualstudio.com/internal/_build/results?buildId=1120011