### PR TITLE
Add FilterSpecs to EventLogsPipeline

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -41,8 +41,8 @@
     <MicrosoftDiaSymReaderNativePackageVersion>1.7.0</MicrosoftDiaSymReaderNativePackageVersion>
     <MicrosoftDiagnosticsTracingTraceEventVersion>2.0.64</MicrosoftDiagnosticsTracingTraceEventVersion>
     <MicrosoftExtensionsLoggingVersion>2.1.1</MicrosoftExtensionsLoggingVersion>
-    <!-- We use a newer version of LoggingEventSource due to a bug in an older version-->
-    <MicrosoftExtensionsLoggingEventSourceVersion>3.1.4</MicrosoftExtensionsLoggingEventSourceVersion>
+    <!-- Need version that understands UseAppFilters sentinel. -->
+    <MicrosoftExtensionsLoggingEventSourceVersion>5.0.1</MicrosoftExtensionsLoggingEventSourceVersion>
     <SystemCommandLineVersion>2.0.0-beta1.20468.1</SystemCommandLineVersion>
     <SystemCommandLineRenderingVersion>2.0.0-beta1.20074.1</SystemCommandLineRenderingVersion>
     <SystemMemoryVersion>4.5.4</SystemMemoryVersion>

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/LogMessageType.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/LogMessageType.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.Diagnostics.Monitoring.EventPipe
+{
+    [Flags]
+    public enum LogMessageType
+    {
+        Message = 0x2,
+        FormattedMessage = 0x4,
+        JsonMessage = 0x8
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/LoggingSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/LoggingSourceConfiguration.cs
@@ -84,6 +84,8 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
         {
             switch (logLevel)
             {
+                case LogLevel.None:
+                    throw new NotSupportedException($"{nameof(LogLevel)} {nameof(LogLevel.None)} is not supported as the default log level.");
                 case LogLevel.Trace:
                     return EventLevel.LogAlways;
                 case LogLevel.Debug:

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/EventLogsPipeline.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/EventLogsPipeline.cs
@@ -25,7 +25,11 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
 
         protected override MonitoringSourceConfiguration CreateConfiguration()
         {
-            return new LoggingSourceConfiguration(Settings.LogLevel, Settings.UseAppFilters);
+            return new LoggingSourceConfiguration(
+                Settings.LogLevel,
+                LogMessageType.FormattedMessage | LogMessageType.JsonMessage,
+                Settings.FilterSpecs,
+                Settings.UseAppFilters);
         }
 
         protected override Task OnEventSourceAvailable(EventPipeEventSource eventSource, Func<Task> stopSessionAsync, CancellationToken token)

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/EventLogsPipelineSettings.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/EventLogsPipelineSettings.cs
@@ -16,6 +16,6 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
         public IDictionary<string, LogLevel?> FilterSpecs { get; set; }
 
         // This setting will collect logs for the application-defined categories and levels.
-        public bool UseAppFilters { get; set; } = false;
+        public bool UseAppFilters { get; set; } = true;
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/EventLogsPipelineSettings.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/EventLogsPipelineSettings.cs
@@ -3,17 +3,19 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Logging;
-using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Microsoft.Diagnostics.Monitoring.EventPipe
 {
     internal class EventLogsPipelineSettings : EventSourcePipelineSettings
     {
-        public LogLevel LogLevel { get; set; }
+        // The default log level for all categories
+        public LogLevel LogLevel { get; set; } = LogLevel.Trace;
 
-        //This setting will set the levels to application default.
-        public bool UseAppFilters { get; set; }
+        // The logger categories and levels at which log entries are collected.
+        public IDictionary<string, LogLevel?> FilterSpecs { get; set; }
+
+        // This setting will collect logs for the application-defined categories and levels.
+        public bool UseAppFilters { get; set; } = false;
     }
 }

--- a/src/tests/EventPipeTracee/Program.cs
+++ b/src/tests/EventPipeTracee/Program.cs
@@ -1,4 +1,8 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
@@ -8,6 +12,8 @@ namespace EventPipeTracee
 {
     class Program
     {
+        private const string AppLoggerCategoryName = "AppLoggerCategory";
+
         static void Main(string[] args)
         {
             TestBody(args[0]);
@@ -22,10 +28,14 @@ namespace EventPipeTracee
             serviceCollection.AddLogging(builder =>
             {
                 builder.AddEventSourceLogger();
+                // Set application defined levels
+                builder.AddFilter(null, LogLevel.Error); // Default
+                builder.AddFilter(AppLoggerCategoryName, LogLevel.Warning);
             });
 
             using var loggerFactory = serviceCollection.BuildServiceProvider().GetService<ILoggerFactory>();
-            var logger = loggerFactory.CreateLogger(loggerCategory);
+            var customCategoryLogger = loggerFactory.CreateLogger(loggerCategory);
+            var appCategoryLogger = loggerFactory.CreateLogger(AppLoggerCategoryName);
 
             Console.Error.WriteLine($"{DateTime.UtcNow} Awaiting start");
             Console.Error.Flush();
@@ -36,7 +46,7 @@ namespace EventPipeTracee
 
             Console.Error.WriteLine($"{DateTime.UtcNow} Starting test body");
             Console.Error.Flush();
-            TestBodyCore(logger);
+            TestBodyCore(customCategoryLogger, appCategoryLogger);
 
             //Signal end of test data
             Console.WriteLine("1");
@@ -52,18 +62,22 @@ namespace EventPipeTracee
         }
 
         //TODO At some point we may want parameters to choose different test bodies.
-        private static void TestBodyCore(ILogger logger)
+        private static void TestBodyCore(ILogger customCategoryLogger, ILogger appCategoryLogger)
         {
             //Json data is always converted to strings for ActivityStart events.
-            using (var scope = logger.BeginScope(new Dictionary<string, object> {
+            using (var scope = customCategoryLogger.BeginScope(new Dictionary<string, object> {
                     { "IntValue", "5" },
                     { "BoolValue", "true" },
                     { "StringValue", "test" } }.ToList()))
             {
-                logger.LogWarning("Some warning message with {arg}", 6);
+                customCategoryLogger.LogInformation("Some warning message with {arg}", 6);
             }
 
-            logger.LogWarning("Another message");
+            customCategoryLogger.LogWarning("Another message");
+
+            appCategoryLogger.LogInformation("Information message.");
+            appCategoryLogger.LogWarning("Warning message.");
+            appCategoryLogger.LogError("Error message.");
         }
     }
 }

--- a/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventLogsPipelineUnitTests.cs
+++ b/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventLogsPipelineUnitTests.cs
@@ -35,7 +35,10 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
         [Fact]
         public async Task TestLogsAllCategoriesAllLevels()
         {
-            using Stream outputStream = await GetLogsAsync();
+            using Stream outputStream = await GetLogsAsync(settings =>
+            {
+                settings.UseAppFilters = false;
+            });
 
             Assert.True(outputStream.Length > 0, "No data written by logging process.");
 
@@ -58,6 +61,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
         {
             using Stream outputStream = await GetLogsAsync(settings =>
             {
+                settings.UseAppFilters = false;
                 settings.LogLevel = LogLevel.Warning;
             });
 
@@ -80,6 +84,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
         {
             using Stream outputStream = await GetLogsAsync(settings =>
             {
+                settings.UseAppFilters = false;
                 settings.LogLevel = LogLevel.Error;
                 settings.FilterSpecs = new Dictionary<string, LogLevel?>()
                 {
@@ -105,10 +110,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
         [Fact]
         public async Task TestLogsUseAppFilters()
         {
-            using Stream outputStream = await GetLogsAsync(settings =>
-            {
-                settings.UseAppFilters = true;
-            });
+            using Stream outputStream = await GetLogsAsync();
 
             Assert.True(outputStream.Length > 0, "No data written by logging process.");
 
@@ -129,7 +131,6 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
         {
             using Stream outputStream = await GetLogsAsync(settings =>
             {
-                settings.UseAppFilters = true;
                 settings.FilterSpecs = new Dictionary<string, LogLevel?>()
                 {
                     { LoggerRemoteTestName, LogLevel.Warning }
@@ -155,6 +156,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
         {
             using Stream outputStream = await GetLogsAsync(settings =>
             {
+                settings.UseAppFilters = false;
                 settings.LogLevel = LogLevel.Critical;
                 settings.FilterSpecs = new Dictionary<string, LogLevel?>()
                 {

--- a/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventLogsPipelineUnitTests.cs
+++ b/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventLogsPipelineUnitTests.cs
@@ -105,6 +105,19 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
         }
 
         /// <summary>
+        /// Test that LogLevel.None is not supported as the default log level.
+        /// </summary>
+        [Fact]
+        public Task TestLogsAllCategoriesDefaultLevelNoneNotSupported()
+        {
+            return Assert.ThrowsAsync<NotSupportedException>(() => GetLogsAsync(settings =>
+            {
+                settings.UseAppFilters = false;
+                settings.LogLevel = LogLevel.None;
+            }));
+        }
+
+        /// <summary>
         /// Test that log events are collected for the categories and levels specified by the application.
         /// </summary>
         [Fact]

--- a/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventLogsPipelineUnitTests.cs
+++ b/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventLogsPipelineUnitTests.cs
@@ -2,28 +2,26 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.IO;
-using System.Runtime.InteropServices;
-using System.Text;
-using System.Text.Json;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.Diagnostics.Monitoring;
-using Microsoft.Diagnostics.Monitoring.EventPipe;
 using Microsoft.Diagnostics.NETCore.Client;
 using Microsoft.Diagnostics.NETCore.Client.UnitTests;
 using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
-using Xunit.Extensions;
 
 namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
 {
     public class EventLogsPipelineUnitTests
     {
+        private const string WildcardCagetoryName = "*";
+        private const string AppLoggerCategoryName = "AppLoggerCategory";
+        private const string LoggerRemoteTestName = "LoggerRemoteTest";
+
         private readonly ITestOutputHelper _output;
 
         public EventLogsPipelineUnitTests(ITestOutputHelper output)
@@ -31,19 +29,166 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
             _output = output;
         }
 
+        /// <summary>
+        /// Test that all log events are collected if no filters are specified.
+        /// </summary>
         [Fact]
-        public async Task TestLogs()
+        public async Task TestLogsAllCategoriesAllLevels()
+        {
+            using Stream outputStream = await GetLogsAsync();
+
+            Assert.True(outputStream.Length > 0, "No data written by logging process.");
+
+            using var reader = new StreamReader(outputStream);
+
+            ValidateLoggerRemoteCategoryInformationMessage(reader);
+            ValidateLoggerRemoteCategoryWarningMessage(reader);
+            ValidateAppLoggerCategoryInformationMessage(reader);
+            ValidateAppLoggerCategoryWarningMessage(reader);
+            ValidateAppLoggerCategoryErrorMessage(reader);
+
+            Assert.True(reader.EndOfStream, "Expected to have read all entries from stream.");
+        }
+
+        /// <summary>
+        /// Test that log events at or above the default level are collected.
+        /// </summary>
+        [Fact]
+        public async Task TestLogsAllCategoriesDefaultLevel()
+        {
+            using Stream outputStream = await GetLogsAsync(settings =>
+            {
+                settings.LogLevel = LogLevel.Warning;
+            });
+
+            Assert.True(outputStream.Length > 0, "No data written by logging process.");
+
+            using var reader = new StreamReader(outputStream);
+
+            ValidateLoggerRemoteCategoryWarningMessage(reader);
+            ValidateAppLoggerCategoryWarningMessage(reader);
+            ValidateAppLoggerCategoryErrorMessage(reader);
+
+            Assert.True(reader.EndOfStream, "Expected to have read all entries from stream.");
+        }
+
+        /// <summary>
+        /// Test that log events at the default level are collected for categories without a specified level.
+        /// </summary>
+        [Fact]
+        public async Task TestLogsAllCategoriesDefaultLevelFallback()
+        {
+            using Stream outputStream = await GetLogsAsync(settings =>
+            {
+                settings.LogLevel = LogLevel.Error;
+                settings.FilterSpecs = new Dictionary<string, LogLevel?>()
+                {
+                    { AppLoggerCategoryName, null },
+                    { LoggerRemoteTestName, LogLevel.Trace }
+                };
+            });
+
+            Assert.True(outputStream.Length > 0, "No data written by logging process.");
+
+            using var reader = new StreamReader(outputStream);
+
+            ValidateLoggerRemoteCategoryInformationMessage(reader);
+            ValidateLoggerRemoteCategoryWarningMessage(reader);
+            ValidateAppLoggerCategoryErrorMessage(reader);
+
+            Assert.True(reader.EndOfStream, "Expected to have read all entries from stream.");
+        }
+
+        /// <summary>
+        /// Test that log events are collected for the categories and levels specified by the application.
+        /// </summary>
+        [Fact]
+        public async Task TestLogsUseAppFilters()
+        {
+            using Stream outputStream = await GetLogsAsync(settings =>
+            {
+                settings.UseAppFilters = true;
+            });
+
+            Assert.True(outputStream.Length > 0, "No data written by logging process.");
+
+            using var reader = new StreamReader(outputStream);
+
+            ValidateAppLoggerCategoryWarningMessage(reader);
+            ValidateAppLoggerCategoryErrorMessage(reader);
+
+            Assert.True(reader.EndOfStream, "Expected to have read all entries from stream.");
+        }
+
+        /// <summary>
+        /// Test that log events are collected for the categories and levels specified by the application
+        /// and for the categories and levels specified in the filter specs.
+        /// </summary>
+        [Fact]
+        public async Task TestLogsUseAppFiltersAndFilterSpecs()
+        {
+            using Stream outputStream = await GetLogsAsync(settings =>
+            {
+                settings.UseAppFilters = true;
+                settings.FilterSpecs = new Dictionary<string, LogLevel?>()
+                {
+                    { LoggerRemoteTestName, LogLevel.Warning }
+                };
+            });
+
+            Assert.True(outputStream.Length > 0, "No data written by logging process.");
+
+            using var reader = new StreamReader(outputStream);
+
+            ValidateLoggerRemoteCategoryWarningMessage(reader);
+            ValidateAppLoggerCategoryWarningMessage(reader);
+            ValidateAppLoggerCategoryErrorMessage(reader);
+
+            Assert.True(reader.EndOfStream, "Expected to have read all entries from stream.");
+        }
+
+        /// <summary>
+        /// Test that log events are collected for wildcard categories.
+        /// </summary>
+        [Fact]
+        public async Task TestLogsWildcardCategory()
+        {
+            using Stream outputStream = await GetLogsAsync(settings =>
+            {
+                settings.LogLevel = LogLevel.Critical;
+                settings.FilterSpecs = new Dictionary<string, LogLevel?>()
+                {
+                    { WildcardCagetoryName, LogLevel.Warning },
+                    { LoggerRemoteTestName, LogLevel.Error },
+                };
+            });
+
+            Assert.True(outputStream.Length > 0, "No data written by logging process.");
+
+            using var reader = new StreamReader(outputStream);
+
+            ValidateAppLoggerCategoryWarningMessage(reader);
+            ValidateAppLoggerCategoryErrorMessage(reader);
+
+            Assert.True(reader.EndOfStream, "Expected to have read all entries from stream.");
+        }
+
+        private async Task<Stream> GetLogsAsync(Action<EventLogsPipelineSettings> settingsCallback = null)
         {
             var outputStream = new MemoryStream();
 
-            await using (var testExecution = StartTraceeProcess("LoggerRemoteTest"))
+            await using (var testExecution = StartTraceeProcess(LoggerRemoteTestName))
             {
                 //TestRunner should account for start delay to make sure that the diagnostic pipe is available.
 
                 using var loggerFactory = new LoggerFactory(new[] { new TestStreamingLoggerProvider(outputStream) });
                 var client = new DiagnosticsClient(testExecution.TestRunner.Pid);
 
-                var logSettings = new EventLogsPipelineSettings { Duration = Timeout.InfiniteTimeSpan};
+                var logSettings = new EventLogsPipelineSettings { Duration = Timeout.InfiniteTimeSpan };
+                if (null != settingsCallback)
+                {
+                    settingsCallback(logSettings);
+                }
                 await using var pipeline = new EventLogsPipeline(client, logSettings, loggerFactory);
 
                 await PipelineTestUtilities.ExecutePipelineWithDebugee(pipeline, testExecution);
@@ -51,28 +196,77 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
 
             outputStream.Position = 0L;
 
-            Assert.True(outputStream.Length > 0, "No data written by logging process.");
+            return outputStream;
+        }
 
-            using var reader = new StreamReader(outputStream);
+        private static void ValidateLoggerRemoteCategoryInformationMessage(StreamReader reader)
+        {
+            string message = reader.ReadLine();
+            Assert.NotNull(message);
 
-            string firstMessage = reader.ReadLine();
-            Assert.NotNull(firstMessage);
-
-            LoggerTestResult result = JsonSerializer.Deserialize<LoggerTestResult>(firstMessage);
+            LoggerTestResult result = JsonSerializer.Deserialize<LoggerTestResult>(message);
             Assert.Equal("Some warning message with 6", result.Message);
-            Assert.Equal("LoggerRemoteTest", result.Category);
-            Assert.Equal("Warning", result.LogLevel);
+            Assert.Equal(LoggerRemoteTestName, result.Category);
+            Assert.Equal("Information", result.LogLevel);
             Assert.Equal("0", result.EventId);
             Validate(result.Scopes, ("BoolValue", "true"), ("StringValue", "test"), ("IntValue", "5"));
             Validate(result.Arguments, ("arg", "6"));
+        }
 
-            string secondMessage = reader.ReadLine();
-            Assert.NotNull(secondMessage);
+        private static void ValidateLoggerRemoteCategoryWarningMessage(StreamReader reader)
+        {
+            string message = reader.ReadLine();
+            Assert.NotNull(message);
 
-            result = JsonSerializer.Deserialize<LoggerTestResult>(secondMessage);
+            LoggerTestResult result = JsonSerializer.Deserialize<LoggerTestResult>(message);
             Assert.Equal("Another message", result.Message);
-            Assert.Equal("LoggerRemoteTest", result.Category);
+            Assert.Equal(LoggerRemoteTestName, result.Category);
             Assert.Equal("Warning", result.LogLevel);
+            Assert.Equal("0", result.EventId);
+            Assert.Equal(0, result.Scopes.Count);
+            //We are expecting only the original format
+            Assert.Equal(1, result.Arguments.Count);
+        }
+
+        private static void ValidateAppLoggerCategoryInformationMessage(StreamReader reader)
+        {
+            string message = reader.ReadLine();
+            Assert.NotNull(message);
+
+            LoggerTestResult result = JsonSerializer.Deserialize<LoggerTestResult>(message);
+            Assert.Equal("Information message.", result.Message);
+            Assert.Equal(AppLoggerCategoryName, result.Category);
+            Assert.Equal("Information", result.LogLevel);
+            Assert.Equal("0", result.EventId);
+            Assert.Equal(0, result.Scopes.Count);
+            //We are expecting only the original format
+            Assert.Equal(1, result.Arguments.Count);
+        }
+
+        private static void ValidateAppLoggerCategoryWarningMessage(StreamReader reader)
+        {
+            string message = reader.ReadLine();
+            Assert.NotNull(message);
+
+            LoggerTestResult result = JsonSerializer.Deserialize<LoggerTestResult>(message);
+            Assert.Equal("Warning message.", result.Message);
+            Assert.Equal(AppLoggerCategoryName, result.Category);
+            Assert.Equal("Warning", result.LogLevel);
+            Assert.Equal("0", result.EventId);
+            Assert.Equal(0, result.Scopes.Count);
+            //We are expecting only the original format
+            Assert.Equal(1, result.Arguments.Count);
+        }
+
+        private static void ValidateAppLoggerCategoryErrorMessage(StreamReader reader)
+        {
+            string message = reader.ReadLine();
+            Assert.NotNull(message);
+
+            LoggerTestResult result = JsonSerializer.Deserialize<LoggerTestResult>(message);
+            Assert.Equal("Error message.", result.Message);
+            Assert.Equal(AppLoggerCategoryName, result.Category);
+            Assert.Equal("Error", result.LogLevel);
             Assert.Equal("0", result.EventId);
             Assert.Equal(0, result.Scopes.Count);
             //We are expecting only the original format

--- a/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests.csproj
+++ b/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests.csproj
@@ -8,7 +8,9 @@
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Microsoft.Diagnostics.Monitoring.EventPipe\Microsoft.Diagnostics.Monitoring.EventPipe.csproj" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Microsoft.Diagnostics.NETCore.Client\Microsoft.Diagnostics.NETCore.Client.csproj" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\Microsoft.Diagnostics.NETCore.Client\Microsoft.Diagnostics.NETCore.Client.UnitTests.csproj" />
-    <ProjectReference Include="..\EventPipeTracee\EventPipeTracee.csproj" PrivateAssets="all" />
+    <ProjectReference Include="..\EventPipeTracee\EventPipeTracee.csproj" PrivateAssets="all">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/tests/Microsoft.Diagnostics.Monitoring/Microsoft.Diagnostics.Monitoring.UnitTests.csproj
+++ b/src/tests/Microsoft.Diagnostics.Monitoring/Microsoft.Diagnostics.Monitoring.UnitTests.csproj
@@ -9,7 +9,9 @@
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Microsoft.Diagnostics.Monitoring.EventPipe\Microsoft.Diagnostics.Monitoring.EventPipe.csproj" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Microsoft.Diagnostics.NETCore.Client\Microsoft.Diagnostics.NETCore.Client.csproj" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\Microsoft.Diagnostics.NETCore.Client\Microsoft.Diagnostics.NETCore.Client.UnitTests.csproj" />
-    <ProjectReference Include="..\EventPipeTracee\EventPipeTracee.csproj" PrivateAssets="all" />
+    <ProjectReference Include="..\EventPipeTracee\EventPipeTracee.csproj" PrivateAssets="all">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
These changes allow for customized logs collection from a target process. Logs can be collected using:
- a default log level for all categories (`EventLogsPipelineSettings.LogLevel`)
- the application-defined categories and levels (`EventLogsPipelineSettings.UseAppFilters`)
- a custom mapping of categories and levels (`EventLogsPipelineSettings.FilterSpecs`)

This change adds the `FilterSpecs` property to the settings and allows all settings to be used in combination. It also adds logs tests to cover all combinations of usage of these settings.

These changes enable https://github.com/dotnet/dotnet-monitor/issues/54 for dotnet-monitor.