### PR TITLE
Add support for server-client mode in dsrouter.

### DIFF
--- a/src/Tools/dotnet-dsrouter/DiagnosticsServerRouterCommands.cs
+++ b/src/Tools/dotnet-dsrouter/DiagnosticsServerRouterCommands.cs
@@ -16,13 +16,14 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
     {
         public CancellationToken CommandToken { get; set; }
         public bool SuspendProcess { get; set; }
+        public bool ConnectMode { get; set; }
         public bool Verbose { get; set; }
 
-        public void OnRouterStarted(string boundTcpServerAddress)
+        public void OnRouterStarted(string tcpAddress)
         {
             if (ProcessLauncher.Launcher.HasChildProc)
             {
-                string diagnosticPorts = boundTcpServerAddress + (SuspendProcess ? ",suspend" : ",nosuspend");
+                string diagnosticPorts = tcpAddress + (SuspendProcess ? ",suspend" : ",nosuspend") + (ConnectMode ? ",connect" : ",listen");
                 if (ProcessLauncher.Launcher.ChildProc.StartInfo.Arguments.Contains("${DOTNET_DiagnosticPorts}", StringComparison.OrdinalIgnoreCase))
                 {
                     ProcessLauncher.Launcher.ChildProc.StartInfo.Arguments = ProcessLauncher.Launcher.ChildProc.StartInfo.Arguments.Replace("${DOTNET_DiagnosticPorts}", diagnosticPorts);
@@ -64,6 +65,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
             factory.AddConsole(logLevel, false);
 
             Launcher.SuspendProcess = true;
+            Launcher.ConnectMode = true;
             Launcher.Verbose = logLevel != LogLevel.Information;
             Launcher.CommandToken = token;
 
@@ -105,11 +107,53 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
             using var factory = new LoggerFactory();
             factory.AddConsole(logLevel, false);
 
-            Launcher.SuspendProcess = true;
+            Launcher.SuspendProcess = false;
+            Launcher.ConnectMode = true;
             Launcher.Verbose = logLevel != LogLevel.Information;
             Launcher.CommandToken = token;
 
             var routerTask = DiagnosticsServerRouterRunner.runIpcServerTcpServerRouter(linkedCancelToken.Token, ipcServer, tcpServer, runtimeTimeout == Timeout.Infinite ? runtimeTimeout : runtimeTimeout * 1000, factory.CreateLogger("dotnet-dsrounter"), Launcher);
+
+            while (!linkedCancelToken.IsCancellationRequested)
+            {
+                await Task.WhenAny(routerTask, Task.Delay(250)).ConfigureAwait(false);
+                if (routerTask.IsCompleted)
+                    break;
+
+                if (!Console.IsInputRedirected && Console.KeyAvailable)
+                {
+                    ConsoleKey cmd = Console.ReadKey(true).Key;
+                    if (cmd == ConsoleKey.Q)
+                    {
+                        cancelRouterTask.Cancel();
+                        break;
+                    }
+                }
+            }
+
+            return routerTask.Result;
+        }
+
+        public async Task<int> RunIpcServerTcpClientRouter(CancellationToken token, string ipcServer, string tcpClient, int runtimeTimeout, string verbose)
+        {
+            using CancellationTokenSource cancelRouterTask = new CancellationTokenSource();
+            using CancellationTokenSource linkedCancelToken = CancellationTokenSource.CreateLinkedTokenSource(token, cancelRouterTask.Token);
+
+            LogLevel logLevel = LogLevel.Information;
+            if (string.Compare(verbose, "debug", StringComparison.OrdinalIgnoreCase) == 0)
+                logLevel = LogLevel.Debug;
+            else if (string.Compare(verbose, "trace", StringComparison.OrdinalIgnoreCase) == 0)
+                logLevel = LogLevel.Trace;
+
+            using var factory = new LoggerFactory();
+            factory.AddConsole(logLevel, false);
+
+            Launcher.SuspendProcess = false;
+            Launcher.ConnectMode = false;
+            Launcher.Verbose = logLevel != LogLevel.Information;
+            Launcher.CommandToken = token;
+
+            var routerTask = DiagnosticsServerRouterRunner.runIpcServerTcpClientRouter(linkedCancelToken.Token, ipcServer, tcpClient, runtimeTimeout == Timeout.Infinite ? runtimeTimeout : runtimeTimeout * 1000, factory.CreateLogger("dotnet-dsrounter"), Launcher);
 
             while (!linkedCancelToken.IsCancellationRequested)
             {


### PR DESCRIPTION
Adds an additional router mode into dsrouter, server-client. In this router mode the front of router acts as an IPC server, where diagnostics tooling like dotnet-trace will connect, while backend acts as a TCP/IP client towards a runtime running a TCP/IP listener. 

This scenario could be beneficial if we can run on device TCP/IP listener (during development) and since it moves the TCP/IP listener over to a sandboxed app (normally accessed over a tunnelled usb connection), it will also reduce the need to open ports or bind to loopback interface on development machine.

In order to be more flexible in the architecture, this PR make some restructure of code in DiagnosticsServerRouterFactory moving over to a aggregation based architecture (instead of inheritance based) when constructing the different router configs. What is new is IpcServerTcpClientRouterFactory, rest of changes in that file is mainly due to restructure of code.

With this additional mode router now supports, server-server, client-server and server-client modes. It would even be possible to add a client-client mode, but currently that mode is a little more complex to implement due to advertising and resume commands when acting in reverse connect scenarios and currently that scenario is not needed (or can already be solved using one of existing router modes).

//CC @josalem 