### PR TITLE
Refactor IPC communication to allow for async and cancellation.

### DIFF
--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -68,7 +67,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
         /// </returns> 
         public EventPipeSession StartEventPipeSession(IEnumerable<EventPipeProvider> providers, bool requestRundown = true, int circularBufferMB = 256)
         {
-            return new EventPipeSession(_endpoint, providers, requestRundown, circularBufferMB);
+            return EventPipeSession.Start(_endpoint, providers, requestRundown, circularBufferMB);
         }
 
         /// <summary>
@@ -82,7 +81,37 @@ namespace Microsoft.Diagnostics.NETCore.Client
         /// </returns> 
         public EventPipeSession StartEventPipeSession(EventPipeProvider provider, bool requestRundown = true, int circularBufferMB = 256)
         {
-            return new EventPipeSession(_endpoint, new[] { provider }, requestRundown, circularBufferMB);
+            return EventPipeSession.Start(_endpoint, new[] { provider }, requestRundown, circularBufferMB);
+        }
+
+        /// <summary>
+        /// Start tracing the application and return an EventPipeSession object
+        /// </summary>
+        /// <param name="providers">An IEnumerable containing the list of Providers to turn on.</param>
+        /// <param name="requestRundown">If true, request rundown events from the runtime</param>
+        /// <param name="circularBufferMB">The size of the runtime's buffer for collecting events in MB</param>
+        /// <param name="token">The token to monitor for cancellation requests.</param>
+        /// <returns>
+        /// An EventPipeSession object representing the EventPipe session that just started.
+        /// </returns> 
+        internal Task<EventPipeSession> StartEventPipeSessionAsync(IEnumerable<EventPipeProvider> providers, bool requestRundown, int circularBufferMB, CancellationToken token)
+        {
+            return EventPipeSession.StartAsync(_endpoint, providers, requestRundown, circularBufferMB, token);
+        }
+
+        /// <summary>
+        /// Start tracing the application and return an EventPipeSession object
+        /// </summary>
+        /// <param name="provider">An EventPipeProvider to turn on.</param>
+        /// <param name="requestRundown">If true, request rundown events from the runtime</param>
+        /// <param name="circularBufferMB">The size of the runtime's buffer for collecting events in MB</param>
+        /// <param name="token">The token to monitor for cancellation requests.</param>
+        /// <returns>
+        /// An EventPipeSession object representing the EventPipe session that just started.
+        /// </returns>
+        internal Task<EventPipeSession> StartEventPipeSessionAsync(EventPipeProvider provider, bool requestRundown, int circularBufferMB, CancellationToken token)
+        {
+            return EventPipeSession.StartAsync(_endpoint, new[] { provider }, requestRundown, circularBufferMB, token);
         }
 
         /// <summary>
@@ -93,26 +122,23 @@ namespace Microsoft.Diagnostics.NETCore.Client
         /// <param name="logDumpGeneration">When set to true, display the dump generation debug log to the console.</param>
         public void WriteDump(DumpType dumpType, string dumpPath, bool logDumpGeneration = false)
         {
-            if (string.IsNullOrEmpty(dumpPath))
-                throw new ArgumentNullException($"{nameof(dumpPath)} required");
+            IpcMessage request = CreateWriteDumpMessage(dumpType, dumpPath, logDumpGeneration);
+            IpcMessage response = IpcClient.SendMessage(_endpoint, request);
+            ValidateResponseMessage(response, nameof(WriteDump));
+        }
 
-            byte[] payload = SerializePayload(dumpPath, (uint)dumpType, logDumpGeneration);
-            IpcMessage message = new IpcMessage(DiagnosticsServerCommandSet.Dump, (byte)DumpCommandId.GenerateCoreDump, payload);
-            IpcMessage response = IpcClient.SendMessage(_endpoint, message);
-            switch ((DiagnosticsServerResponseId)response.Header.CommandId)
-            {
-                case DiagnosticsServerResponseId.Error:
-                    uint hr = BitConverter.ToUInt32(response.Payload, 0);
-                    if (hr == (uint)DiagnosticsIpcError.UnknownCommand)
-                    {
-                        throw new UnsupportedCommandException($"Unsupported operating system: {RuntimeInformation.OSDescription}");
-                    }
-                    throw new ServerErrorException($"Writing dump failed (HRESULT: 0x{hr:X8})");
-                case DiagnosticsServerResponseId.OK:
-                    return;
-                default:
-                    throw new ServerErrorException($"Writing dump failed - server responded with unknown command");
-            }
+        /// <summary>
+        /// Trigger a core dump generation.
+        /// </summary> 
+        /// <param name="dumpType">Type of the dump to be generated</param>
+        /// <param name="dumpPath">Full path to the dump to be generated. By default it is /tmp/coredump.{pid}</param>
+        /// <param name="logDumpGeneration">When set to true, display the dump generation debug log to the console.</param>
+        /// <param name="token">The token to monitor for cancellation requests.</param>
+        internal async Task WriteDumpAsync(DumpType dumpType, string dumpPath, bool logDumpGeneration, CancellationToken token)
+        {
+            IpcMessage request = CreateWriteDumpMessage(dumpType, dumpPath, logDumpGeneration);
+            IpcMessage response = await IpcClient.SendMessageAsync(_endpoint, request, token).ConfigureAwait(false);
+            ValidateResponseMessage(response, nameof(WriteDumpAsync));
         }
 
         /// <summary>
