### PR TITLE
Add runtime resume option to dotnet-trace and dotnet-counters.

### DIFF
--- a/src/Tools/dotnet-counters/CounterMonitor.cs
+++ b/src/Tools/dotnet-counters/CounterMonitor.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
             _renderer.Stop();
         }
 
-        public async Task<int> Monitor(CancellationToken ct, List<string> counter_list, string counters, IConsole console, int processId, int refreshInterval, string name, string diagnosticPort)
+        public async Task<int> Monitor(CancellationToken ct, List<string> counter_list, string counters, IConsole console, int processId, int refreshInterval, string name, string diagnosticPort, bool resumeRuntime)
         {
             if (!ProcessLauncher.Launcher.HasChildProc && !CommandUtils.ValidateArgumentsForAttach(processId, name, diagnosticPort, out _processId))
             {
@@ -115,7 +115,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
                     _interval = refreshInterval;
                     _renderer = new ConsoleWriter();
                     _diagnosticsClient = holder.Client;
-                    shouldResumeRuntime = ProcessLauncher.Launcher.HasChildProc || !string.IsNullOrEmpty(diagnosticPort);
+                    shouldResumeRuntime = ProcessLauncher.Launcher.HasChildProc || !string.IsNullOrEmpty(diagnosticPort) || resumeRuntime;
                     int ret = await Start();
                     ProcessLauncher.Launcher.Cleanup();
                     return ret;
@@ -135,7 +135,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
         }
 
 
-        public async Task<int> Collect(CancellationToken ct, List<string> counter_list, string counters, IConsole console, int processId, int refreshInterval, CountersExportFormat format, string output, string name, string diagnosticPort)
+        public async Task<int> Collect(CancellationToken ct, List<string> counter_list, string counters, IConsole console, int processId, int refreshInterval, CountersExportFormat format, string output, string name, string diagnosticPort, bool resumeRuntime)
         {
             if (!ProcessLauncher.Launcher.HasChildProc && !CommandUtils.ValidateArgumentsForAttach(processId, name, diagnosticPort, out _processId))
             {
@@ -190,7 +190,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
                         _console.Error.WriteLine($"The output format {format} is not a valid output format.");
                         return 0;
                     }
-                    shouldResumeRuntime = ProcessLauncher.Launcher.HasChildProc || !string.IsNullOrEmpty(diagnosticPort);
+                    shouldResumeRuntime = ProcessLauncher.Launcher.HasChildProc || !string.IsNullOrEmpty(diagnosticPort) || resumeRuntime;
                     int ret = await Start();
                     return ret;
                 }

--- a/src/Tools/dotnet-counters/Program.cs
+++ b/src/Tools/dotnet-counters/Program.cs
@@ -22,8 +22,8 @@ namespace Microsoft.Diagnostics.Tools.Counters
 
     internal class Program
     {
-        delegate Task<int> CollectDelegate(CancellationToken ct, List<string> counter_list, string counters, IConsole console, int processId, int refreshInterval, CountersExportFormat format, string output, string processName, string port);
-        delegate Task<int> MonitorDelegate(CancellationToken ct, List<string> counter_list, string counters, IConsole console, int processId, int refreshInterval, string processName, string port);
+        delegate Task<int> CollectDelegate(CancellationToken ct, List<string> counter_list, string counters, IConsole console, int processId, int refreshInterval, CountersExportFormat format, string output, string processName, string port, bool resumeRuntime);
+        delegate Task<int> MonitorDelegate(CancellationToken ct, List<string> counter_list, string counters, IConsole console, int processId, int refreshInterval, string processName, string port, bool resumeRuntime);
 
         private static Command MonitorCommand() =>
             new Command(
@@ -33,7 +33,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 // Handler
                 HandlerDescriptor.FromDelegate((MonitorDelegate)new CounterMonitor().Monitor).GetCommandHandler(),
                 // Arguments and Options
-                CounterList(), CounterOption(), ProcessIdOption(), RefreshIntervalOption(), NameOption(), DiagnosticPortOption(),
+                CounterList(), CounterOption(), ProcessIdOption(), RefreshIntervalOption(), NameOption(), DiagnosticPortOption(), ResumeRuntimeOption()
             };
         
         private static Command CollectCommand() =>
@@ -44,7 +44,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 // Handler
                 HandlerDescriptor.FromDelegate((CollectDelegate)new CounterMonitor().Collect).GetCommandHandler(),
                 // Arguments and Options
-                CounterList(), CounterOption(), ProcessIdOption(), RefreshIntervalOption(), ExportFormatOption(), ExportFileNameOption(), NameOption(), DiagnosticPortOption()
+                CounterList(), CounterOption(), ProcessIdOption(), RefreshIntervalOption(), ExportFormatOption(), ExportFileNameOption(), NameOption(), DiagnosticPortOption(), ResumeRuntimeOption()
             };
 
         private static Option NameOption() =>
@@ -125,6 +125,14 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 description: "The path to diagnostic port")
             {
                 Argument = new Argument<string>(name: "diagnosticPort", getDefaultValue: () => "")
+            };
+
+        private static Option ResumeRuntimeOption() =>
+            new Option(
+                alias: "--resume-runtime",
+                description: @"Resume runtime once session has been initialized.")
+            {
+                Argument = new Argument<bool>(name: "resumeRuntime", getDefaultValue: () => false)
             };
 
         private static readonly string[] s_SupportedRuntimeVersions = new[] { "3.0", "3.1", "5.0" };

