### PR TITLE
Handle exception when runtime instance shuts down while enumerating processes

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring/ClientEndpointInfoSource.cs
+++ b/src/Microsoft.Diagnostics.Monitoring/ClientEndpointInfoSource.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -25,6 +26,11 @@ namespace Microsoft.Diagnostics.Monitoring
                     try
                     {
                         return EndpointInfo.FromProcessId(pid);
+                    }
+                    // Catch when runtime instance shuts down while attepting to use the established diagnostic port connection.
+                    catch (EndOfStreamException)
+                    {
+                        return null;
                     }
                     //Catch when the application is running a more privilaged socket than dotnet-monitor. For example, running a web app as administrator
                     //while running dotnet-monitor without elevation.


### PR DESCRIPTION
After having just discovered the list of processes with diagnostic ports, if a runtime instance shuts down while the ClientEndpointInfoSource is attempting to get additional information about the process via its diagnostic port connection, it will throw EndOfStreamException and fail the entire enumeration. Handle this exception so that the other processes that are valid may still be returned.

Call stack when this issue occurs:
```
System.IO.EndOfStreamException: Unable to read beyond the end of the stream.
    at System.IO.BinaryReader.InternalRead(Int32 numBytes)
    at System.IO.BinaryReader.ReadUInt16()
    at Microsoft.Diagnostics.NETCore.Client.IpcHeader.TryParse(BinaryReader reader)
    at Microsoft.Diagnostics.NETCore.Client.IpcMessage.Parse(Stream stream)
    at Microsoft.Diagnostics.NETCore.Client.IpcClient.Read(Stream stream)
    at Microsoft.Diagnostics.NETCore.Client.IpcClient.SendMessage(IpcEndpoint endpoint, IpcMessage message)
    at Microsoft.Diagnostics.NETCore.Client.DiagnosticsClient.GetProcessInfo()
    at Microsoft.Diagnostics.Monitoring.EndpointInfo.FromProcessId(Int32 processId)
    at Microsoft.Diagnostics.Monitoring.ClientEndpointInfoSource.<>c__DisplayClass0_0.<GetEndpointInfoAsync>b__2()
    at System.Threading.Tasks.Task`1.InnerInvoke()
    at System.Threading.Tasks.Task.<>c.<.cctor>b__274_0(Object obj)
    at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
 --- End of stack trace from previous location where exception was thrown ---
    at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
    at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot, Thread threadPoolThread)
 --- End of stack trace from previous location where exception was thrown ---
    at Microsoft.Diagnostics.Monitoring.ClientEndpointInfoSource.GetEndpointInfoAsync(CancellationToken token)
    at Microsoft.Diagnostics.Tools.Monitor.FilteredEndpointInfoSource.GetEndpointInfoAsync(CancellationToken token) in /_/src/Tools/dotnet-monitor/FilteredEndpointInfoSource.cs:line 76
    at Microsoft.Diagnostics.Monitoring.RestServer.DiagnosticServices.GetProcessesAsync(DiagProcessFilter processFilterConfig, CancellationToken token) in /_/src/Microsoft.Diagnostics.Monitoring.RestServer/DiagnosticServices.cs:line 51
    at Microsoft.Diagnostics.Monitoring.RestServer.Controllers.DiagController.<GetProcesses>b__10_0() in /_/src/Microsoft.Diagnostics.Monitoring.RestServer/Controllers/DiagController.cs:line 67
    at Microsoft.Diagnostics.Monitoring.RestServer.Controllers.DiagControllerExtensions.InvokeService[T](ControllerBase controller, Func`1 serviceCall, ILogger logger) in /_/src/Microsoft.Diagnostics.Monitoring.RestServer/Controllers/DiagControllerExtensions.cs:line 56
    at lambda_method(Closure , Object )
    at Microsoft.Extensions.Internal.ObjectMethodExecutorAwaitable.Awaiter.GetResult()
    at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.AwaitableObjectResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
    at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Awaited|12_0(ControllerActionInvoker invoker, ValueTask`1 actionResultValueTask)
    at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
    at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
    at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
    at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeInnerFilterAsync>g__Awaited|13_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
    at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeFilterPipelineAsync>g__Awaited|19_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
    at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Awaited|17_0(ResourceInvoker invoker, Task task, IDisposable scope)
    at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
    at Microsoft.Diagnostics.Tools.Monitor.Throttling.Invoke(HttpContext context) in /_/src/Tools/dotnet-monitor/Throttling.cs:line 66
    at Microsoft.AspNetCore.ResponseCompression.ResponseCompressionMiddleware.Invoke(HttpContext context)
    at Microsoft.AspNetCore.Authorization.AuthorizationMiddleware.Invoke(HttpContext context)
    at Microsoft.AspNetCore.Authentication.AuthenticationMiddleware.Invoke(HttpContext context)
    at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application)
```