### PR TITLE
Skip logs pipeline test on Windows.

### DIFF
--- a/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventLogsPipelineUnitTests.cs
+++ b/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventLogsPipelineUnitTests.cs
@@ -31,9 +31,14 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
             _output = output;
         }
 
-        [Fact]
+        [SkippableFact]
         public async Task TestLogs()
         {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                throw new SkipTestException("https://github.com/dotnet/diagnostics/issues/2234");
+            }
+
             var outputStream = new MemoryStream();
 
             await using (var testExecution = StartTraceeProcess("LoggerRemoteTest"))


### PR DESCRIPTION
Test fails fairly regularly on Windows for each PR build. Disable for now while investigating cause. Issue already logged here: https://github.com/dotnet/diagnostics/issues/2234