### PR TITLE
Add IVT for Microsoft.Diagnostics.Monitoring.WebApi

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Microsoft.Diagnostics.Monitoring.EventPipe.csproj
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Microsoft.Diagnostics.Monitoring.EventPipe.csproj
@@ -42,5 +42,6 @@
     <InternalsVisibleTo Include="DotnetMonitor.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.RestServer" />
     <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests" />
+    <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.WebApi" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Diagnostics.Monitoring/Microsoft.Diagnostics.Monitoring.csproj
+++ b/src/Microsoft.Diagnostics.Monitoring/Microsoft.Diagnostics.Monitoring.csproj
@@ -32,5 +32,6 @@
     <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.RestServer" />
     <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.UnitTests" />
+    <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.WebApi" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj
+++ b/src/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj
@@ -25,6 +25,7 @@
     <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring" />
     <!-- Temporary until Diagnostic Apis are finalized-->
     <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.RestServer" />
+    <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.WebApi" />
     <InternalsVisibleTo Include="Microsoft.Diagnostics.NETCore.Client.UnitTests" />
     <InternalsVisibleTo Include="dotnet-counters" />
     <InternalsVisibleTo Include="dotnet-trace" />

--- a/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/TestStreamingLogger.cs
+++ b/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/TestStreamingLogger.cs
@@ -10,7 +10,7 @@ using System.Text.Json;
 namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
 {
     /// <summary>
-    /// CONSIDER We can't reuse StreamingLoggerProvider from using Microsoft.Diagnostics.Monitoring.RestServer.
+    /// CONSIDER We can't reuse StreamingLoggerProvider from using Microsoft.Diagnostics.Monitoring.WebApi.
     /// Adding a reference to that project causes assembly resolution issues.
     /// </summary>
     internal sealed class TestStreamingLoggerProvider : ILoggerProvider


### PR DESCRIPTION
The RestServer assembly in https://github.com/dotnet/dotnet-monitor is being renamed to WebApi. Keep old IVTs until insertion is made into https://github.com/dotnet/dotnet-monitor