### PR TITLE
Add adb port forward and usbmux support to dsrouter.

### DIFF
--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsServerRouter/DiagnosticsServerRouterRunner.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsServerRouter/DiagnosticsServerRouterRunner.cs
@@ -32,9 +32,9 @@ namespace Microsoft.Diagnostics.NETCore.Client
             return await runRouter(token, new IpcServerTcpServerRouterFactory(ipcServer, tcpServer, runtimeTimeoutMs, logger), callbacks).ConfigureAwait(false);
         }
 
-        public static async Task<int> runIpcServerTcpClientRouter(CancellationToken token, string ipcServer, string tcpClient, int runtimeTimeoutMs, ILogger logger, Callbacks callbacks)
+        public static async Task<int> runIpcServerTcpClientRouter(CancellationToken token, string ipcServer, string tcpClient, int runtimeTimeoutMs, TcpClientRouterFactory.CreateInstanceDelegate tcpClientRouterFactory, ILogger logger, Callbacks callbacks)
         {
-            return await runRouter(token, new IpcServerTcpClientRouterFactory(ipcServer, tcpClient, runtimeTimeoutMs, logger), callbacks).ConfigureAwait(false);
+            return await runRouter(token, new IpcServerTcpClientRouterFactory(ipcServer, tcpClient, runtimeTimeoutMs, logger, tcpClientRouterFactory), callbacks).ConfigureAwait(false);
         }
 
         public static bool isLoopbackOnly(string address)

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsServerRouter/DiagnosticsServerRouterRunner.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsServerRouter/DiagnosticsServerRouterRunner.cs
@@ -22,19 +22,19 @@ namespace Microsoft.Diagnostics.NETCore.Client
             void OnRouterStopped();
         }
 
-        public static async Task<int> runIpcClientTcpServerRouter(CancellationToken token, string ipcClient, string tcpServer, int runtimeTimeoutMs, ILogger logger, Callbacks callbacks)
+        public static async Task<int> runIpcClientTcpServerRouter(CancellationToken token, string ipcClient, string tcpServer, int runtimeTimeoutMs, TcpServerRouterFactory.CreateInstanceDelegate tcpServerRouterFactory, ILogger logger, Callbacks callbacks)
         {
-            return await runRouter(token, new IpcClientTcpServerRouterFactory(ipcClient, tcpServer, runtimeTimeoutMs, logger), callbacks).ConfigureAwait(false);
+            return await runRouter(token, new IpcClientTcpServerRouterFactory(ipcClient, tcpServer, runtimeTimeoutMs, tcpServerRouterFactory, logger), callbacks).ConfigureAwait(false);
         }
 
-        public static async Task<int> runIpcServerTcpServerRouter(CancellationToken token, string ipcServer, string tcpServer, int runtimeTimeoutMs, ILogger logger, Callbacks callbacks)
+        public static async Task<int> runIpcServerTcpServerRouter(CancellationToken token, string ipcServer, string tcpServer, int runtimeTimeoutMs, TcpServerRouterFactory.CreateInstanceDelegate tcpServerRouterFactory, ILogger logger, Callbacks callbacks)
         {
-            return await runRouter(token, new IpcServerTcpServerRouterFactory(ipcServer, tcpServer, runtimeTimeoutMs, logger), callbacks).ConfigureAwait(false);
+            return await runRouter(token, new IpcServerTcpServerRouterFactory(ipcServer, tcpServer, runtimeTimeoutMs, tcpServerRouterFactory, logger), callbacks).ConfigureAwait(false);
         }
 
         public static async Task<int> runIpcServerTcpClientRouter(CancellationToken token, string ipcServer, string tcpClient, int runtimeTimeoutMs, TcpClientRouterFactory.CreateInstanceDelegate tcpClientRouterFactory, ILogger logger, Callbacks callbacks)
         {
-            return await runRouter(token, new IpcServerTcpClientRouterFactory(ipcServer, tcpClient, runtimeTimeoutMs, logger, tcpClientRouterFactory), callbacks).ConfigureAwait(false);
+            return await runRouter(token, new IpcServerTcpClientRouterFactory(ipcServer, tcpClient, runtimeTimeoutMs, tcpClientRouterFactory, logger), callbacks).ConfigureAwait(false);
         }
 
         public static bool isLoopbackOnly(string address)