@@ -124,41 +150,20 @@ namespace Microsoft.Diagnostics.NETCore.Client
         /// <param name="additionalData">Additional data to be passed to the profiler</param>
         public void AttachProfiler(TimeSpan attachTimeout, Guid profilerGuid, string profilerPath, byte[] additionalData = null)
         {
-            if (profilerGuid == null || profilerGuid == Guid.Empty)
-            {
-                throw new ArgumentException($"{nameof(profilerGuid)} must be a valid Guid");
-            }
-
-            if (String.IsNullOrEmpty(profilerPath))
-            {
-                throw new ArgumentException($"{nameof(profilerPath)} must be non-null");
-            }
-
-            byte[] serializedConfiguration = SerializePayload((uint)attachTimeout.TotalSeconds, profilerGuid, profilerPath, additionalData);
-            var message = new IpcMessage(DiagnosticsServerCommandSet.Profiler, (byte)ProfilerCommandId.AttachProfiler, serializedConfiguration);
-            var response = IpcClient.SendMessage(_endpoint, message);
-            switch ((DiagnosticsServerResponseId)response.Header.CommandId)
-            {
-                case DiagnosticsServerResponseId.Error:
-                    uint hr = BitConverter.ToUInt32(response.Payload, 0);
-                    if (hr == (uint)DiagnosticsIpcError.UnknownCommand)
-                    {
-                        throw new UnsupportedCommandException("The target runtime does not support profiler attach");
-                    }
-                    if (hr == (uint)DiagnosticsIpcError.ProfilerAlreadyActive)
-                    {
-                        throw new ProfilerAlreadyActiveException("The request to attach a profiler was denied because a profiler is already loaded");
-                    }
-                    throw new ServerErrorException($"Profiler attach failed (HRESULT: 0x{hr:X8})");
-                case DiagnosticsServerResponseId.OK:
-                    return;
-                default:
-                    throw new ServerErrorException($"Profiler attach failed - server responded with unknown command");
-            }
+            IpcMessage request = CreateAttachProfilerMessage(attachTimeout, profilerGuid, profilerPath, additionalData);
+            IpcMessage response = IpcClient.SendMessage(_endpoint, request);
+            ValidateResponseMessage(response, nameof(AttachProfiler));
 
             // The call to set up the pipe and send the message operates on a different timeout than attachTimeout, which is for the runtime.
             // We should eventually have a configurable timeout for the message passing, potentially either separately from the 
             // runtime timeout or respect attachTimeout as one total duration.
+        }
+
+        internal async Task AttachProfilerAsync(TimeSpan attachTimeout, Guid profilerGuid, string profilerPath, byte[] additionalData, CancellationToken token)
+        {
+            IpcMessage request = CreateAttachProfilerMessage(attachTimeout, profilerGuid, profilerPath, additionalData);
+            IpcMessage response = await IpcClient.SendMessageAsync(_endpoint, request, token).ConfigureAwait(false);
+            ValidateResponseMessage(response, nameof(AttachProfilerAsync));
         }
 
         /// <summary>
@@ -169,38 +174,16 @@ namespace Microsoft.Diagnostics.NETCore.Client
         /// <param name="profilerPath">Path to the profiler to be attached</param>
         public void SetStartupProfiler(Guid profilerGuid, string profilerPath)
         {
-            if (profilerGuid == null || profilerGuid == Guid.Empty)
-            {
-                throw new ArgumentException($"{nameof(profilerGuid)} must be a valid Guid");
-            }
+            IpcMessage request = CreateSetStartupProfilerMessage(profilerGuid, profilerPath);
+            IpcMessage response = IpcClient.SendMessage(_endpoint, request);
+            ValidateResponseMessage(response, nameof(SetStartupProfiler), ValidateResponseOptions.InvalidArgumentIsRequiresSuspension);
+        }
 
-            if (String.IsNullOrEmpty(profilerPath))
-            {
-                throw new ArgumentException($"{nameof(profilerPath)} must be non-null");
-            }
-
-            byte[] serializedConfiguration = SerializePayload(profilerGuid, profilerPath);
-            var message = new IpcMessage(DiagnosticsServerCommandSet.Profiler, (byte)ProfilerCommandId.StartupProfiler, serializedConfiguration);
-            var response = IpcClient.SendMessage(_endpoint, message);
-            switch ((DiagnosticsServerResponseId)response.Header.CommandId)
-            {
-                case DiagnosticsServerResponseId.Error:
-                    uint hr = BitConverter.ToUInt32(response.Payload, 0);
-                    if (hr == (uint)DiagnosticsIpcError.UnknownCommand)
-                    {
-                        throw new UnsupportedCommandException("The target runtime does not support the ProfilerStartup command.");
-                    }
-                    else if (hr == (uint)DiagnosticsIpcError.InvalidArgument)
-                    {
-                        throw new ServerErrorException("The runtime must be suspended to issue the SetStartupProfiler command.");
-                    }
-
-                    throw new ServerErrorException($"Profiler startup failed (HRESULT: 0x{hr:X8})");
-                case DiagnosticsServerResponseId.OK:
-                    return;
-                default:
-                    throw new ServerErrorException($"Profiler startup failed - server responded with unknown command");
-            }
+        internal async Task SetStartupProfilerAsync(Guid profilerGuid, string profilerPath, CancellationToken token)
+        {
+            IpcMessage request = CreateSetStartupProfilerMessage(profilerGuid, profilerPath);
+            IpcMessage response = await IpcClient.SendMessageAsync(_endpoint, request, token).ConfigureAwait(false);
+            ValidateResponseMessage(response, nameof(SetStartupProfilerAsync), ValidateResponseOptions.InvalidArgumentIsRequiresSuspension);
         }
 
         /// <summary>
@@ -208,19 +191,16 @@ namespace Microsoft.Diagnostics.NETCore.Client
         /// </summary>
         public void ResumeRuntime()
         {
-            IpcMessage message = new IpcMessage(DiagnosticsServerCommandSet.Process, (byte)ProcessCommandId.ResumeRuntime);
-            var response = IpcClient.SendMessage(_endpoint, message);
-            switch ((DiagnosticsServerResponseId)response.Header.CommandId)
-            {
-                case DiagnosticsServerResponseId.Error:
-                    // Try fallback for Preview 7 and Preview 8
-                    ResumeRuntimeFallback();
-                    return;
-                case DiagnosticsServerResponseId.OK:
-                    return;
-                default:
-                    throw new ServerErrorException($"Resume runtime failed - server responded with unknown command");
-            }
+            IpcMessage request = CreateResumeRuntimeMessage();
+            IpcMessage response = IpcClient.SendMessage(_endpoint, request);
+            ValidateResponseMessage(response, nameof(ResumeRuntime));
+        }
+
+        internal async Task ResumeRuntimeAsync(CancellationToken token)
+        {
+            IpcMessage request = CreateResumeRuntimeMessage();
+            IpcMessage response = await IpcClient.SendMessageAsync(_endpoint, request, token).ConfigureAwait(false);
+            ValidateResponseMessage(response, nameof(ResumeRuntimeAsync));
         }
 
         /// <summary>
