### PR TITLE
Enabled POH in dotnet-dump dumpgen command

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -8,13 +8,13 @@
       <Uri>https://github.com/dotnet/symstore</Uri>
       <Sha>3ed87724fe4e98c7ecc77617720591783ee2e676</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Diagnostics.Runtime" Version="2.0.226401">
+    <Dependency Name="Microsoft.Diagnostics.Runtime" Version="2.0.226801">
       <Uri>https://github.com/microsoft/clrmd</Uri>
-      <Sha>70f704932fd93805612d4261fb09c3e34e372abd</Sha>
+      <Sha>52b244f9b62e7a4e398f0cd9cb99d3c9a76f3130</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Diagnostics.Runtime.Utilities" Version="2.0.226401">
+    <Dependency Name="Microsoft.Diagnostics.Runtime.Utilities" Version="2.0.226801">
       <Uri>https://github.com/microsoft/clrmd</Uri>
-      <Sha>70f704932fd93805612d4261fb09c3e34e372abd</Sha>
+      <Sha>52b244f9b62e7a4e398f0cd9cb99d3c9a76f3130</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="6.0.100-preview.1.21103.13">
       <Uri>https://github.com/dotnet/installer</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -36,8 +36,8 @@
     <MicrosoftWin32PrimitivesVersion>4.3.0</MicrosoftWin32PrimitivesVersion>
     <!-- Other libs -->
     <MicrosoftBclAsyncInterfacesVersion>1.1.0</MicrosoftBclAsyncInterfacesVersion>
-    <MicrosoftDiagnosticsRuntimeVersion>2.0.226401</MicrosoftDiagnosticsRuntimeVersion>
-    <MicrosoftDiagnosticsRuntimeUtilitiesVersion>2.0.226401</MicrosoftDiagnosticsRuntimeUtilitiesVersion>
+    <MicrosoftDiagnosticsRuntimeVersion>2.0.226801</MicrosoftDiagnosticsRuntimeVersion>
+    <MicrosoftDiagnosticsRuntimeUtilitiesVersion>2.0.226801</MicrosoftDiagnosticsRuntimeUtilitiesVersion>
     <MicrosoftDiaSymReaderNativePackageVersion>1.7.0</MicrosoftDiaSymReaderNativePackageVersion>
     <MicrosoftDiagnosticsTracingTraceEventVersion>2.0.64</MicrosoftDiagnosticsTracingTraceEventVersion>
     <MicrosoftExtensionsLoggingVersion>2.1.1</MicrosoftExtensionsLoggingVersion>

--- a/src/Microsoft.Diagnostics.ExtensionCommands/ClrMDHelper.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/ClrMDHelper.cs
@@ -746,6 +746,13 @@ namespace Microsoft.Diagnostics.ExtensionCommands
                         end = segment.End;
                     }
                     return start != end;
+                case GCGeneration.PinnedObjectHeap:
+                    if (segment.IsPinnedObjectSegment)
+                    {
+                        start = segment.Start;
+                        end = segment.End;
+                    }
+                    return start != end;
                 default:
                     return false;
             }

--- a/src/Microsoft.Diagnostics.ExtensionCommands/ClrMDHelper.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/ClrMDHelper.cs
@@ -733,7 +733,7 @@ namespace Microsoft.Diagnostics.ExtensionCommands
                     }
                     return start != end;
                 case GCGeneration.Generation2:
-                    if (!segment.IsLargeObjectSegment)
+                    if (!(segment.IsLargeObjectSegment || segment.IsPinnedObjectSegment))
                     {
                         start = segment.Generation2.Start;
                         end = segment.Generation2.End;

--- a/src/Microsoft.Diagnostics.ExtensionCommands/DumpGen.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/DumpGen.cs
@@ -2,14 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.Diagnostics.Runtime;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using System;
+using Microsoft.Diagnostics.Runtime;
 
 namespace Microsoft.Diagnostics.ExtensionCommands
 {
-
     public class DumpGen
     {
         private readonly ClrMDHelper _helper;
@@ -48,12 +47,9 @@ namespace Microsoft.Diagnostics.ExtensionCommands
                 .Where(obj => obj.Type.MethodTable == methodTableAddress);
         }
 
-
         private static bool IsTypeNameMatching(string typeName, string typeNameFilter)
         {
-            return typeName.ToLower().Contains(typeNameFilter.ToLower());
+            return typeName.IndexOf(typeNameFilter, StringComparison.OrdinalIgnoreCase) >= 0;
         }
-
     }
-
 }

--- a/src/Microsoft.Diagnostics.ExtensionCommands/DumpGenCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/DumpGenCommand.cs
@@ -107,8 +107,10 @@ namespace Microsoft.Diagnostics.ExtensionCommands
                     return GCGeneration.Generation2;
                 case "loh":
                     return GCGeneration.LargeObjectHeap;
