### PR TITLE
Add couple of smaller enhancements in dsrouter.

### DIFF
--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsServerRouter/DiagnosticsServerRouterFactory.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsServerRouter/DiagnosticsServerRouterFactory.cs
@@ -634,6 +634,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
             _ipcServerRouterFactory.Start();
 
             _logger?.LogInformation($"Starting IPC server ({_ipcServerRouterFactory.IpcServerPath}) <--> TCP server ({_tcpServerRouterFactory.TcpServerAddress}) router.");
+            _logger?.LogInformation($"Use --process-id {Process.GetCurrentProcess().Id} to connect diagnostics tooling against this router instance.");
         }
 
         public override Task Stop()
@@ -821,6 +822,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
         {
             _ipcServerRouterFactory.Start();
             _logger?.LogInformation($"Starting IPC server ({_ipcServerRouterFactory.IpcServerPath}) <--> TCP client ({_tcpClientRouterFactory.TcpClientAddress}) router.");
+            _logger?.LogInformation($"Use --process-id {Process.GetCurrentProcess().Id} to connect diagnostics tooling against this router instance.");
         }
 
         public override Task Stop()

--- a/src/Tools/Common/ReversedServerHelpers/ReversedServerHelpers.cs
+++ b/src/Tools/Common/ReversedServerHelpers/ReversedServerHelpers.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Internal.Common.Utils
     internal class ProcessLauncher
     {
         private Process _childProc = null;
+        private bool _started = false;
         private Task _stdOutTask = Task.CompletedTask;
         private Task _stdErrTask = Task.CompletedTask;
         internal static ProcessLauncher Launcher = new ProcessLauncher();
@@ -76,6 +77,15 @@ namespace Microsoft.Internal.Common.Utils
             }
         }
 
+        public bool HasStarted
+        {
+            get
+            {
+                return _started;
+            }
+
+        }
+
         public Process ChildProc
         {
             get
@@ -110,12 +120,14 @@ namespace Microsoft.Internal.Common.Utils
                 _stdErrTask = ReadAndIgnoreAllStreamAsync(_childProc.StandardError, ct);
             }
 
+            _started = true;
+
             return true;
         }
 
         public void Cleanup()
         {
-            if (_childProc != null && !_childProc.HasExited)
+            if (_childProc != null && _started && !_childProc.HasExited)
             {
                 try
                 {

--- a/src/Tools/dotnet-dsrouter/DiagnosticsServerRouterCommands.cs
+++ b/src/Tools/dotnet-dsrouter/DiagnosticsServerRouterCommands.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
             return routerTask.Result;
         }
 
-        public async Task<int> RunIpcServerTcpClientRouter(CancellationToken token, string ipcServer, string tcpClient, int runtimeTimeout, bool shutdownOnChildExit, string verbose)
+        public async Task<int> RunIpcServerTcpClientRouter(CancellationToken token, string ipcServer, string tcpClient, int runtimeTimeout, bool shutdownOnChildExit, bool suspend, string verbose)
         {
             using CancellationTokenSource cancelRouterTask = new CancellationTokenSource();
             using CancellationTokenSource linkedCancelToken = CancellationTokenSource.CreateLinkedTokenSource(token, cancelRouterTask.Token);
@@ -114,7 +114,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
             using var factory = new LoggerFactory();
             factory.AddConsole(logLevel, false);
 
-            Launcher.SuspendProcess = false;
+            Launcher.SuspendProcess = suspend;
             Launcher.ConnectMode = false;
             Launcher.Verbose = logLevel != LogLevel.Information;
             Launcher.CommandToken = token;

--- a/src/Tools/dotnet-dsrouter/DiagnosticsServerRouterCommands.cs
+++ b/src/Tools/dotnet-dsrouter/DiagnosticsServerRouterCommands.cs
@@ -30,13 +30,15 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
                     diagnosticPorts = "";
                 }
 
-                ProcessLauncher.Launcher.Start(diagnosticPorts, CommandToken, Verbose, Verbose);
+                if (!ProcessLauncher.Launcher.Start(diagnosticPorts, CommandToken, Verbose, Verbose))
+                    throw new Exception($"Failed to launch command.");
             }
         }
 
         public void OnRouterStopped()
         {
-            ProcessLauncher.Launcher.Cleanup();
+            if (ProcessLauncher.Launcher.HasChildProc && ProcessLauncher.Launcher.HasStarted)
+                ProcessLauncher.Launcher.Cleanup();
         }
     }
 