@@ -230,29 +210,16 @@ namespace Microsoft.Diagnostics.NETCore.Client
         /// <param name="value">The value of the environment variable to set.</param>
         public void SetEnvironmentVariable(string name, string value)
         {
-            if (String.IsNullOrEmpty(name))
-            {
-                throw new ArgumentException($"{nameof(name)} must be non-null.");
-            }
+            IpcMessage request = CreateSetEnvironmentVariableMessage(name, value);
+            IpcMessage response = IpcClient.SendMessage(_endpoint, request);
+            ValidateResponseMessage(response, nameof(SetEnvironmentVariable));
+        }
 
-            byte[] serializedConfiguration = SerializePayload(name, value);
-            var message = new IpcMessage(DiagnosticsServerCommandSet.Process, (byte)ProcessCommandId.SetEnvironmentVariable, serializedConfiguration);
-            var response = IpcClient.SendMessage(_endpoint, message);
-            switch ((DiagnosticsServerResponseId)response.Header.CommandId)
-            {
-                case DiagnosticsServerResponseId.Error:
-                    uint hr = BitConverter.ToUInt32(response.Payload, 0);
-                    if (hr == (uint)DiagnosticsIpcError.UnknownCommand)
-                    {
-                        throw new UnsupportedCommandException("The target runtime does not support the SetEnvironmentVariable command.");
-                    }
-
-                    throw new ServerErrorException($"SetEnvironmentVariable failed (HRESULT: 0x{hr:X8})");
-                case DiagnosticsServerResponseId.OK:
-                    return;
-                default:
-                    throw new ServerErrorException($"SetEnvironmentVariable failed - server responded with unknown command");
-            }
+        internal async Task SetEnvironmentVariableAsync(string name, string value, CancellationToken token)
+        {
+            IpcMessage request = CreateSetEnvironmentVariableMessage(name, value);
+            IpcMessage response = await IpcClient.SendMessageAsync(_endpoint, request, token).ConfigureAwait(false);
+            ValidateResponseMessage(response, nameof(SetEnvironmentVariableAsync));
         }
 
         /// <summary>