+                case "poh":
+                    return GCGeneration.PinnedObjectHeap;
                 default:
-                    WriteLine($"{generation} is not a supported generation (gen0, gen1, gen2, loh)");
+                    WriteLine($"{generation} is not a supported generation (gen0, gen1, gen2, loh, poh)");
                     return GCGeneration.NotSet;
             }
         }
@@ -131,6 +133,7 @@ Generation number can take the following values (case insensitive):
 - gen1
 - gen2
 - loh
+- poh
 
 > dumpgen gen0
 Statistics:

--- a/src/Microsoft.Diagnostics.ExtensionCommands/GCGeneration.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/GCGeneration.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Diagnostics.ExtensionCommands
         Generation0 = 1,
         Generation1 = 2,
         Generation2 = 3,
-        LargeObjectHeap = 4
+        LargeObjectHeap = 4,
+        PinnedObjectHeap = 5
     }
 }

--- a/src/SOS/SOS.UnitTests/Debuggees/DotnetDumpCommands/Program.cs
+++ b/src/SOS/SOS.UnitTests/Debuggees/DotnetDumpCommands/Program.cs
@@ -127,6 +127,11 @@ namespace DotnetDumpCommands
             // This object should go into LOH
             yield return new DumpSampleClass[50000];
 
+#if NET5_0_OR_GREATER
+            // This object should go into POH
+            yield return GC.AllocateUninitializedArray<byte>(10000, pinned: true);
+#endif
+
             for (var i = 0; i < 5; i++)
             {
                 yield return new DumpSampleClass();
@@ -151,7 +156,6 @@ namespace DotnetDumpCommands
             public string Value2 { get; set; }
             public DateTime Date { get; set; }
         }
-
 
         public struct DumpSampleStruct
         {

--- a/src/SOS/SOS.UnitTests/SOS.cs
+++ b/src/SOS/SOS.UnitTests/SOS.cs
@@ -138,7 +138,6 @@ public class SOS
         {
             throw new SkipTestException("This test validates POH behavior, which was introduced in .net 5");
         }
-
         await RunTest(config, "GCPOH", "GCPOH.script", testName: "SOS.GCPOHTests", testDump: false);
     }
 
@@ -214,6 +213,7 @@ public class SOS
                 TestName = "SOS.StackAndOtherTests",
                 DebuggeeName = "SymbolTestApp",
                 DebuggeeArguments = "%DEBUG_ROOT%",
+                DumpNameSuffix = currentConfig.DebugType
             });
 
             // This tests using regular Windows PDBs with no managed hosting. SOS should fallback 
@@ -228,6 +228,7 @@ public class SOS
                     TestName = "SOS.StackAndOtherTests",
                     DebuggeeName = "SymbolTestApp",
                     DebuggeeArguments = "%DEBUG_ROOT%",
+                    DumpNameSuffix = currentConfig.DebugType
                 });
             }
         }
@@ -271,7 +272,7 @@ public class SOS
             DebuggeeArguments = desktopTestParameters,
             UsePipeSync = true,
             DumpGenerator = SOSRunner.DumpGenerator.DotNetDump
-        }); ;
+        });
     }
 
     [SkippableTheory, MemberData(nameof(GetConfigurations), "TestName", "DotnetDumpCommands")]
@@ -282,9 +283,10 @@ public class SOS
             TestConfiguration = config,
             DebuggeeName = "DotnetDumpCommands",
             DebuggeeArguments = "dcd",
+            DumpNameSuffix = "dcd",
             UsePipeSync = true,
             DumpGenerator = SOSRunner.DumpGenerator.DotNetDump,
-        }); ;
+        });
     }
 
     [SkippableTheory, MemberData(nameof(GetConfigurations), "TestName", "DotnetDumpCommands")]
@@ -295,9 +297,10 @@ public class SOS
             TestConfiguration = config,
             DebuggeeName = "DotnetDumpCommands",
             DebuggeeArguments = "dumpgen",
+            DumpNameSuffix = "dumpgen",
             UsePipeSync = true,
             DumpGenerator = SOSRunner.DumpGenerator.DotNetDump,
-        }); ;
+        });
     }
 
     [SkippableTheory, MemberData(nameof(Configurations))]

--- a/src/SOS/SOS.UnitTests/SOSRunner.cs
+++ b/src/SOS/SOS.UnitTests/SOSRunner.cs
@@ -90,6 +90,8 @@ public class SOSRunner : IDisposable
 
         public bool DumpDiagnostics { get; set; } = true;
 