--- a/src/Tools/dotnet-counters/Program.cs
+++ b/src/Tools/dotnet-counters/Program.cs
@@ -130,9 +130,9 @@ namespace Microsoft.Diagnostics.Tools.Counters
         private static Option ResumeRuntimeOption() =>
             new Option(
                 alias: "--resume-runtime",
-                description: @"Resume runtime once session has been initialized.")
+                description: @"Resume runtime once session has been initialized, defaults to true. Disable resume of runtime using --resume-runtime:false")
             {
-                Argument = new Argument<bool>(name: "resumeRuntime", getDefaultValue: () => false)
+                Argument = new Argument<bool>(name: "resumeRuntime", getDefaultValue: () => true)
             };
 
         private static readonly string[] s_SupportedRuntimeVersions = new[] { "3.0", "3.1", "5.0" };

--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
@@ -163,7 +163,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                         return await Task.FromResult(ret);
                     }
                     diagnosticsClient = holder.Client;
-                    if (shouldResumeRuntime)
+                    if (ProcessLauncher.Launcher.HasChildProc || !string.IsNullOrEmpty(diagnosticPort))
                     {
                         process = Process.GetProcessById(holder.EndpointInfo.ProcessId);
                     }

--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
 {
     internal static class CollectCommandHandler
     {
-        delegate Task<int> CollectDelegate(CancellationToken ct, IConsole console, int processId, FileInfo output, uint buffersize, string providers, string profile, TraceFileFormat format, TimeSpan duration, string clrevents, string clreventlevel, string name, string port, bool showchildio);
+        delegate Task<int> CollectDelegate(CancellationToken ct, IConsole console, int processId, FileInfo output, uint buffersize, string providers, string profile, TraceFileFormat format, TimeSpan duration, string clrevents, string clreventlevel, string name, string port, bool showchildio, bool resumeRuntime);
 
         /// <summary>
         /// Collects a diagnostic trace from a currently running process or launch a child process and trace it.
@@ -41,8 +41,9 @@ namespace Microsoft.Diagnostics.Tools.Trace
         /// <param name="clreventlevel">The verbosity level of CLR events</param>
         /// <param name="port">Path to the diagnostic port to be created.</param>
         /// <param name="showchildio">Should IO from a child process be hidden.</param>
+        /// <param name="resumeRuntime">Resume runtime once session has been initialized.</param>
         /// <returns></returns>
-        private static async Task<int> Collect(CancellationToken ct, IConsole console, int processId, FileInfo output, uint buffersize, string providers, string profile, TraceFileFormat format, TimeSpan duration, string clrevents, string clreventlevel, string name, string diagnosticPort, bool showchildio)
+        private static async Task<int> Collect(CancellationToken ct, IConsole console, int processId, FileInfo output, uint buffersize, string providers, string profile, TraceFileFormat format, TimeSpan duration, string clrevents, string clreventlevel, string name, string diagnosticPort, bool showchildio, bool resumeRuntime)
         {
             int ret = 0;
             bool collectionStopped = false;
@@ -150,7 +151,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 DiagnosticsClient diagnosticsClient;
                 Process process;
                 DiagnosticsClientBuilder builder = new DiagnosticsClientBuilder("dotnet-trace", 10);
-                bool shouldResumeRuntime = ProcessLauncher.Launcher.HasChildProc || !string.IsNullOrEmpty(diagnosticPort);
+                bool shouldResumeRuntime = ProcessLauncher.Launcher.HasChildProc || !string.IsNullOrEmpty(diagnosticPort) || resumeRuntime;
                 var shouldExit = new ManualResetEvent(false);
                 ct.Register(() => shouldExit.Set());
 
@@ -399,7 +400,8 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 CLREventLevelOption(),
                 CommonOptions.NameOption(),
                 DiagnosticPortOption(),
-                ShowChildIOOption()
+                ShowChildIOOption(),
+                ResumeRuntimeOption()
             };
 
         private static uint DefaultCircularBufferSizeInMB() => 256;
@@ -481,6 +483,14 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 description: @"Shows the input and output streams of a launched child process in the current console.")
             {
                 Argument = new Argument<bool>(name: "show-child-io", getDefaultValue: () => false)
+            };
+
+        private static Option ResumeRuntimeOption() =>
+            new Option(
+                alias: "--resume-runtime",
+                description: @"Resume runtime once session has been initialized.")
+            {
+                Argument = new Argument<bool>(name: "resumeRuntime", getDefaultValue: () => false)
             };
     }
 }

