### PR TITLE
Update `ThreadCounts` usage based on a change

### DIFF
--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -8626,6 +8626,7 @@ DECLARE_API(ThreadPool)
     do // while (false)
     {
         UINT64 ui64Value = 0;
+        UINT32 ui32Value = 0;
 
         // Determine if the portable thread pool is enabled
         if (FAILED(
@@ -8722,12 +8723,12 @@ DECLARE_API(ThreadPool)
             accumulatedOffset += offset;
 
             offset = GetValueFieldOffset(vCountsField.MTOfType, W("_data"));
-            if (offset < 0 || FAILED(MOVE(ui64Value, cdaTpInstance + accumulatedOffset + offset)))
+            if (offset < 0 || FAILED(MOVE(ui32Value, cdaTpInstance + accumulatedOffset + offset)))
             {
                 ExtOut("    %s\n", "Failed to read PortableThreadPool._separated.counts._data");
                 break;
             }
-            UINT64 data = ui64Value;
+            UINT32 data = ui32Value;
 
             const UINT8 NumProcessingWorkShift = 0;
             const UINT8 NumExistingThreadsShift = 16;


### PR DESCRIPTION
- Depends on https://github.com/dotnet/runtime/pull/53471
- In the above change `ThreadCounts._data` was changed from `ulong` to `uint`. Its usage in SOS was reading 8 bytes and only using the lower 4 bytes. Updated to read 4 bytes instead. No functional change, just updated to match.