@@ -261,21 +228,18 @@ namespace Microsoft.Diagnostics.NETCore.Client
         /// <returns>A dictionary containing all of the environment variables defined in the target process.</returns>
         public Dictionary<string, string> GetProcessEnvironment()
         {
-            var message = new IpcMessage(DiagnosticsServerCommandSet.Process, (byte)ProcessCommandId.GetProcessEnvironment);
-            Stream continuation = IpcClient.SendMessage(_endpoint, message, out IpcMessage response);
-            switch ((DiagnosticsServerResponseId)response.Header.CommandId)
-            {
-                case DiagnosticsServerResponseId.Error:
-                    int hr = BitConverter.ToInt32(response.Payload, 0);
-                    throw new ServerErrorException($"Get process environment failed (HRESULT: 0x{hr:X8})");
-                case DiagnosticsServerResponseId.OK:
-                    ProcessEnvironmentHelper helper = ProcessEnvironmentHelper.Parse(response.Payload);
-                    Task<Dictionary<string, string>> envTask = helper.ReadEnvironmentAsync(continuation);
-                    envTask.Wait();
-                    return envTask.Result;
-                default:
-                    throw new ServerErrorException($"Get process environment failed - server responded with unknown command");
-            }
+            IpcMessage message = CreateProcessEnvironmentMessage();
+            using IpcResponse response = IpcClient.SendMessageGetContinuation(_endpoint, message);
+            Task<Dictionary<string, string>> envTask = GetProcessEnvironmentFromResponse(response, nameof(GetProcessEnvironment), CancellationToken.None);
+            envTask.Wait();
+            return envTask.Result;
+        }
+
+        internal async Task<Dictionary<string, string>> GetProcessEnvironmentAsync(CancellationToken token)
+        {
+            IpcMessage message = CreateProcessEnvironmentMessage();
+            using IpcResponse response = await IpcClient.SendMessageGetContinuationAsync(_endpoint, message, token).ConfigureAwait(false);
+            return await GetProcessEnvironmentFromResponse(response, nameof(GetProcessEnvironmentAsync), token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -304,28 +268,6 @@ namespace Microsoft.Diagnostics.NETCore.Client
             return GetAllPublishedProcesses().Distinct();
         }
 
-
-        // Fallback command for .NET 5 Preview 7 and Preview 8
-        internal void ResumeRuntimeFallback()
-        {
-            IpcMessage message = new IpcMessage(DiagnosticsServerCommandSet.Server, (byte)DiagnosticServerCommandId.ResumeRuntime);
-            var response = IpcClient.SendMessage(_endpoint, message);
-            switch ((DiagnosticsServerResponseId)response.Header.CommandId)
-            {
-                case DiagnosticsServerResponseId.Error:
-                    var hr = BitConverter.ToUInt32(response.Payload, 0);
-                    if (hr == (uint)DiagnosticsIpcError.UnknownCommand)
-                    {
-                        throw new UnsupportedCommandException($"Resume runtime command is unknown by target runtime.");
-                    }
-                    throw new ServerErrorException($"Resume runtime failed (HRESULT: 0x{hr:X8})");
-                case DiagnosticsServerResponseId.OK:
-                    return;
-                default:
-                    throw new ServerErrorException($"Resume runtime failed - server responded with unknown command");
-            }
-        }
-
         internal ProcessInfo GetProcessInfo()
         {
             // RE: https://github.com/dotnet/runtime/issues/54083
@@ -333,47 +275,47 @@ namespace Microsoft.Diagnostics.NETCore.Client
             // Disable the usage of the command until that issue is fixed.
 
             // Attempt to get ProcessInfo v2
-            //ProcessInfo processInfo = GetProcessInfo2();
+            //ProcessInfo processInfo = TryGetProcessInfo2();
             //if (null != processInfo)
             //{
             //    return processInfo;
             //}
 
-            // Attempt to get ProcessInfo v1
-            IpcMessage message = new IpcMessage(DiagnosticsServerCommandSet.Process, (byte)ProcessCommandId.GetProcessInfo);
-            var response = IpcClient.SendMessage(_endpoint, message);
-            switch ((DiagnosticsServerResponseId)response.Header.CommandId)
-            {
-                case DiagnosticsServerResponseId.Error:
-                    var hr = BitConverter.ToInt32(response.Payload, 0);
-                    throw new ServerErrorException($"Get process info failed (HRESULT: 0x{hr:X8})");
-                case DiagnosticsServerResponseId.OK:
-                    return ProcessInfo.ParseV1(response.Payload);
-                default:
-                    throw new ServerErrorException($"Get process info failed - server responded with unknown command");
-            }
+            IpcMessage request = CreateProcessInfoMessage();
+            using IpcResponse response = IpcClient.SendMessageGetContinuation(_endpoint, request);
+            return GetProcessInfoFromResponse(response, nameof(GetProcessInfo));
         }
 
-        private ProcessInfo GetProcessInfo2()
+        internal async Task<ProcessInfo> GetProcessInfoAsync(CancellationToken token)
         {
-            IpcMessage message = new IpcMessage(DiagnosticsServerCommandSet.Process, (byte)ProcessCommandId.GetProcessInfo2);
-            var response = IpcClient.SendMessage(_endpoint, message);
-            switch ((DiagnosticsServerResponseId)response.Header.CommandId)
-            {
-                case DiagnosticsServerResponseId.Error:
-                    uint hr = BitConverter.ToUInt32(response.Payload, 0);
-                    // In the case that the runtime doesn't understand the GetProcessInfo2 command,
-                    // just break to allow fallback to try to get ProcessInfo v1.
-                    if (hr == (uint)DiagnosticsIpcError.UnknownCommand)
-                    {
-                        return null;
-                    }
-                    throw new ServerErrorException($"GetProcessInfo2 failed (HRESULT: 0x{hr:X8})");
-                case DiagnosticsServerResponseId.OK:
-                    return ProcessInfo.ParseV2(response.Payload);
-                default:
-                    throw new ServerErrorException($"Get process info failed - server responded with unknown command");
-            }
+            // RE: https://github.com/dotnet/runtime/issues/54083
+            // If the GetProcessInfo2 command is sent too early, it will crash the runtime instance.
+            // Disable the usage of the command until that issue is fixed.
+
+            // Attempt to get ProcessInfo v2
+            //ProcessInfo processInfo = await TryGetProcessInfo2Async(token);
+            //if (null != processInfo)
+            //{
+            //    return processInfo;
+            //}
+
+            IpcMessage request = CreateProcessInfoMessage();
+            using IpcResponse response = await IpcClient.SendMessageGetContinuationAsync(_endpoint, request, token).ConfigureAwait(false);
+            return GetProcessInfoFromResponse(response, nameof(GetProcessInfoAsync));
+        }
+
+        private ProcessInfo TryGetProcessInfo2()
+        {
+            IpcMessage request = CreateProcessInfo2Message();
+            using IpcResponse response2 = IpcClient.SendMessageGetContinuation(_endpoint, request);
+            return TryGetProcessInfo2FromResponse(response2, nameof(GetProcessInfo));
+        }
+
+        private async Task<ProcessInfo> TryGetProcessInfo2Async(CancellationToken token)
+        {
+            IpcMessage request = CreateProcessInfo2Message();
+            using IpcResponse response2 = await IpcClient.SendMessageGetContinuationAsync(_endpoint, request, token).ConfigureAwait(false);
+            return TryGetProcessInfo2FromResponse(response2, nameof(GetProcessInfoAsync));
         }
 
         private static byte[] SerializePayload<T>(T arg)
@@ -454,6 +396,142 @@ namespace Microsoft.Diagnostics.NETCore.Client
             {
                 throw new ArgumentException($"Type {obj.GetType()} is not supported in SerializePayloadArgument, please add it.");
             }
+        }
+
+        private static IpcMessage CreateAttachProfilerMessage(TimeSpan attachTimeout, Guid profilerGuid, string profilerPath, byte[] additionalData)
+        {
+            if (profilerGuid == null || profilerGuid == Guid.Empty)
+            {
+                throw new ArgumentException($"{nameof(profilerGuid)} must be a valid Guid");
+            }
+
+            if (String.IsNullOrEmpty(profilerPath))
+            {
+                throw new ArgumentException($"{nameof(profilerPath)} must be non-null");
+            }
+
+            byte[] serializedConfiguration = SerializePayload((uint)attachTimeout.TotalSeconds, profilerGuid, profilerPath, additionalData);
+            return new IpcMessage(DiagnosticsServerCommandSet.Profiler, (byte)ProfilerCommandId.AttachProfiler, serializedConfiguration);
+        }
+
+        private static IpcMessage CreateProcessEnvironmentMessage()
+        {
+            return new IpcMessage(DiagnosticsServerCommandSet.Process, (byte)ProcessCommandId.GetProcessEnvironment);
+        }
+
+        private static IpcMessage CreateProcessInfoMessage()
+        {
+            return new IpcMessage(DiagnosticsServerCommandSet.Process, (byte)ProcessCommandId.GetProcessInfo);
+        }
+
+        private static IpcMessage CreateProcessInfo2Message()
+        {
+            return new IpcMessage(DiagnosticsServerCommandSet.Process, (byte)ProcessCommandId.GetProcessInfo2);
+        }
+
+        private static IpcMessage CreateResumeRuntimeMessage()
+        {
+            return new IpcMessage(DiagnosticsServerCommandSet.Process, (byte)ProcessCommandId.ResumeRuntime);
+        }
+
+        private static IpcMessage CreateSetEnvironmentVariableMessage(string name, string value)
+        {
+            if (String.IsNullOrEmpty(name))
+            {
+                throw new ArgumentException($"{nameof(name)} must be non-null.");
+            }
+
+            byte[] serializedConfiguration = SerializePayload(name, value);
+            return new IpcMessage(DiagnosticsServerCommandSet.Process, (byte)ProcessCommandId.SetEnvironmentVariable, serializedConfiguration);
+        }
+
+        private static IpcMessage CreateSetStartupProfilerMessage(Guid profilerGuid, string profilerPath)
+        {
+            if (profilerGuid == null || profilerGuid == Guid.Empty)
+            {
+                throw new ArgumentException($"{nameof(profilerGuid)} must be a valid Guid");
+            }
+
+            if (String.IsNullOrEmpty(profilerPath))
+            {
+                throw new ArgumentException($"{nameof(profilerPath)} must be non-null");
+            }
+
+            byte[] serializedConfiguration = SerializePayload(profilerGuid, profilerPath);
+            return new IpcMessage(DiagnosticsServerCommandSet.Profiler, (byte)ProfilerCommandId.StartupProfiler, serializedConfiguration);
+        }
+
+        private static IpcMessage CreateWriteDumpMessage(DumpType dumpType, string dumpPath, bool logDumpGeneration)
+        {
+            if (string.IsNullOrEmpty(dumpPath))
+                throw new ArgumentNullException($"{nameof(dumpPath)} required");
+
+            byte[] payload = SerializePayload(dumpPath, (uint)dumpType, logDumpGeneration);
+            return new IpcMessage(DiagnosticsServerCommandSet.Dump, (byte)DumpCommandId.GenerateCoreDump, payload);
+        }
+
+        private static Task<Dictionary<string, string>> GetProcessEnvironmentFromResponse(IpcResponse response, string operationName, CancellationToken token)
+        {
+            ValidateResponseMessage(response.Message, operationName);
+
+            ProcessEnvironmentHelper helper = ProcessEnvironmentHelper.Parse(response.Message.Payload);
+            return helper.ReadEnvironmentAsync(response.Continuation, token);
+        }
+
+        private static ProcessInfo GetProcessInfoFromResponse(IpcResponse response, string operationName)
+        {
+            ValidateResponseMessage(response.Message, operationName);
+
+            return ProcessInfo.ParseV1(response.Message.Payload);
+        }
+
+        private static ProcessInfo TryGetProcessInfo2FromResponse(IpcResponse response, string operationName)
+        {
+            if (!ValidateResponseMessage(response.Message, operationName, ValidateResponseOptions.UnknownCommandReturnsFalse))
+            {
+                return null;
+            }
+
+            return ProcessInfo.ParseV2(response.Message.Payload);
+        }
+
+        internal static bool ValidateResponseMessage(IpcMessage responseMessage, string operationName, ValidateResponseOptions options = ValidateResponseOptions.None)
+        {
+            switch ((DiagnosticsServerResponseId)responseMessage.Header.CommandId)
+            {
+                case DiagnosticsServerResponseId.Error:
+                    uint hr = BitConverter.ToUInt32(responseMessage.Payload, 0);
+                    switch (hr)
+                    {
+                        case (uint)DiagnosticsIpcError.UnknownCommand:
+                            if (options.HasFlag(ValidateResponseOptions.UnknownCommandReturnsFalse))
+                            {
+                                return false;
+                            }
+                            throw new UnsupportedCommandException($"{operationName} failed - Command is not supported.");
+                        case (uint)DiagnosticsIpcError.ProfilerAlreadyActive:
+                            throw new ProfilerAlreadyActiveException($"{operationName} failed - A profiler is already loaded.");
+                        case (uint)DiagnosticsIpcError.InvalidArgument:
+                            if (options.HasFlag(ValidateResponseOptions.InvalidArgumentIsRequiresSuspension))
+                            {
+                                throw new ServerErrorException($"{operationName} failed - The runtime must be suspended for this command.");
+                            }
+                            throw new UnsupportedCommandException($"{operationName} failed - Invalid command argument.");
+                    }
+                    throw new ServerErrorException($"{operationName} failed - HRESULT: 0x{hr:X8}");
+                case DiagnosticsServerResponseId.OK:
+                    return true;
+                default:
+                    throw new ServerErrorException($"{operationName} failed - Server responded with unknown response.");
+            }
+        }
+
+        [Flags]
+        internal enum ValidateResponseOptions
+        {
+            None = 0x0,
+            UnknownCommandReturnsFalse = 0x1,
+            InvalidArgumentIsRequiresSuspension = 0x2,
         }
     }
 }

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcClient.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcClient.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
 
                 IpcMessage response = Read(stream);
 