+        public string DumpNameSuffix { get; set; }
+
         public bool IsValid()
         {
             return TestConfiguration != null && OutputHelper != null && DebuggeeName != null;
@@ -973,7 +975,17 @@ public class SOSRunner : IDisposable
         TestConfiguration config = information.TestConfiguration;
         string dumpRoot = action == DebuggerAction.GenerateDump ? config.DebuggeeDumpOutputRootDir() : config.DebuggeeDumpInputRootDir();
         if (!string.IsNullOrEmpty(dumpRoot)) {
-            return Path.Combine(dumpRoot, information.TestName + "." + information.DumpType.ToString() + ".dmp");
+            var sb = new StringBuilder();
+            sb.Append(information.TestName);
+            sb.Append(".");
+            sb.Append(information.DumpType.ToString());
+            if (information.DumpNameSuffix != null)
+            {
+                sb.Append(".");
+                sb.Append(information.DumpNameSuffix);
+            }
+            sb.Append(".dmp");
+            return Path.Combine(dumpRoot, sb.ToString());
         }
         return null;
     }

--- a/src/SOS/SOS.UnitTests/Scripts/DumpGen.script
+++ b/src/SOS/SOS.UnitTests/Scripts/DumpGen.script
@@ -22,7 +22,7 @@ VERIFY: Hexadecimal address expected for -mt option
 
 COMMAND: dumpgen gen0
 VERIFY: ^\s+MT\s+Count\s+TotalSize\s+Class Name
-VERIFY:^<HEXVAL>\s+10\s+<DECVAL>\s+DotnetDumpCommands\.Program\+DumpSampleClass
+VERIFY: ^<HEXVAL>\s+10\s+<DECVAL>\s+DotnetDumpCommands\.Program\+DumpSampleClass
 
 COMMAND: dumpgen gen0 -type DotnetDumpCommands
 VERIFY: ^<HEXVAL>\s+10\s+<DECVAL>\s+DotnetDumpCommands\.Program\+DumpSampleClass
@@ -47,6 +47,11 @@ VERIFY: ^<HEXVAL>\s+5\s+<DECVAL>\s+DotnetDumpCommands\.Program\+DumpSampleClass
 
 COMMAND: dumpgen loh
 VERIFY: ^<HEXVAL>\s+1\s+<DECVAL>\s+DotnetDumpCommands\.Program\+DumpSampleClass\[\]
+
+IFDEF:MAJOR_RUNTIME_VERSION_GE_5
+COMMAND: dumpgen poh
+VERIFY: ^<HEXVAL>\s+1\s+10024\s+System.Byte\[\]
+ENDIF:MAJOR_RUNTIME_VERSION_GE_5
 
 SOSCOMMAND: dumpheap -stat
 

--- a/src/SOS/SOS.UnitTests/Scripts/DumpGen.script
+++ b/src/SOS/SOS.UnitTests/Scripts/DumpGen.script
@@ -44,6 +44,7 @@ VERIFY: ^<HEXVAL>\s+3\s+<DECVAL>\s+DotnetDumpCommands\.Program\+DumpSampleClass
 
 COMMAND: dumpgen gen2
 VERIFY: ^<HEXVAL>\s+5\s+<DECVAL>\s+DotnetDumpCommands\.Program\+DumpSampleClass
+!VERIFY: ^<HEXVAL>\s+1\s+10024\s+System.Byte\[\]
 
 COMMAND: dumpgen loh
 VERIFY: ^<HEXVAL>\s+1\s+<DECVAL>\s+DotnetDumpCommands\.Program\+DumpSampleClass\[\]

--- a/src/SOS/SOS.UnitTests/Scripts/DumpGen.script
+++ b/src/SOS/SOS.UnitTests/Scripts/DumpGen.script
@@ -44,14 +44,14 @@ VERIFY: ^<HEXVAL>\s+3\s+<DECVAL>\s+DotnetDumpCommands\.Program\+DumpSampleClass
 
 COMMAND: dumpgen gen2
 VERIFY: ^<HEXVAL>\s+5\s+<DECVAL>\s+DotnetDumpCommands\.Program\+DumpSampleClass
-!VERIFY: ^<HEXVAL>\s+1\s+10024\s+System.Byte\[\]
+!VERIFY: ^<HEXVAL>\s+1\s+100<DECVAL>\s+System.Byte\[\]
 
 COMMAND: dumpgen loh
 VERIFY: ^<HEXVAL>\s+1\s+<DECVAL>\s+DotnetDumpCommands\.Program\+DumpSampleClass\[\]
 
 IFDEF:MAJOR_RUNTIME_VERSION_GE_5
 COMMAND: dumpgen poh
-VERIFY: ^<HEXVAL>\s+1\s+10024\s+System.Byte\[\]
+VERIFY: ^<HEXVAL>\s+1\s+100<DECVAL>\s+System.Byte\[\]
 ENDIF:MAJOR_RUNTIME_VERSION_GE_5
 
 SOSCOMMAND: dumpheap -stat


### PR DESCRIPTION
https://github.com/dotnet/diagnostics/pull/1816 introduced `dumpgen` command, https://github.com/microsoft/clrmd/pull/802 added support for the POH, so let's extend `dumpgen` to show the POH.