### PR TITLE
dotnet-dump analyze allow hex-addresses with and w/o 0x prefix

### DIFF
--- a/src/Microsoft.Diagnostics.DebugServices/CommandBase.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/CommandBase.cs
@@ -78,12 +78,28 @@ namespace Microsoft.Diagnostics.DebugServices
         /// <returns></returns>
         protected bool TryParseAddress(string addressInHexa, out ulong address)
         {
+            if (addressInHexa == null)
+            {
+                address = 0;
+                return false;
+            }
+
             // skip 0x or leading 0000 if needed
             if (addressInHexa.StartsWith("0x"))
                 addressInHexa = addressInHexa.Substring(2);
             addressInHexa = addressInHexa.TrimStart('0');
 
             return ulong.TryParse(addressInHexa, System.Globalization.NumberStyles.HexNumber, System.Globalization.CultureInfo.InvariantCulture, out address);
+        }
+
+        /// <summary>
+        /// Convert hexadecimal string address into ulong or <c>null</c>
+        /// </summary>
+        /// <param name="addressInHexa">0x12345678 or 000012345670 format are supported</param>
+        /// <returns></returns>
+        protected ulong? ParseAddress(string addressInHexa)
+        {
+            return TryParseAddress(addressInHexa, out ulong address) ? address : null;
         }
     }
 }

--- a/src/Tools/dotnet-dump/Commands/ReadMemoryCommand.cs
+++ b/src/Tools/dotnet-dump/Commands/ReadMemoryCommand.cs
@@ -20,9 +20,21 @@ namespace Microsoft.Diagnostics.ExtensionCommands
     public sealed class ReadMemoryCommand : CommandBase
     {
         [Argument(Name = "address", Help = "Address to dump.")]
+        public string AddressValue
+        {
+            get => Address?.ToString();
+            set => Address = ParseAddress(value);
+        }
+
         public ulong? Address { get; set; }
 
         [Option(Name = "--end", Aliases = new string[] { "-e" }, Help = "Ending address to dump.")]
+        public string EndAddressValue
+        {
+            get => EndAddress?.ToString();
+            set => EndAddress = ParseAddress(value);
+        }
+
         public ulong? EndAddress { get; set; }
 
         // ****************************************************************************************


### PR DESCRIPTION
Contributes to https://github.com/dotnet/diagnostics/issues/1460
Maybe it fixes that issue? I checked other places and they are written with https://github.com/dotnet/diagnostics/blob/c13a550fd8135e031678015743557ea2a543403f/src/Microsoft.Diagnostics.DebugServices/CommandBase.cs#L79 so work with and without the 0x prefix.

The remaining command was `readmemory` / `d`.

From the issue:
> cut and pasting addresses

This bit me...

/cc: @mikem8361