@@ -142,7 +144,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
                     }
                 }
 
-                if (shutdownOnChildExit && ProcessLauncher.Launcher.HasChildProc && ProcessLauncher.Launcher.ChildProc.HasExited)
+                if (shutdownOnChildExit && ProcessLauncher.Launcher.HasChildProc && ProcessLauncher.Launcher.HasStarted && ProcessLauncher.Launcher.ChildProc.HasExited)
                 {
                     cancelRouterTask.Cancel();
                     break;

--- a/src/Tools/dotnet-dsrouter/Program.cs
+++ b/src/Tools/dotnet-dsrouter/Program.cs
@@ -17,9 +17,9 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
 {
     internal class Program
     {
-        delegate Task<int> DiagnosticsServerIpcClientTcpServerRouterDelegate(CancellationToken ct, string ipcClient, string tcpServer, int runtimeTimeoutS, string verbose);
-        delegate Task<int> DiagnosticsServerIpcServerTcpServerRouterDelegate(CancellationToken ct, string ipcServer, string tcpServer, int runtimeTimeoutS, string verbose);
-        delegate Task<int> DiagnosticsServerIpcServerTcpClientRouterDelegate(CancellationToken ct, string ipcServer, string tcpClient, int runtimeTimeoutS, string verbose);
+        delegate Task<int> DiagnosticsServerIpcClientTcpServerRouterDelegate(CancellationToken ct, string ipcClient, string tcpServer, int runtimeTimeoutS, bool shutdownOnChildExit, string verbose);
+        delegate Task<int> DiagnosticsServerIpcServerTcpServerRouterDelegate(CancellationToken ct, string ipcServer, string tcpServer, int runtimeTimeoutS, bool shutdownOnChildExit, string verbose);
+        delegate Task<int> DiagnosticsServerIpcServerTcpClientRouterDelegate(CancellationToken ct, string ipcServer, string tcpClient, int runtimeTimeoutS, bool shutdownOnChildExit, string verbose);
 
         private static Command IpcClientTcpServerRouterCommand() =>
             new Command(
@@ -31,7 +31,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
                 // Handler
                 HandlerDescriptor.FromDelegate((DiagnosticsServerIpcClientTcpServerRouterDelegate)new DiagnosticsServerRouterCommands().RunIpcClientTcpServerRouter).GetCommandHandler(),
                 // Options
-                IpcClientAddressOption(), TcpServerAddressOption(), RuntimeTimeoutOption(), VerboseOption()
+                IpcClientAddressOption(), TcpServerAddressOption(), RuntimeTimeoutOption(), ShutdownOnChildExit(), VerboseOption()
             };
 
         private static Command IpcServerTcpServerRouterCommand() =>
@@ -44,7 +44,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
                 // Handler
                 HandlerDescriptor.FromDelegate((DiagnosticsServerIpcServerTcpServerRouterDelegate)new DiagnosticsServerRouterCommands().RunIpcServerTcpServerRouter).GetCommandHandler(),
                 // Options
-                IpcServerAddressOption(), TcpServerAddressOption(), RuntimeTimeoutOption(), VerboseOption()
+                IpcServerAddressOption(), TcpServerAddressOption(), RuntimeTimeoutOption(), ShutdownOnChildExit(), VerboseOption()
             };
 
         private static Command IpcServerTcpClientRouterCommand() =>
@@ -57,7 +57,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
                 // Handler
                 HandlerDescriptor.FromDelegate((DiagnosticsServerIpcServerTcpClientRouterDelegate)new DiagnosticsServerRouterCommands().RunIpcServerTcpClientRouter).GetCommandHandler(),
                 // Options
-                IpcServerAddressOption(), TcpClientAddressOption(), RuntimeTimeoutOption(), VerboseOption()
+                IpcServerAddressOption(), TcpClientAddressOption(), RuntimeTimeoutOption(),ShutdownOnChildExit(), VerboseOption()
             };
 
         private static Option IpcClientAddressOption() =>
@@ -108,6 +108,15 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
                                 "If not specified, router won't trigger an automatic shutdown.")
             {
                 Argument = new Argument<int>(name: "runtimeTimeout", getDefaultValue: () => Timeout.Infinite)
+            };
+
+        private static Option ShutdownOnChildExit() =>
+            new Option(
+                aliases: new[] { "--shutdown-on-child-exit" },
+                description: "Autmoatically shutdown router when any child process exits." +
+                                "If not specified or no child process is executed, router won't trigger an automatic shutdown.")
+            {
+                Argument = new Argument<bool>(name: "shutdownOnChildExit", getDefaultValue: () => false)
             };
 
         private static Option VerboseOption() =>