--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
@@ -488,9 +488,9 @@ namespace Microsoft.Diagnostics.Tools.Trace
         private static Option ResumeRuntimeOption() =>
             new Option(
                 alias: "--resume-runtime",
-                description: @"Resume runtime once session has been initialized.")
+                description: @"Resume runtime once session has been initialized, defaults to true. Disable resume of runtime using --resume-runtime:false")
             {
-                Argument = new Argument<bool>(name: "resumeRuntime", getDefaultValue: () => false)
+                Argument = new Argument<bool>(name: "resumeRuntime", getDefaultValue: () => true)
             };
     }
 }


### PR DESCRIPTION
Mono has option to push diagnostic server TCP/IP listener to device loopback interface. This opens up the ability to run dotnet-dsrouter in server-client mode, where diagnostic tooling connect using regular IPC server (using --process-id) and dsrouter will connect runtime as a TCP/IP client. Users/tooling use adb (on Android) or mlaunch (for all iOS devices), to do port forwarding/tcp tunnelling working in the same way on simulator/emulator as well as physical device connected over usb.

Another advantage of this configuration is security, since it opens up the ability and simplify working with loopback interface all the way over to device, meaning that dsrouter only acts as IPC server over namedpipes/unix domain sockets and as a TCP/IP client connecting 127.0.0.1:x (using port forwarding) and device just listens on local loopback interface 127.0.0.1:x reduce any needs to bind any interface that can be access from outside local machine.

We current have limitation using this schema for suspended ports since no tooling will send a resume command to runtime if not using --diagnostic-port command (or run child process) using the reverse connect scenario. This PR adds a new option to dotnet-counters and dotnet-trace, --resume-runtime, that can be used to mitigate this limitation, open up ability to do start-up tracing on suspended runtime using dsrouter, without need to use reverse connect scenario, complicating configuration when targeting mobile devices. Since diagnostics server can always be resumed (even if not in suspend state), the default behaviour is changed to always send a resume command after setting up session, if user is interested to start multiple tools and keep runtime suspended, dotnet-counters and dotnet-trace accepts `--resume-runtime:false` that will turn of sending resume command to diagnostic server.