-                return new IpcResponse(response, Exchange(ref stream, null));
+                return new IpcResponse(response, Release(ref stream));
             }
             finally
             {
@@ -83,7 +83,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
 
                 IpcMessage response = await ReadAsync(stream, cancellationToken).ConfigureAwait(false);
 
-                return new IpcResponse(response, Exchange(ref stream, null));
+                return new IpcResponse(response, Release(ref stream));
             }
             finally
             {
@@ -113,10 +113,10 @@ namespace Microsoft.Diagnostics.NETCore.Client
             return IpcMessage.ParseAsync(stream, cancellationToken);
         }
 
-        private static Stream Exchange(ref Stream stream1, Stream stream2)
+        private static Stream Release(ref Stream stream1)
         {
             Stream intermediate = stream1;
-            stream1 = stream2;
+            stream1 = null;
             return intermediate;
         }
     }

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcClient.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcClient.cs
@@ -13,10 +13,10 @@ namespace Microsoft.Diagnostics.NETCore.Client
     {
         // The amount of time to wait for a stream to be available for consumption by the Connect method.
         // Normally expect the runtime to respond quickly but resource constrained machines may take longer.
-        private static readonly TimeSpan ConnectTimeout = TimeSpan.FromSeconds(30);
+        internal static readonly TimeSpan ConnectTimeout = TimeSpan.FromSeconds(30);
 
         /// <summary>
-        /// Sends a single DiagnosticsIpc Message to the dotnet process with PID processId.
+        /// Sends a single DiagnosticsIpc Message to the dotnet process associated with the <paramref name="endpoint"/>.
         /// </summary>
         /// <param name="endpoint">An endpoint that provides a diagnostics connection to a runtime instance.</param>
         /// <param name="message">The DiagnosticsIpc Message to be sent</param>
@@ -28,7 +28,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
         }
 
         /// <summary>
-        /// Sends a single DiagnosticsIpc Message to the dotnet process with PID processId.
+        /// Sends a single DiagnosticsIpc Message to the dotnet process associated with the <paramref name="endpoint"/>.
         /// </summary>
         /// <param name="endpoint">An endpoint that provides a diagnostics connection to a runtime instance.</param>
         /// <param name="message">The DiagnosticsIpc Message to be sent</param>
@@ -53,7 +53,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
         }
 
         /// <summary>
-        /// Sends a single DiagnosticsIpc Message to the dotnet process with PID processId.
+        /// Sends a single DiagnosticsIpc Message to the dotnet process associated with the <paramref name="endpoint"/>.
         /// </summary>
         /// <param name="endpoint">An endpoint that provides a diagnostics connection to a runtime instance.</param>
         /// <param name="message">The DiagnosticsIpc Message to be sent</param>
@@ -66,7 +66,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
         }
 
         /// <summary>
-        /// Sends a single DiagnosticsIpc Message to the dotnet process with PID processId.
+        /// Sends a single DiagnosticsIpc Message to the dotnet process associated with the <paramref name="endpoint"/>.
         /// </summary>
         /// <param name="endpoint">An endpoint that provides a diagnostics connection to a runtime instance.</param>
         /// <param name="message">The DiagnosticsIpc Message to be sent</param>

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcCommands.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcCommands.cs
@@ -18,17 +18,6 @@ namespace Microsoft.Diagnostics.NETCore.Client
         Server         = 0xFF,
     }
 