--- a/src/Tools/dotnet-dsrouter/Program.cs
+++ b/src/Tools/dotnet-dsrouter/Program.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
     {
         delegate Task<int> DiagnosticsServerIpcClientTcpServerRouterDelegate(CancellationToken ct, string ipcClient, string tcpServer, int runtimeTimeoutS, bool shutdownOnChildExit, string verbose);
         delegate Task<int> DiagnosticsServerIpcServerTcpServerRouterDelegate(CancellationToken ct, string ipcServer, string tcpServer, int runtimeTimeoutS, bool shutdownOnChildExit, string verbose);
-        delegate Task<int> DiagnosticsServerIpcServerTcpClientRouterDelegate(CancellationToken ct, string ipcServer, string tcpClient, int runtimeTimeoutS, bool shutdownOnChildExit, string verbose);
+        delegate Task<int> DiagnosticsServerIpcServerTcpClientRouterDelegate(CancellationToken ct, string ipcServer, string tcpClient, int runtimeTimeoutS, bool shutdownOnChildExit, bool suspend, string verbose);
 
         private static Command IpcClientTcpServerRouterCommand() =>
             new Command(
@@ -57,7 +57,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
                 // Handler
                 HandlerDescriptor.FromDelegate((DiagnosticsServerIpcServerTcpClientRouterDelegate)new DiagnosticsServerRouterCommands().RunIpcServerTcpClientRouter).GetCommandHandler(),
                 // Options
-                IpcServerAddressOption(), TcpClientAddressOption(), RuntimeTimeoutOption(),ShutdownOnChildExit(), VerboseOption()
+                IpcServerAddressOption(), TcpClientAddressOption(), RuntimeTimeoutOption(), ShutdownOnChildExit(), Suspend(), VerboseOption()
             };
 
         private static Option IpcClientAddressOption() =>
@@ -113,10 +113,18 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
         private static Option ShutdownOnChildExit() =>
             new Option(
                 aliases: new[] { "--shutdown-on-child-exit" },
-                description: "Autmoatically shutdown router when any child process exits." +
+                description: "Autmatically shutdown router when any child process exits." +
                                 "If not specified or no child process is executed, router won't trigger an automatic shutdown.")
             {
                 Argument = new Argument<bool>(name: "shutdownOnChildExit", getDefaultValue: () => false)
+            };
+
+        private static Option Suspend() =>
+            new Option(
+                aliases: new[] { "--suspend" },
+                description: "Runtime is in suspend mode and needs to be resumed on connect.")
+            {
+                Argument = new Argument<bool>(name: "suspend", getDefaultValue: () => false)
             };
 
         private static Option VerboseOption() =>

--- a/src/Tools/dotnet-dsrouter/Program.cs
+++ b/src/Tools/dotnet-dsrouter/Program.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
         private static Option ShutdownOnChildExit() =>
             new Option(
                 aliases: new[] { "--shutdown-on-child-exit" },
-                description: "Autmatically shutdown router when any child process exits." +
+                description: "Automatically shutdown router when any child process exits." +
                                 "If not specified or no child process is executed, router won't trigger an automatic shutdown.")
             {
                 Argument = new Argument<bool>(name: "shutdownOnChildExit", getDefaultValue: () => false)


### PR DESCRIPTION
* Add support to automatically shutdown router when a child process exits.
* Log process id when starting up dsrouter make it easier to know what process to connect from diagnostics tooling.
* Add ability to set suspend port options when launching custom commands.
* Add HasStarted property to ProcessLauncher to know when we have a success/failed launch, or HasExited will throw in cases where we fail to launch process.