--- a/src/Tools/dotnet-dsrouter/ADBTcpClientRouterFactory.cs
+++ b/src/Tools/dotnet-dsrouter/ADBTcpClientRouterFactory.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using Microsoft.Diagnostics.NETCore.Client;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
+{
+    internal class ADBTcpClientRouterFactory : TcpClientRouterFactory
+    {
+        readonly int _port;
+        bool ownsPortForward;
+
+        public static TcpClientRouterFactory CreateADBInstance(string tcpClient, int runtimeTimeoutMs, ILogger logger)
+        {
+            return new ADBTcpClientRouterFactory(tcpClient, runtimeTimeoutMs, logger);
+        }
+
+        public ADBTcpClientRouterFactory(string tcpClient, int runtimeTimeoutMs, ILogger logger)
+            : base(tcpClient, runtimeTimeoutMs, logger)
+        {
+            _port = new IpcTcpSocketEndPoint(tcpClient).EndPoint.Port;
+        }
+
+        public override void Start()
+        {
+            // Enable port forwarding.
+            AdbAddPortForward();
+        }
+
+        public override void Stop()
+        {
+            // Disable port forwarding.
+            AdbRemovePortForward();
+        }
+
+        void AdbAddPortForward()
+        {
+            if (!RunAdbCommandInternal($"forward --list", $"tcp:{_port}", 0))
+            {
+                ownsPortForward = RunAdbCommandInternal($"forward tcp:{_port} tcp:{_port}", "", 0);
+                if (!ownsPortForward)
+                    _logger?.LogError($"Failed creating port forward for tcp:{_port}.");
+            }
+        }
+
+        void AdbRemovePortForward()
+        {
+            if (ownsPortForward)
+            {
+                if (!RunAdbCommandInternal($"forward --remove tcp:{_port}", "", 0))
+                    _logger?.LogError($"Failed removing port forward for tcp:{_port}.");
+            }
+            ownsPortForward = false;
+        }
+
+        bool RunAdbCommandInternal(string command, string expectedOutput, int expectedExitCode)
+        {
+            var sdkRoot = Environment.GetEnvironmentVariable("ANDROID_SDK_ROOT");
+            var adbTool = "adb";
+
+            if (!string.IsNullOrEmpty(sdkRoot))
+                adbTool = sdkRoot + Path.DirectorySeparatorChar + "platform-tools" + Path.DirectorySeparatorChar + adbTool;
+
+            _logger?.LogDebug($"Executing {adbTool} {command}.");
+
+            var process = new Process();
+            process.StartInfo.FileName = adbTool;
+            process.StartInfo.Arguments = command;
+
+            process.StartInfo.UseShellExecute = false;
+            process.StartInfo.RedirectStandardOutput = !string.IsNullOrEmpty(expectedOutput);
+            process.StartInfo.RedirectStandardError = false;
+            process.StartInfo.RedirectStandardInput = false;
+
+            bool result = false;
+            try
+            {
+                result = process.Start();
+            }
+            catch (Exception)
+            {
+            }
+
+            if (result && !string.IsNullOrEmpty(expectedOutput))
+            {
+                var stdout = process.StandardOutput.ReadToEnd();
+                result = stdout.Contains(expectedOutput);
+            }
+
+            process.WaitForExit();
+
+            if (result && expectedExitCode != -1)
+            {
+                result = process.ExitCode == expectedExitCode;
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/Tools/dotnet-dsrouter/ADBTcpClientRouterFactory.cs
+++ b/src/Tools/dotnet-dsrouter/ADBTcpClientRouterFactory.cs
@@ -1,15 +1,141 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
+using System.Threading.Tasks;
 using Microsoft.Diagnostics.NETCore.Client;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
 {
+    internal class ADBCommandExec
+    {
+        public static bool AdbAddPortForward(int port, ILogger logger)
+        {
+            bool ownsPortForward = false;
+            if (!RunAdbCommandInternal($"forward --list", $"tcp:{port}", 0, logger))
+            {
+                ownsPortForward = RunAdbCommandInternal($"forward tcp:{port} tcp:{port}", "", 0, logger);
+                if (!ownsPortForward)
+                    logger?.LogError($"Failed setting up port forward for tcp:{port}.");
+            }
+            return ownsPortForward;
+        }
+
+        public static bool AdbAddPortReverse(int port, ILogger logger)
+        {
+            bool ownsPortForward = false;
+            if (!RunAdbCommandInternal($"reverse --list", $"tcp:{port}", 0, logger))
+            {
+                ownsPortForward = RunAdbCommandInternal($"reverse tcp:{port} tcp:{port}", "", 0, logger);
+                if (!ownsPortForward)
+                    logger?.LogError($"Failed setting up port forward for tcp:{port}.");
+            }
+            return ownsPortForward;
+        }
+
+        public static void AdbRemovePortForward(int port, bool ownsPortForward, ILogger logger)
+        {
+            if (ownsPortForward)
+            {
+                if (!RunAdbCommandInternal($"forward --remove tcp:{port}", "", 0, logger))
+                    logger?.LogError($"Failed removing port forward for tcp:{port}.");
+            }
+        }
+
+        public static void AdbRemovePortReverse(int port, bool ownsPortForward, ILogger logger)
+        {
+            if (ownsPortForward)
+            {
+                if (!RunAdbCommandInternal($"reverse --remove tcp:{port}", "", 0, logger))
+                    logger?.LogError($"Failed removing port forward for tcp:{port}.");
+            }
+        }
+
+        public static bool RunAdbCommandInternal(string command, string expectedOutput, int expectedExitCode, ILogger logger)
+        {
+            var sdkRoot = Environment.GetEnvironmentVariable("ANDROID_SDK_ROOT");
+            var adbTool = "adb";
+
+            if (!string.IsNullOrEmpty(sdkRoot))
+                adbTool = sdkRoot + Path.DirectorySeparatorChar + "platform-tools" + Path.DirectorySeparatorChar + adbTool;
+
+            logger?.LogDebug($"Executing {adbTool} {command}.");
+
+            var process = new Process();
+            process.StartInfo.FileName = adbTool;
+            process.StartInfo.Arguments = command;
+
+            process.StartInfo.UseShellExecute = false;
+            process.StartInfo.RedirectStandardOutput = !string.IsNullOrEmpty(expectedOutput);
+            process.StartInfo.RedirectStandardError = false;
+            process.StartInfo.RedirectStandardInput = false;
+
+            bool processStartedResult = false;
+            bool expectedOutputResult = true;
+            bool expectedExitCodeResult = true;
+
+            try
+            {
+                processStartedResult = process.Start();
+            }
+            catch (Exception)
+            {
+            }
+
+            if (processStartedResult && !string.IsNullOrEmpty(expectedOutput))
+            {
+                var stdout = process.StandardOutput.ReadToEnd();
+                expectedOutputResult = stdout.Contains(expectedOutput);
+            }
+
+            if (processStartedResult)
+            {
+                process.WaitForExit();
+                expectedExitCodeResult = (expectedExitCode != -1) ? (process.ExitCode == expectedExitCode) : true;
+            }
+
+            return processStartedResult && expectedOutputResult && expectedExitCodeResult;
+        }
+    }
+
+    internal class ADBTcpServerRouterFactory : TcpServerRouterFactory
+    {
+        readonly int _port;
+        bool _ownsPortReverse;
+
+        public static TcpServerRouterFactory CreateADBInstance(string tcpServer, int runtimeTimeoutMs, ILogger logger)
+        {
+            return new ADBTcpServerRouterFactory(tcpServer, runtimeTimeoutMs, logger);
+        }
+
+        public ADBTcpServerRouterFactory(string tcpServer, int runtimeTimeoutMs, ILogger logger)
+            : base(tcpServer, runtimeTimeoutMs, logger)
+        {
+            _port = new IpcTcpSocketEndPoint(tcpServer).EndPoint.Port;
+        }
+
+        public override void Start()
+        {
+            // Enable port reverse.
+            _ownsPortReverse = ADBCommandExec.AdbAddPortReverse(_port, _logger);
+
+            base.Start();
+        }
+
+        public override async Task Stop()
+        {
+            await base.Stop().ConfigureAwait(false);
+
+            // Disable port reverse.
+            ADBCommandExec.AdbRemovePortReverse(_port, _ownsPortReverse, _logger);
+            _ownsPortReverse = false;
+        }
+    }
+
     internal class ADBTcpClientRouterFactory : TcpClientRouterFactory
     {
         readonly int _port;
-        bool ownsPortForward;
+        bool _ownsPortForward;
 
         public static TcpClientRouterFactory CreateADBInstance(string tcpClient, int runtimeTimeoutMs, ILogger logger)
         {
@@ -25,77 +151,14 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
         public override void Start()
         {
             // Enable port forwarding.
-            AdbAddPortForward();
+            _ownsPortForward = ADBCommandExec.AdbAddPortForward(_port, _logger);
         }
 
         public override void Stop()
         {
             // Disable port forwarding.
-            AdbRemovePortForward();
-        }
-
-        void AdbAddPortForward()
-        {
-            if (!RunAdbCommandInternal($"forward --list", $"tcp:{_port}", 0))
-            {
-                ownsPortForward = RunAdbCommandInternal($"forward tcp:{_port} tcp:{_port}", "", 0);
-                if (!ownsPortForward)
-                    _logger?.LogError($"Failed creating port forward for tcp:{_port}.");
-            }
-        }
-
-        void AdbRemovePortForward()
-        {
-            if (ownsPortForward)
-            {
-                if (!RunAdbCommandInternal($"forward --remove tcp:{_port}", "", 0))
-                    _logger?.LogError($"Failed removing port forward for tcp:{_port}.");
-            }
-            ownsPortForward = false;
-        }
-
-        bool RunAdbCommandInternal(string command, string expectedOutput, int expectedExitCode)
-        {
-            var sdkRoot = Environment.GetEnvironmentVariable("ANDROID_SDK_ROOT");
-            var adbTool = "adb";
-
-            if (!string.IsNullOrEmpty(sdkRoot))
-                adbTool = sdkRoot + Path.DirectorySeparatorChar + "platform-tools" + Path.DirectorySeparatorChar + adbTool;
-
-            _logger?.LogDebug($"Executing {adbTool} {command}.");
-
-            var process = new Process();
-            process.StartInfo.FileName = adbTool;
-            process.StartInfo.Arguments = command;
-
-            process.StartInfo.UseShellExecute = false;
-            process.StartInfo.RedirectStandardOutput = !string.IsNullOrEmpty(expectedOutput);
-            process.StartInfo.RedirectStandardError = false;
-            process.StartInfo.RedirectStandardInput = false;
-
-            bool result = false;
-            try
-            {
-                result = process.Start();
-            }
-            catch (Exception)
-            {
-            }
-
-            if (result && !string.IsNullOrEmpty(expectedOutput))
-            {
-                var stdout = process.StandardOutput.ReadToEnd();
-                result = stdout.Contains(expectedOutput);
-            }
-
-            process.WaitForExit();
-
-            if (result && expectedExitCode != -1)
-            {
-                result = process.ExitCode == expectedExitCode;
-            }
-
-            return result;
+            ADBCommandExec.AdbRemovePortForward(_port, _ownsPortForward, _logger);
+            _ownsPortForward = false;
         }
     }
 }

--- a/src/Tools/dotnet-dsrouter/ADBTcpRouterFactory.cs
+++ b/src/Tools/dotnet-dsrouter/ADBTcpRouterFactory.cs
@@ -66,8 +66,8 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
             process.StartInfo.Arguments = command;
 
             process.StartInfo.UseShellExecute = false;
-            process.StartInfo.RedirectStandardOutput = !string.IsNullOrEmpty(expectedOutput);
-            process.StartInfo.RedirectStandardError = false;
+            process.StartInfo.RedirectStandardOutput = true;
+            process.StartInfo.RedirectStandardError = true;
             process.StartInfo.RedirectStandardInput = false;
 
             bool processStartedResult = false;
@@ -82,10 +82,19 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
             {
             }
 
-            if (processStartedResult && !string.IsNullOrEmpty(expectedOutput))
+            if (processStartedResult)
             {
                 var stdout = process.StandardOutput.ReadToEnd();
-                expectedOutputResult = stdout.Contains(expectedOutput);
+                var stderr = process.StandardError.ReadToEnd();
+
+                if (!string.IsNullOrEmpty(expectedOutput))
+                    expectedOutputResult = !string.IsNullOrEmpty(stdout) ? stdout.Contains(expectedOutput) : false;
+
+                if (!string.IsNullOrEmpty(stdout))
+                    logger.LogTrace($"stdout: {stdout}");
+
+                if (!string.IsNullOrEmpty(stderr))
+                    logger.LogError($"stderr: {stderr}");
             }
 
             if (processStartedResult)

--- a/src/Tools/dotnet-dsrouter/DiagnosticsServerRouterCommands.cs
+++ b/src/Tools/dotnet-dsrouter/DiagnosticsServerRouterCommands.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
             Launcher.Verbose = logLevel != LogLevel.Information;
             Launcher.CommandToken = token;
 
-            var logger = factory.CreateLogger("dotnet-dsrounter");
+            var logger = factory.CreateLogger("dotnet-dsrouter");
 
             TcpServerRouterFactory.CreateInstanceDelegate tcpServerRouterFactory = TcpServerRouterFactory.CreateDefaultInstance;
             if (!string.IsNullOrEmpty(forwardPort))
@@ -127,7 +127,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
             Launcher.Verbose = logLevel != LogLevel.Information;
             Launcher.CommandToken = token;
 
-            var logger = factory.CreateLogger("dotnet-dsrounter");
+            var logger = factory.CreateLogger("dotnet-dsrouter");
 
             TcpServerRouterFactory.CreateInstanceDelegate tcpServerRouterFactory = TcpServerRouterFactory.CreateDefaultInstance;
             if (!string.IsNullOrEmpty(forwardPort))
@@ -183,7 +183,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
             Launcher.Verbose = logLevel != LogLevel.Information;
             Launcher.CommandToken = token;
 
-            var logger = factory.CreateLogger("dotnet-dsrounter");
+            var logger = factory.CreateLogger("dotnet-dsrouter");
 
             TcpClientRouterFactory.CreateInstanceDelegate tcpClientRouterFactory = TcpClientRouterFactory.CreateDefaultInstance;
             if (!string.IsNullOrEmpty(forwardPort))

--- a/src/Tools/dotnet-dsrouter/DiagnosticsServerRouterCommands.cs
+++ b/src/Tools/dotnet-dsrouter/DiagnosticsServerRouterCommands.cs
@@ -69,6 +69,8 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
             Launcher.Verbose = logLevel != LogLevel.Information;
             Launcher.CommandToken = token;
 
+            var logger = factory.CreateLogger("dotnet-dsrounter");
+
             TcpServerRouterFactory.CreateInstanceDelegate tcpServerRouterFactory = TcpServerRouterFactory.CreateDefaultInstance;
             if (!string.IsNullOrEmpty(forwardPort))
             {
@@ -78,11 +80,11 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
                 }
                 else
                 {
-                    throw new ArgumentException($"Unknown port forwarding argument, {forwardPort}. Only Android port fowarding is supported for TcpServer mode.");
+                    logger.LogError($"Unknown port forwarding argument, {forwardPort}. Only Android port fowarding is supported for TcpServer mode. Ignoring --forward-port argument.");
                 }
             }
 
-            var routerTask = DiagnosticsServerRouterRunner.runIpcClientTcpServerRouter(linkedCancelToken.Token, ipcClient, tcpServer, runtimeTimeout == Timeout.Infinite ? runtimeTimeout : runtimeTimeout * 1000, tcpServerRouterFactory, factory.CreateLogger("dotnet-dsrounter"), Launcher);
+            var routerTask = DiagnosticsServerRouterRunner.runIpcClientTcpServerRouter(linkedCancelToken.Token, ipcClient, tcpServer, runtimeTimeout == Timeout.Infinite ? runtimeTimeout : runtimeTimeout * 1000, tcpServerRouterFactory, logger, Launcher);
 
             while (!linkedCancelToken.IsCancellationRequested)
             {
@@ -125,6 +127,8 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
             Launcher.Verbose = logLevel != LogLevel.Information;
             Launcher.CommandToken = token;
 
+            var logger = factory.CreateLogger("dotnet-dsrounter");
+
             TcpServerRouterFactory.CreateInstanceDelegate tcpServerRouterFactory = TcpServerRouterFactory.CreateDefaultInstance;
             if (!string.IsNullOrEmpty(forwardPort))
             {
@@ -134,11 +138,11 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
                 }
                 else
                 {
-                    throw new ArgumentException($"Unknown port forwarding argument, {forwardPort}. Only Android port fowarding is supported for TcpServer mode.");
+                    logger.LogError($"Unknown port forwarding argument, {forwardPort}. Only Android port fowarding is supported for TcpServer mode. Ignoring --forward-port argument.");
                 }
             }
 
-            var routerTask = DiagnosticsServerRouterRunner.runIpcServerTcpServerRouter(linkedCancelToken.Token, ipcServer, tcpServer, runtimeTimeout == Timeout.Infinite ? runtimeTimeout : runtimeTimeout * 1000, tcpServerRouterFactory, factory.CreateLogger("dotnet-dsrounter"), Launcher);
+            var routerTask = DiagnosticsServerRouterRunner.runIpcServerTcpServerRouter(linkedCancelToken.Token, ipcServer, tcpServer, runtimeTimeout == Timeout.Infinite ? runtimeTimeout : runtimeTimeout * 1000, tcpServerRouterFactory, logger, Launcher);
 
             while (!linkedCancelToken.IsCancellationRequested)
             {
@@ -179,6 +183,8 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
             Launcher.Verbose = logLevel != LogLevel.Information;
             Launcher.CommandToken = token;
 
+            var logger = factory.CreateLogger("dotnet-dsrounter");
+
             TcpClientRouterFactory.CreateInstanceDelegate tcpClientRouterFactory = TcpClientRouterFactory.CreateDefaultInstance;
             if (!string.IsNullOrEmpty(forwardPort))
             {
@@ -192,11 +198,11 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
                 }
                 else
                 {
-                    throw new ArgumentException($"Unknown port forwarding argument, {forwardPort}");
+                    logger.LogError($"Unknown port forwarding argument, {forwardPort}. Ignoring --forward-port argument.");
                 }
             }
 
-            var routerTask = DiagnosticsServerRouterRunner.runIpcServerTcpClientRouter(linkedCancelToken.Token, ipcServer, tcpClient, runtimeTimeout == Timeout.Infinite ? runtimeTimeout : runtimeTimeout * 1000, tcpClientRouterFactory, factory.CreateLogger("dotnet-dsrounter"), Launcher);
+            var routerTask = DiagnosticsServerRouterRunner.runIpcServerTcpClientRouter(linkedCancelToken.Token, ipcServer, tcpClient, runtimeTimeout == Timeout.Infinite ? runtimeTimeout : runtimeTimeout * 1000, tcpClientRouterFactory, logger, Launcher);
 
             while (!linkedCancelToken.IsCancellationRequested)
             {

--- a/src/Tools/dotnet-dsrouter/Program.cs
+++ b/src/Tools/dotnet-dsrouter/Program.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
     {
         delegate Task<int> DiagnosticsServerIpcClientTcpServerRouterDelegate(CancellationToken ct, string ipcClient, string tcpServer, int runtimeTimeoutS, string verbose);
         delegate Task<int> DiagnosticsServerIpcServerTcpServerRouterDelegate(CancellationToken ct, string ipcServer, string tcpServer, int runtimeTimeoutS, string verbose);
-        delegate Task<int> DiagnosticsServerIpcServerTcpClientRouterDelegate(CancellationToken ct, string ipcServer, string tcpClient, int runtimeTimeoutS, string verbose);
+        delegate Task<int> DiagnosticsServerIpcServerTcpClientRouterDelegate(CancellationToken ct, string ipcServer, string tcpClient, int runtimeTimeoutS, string verbose, string forwardPort);
 
         private static Command IpcClientTcpServerRouterCommand() =>
             new Command(
@@ -57,7 +57,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
                 // Handler
                 HandlerDescriptor.FromDelegate((DiagnosticsServerIpcServerTcpClientRouterDelegate)new DiagnosticsServerRouterCommands().RunIpcServerTcpClientRouter).GetCommandHandler(),
                 // Options
-                IpcServerAddressOption(), TcpClientAddressOption(), RuntimeTimeoutOption(), VerboseOption()
+                IpcServerAddressOption(), TcpClientAddressOption(), RuntimeTimeoutOption(), VerboseOption(), ForwardPortOption()
             };
 
         private static Option IpcClientAddressOption() =>
@@ -116,6 +116,14 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
                 description:    "Enable verbose logging (debug|trace)")
             {
                 Argument = new Argument<string>(name: "verbose", getDefaultValue: () => "")
+            };
+
+        private static Option ForwardPortOption() =>
+            new Option(
+                aliases: new[] { "--forward-port", "-fp" },
+                description: "Enable port forwarding, values Android|iOS. Make sure to set ANDROID_SDK_ROOT before using this option on Android.")
+            {
+                Argument = new Argument<string>(name: "forwardPort", getDefaultValue: () => "")
             };
 
         private static int Main(string[] args)

--- a/src/Tools/dotnet-dsrouter/Program.cs
+++ b/src/Tools/dotnet-dsrouter/Program.cs
@@ -17,8 +17,8 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
 {
     internal class Program
     {
-        delegate Task<int> DiagnosticsServerIpcClientTcpServerRouterDelegate(CancellationToken ct, string ipcClient, string tcpServer, int runtimeTimeoutS, string verbose);
-        delegate Task<int> DiagnosticsServerIpcServerTcpServerRouterDelegate(CancellationToken ct, string ipcServer, string tcpServer, int runtimeTimeoutS, string verbose);
+        delegate Task<int> DiagnosticsServerIpcClientTcpServerRouterDelegate(CancellationToken ct, string ipcClient, string tcpServer, int runtimeTimeoutS, string verbose, string forwardPort);
+        delegate Task<int> DiagnosticsServerIpcServerTcpServerRouterDelegate(CancellationToken ct, string ipcServer, string tcpServer, int runtimeTimeoutS, string verbose, string forwardPort);
         delegate Task<int> DiagnosticsServerIpcServerTcpClientRouterDelegate(CancellationToken ct, string ipcServer, string tcpClient, int runtimeTimeoutS, string verbose, string forwardPort);
 
         private static Command IpcClientTcpServerRouterCommand() =>
@@ -31,7 +31,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
                 // Handler
                 HandlerDescriptor.FromDelegate((DiagnosticsServerIpcClientTcpServerRouterDelegate)new DiagnosticsServerRouterCommands().RunIpcClientTcpServerRouter).GetCommandHandler(),
                 // Options
-                IpcClientAddressOption(), TcpServerAddressOption(), RuntimeTimeoutOption(), VerboseOption()
+                IpcClientAddressOption(), TcpServerAddressOption(), RuntimeTimeoutOption(), VerboseOption(), ForwardPortOption()
             };
 
         private static Command IpcServerTcpServerRouterCommand() =>
@@ -44,7 +44,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
                 // Handler
                 HandlerDescriptor.FromDelegate((DiagnosticsServerIpcServerTcpServerRouterDelegate)new DiagnosticsServerRouterCommands().RunIpcServerTcpServerRouter).GetCommandHandler(),
                 // Options
-                IpcServerAddressOption(), TcpServerAddressOption(), RuntimeTimeoutOption(), VerboseOption()
+                IpcServerAddressOption(), TcpServerAddressOption(), RuntimeTimeoutOption(), VerboseOption(), ForwardPortOption()
             };
 
         private static Command IpcServerTcpClientRouterCommand() =>
@@ -121,7 +121,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
         private static Option ForwardPortOption() =>
             new Option(
                 aliases: new[] { "--forward-port", "-fp" },
-                description: "Enable port forwarding, values Android|iOS. Make sure to set ANDROID_SDK_ROOT before using this option on Android.")
+                description: "Enable port forwarding, values Android|iOS for TcpClient and only Android for TcpServer. Make sure to set ANDROID_SDK_ROOT before using this option on Android.")
             {
                 Argument = new Argument<string>(name: "forwardPort", getDefaultValue: () => "")
             };

--- a/src/Tools/dotnet-dsrouter/USBMuxTcpClientRouterFactory.cs
+++ b/src/Tools/dotnet-dsrouter/USBMuxTcpClientRouterFactory.cs
@@ -1,0 +1,492 @@
+﻿using System;
+using System.IO;
+using System.Net;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Diagnostics.NETCore.Client;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
+{
+    internal class USBMuxInterop
+    {
+        public const string CoreFoundationLibrary = "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation";
+        public const string MobileDeviceLibrary = "/System/Library/PrivateFrameworks/MobileDevice.framework/MobileDevice";
+        public const string LibC = "libc";
+
+        public const int EINTR = 4;
+
+        public enum AMDeviceNotificationMessage : uint
+        {
+            None = 0,
+            Connected = 1,
+            Disconnected = 2,
+            Unsubscribed = 3
+        }
+
+        public struct AMDeviceNotificationCallbackInfo
+        {
+            public AMDeviceNotificationCallbackInfo(IntPtr device, AMDeviceNotificationMessage message)
+            {
+                this.am_device = device;
+                this.message = message;
+            }
+
+            public IntPtr am_device;
+            public AMDeviceNotificationMessage message;
+        }
+
+        public delegate void DeviceNotificationDelegate(ref AMDeviceNotificationCallbackInfo info);
+
+#region MobileDeviceLibrary
+        [DllImport(MobileDeviceLibrary)]
+        public static extern uint AMDeviceNotificationSubscribe(DeviceNotificationDelegate callback, uint unused0, uint unused1, uint unused2, out IntPtr context);
+
+        [DllImport(MobileDeviceLibrary)]
+        public static extern uint AMDeviceNotificationUnsubscribe(IntPtr context);
+
+        [DllImport(MobileDeviceLibrary)]
+        public static extern uint AMDeviceConnect(IntPtr device);
+
+        [DllImport(MobileDeviceLibrary)]
+        public static extern uint AMDeviceDisconnect(IntPtr device);
+
+        [DllImport(MobileDeviceLibrary)]
+        public static extern uint AMDeviceGetConnectionID(IntPtr device);
+
+        [DllImport(MobileDeviceLibrary)]
+        public static extern int AMDeviceGetInterfaceType(IntPtr device);
+
+        [DllImport(MobileDeviceLibrary)]
+        public static extern uint USBMuxConnectByPort(uint connection, ushort port, out int socketHandle);
+#endregion
+#region CoreFoundationLibrary
+        [DllImport(CoreFoundationLibrary)]
+        public static extern void CFRunLoopRun();
+
+        [DllImport(CoreFoundationLibrary)]
+        public static extern void CFRunLoopStop(IntPtr runLoop);
+
+        [DllImport(CoreFoundationLibrary)]
+        public static extern IntPtr CFRunLoopGetCurrent();
+#endregion
+#region LibC
+        [DllImport(LibC, SetLastError = true)]
+        public static extern unsafe int send(int handle, byte* buffer, IntPtr length, int flags);
+
+        [DllImport(LibC, SetLastError = true)]
+        public static extern unsafe int recv(int handle, byte* buffer, IntPtr length, int flags);
+
+        [DllImport(LibC, SetLastError = true)]
+        public static extern int close(int handle);
+#endregion
+    }
+
+    internal class USBMuxStream : Stream
+    {
+        int _handle = -1;
+
+        public USBMuxStream(int handle)
+        {
+            _handle = handle;
+        }
+
+        public bool IsOpen => _handle != -1;
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => true;
+
+        public override long Length => throw new NotImplementedException();
+
+        public override long Position {
+            get => throw new NotImplementedException();
+            set => throw new NotImplementedException();
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override Task FlushAsync(CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            bool continueRead = true;
+            int bytesToRead = count;
+            int totalBytesRead = 0;
+            int currentBytesRead = 0;
+
+            while (continueRead && bytesToRead - totalBytesRead > 0)
+            {
+                if (!IsOpen)
+                    throw new EndOfStreamException();
+
+                unsafe
+                {
+                    fixed (byte* fixedBuffer = buffer)
+                    {
+                        currentBytesRead = USBMuxInterop.recv(_handle, fixedBuffer + totalBytesRead, new IntPtr(bytesToRead - totalBytesRead), 0);
+                    }
+                }
+
+                if (currentBytesRead == -1 && Marshal.GetLastWin32Error() == USBMuxInterop.EINTR)
+                    continue;
+
+                continueRead = currentBytesRead > 0;
+                if (!continueRead)
+                    break;
+
+                totalBytesRead += currentBytesRead;
+            }
+
+            return totalBytesRead;
+        }
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            return Task.Run(() =>
+            {
+                int result = 0;
+                using (cancellationToken.Register(() => Close()))
+                {
+                    try
+                    {
+                        result = Read(buffer, offset, count);
+                    }
+                    catch (Exception)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        result = 0;
+                    }
+                }
+                return result;
+            });
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            bool continueWrite = true;
+            int bytesToWrite = count;
+            int currentBytesWritten = 0;
+            int totalBytesWritten = 0;
+
+            while (continueWrite && bytesToWrite - totalBytesWritten > 0)
+            {
+                if (!IsOpen)
+                    throw new EndOfStreamException();
+
+                unsafe
+                {
+                    fixed (byte* fixedBuffer = buffer)
+                    {
+                        currentBytesWritten = USBMuxInterop.send(_handle, fixedBuffer + totalBytesWritten, new IntPtr(bytesToWrite - totalBytesWritten), 0);
+                    }
+                }
+
+                if (currentBytesWritten == -1 && Marshal.GetLastWin32Error() == USBMuxInterop.EINTR)
+                    continue;
+
+                continueWrite = currentBytesWritten != -1;
+
+                if (!continueWrite)
+                    break;
+
+                totalBytesWritten += currentBytesWritten;
+            }
+        }
+
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            return Task.Run(() =>
+            {
+                using (cancellationToken.Register(() => Close()))
+                {
+                    Write(buffer, offset, count);
+                }
+            });
+        }
+
+        public override void Close()
+        {
+            if (IsOpen)
+            {
+                USBMuxInterop.close(_handle);
+                _handle = -1;
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            Close();
+            base.Dispose(disposing);
+        }
+    }
+
+    internal class USBMuxTcpClientRouterFactory : TcpClientRouterFactory
+    {
+        readonly int _port;
+
+        IntPtr _device = IntPtr.Zero;
+        uint _deviceConnectionID = 0;
+        IntPtr _loopingThread = IntPtr.Zero;
+
+        public static TcpClientRouterFactory CreateUSBMuxInstance(string tcpClient, int runtimeTimeoutMs, ILogger logger)
+        {
+            return new USBMuxTcpClientRouterFactory(tcpClient, runtimeTimeoutMs, logger);
+        }
+
+        public USBMuxTcpClientRouterFactory(string tcpClient, int runtimeTimeoutMs, ILogger logger)
+            : base(tcpClient, runtimeTimeoutMs, logger)
+        {
+            _port = new IpcTcpSocketEndPoint(tcpClient).EndPoint.Port;
+        }
+
+        public override async Task<Stream> ConnectTcpStreamAsync(CancellationToken token)
+        {
+            bool retry = false;
+            int handle = -1;
+            ushort networkPort = (ushort)IPAddress.HostToNetworkOrder(unchecked((short)_port));
+
+            _logger?.LogDebug($"Connecting new tcp endpoint over usbmux \"{_tcpClientAddress}\".");
+
+            using var connectTimeoutTokenSource = new CancellationTokenSource();
+            using var connectTokenSource = CancellationTokenSource.CreateLinkedTokenSource(token, connectTimeoutTokenSource.Token);
+
+            connectTimeoutTokenSource.CancelAfter(TcpClientTimeoutMs);
+
+            do
+            {
+                try
+                {
+                    handle = ConnectTcpClientOverUSBMux();
+                    retry = false;
+                }
+                catch (Exception)
+                {
+                    if (connectTimeoutTokenSource.IsCancellationRequested)
+                    {
+                        _logger?.LogDebug("No USB stream connected, timing out.");
+
+                        if (_auto_shutdown)
+                            throw new RuntimeTimeoutException(TcpClientTimeoutMs);
+
+                        throw new TimeoutException();
+                    }
+
+                    // If we are not doing auto shutdown when runtime is unavailable, fail right away, this will
+                    // break any accepted IPC connections, making sure client is notified and could reconnect.
+                    // If we do have auto shutdown enabled, retry until succeed or time out.
+                    if (!_auto_shutdown)
+                    {
+                        _logger?.LogTrace($"Failed connecting {_port} over usbmux.");
+                        throw;
+                    }
+
+                    _logger?.LogTrace($"Failed connecting {_port} over usbmux, wait {TcpClientRetryTimeoutMs} ms before retrying.");
+
+                    // If we get an error (without hitting timeout above), most likely due to unavailable device/listener.
+                    // Delay execution to prevent to rapid retry attempts.
+                    await Task.Delay(TcpClientRetryTimeoutMs, token).ConfigureAwait(false);
+
+                    retry = true;
+                }
+            }
+            while (retry);
+
+            return new USBMuxStream(handle);
+        }
+
+        public override void Start()
+        {
+            // Start device subscription thread.
+            StartNotificationSubscribeThread();
+        }
+
+        public override void Stop()
+        {
+            // Stop device subscription thread.
+            StopNotificationSubscribeThread();
+        }
+
+        int ConnectTcpClientOverUSBMux()
+        {
+            uint result = 0;
+            int handle = -1;
+            ushort networkPort = (ushort)IPAddress.HostToNetworkOrder(unchecked((short)_port));
+
+            lock (this)
+            {
+                if (_deviceConnectionID == 0)
+                    throw new Exception($"Failed to connect device over USB, no device currently connected.");
+
+                result = USBMuxInterop.USBMuxConnectByPort(_deviceConnectionID, networkPort, out handle);
+            }
+
+            if (result != 0)
+                throw new Exception($"Failed to connect device over USB using connection {_deviceConnectionID} and port {_port}.");
+
+            return handle;
+        }
+
+        bool ConnectDevice(IntPtr newDevice)
+        {
+            if (_device != IntPtr.Zero)
+                return false;
+
+            _device = newDevice;
+            if (USBMuxInterop.AMDeviceConnect(_device) == 0)
+            {
+                _deviceConnectionID = USBMuxInterop.AMDeviceGetConnectionID(_device);
+                _logger?.LogInformation($"Successfully connected new device, id={_deviceConnectionID}.");
+                return true;
+            }
+            else
+            {
+                _logger?.LogError($"Failed connecting new device.");
+                return false;
+            }
+        }
+
+        bool DisconnectDevice()
+        {
+            if (_device != IntPtr.Zero)
+            {
+                if (_deviceConnectionID != 0)
+                {
+                    USBMuxInterop.AMDeviceDisconnect(_device);
+                    _logger?.LogInformation($"Successfully disconnected device, id={_deviceConnectionID}.");
+                    _deviceConnectionID = 0;
+                }
+
+                _device = IntPtr.Zero;
+            }
+
+            return true;
+        }
+
+        void AMDeviceNotificationCallback(ref USBMuxInterop.AMDeviceNotificationCallbackInfo info)
+        {
+            _logger?.LogTrace($"AMDeviceNotificationInternal callback, device={info.am_device}, action={info.message}");
+
+            try
+            {
+                lock (this)
+                {
+                    int interfaceType = USBMuxInterop.AMDeviceGetInterfaceType(info.am_device);
+                    switch (info.message)
+                    {
+                        case USBMuxInterop.AMDeviceNotificationMessage.Connected:
+                            if (interfaceType == 1 && _device == IntPtr.Zero)
+                            {
+                                ConnectDevice(info.am_device);
+                            }
+                            else if (interfaceType == 1 && _device != IntPtr.Zero)
+                            {
+                                _logger?.LogInformation($"Discovered new device, but one is already connected, ignoring new device.");
+                            }
+                            else if (interfaceType == 0)
+                            {
+                                _logger?.LogInformation($"Discovered new device not connected over USB, ignoring new device.");
+                            }
+                            break;
+                        case USBMuxInterop.AMDeviceNotificationMessage.Disconnected:
+                        case USBMuxInterop.AMDeviceNotificationMessage.Unsubscribed:
+                            if (_device == info.am_device)
+                            {
+                                DisconnectDevice();
+                            }
+                            break;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError($"Failed AMDeviceNotificationCallback: {ex.Message}. Failed handling device={info.am_device} using action={info.message}");
+            }
+        }
+
+        void AMDeviceNotificationSubscribeLoop()
+        {
+            IntPtr context = IntPtr.Zero;
+
+            try
+            {
+                lock (this)
+                {
+                    if (_loopingThread != IntPtr.Zero)
+                    {
+                        _logger?.LogError($"AMDeviceNotificationSubscribeLoop already running.");
+                        throw new Exception("AMDeviceNotificationSubscribeLoop already running.");
+                    }
+
+                    _loopingThread = USBMuxInterop.CFRunLoopGetCurrent();
+                }
+
+                _logger?.LogTrace($"Calling AMDeviceNotificationSubscribe.");
+
+                if (USBMuxInterop.AMDeviceNotificationSubscribe(AMDeviceNotificationCallback, 0, 0, 0, out context) != 0)
+                {
+                    _logger?.LogError($"Failed AMDeviceNotificationSubscribe call.");
+                    throw new Exception("Failed AMDeviceNotificationSubscribe call.");
+                }
+
+                _logger?.LogTrace($"Start dispatching notifications.");
+                USBMuxInterop.CFRunLoopRun();
+                _logger?.LogTrace($"Stop dispatching notifications.");
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError($"Failed running subscribe loop: {ex.Message}. Disabling detection of devices connected over USB.");
+            }
+            finally
+            {
+                lock (this)
+                {
+                    if (_loopingThread != IntPtr.Zero)
+                    {
+                        _loopingThread = IntPtr.Zero;
+                    }
+
+                    DisconnectDevice();
+                }
+
+                if (context != IntPtr.Zero)
+                {
+                    _logger?.LogTrace($"Calling AMDeviceNotificationUnsubscribe.");
+                    USBMuxInterop.AMDeviceNotificationUnsubscribe(context);
+                }
+            }
+        }
+
+        void StartNotificationSubscribeThread()
+        {
+            new Thread(new ThreadStart(() => AMDeviceNotificationSubscribeLoop())).Start();
+        }
+
+        void StopNotificationSubscribeThread()
+        {
+            lock (this)
+            {
+                if (_loopingThread != IntPtr.Zero)
+                    USBMuxInterop.CFRunLoopStop(_loopingThread);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR together with https://github.com/dotnet/diagnostics/pull/2343 and https://github.com/dotnet/diagnostics/pull/2344 simplifies the diagnostics scenarios on Android/iOS simulator/devices. This PR adds support into dsrouter to setup/tear down adb port forwarding on Android matching configured dsrouter tcp client configuration and implementation of usbmux on iOS, setting up option to connect to iOS device over usb, using tcp client port configuration. All this pushes the listener all the way over to device using loopback interface together with dsrouter `server-client` mode, where dsrouter acts as a TCP/IP client, connecting towards 127.0.0.1:x for all scenarios (including runtime startup profiling).

Without this PR, Android scenario needs to manually setup adb port forwarding, and for iOS device, all must be handled over wifi connection, running dsrouter in server-server mode, binding to a interface accessible from wifi connected phone. This dramatically adding complexity and reducing security in the end-end solution.

With this PR, it is now possible to run diagnostics on iOS device using the following commands:

Launch application using mlaunch/xcode etc, using `DOTNET_DiagnosticPorts=127.0.0.1:9000,nosuspend,listen`.

Run `dotnet-dsrouter server-client -tcpc 127.0.0.1:9000 --forward-port iOS`.

or use dsrouter launch capabilities:

`dotnet-dsrouter server-client -tcpc 127.0.0.1:9000 --forward-port iOS -- mlaunch [appid] -setenv ${DOTNET_DiagnosticPorts}`

Once dsrouter and app is running, run regular diagnostics tooling against IPC server setup by dsrouter instance.

Running the same on iOS simulator looks similar, just drop `--forward-port` argument and direct mlaunch towards simulator instance.

On Android you run things in a similar way, but you can always use port forwarding, regardless if targeting emulator or device.