-    // For .NET 5 Preview 7 and Preview 8, use this with the
-    // DiagnosticsServerCommandSet.Server command set.
-    // For .NET 5 RC and later, use ProcessCommandId.ResumeRuntime with
-    // the DiagnosticsServerCommandSet.Process command set.
-    internal enum DiagnosticServerCommandId : byte
-    {
-        // 0x00 used in DiagnosticServerResponseId
-        ResumeRuntime = 0x01,
-        // 0xFF used DiagnosticServerResponseId
-    };
-
     internal enum DiagnosticsServerResponseId : byte
     {
         OK            = 0x00,

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcMessage.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcMessage.cs
@@ -7,6 +7,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.Diagnostics.NETCore.Client
 {
@@ -112,10 +114,18 @@ namespace Microsoft.Diagnostics.NETCore.Client
             IpcMessage message = new IpcMessage();
             using (var reader = new BinaryReader(stream, Encoding.UTF8, true))
             {
-                message.Header = IpcHeader.TryParse(reader);
+                message.Header = IpcHeader.Parse(reader);
                 message.Payload = reader.ReadBytes(message.Header.Size - IpcHeader.HeaderSizeInBytes);
                 return message;
             }
+        }
+
+        public static async Task<IpcMessage> ParseAsync(Stream stream, CancellationToken cancellationToken)
+        {
+            IpcMessage message = new IpcMessage();
+            message.Header = await IpcHeader.ParseAsync(stream, cancellationToken).ConfigureAwait(false);
+            message.Payload = await stream.ReadBytesAsync(message.Header.Size - IpcHeader.HeaderSizeInBytes, cancellationToken).ConfigureAwait(false);
+            return message;
         }
     }
 }

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcResponse.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcResponse.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+
+namespace Microsoft.Diagnostics.NETCore.Client
+{
+    internal struct IpcResponse : IDisposable
+    {
+        public readonly IpcMessage Message;
+
+        public readonly Stream Continuation;
+
+        public IpcResponse(IpcMessage message, Stream continuation)
+        {
+            Message = message;
+            Continuation = continuation;
+        }
+
+        public void Dispose()
+        {
+            Continuation?.Dispose();
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj
+++ b/src/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj
@@ -24,6 +24,7 @@
     <InternalsVisibleTo Include="dotnet-monitor" />
     <InternalsVisibleTo Include="dotnet-trace" />
     <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring" />
+    <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.EventPipe" />
     <!-- Temporary until Diagnostic Apis are finalized-->
     <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.WebApi" />
     <InternalsVisibleTo Include="Microsoft.Diagnostics.NETCore.Client.UnitTests" />

--- a/src/Microsoft.Diagnostics.NETCore.Client/StreamExtensions.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/StreamExtensions.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.NETCore.Client
+{
+    internal static class StreamExtensions
+    {
+        public static async Task<byte[]> ReadBytesAsync(this Stream stream, int length, CancellationToken cancellationToken)
+        {
+            byte[] buffer = new byte[length];
+
+            int totalRead = 0;
+            int remaining = length;
+            while (remaining > 0)
+            {
+                int read = await stream.ReadAsync(buffer, totalRead, remaining, cancellationToken);
+                if (0 == read)
+                {
+                    throw new EndOfStreamException();
+                }
+
+                remaining -= read;
+                totalRead += read;
+            }
+
+            return buffer;
+        }
+    }
+}

--- a/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventLogsPipelineUnitTests.cs
+++ b/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventLogsPipelineUnitTests.cs
@@ -8,11 +8,13 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
+using Xunit.Extensions;
 
 namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
 {
@@ -79,9 +81,14 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
         /// <summary>
         /// Test that log events at the default level are collected for categories without a specified level.
         /// </summary>
-        [Fact]
+        [SkippableFact]
         public async Task TestLogsAllCategoriesDefaultLevelFallback()
         {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                throw new SkipTestException("https://github.com/dotnet/diagnostics/issues/2541");
+            }
+
             using Stream outputStream = await GetLogsAsync(settings =>
             {
                 settings.UseAppFilters = false;

--- a/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventLogsPipelineUnitTests.cs
+++ b/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventLogsPipelineUnitTests.cs
@@ -151,9 +151,14 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
         /// Test that log events are collected for the categories and levels specified by the application
         /// and for the categories and levels specified in the filter specs.
         /// </summary>
-        [Fact]
+        [SkippableFact]
         public async Task TestLogsUseAppFiltersAndFilterSpecs()
         {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                throw new SkipTestException("https://github.com/dotnet/diagnostics/issues/2541");
+            }
+
             using Stream outputStream = await GetLogsAsync(settings =>
             {
                 settings.FilterSpecs = new Dictionary<string, LogLevel?>()

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClientApiShim.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClientApiShim.cs
@@ -1,0 +1,93 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.NETCore.Client
+{
+    /// <summary>
+    /// Unifies the async and non-async methods of the DiagnosticsClient class
+    /// so that tests do not need to be duplicated for testing each version of the
+    /// same API.
+    /// </summary>
+    internal sealed class DiagnosticsClientApiShim
+    {
+        private readonly DiagnosticsClient _client;
+        private readonly bool _useAsync;
+
+        public DiagnosticsClientApiShim(DiagnosticsClient client, bool useAsync)
+        {
+            _client = client;
+            _useAsync = useAsync;
+        }
+
+        public async Task<Dictionary<string, string>> GetProcessEnvironment(TimeSpan timeout)
+        {
+            if (_useAsync)
+            {
+                using CancellationTokenSource cancellation = new CancellationTokenSource(timeout);
+                return await _client.GetProcessEnvironmentAsync(cancellation.Token).ConfigureAwait(false);
+            }
+            else
+            {
+                return _client.GetProcessEnvironment();
+            }
+        }
+
+        public async Task<ProcessInfo> GetProcessInfo(TimeSpan timeout)
+        {
+            if (_useAsync)
+            {
+                using CancellationTokenSource cancellation = new CancellationTokenSource(timeout);
+                return await _client.GetProcessInfoAsync(cancellation.Token).ConfigureAwait(false);
+            }
+            else
+            {
+                return _client.GetProcessInfo();
+            }
+        }
+
+        public async Task ResumeRuntime(TimeSpan timeout)
+        {
+            if (_useAsync)
+            {
+                using CancellationTokenSource cancellation = new CancellationTokenSource(timeout);
+                await _client.ResumeRuntimeAsync(cancellation.Token).ConfigureAwait(false);
+            }
+            else
+            {
+                _client.ResumeRuntime();
+            }
+        }
+
+        public async Task<EventPipeSession> StartEventPipeSession(IEnumerable<EventPipeProvider> providers, TimeSpan timeout)
+        {
+            if (_useAsync)
+            {
+                CancellationTokenSource cancellation = new CancellationTokenSource(timeout);
+                return await _client.StartEventPipeSessionAsync(providers, true, circularBufferMB: 256, cancellation.Token).ConfigureAwait(false);
+            }
+            else
+            {
+                return _client.StartEventPipeSession(providers);
+            }
+        }
+
+        public async Task<EventPipeSession> StartEventPipeSession(EventPipeProvider provider, TimeSpan timeout)
+        {
+            if (_useAsync)
+            {
+                CancellationTokenSource cancellation = new CancellationTokenSource(timeout);
+                return await _client.StartEventPipeSessionAsync(provider, true, circularBufferMB: 256, cancellation.Token).ConfigureAwait(false);
+            }
+            else
+            {
+                return _client.StartEventPipeSession(provider);
+            }
+        }
+    }
+}

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClientApiShimExtensions.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClientApiShimExtensions.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.NETCore.Client
+{
+    internal static class DiagnosticsClientApiShimExtensions
+    {
+        // Generous timeout to allow APIs to respond on slower or more constrained machines
+        private static readonly TimeSpan DefaultPositiveVerificationTimeout = TimeSpan.FromSeconds(30);
+
+        public static Task<Dictionary<string, string>> GetProcessEnvironment(this DiagnosticsClientApiShim shim)
+        {
+            return shim.GetProcessEnvironment(DefaultPositiveVerificationTimeout);
+        }
+
+        public static Task<ProcessInfo> GetProcessInfo(this DiagnosticsClientApiShim shim)
+        {
+            return shim.GetProcessInfo(DefaultPositiveVerificationTimeout);
+        }
+
+        public static Task ResumeRuntime(this DiagnosticsClientApiShim shim)
+        {
+            return shim.ResumeRuntime(DefaultPositiveVerificationTimeout);
+        }
+
+        public static Task<EventPipeSession> StartEventPipeSession(this DiagnosticsClientApiShim shim, IEnumerable<EventPipeProvider> providers)
+        {
+            return shim.StartEventPipeSession(providers, DefaultPositiveVerificationTimeout);
+        }
+
+        public static Task<EventPipeSession> StartEventPipeSession(this DiagnosticsClientApiShim shim, EventPipeProvider provider)
+        {
+            return shim.StartEventPipeSession(provider, DefaultPositiveVerificationTimeout);
+        }
+    }
+}

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/EventPipeSessionTests.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/EventPipeSessionTests.cs
@@ -2,21 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Diagnostics.Tracing;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Diagnostics.Tracing;
-using System.IO;
-using System.Runtime.InteropServices;
-using System.Text.RegularExpressions;
-using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
-
-using Microsoft.Diagnostics.Tracing;
-using Microsoft.Diagnostics.TestHelpers;
-using Microsoft.Diagnostics.NETCore.Client;
 
 namespace Microsoft.Diagnostics.NETCore.Client
 {
@@ -29,16 +21,28 @@ namespace Microsoft.Diagnostics.NETCore.Client
             output = outputHelper;
         }
 
+        [Fact]
+        public Task BasicEventPipeSessionTest()
+        {
+            return BasicEventPipeSessionTestCore(useAsync: false);
+        }
+
+        [Fact]
+        public Task BasicEventPipeSessionTestAsync()
+        {
+            return BasicEventPipeSessionTestCore(useAsync: true);
+        }
+
         /// <summary>
         /// A simple test that checks if we can create an EventPipeSession on a child process
         /// </summary>
-        [Fact]
-        public void BasicEventPipeSessionTest()
+        private async Task BasicEventPipeSessionTestCore(bool useAsync)
+
         {
             using TestRunner runner = new TestRunner(CommonHelper.GetTraceePathWithArgs(), output);
             runner.Start(timeoutInMSPipeCreation: 15_000, testProcessTimeout: 60_000);
-            DiagnosticsClient client = new DiagnosticsClient(runner.Pid);
-            using (var session = client.StartEventPipeSession(new List<EventPipeProvider>()
+            DiagnosticsClientApiShim clientShim = new DiagnosticsClientApiShim(new DiagnosticsClient(runner.Pid), useAsync);
+            using (var session = await clientShim.StartEventPipeSession(new List<EventPipeProvider>()
             {
                 new EventPipeProvider("Microsoft-Windows-DotNETRuntime", EventLevel.Informational)
             }))
@@ -48,18 +52,29 @@ namespace Microsoft.Diagnostics.NETCore.Client
             runner.Stop();
         }
 
+        [Fact]
+        public Task EventPipeSessionStreamTest()
+        {
+            return EventPipeSessionStreamTestCore(useAsync: false);
+        }
+
+        [Fact]
+        public Task EventPipeSessionStreamTestAsync()
+        {
+            return EventPipeSessionStreamTestCore(useAsync: true);
+        }
+
         /// <summary>
         /// Checks if we can create an EventPipeSession and can get some expected events out of it.
         /// </summary>
-        [Fact]
-        public void EventPipeSessionStreamTest()
+        private async Task EventPipeSessionStreamTestCore(bool useAsync)
         {
             TestRunner runner = new TestRunner(CommonHelper.GetTraceePathWithArgs(), output);
             runner.Start(timeoutInMSPipeCreation: 15_000, testProcessTimeout: 60_000);
-            DiagnosticsClient client = new DiagnosticsClient(runner.Pid);
+            DiagnosticsClientApiShim clientShim = new DiagnosticsClientApiShim(new DiagnosticsClient(runner.Pid), useAsync);
             runner.PrintStatus();
             output.WriteLine($"[{DateTime.Now.ToString()}] Trying to start an EventPipe session on process {runner.Pid}");
-            using (var session = client.StartEventPipeSession(new List<EventPipeProvider>()
+            using (var session = await clientShim.StartEventPipeSession(new List<EventPipeProvider>()
             {
                 new EventPipeProvider("System.Runtime", EventLevel.Informational, 0, new Dictionary<string, string>() {
                     { "EventCounterIntervalSec", "1" }
@@ -96,33 +111,55 @@ namespace Microsoft.Diagnostics.NETCore.Client
             }
         }
 
+        [Fact]
+        public Task EventPipeSessionUnavailableTest()
+        {
+            return EventPipeSessionUnavailableTestCore(useAsync: false);
+        }
+
+        [Fact]
+        public Task EventPipeSessionUnavailableTestAsync()
+        {
+            return EventPipeSessionUnavailableTestCore(useAsync: true);
+        }
+
         /// <summary>
         /// Tries to start an EventPipe session on a non-existent process
         /// </summary>
-        [Fact]
-        public void EventPipeSessionUnavailableTest()
+        private async Task EventPipeSessionUnavailableTestCore(bool useAsync)
         {
             List<int> pids = new List<int>(DiagnosticsClient.GetPublishedProcesses());
             int arbitraryPid = 1;
 
-            DiagnosticsClient client = new DiagnosticsClient(arbitraryPid);
+            DiagnosticsClientApiShim clientShim = new DiagnosticsClientApiShim(new DiagnosticsClient(arbitraryPid), useAsync);
 
-            Assert.Throws<ServerNotAvailableException>(() => client.StartEventPipeSession(new List<EventPipeProvider>()
+            await Assert.ThrowsAsync<ServerNotAvailableException>(() => clientShim.StartEventPipeSession(new List<EventPipeProvider>()
             {
                 new EventPipeProvider("Microsoft-Windows-DotNETRuntime", EventLevel.Informational)
             }));
         }
 
+        [Fact]
+        public Task StartEventPipeSessionWithSingleProviderTest()
+        {
+            return StartEventPipeSessionWithSingleProviderTestCore(useAsync: false);
+        }
+
+        [Fact]
+        public Task StartEventPipeSessionWithSingleProviderTestAsync()
+        {
+            return StartEventPipeSessionWithSingleProviderTestCore(useAsync: true);
+        }
+
         /// <summary>
         /// Test for the method overload: public EventPipeSession StartEventPipeSession(EventPipeProvider provider, bool requestRundown=true, int circularBufferMB=256)
         /// </summary>
-        [Fact]
-        public void StartEventPipeSessionWithSingleProviderTest()
+        private async Task StartEventPipeSessionWithSingleProviderTestCore(bool useAsync)
         {
             using TestRunner runner = new TestRunner(CommonHelper.GetTraceePathWithArgs(), output);
             runner.Start(timeoutInMSPipeCreation: 15_000, testProcessTimeout: 60_000);
-            DiagnosticsClient client = new DiagnosticsClient(runner.Pid);
-            using (var session = client.StartEventPipeSession(new EventPipeProvider("Microsoft-Windows-DotNETRuntime", EventLevel.Informational)))
+            DiagnosticsClientApiShim clientShim = new DiagnosticsClientApiShim(new DiagnosticsClient(runner.Pid), useAsync);
+            using (var session = await clientShim.StartEventPipeSession(new EventPipeProvider("Microsoft-Windows-DotNETRuntime", EventLevel.Informational)))
             {
                 Assert.True(session.EventStream != null);
             }

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/GetProcessInfoTests.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/GetProcessInfoTests.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -19,16 +19,27 @@ namespace Microsoft.Diagnostics.NETCore.Client
         }
 
         [Fact]
-        public void BasicProcessInfoTest()
+        public Task BasicProcessInfoTest()
+        {
+            return BasicProcessInfoTestCore(useAsync: false);
+        }
+
+        [Fact]
+        public Task BasicProcessInfoTestAsync()
+        {
+            return BasicProcessInfoTestCore(useAsync: true);
+        }
+
+        private async Task BasicProcessInfoTestCore(bool useAsync)
         {
             using TestRunner runner = new TestRunner(CommonHelper.GetTraceePathWithArgs(targetFramework: "net5.0"), output);
             runner.Start();
 
             try
             {
-                DiagnosticsClient client = new DiagnosticsClient(runner.Pid);
+                DiagnosticsClientApiShim clientShim = new DiagnosticsClientApiShim(new DiagnosticsClient(runner.Pid), useAsync);
 
-                ProcessInfo processInfo = client.GetProcessInfo();
+                ProcessInfo processInfo = await clientShim.GetProcessInfo();
 
                 Assert.NotNull(processInfo);
                 Assert.Equal(runner.Pid, (int)processInfo.ProcessId);


### PR DESCRIPTION
These changes add the ability to use async versions of the DiagnosticsClient methods as well as introduce cancellability.

The primary motivation for this change was to add cancellability so that diagnostic tools can cancel connections with runtime instances that are not behaving well (they are hung due to debugging, they are not responding to diagnostic requests in a timely manner, etc).

We've seen this type of issue appear when "dotnet run" is executed on a project but as a background process on Linux: https://github.com/dotnet/dotnet-monitor/issues/399. When dotnet-monitor attempts to send commands to the process via the diagnostics port, no response is produced by the target runtime instance; this causes all HTTP requests to hang when dotnet-monitor is running in 'connect' mode since each request enumerates all of the processes and send the ProcessInfo command to each one.

Overview of changes:
- Refactor underlying IPC communication constructs to fully support async and cancellation in async methods.
- Add new async methods to DiagnosticsClient that allow for cancellation and share common request and response parsing among the async and non-async methods.
- Updated unit tests to flex both async and non-async variants of methods on DiagnosticsClient class via the DiagnosticsClientApiShim.

TODO:
- [x] Use EventPipeSession.StopAsync in EventPipeStreamProvider.StopSession method.
- [x] Properly dispose of IpcResponse in EventPipeSession.Start/StartAsync in exception case.
- [x] Update unit tests to also test EventPipeSession.StopAsync.
- [x] Manually test new async methods with dotnet-monitor tool.

TODO/Future Consideration:
- Add cancellation/timeouts to existing non-async methods on DiagnosticsClient. These would be new overloads rather than updating the existing methods.
- Add async variant of DiagnosticsClient.AttachProfiler. However, there are no existing tests or implementations that call this, so it would be difficult to test and prevent regression.
- Add dump tests to flex the WriteDump code path.
- Create mock runtime instance that published diagnostic port that exhibits failure to respond to messages; allows for testing of cancellability from unit tests.

Partially Fixes #2151 