### PR TITLE
Synchronize pipeline tests with event pipe session start.

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/EventSourcePipeline.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/EventSourcePipeline.cs
@@ -10,11 +10,13 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Diagnostics.Monitoring.EventPipe
 {
-    internal abstract class EventSourcePipeline<T> : Pipeline where T : EventSourcePipelineSettings
+    internal abstract class EventSourcePipeline<T> : Pipeline, IEventSourcePipelineInternal where T : EventSourcePipelineSettings
     {
         private readonly Lazy<DiagnosticsEventPipeProcessor> _processor;
         public DiagnosticsClient Client { get; }
         public T Settings { get; }
+
+        public Task SessionStarted => _processor.Value.SessionStarted;
 
         protected EventSourcePipeline(DiagnosticsClient client, T settings)
         {
@@ -69,5 +71,12 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
         {
             return Task.CompletedTask;
         }
+    }
+
+    internal interface IEventSourcePipelineInternal
+    {
+        // Allows tests to know when the event pipe session has started so that the
+        // target application can start producing events.
+        Task SessionStarted { get; }
     }
 }

--- a/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventLogsPipelineUnitTests.cs
+++ b/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventLogsPipelineUnitTests.cs
@@ -34,10 +34,10 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
         [SkippableFact]
         public async Task TestLogs()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                throw new SkipTestException("https://github.com/dotnet/diagnostics/issues/2234");
-            }
+            //if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            //{
+            //    throw new SkipTestException("https://github.com/dotnet/diagnostics/issues/2234");
+            //}
 
             var outputStream = new MemoryStream();
 

--- a/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/PipelineTestUtilities.cs
+++ b/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/PipelineTestUtilities.cs
@@ -14,6 +14,12 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
         {
             Task processingTask = pipeline.RunAsync(token);
 
+            // Wait for event session to be established before telling target app to produce events.
+            if (pipeline is IEventSourcePipelineInternal eventSourcePipeline)
+            {
+                await eventSourcePipeline.SessionStarted;
+            }
+
             //Begin event production
             testExecution.SendSignal();
 


### PR DESCRIPTION
There is a race condition between starting the event pipe session in the DiagnosticsEventPipeProcessor and the pipeline tests, which will start event production immediately after telling the pipeline to start. This can lead to cases where the events in the target runtime are produced before the session is started, so they are not observed.

This change allows the pipeline tests to wait for the event pipe session to be started within the target application so that the runtime in the target process is ready to receive events for the specified filters before the event production is initiated.