### PR TITLE
Stop pipelines in tests after receiving expected events.

### DIFF
--- a/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventLogsPipelineUnitTests.cs
+++ b/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventLogsPipelineUnitTests.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
                 var logSettings = new EventLogsPipelineSettings { Duration = Timeout.InfiniteTimeSpan};
                 await using var pipeline = new EventLogsPipeline(client, logSettings, loggerFactory);
 
-                await PipelineTestUtilities.ExecutePipelineWithDebugee(pipeline, testExecution);
+                await PipelineTestUtilities.ExecutePipelineWithDebugee(_output, pipeline, testExecution);
             }
 
             outputStream.Position = 0L;

--- a/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventTracePipelineUnitTests.cs
+++ b/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventTracePipelineUnitTests.cs
@@ -68,15 +68,10 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
                 });
 
                 await PipelineTestUtilities.ExecutePipelineWithDebugee(
+                    _output,
                     pipeline,
                     testExecution,
-                    async token => {
-                        using var _ = token.Register(() => {
-                            _output.WriteLine("Did not receive expected events within timeout period.");
-                            foundProviderSource.TrySetCanceled(token);
-                        });
-                        await foundProviderSource.Task;
-                    });
+                    foundProviderSource);
             }
 
             //Validate that the stream is only valid for the lifetime of the callback in the trace pipeline.
@@ -114,6 +109,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
 
                 await Assert.ThrowsAsync<OperationCanceledException>(
                     async () => await PipelineTestUtilities.ExecutePipelineWithDebugee(
+                        _output,
                         pipeline,
                         testExecution,
                         cancellationTokenSource.Token));


### PR DESCRIPTION
The pipeline unit tests quickly start and stop the pipeline which could allow for missed events. These changes allow the pipelines to run until the expected events have been observed and then stops the pipelines. A generous timeout is given for waiting for the events before the operation is canceled and fails the test.

This fixes the tests for counters and trace pipelines. I did not update the test for the logs pipeline (haven't seen this issue in that test), however I will do that in a subsequent change with some other modifications I'm making for that pipeline.

closes #2258