### PR TITLE
Document that SOS dumpheap -min and -max must be in hex values

### DIFF
--- a/src/SOS/Strike/sosdocs.txt
+++ b/src/SOS/Strike/sosdocs.txt
@@ -472,8 +472,8 @@ The arguments in detail:
 -short    Limits output to just the address of each object. This allows you
           to easily pipe output from the command to another debugger 
           command for automation.
--min      Ignore objects less than the size given in bytes
--max      Ignore objects larger than the size given in bytes
+-min      Ignore objects less than the size given in bytes (hex)
+-max      Ignore objects larger than the size given in bytes (hex)
 -live     Only print live objects
 -dead     Only print dead objects (objects which will be collected in the
           next full GC)

--- a/src/SOS/Strike/sosdocsunix.txt
+++ b/src/SOS/Strike/sosdocsunix.txt
@@ -340,8 +340,8 @@ The arguments in detail:
 -short    Limits output to just the address of each object. This allows you
           to easily pipe output from the command to another debugger 
           command for automation.
--min      Ignore objects less than the size given in bytes
--max      Ignore objects larger than the size given in bytes
+-min      Ignore objects less than the size given in bytes (hex)
+-max      Ignore objects larger than the size given in bytes (hex)
 -live     Only print live objects
 -dead     Only print dead objects (objects which will be collected in the
           next full GC)

--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -4003,8 +4003,8 @@ public:
             {"-verify", &mVerify, COBOOL, FALSE},    // verify heap objects (!heapverify)
             {"-thinlock", &mThinlock, COBOOL, FALSE},// list only thinlocks
             {"-short", &mShort, COBOOL, FALSE},      // list only addresses
-            {"-min", &mMinSize, COHEX, TRUE},        // min size of objects to display
-            {"-max", &mMaxSize, COHEX, TRUE},        // max size of objects to display
+            {"-min", &mMinSize, COHEX, TRUE},        // min size of objects to display (hex)
+            {"-max", &mMaxSize, COHEX, TRUE},        // max size of objects to display (hex)
             {"-live", &mLive, COHEX, FALSE},         // only print live objects
             {"-dead", &mDead, COHEX, FALSE},         // only print dead objects
             {"/d", &mDML, COBOOL, FALSE},            // Debugger Markup Language


### PR DESCRIPTION
Right now it's a bit confusing that `dumpheap` displays size in decimal values, but `-min` and `-max` options must be given in hex values.

This PR adds `(hex)` to the info shown by `help dumpheap` so it's clear how to enter the desired byte-size range.

An alternative would be to allow `-min` / `-max` be entered as decimal values. But this would be a new behavior and kind of breaking change.
I have no strong opinion here, but at least there should be a hint if hex only is allowed (as I just wondered why it shows larger objects than wanted).