### PR TITLE
Make stresslog work for clrgc.dll, increment SOS_BREAKING_CHANGE_VERSION

### DIFF
--- a/src/SOS/Strike/stressLogDump.cpp
+++ b/src/SOS/Strike/stressLogDump.cpp
@@ -487,10 +487,12 @@ HRESULT StressLog::Dump(ULONG64 outProcLog, const char* fileName, struct IDebugD
     void** args;
     unsigned msgCtr;
     msgCtr = 0;
-    int version = 0;
+    int version;
+    version = 0;
     CheckBreakingRuntimeChange(&version);
-    BOOL bHasModuleTable = (version >= 3);
-    for (;;) 
+    BOOL bHasModuleTable;
+    bHasModuleTable = (version >= 3);
+    for (;;)
     {
         ThreadStressLog* latestLog = logs->FindLatestThreadLog();
 

--- a/src/inc/sospriv.idl
+++ b/src/inc/sospriv.idl
@@ -413,7 +413,7 @@ interface ISOSDacInterface8 : IUnknown
 // Increment anytime there is a change in the data structures that SOS depends on like
 // stress log structs (StressMsg, StressLogChunck, ThreadStressLog, etc), exception
 // stack traces (StackTraceElement), the PredefinedTlsSlots enums, etc.
-cpp_quote("#define SOS_BREAKING_CHANGE_VERSION 2")
+cpp_quote("#define SOS_BREAKING_CHANGE_VERSION 3")
 
 [
     object,

--- a/src/pal/prebuilt/inc/sospriv.h
+++ b/src/pal/prebuilt/inc/sospriv.h
@@ -2675,7 +2675,7 @@ EXTERN_C const IID IID_ISOSDacInterface8;
 /* interface __MIDL_itf_sospriv_0000_0012 */
 /* [local] */ 
 
-#define SOS_BREAKING_CHANGE_VERSION 2
+#define SOS_BREAKING_CHANGE_VERSION 3
 
 
 extern RPC_IF_HANDLE __MIDL_itf_sospriv_0000_0012_v0_0_c_ifspec;


### PR DESCRIPTION
We would like to run tests with clrgc.dll activated and compiled with USE_REGIONS - as it turns out, the stresslog didn't yet work with the in-memory implementation of the stresslog. This PR has the changes required so we are actually able to dump this version of the stresslog as well.