### PR TITLE
Fix EventLogsPipeline to throw PipelineException when LoggingSourceConfiguration throws NotSupportedException

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/EventLogsPipeline.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/EventLogsPipeline.cs
@@ -25,11 +25,18 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
 
         protected override MonitoringSourceConfiguration CreateConfiguration()
         {
-            return new LoggingSourceConfiguration(
-                Settings.LogLevel,
-                LogMessageType.FormattedMessage | LogMessageType.JsonMessage,
-                Settings.FilterSpecs,
-                Settings.UseAppFilters);
+            try
+            {
+                return new LoggingSourceConfiguration(
+                    Settings.LogLevel,
+                    LogMessageType.FormattedMessage | LogMessageType.JsonMessage,
+                    Settings.FilterSpecs,
+                    Settings.UseAppFilters);
+            }
+            catch (NotSupportedException ex)
+            {
+                throw new PipelineException(ex.Message, ex);
+            }
         }
 
         protected override Task OnEventSourceAvailable(EventPipeEventSource eventSource, Func<Task> stopSessionAsync, CancellationToken token)

--- a/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventLogsPipelineUnitTests.cs
+++ b/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventLogsPipelineUnitTests.cs
@@ -108,13 +108,18 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
         /// Test that LogLevel.None is not supported as the default log level.
         /// </summary>
         [Fact]
-        public Task TestLogsAllCategoriesDefaultLevelNoneNotSupported()
+        public async Task TestLogsAllCategoriesDefaultLevelNoneNotSupported()
         {
-            return Assert.ThrowsAsync<NotSupportedException>(() => GetLogsAsync(settings =>
-            {
-                settings.UseAppFilters = false;
-                settings.LogLevel = LogLevel.None;
-            }));
+            // Pipeline should throw PipelineException with inner exception of NotSupportedException.
+            PipelineException exception = await Assert.ThrowsAsync<PipelineException>(
+                () => GetLogsAsync(
+                    settings =>
+                    {
+                        settings.UseAppFilters = false;
+                        settings.LogLevel = LogLevel.None;
+                    }));
+
+            Assert.IsType<NotSupportedException>(exception.InnerException);
         }
 
         /// <summary>


### PR DESCRIPTION
This fixes the EventLogsPipeline to throw PipelineException instead of NotSupportedException in the known case of when the default level was specified to be LogLevel.None. In general, pipelines should throw PipelineException for expected failures.