### PR TITLE
Updates scripts for LLVM/Clang versions that are double digits

### DIFF
--- a/eng/build.sh
+++ b/eng/build.sh
@@ -100,7 +100,7 @@ case $CPUName in
         __HostArch=x86
         ;;
 
-    x86_64)
+    x86_64|amd64)
         __BuildArch=x64
         __HostArch=x64
         ;;
@@ -259,7 +259,7 @@ while :; do
         -clang*)
             __Compiler=clang
             # clangx.y or clang-x.y
-            version="$(echo "$lowerI" | tr -d '[:alpha:]-=')"
+            version="$(echo "$1" | tr -d '[:alpha:]-=')"
             parts=(${version//./ })
             __ClangMajorVersion="${parts[0]}"
             __ClangMinorVersion="${parts[1]}"

--- a/eng/common/native/find-native-compiler.sh
+++ b/eng/common/native/find-native-compiler.sh
@@ -45,6 +45,10 @@ check_version_exists() {
         desired_version="$1$2"
     elif command -v "$compiler-$1$2" > /dev/null; then
         desired_version="-$1$2"
+    elif command -v "$compiler$1" > /dev/null; then
+        desired_version="$1"
+    elif command -v "$compiler-$1" > /dev/null; then
+        desired_version="-$1"
     fi
 
     echo "$desired_version"
@@ -55,7 +59,7 @@ if [ -z "$CLR_CC" ]; then
     # Set default versions
     if [ -z "$majorVersion" ]; then
         # note: gcc (all versions) and clang versions higher than 6 do not have minor version in file name, if it is zero.
-        if [ "$compiler" = "clang" ]; then versions=( 9 8 7 6.0 5.0 4.0 3.9 3.8 3.7 3.6 3.5 )
+        if [ "$compiler" = "clang" ]; then versions=( 12 11 10 9 8 7 6.0 5.0 4.0 3.9 3.8 3.7 3.6 3.5 )
         elif [ "$compiler" = "gcc" ]; then versions=( 9 8 7 6 5 4.9 ); fi
 
         for version in "${versions[@]}"; do

--- a/eng/gen-buildsys-clang.sh
+++ b/eng/gen-buildsys-clang.sh
@@ -29,6 +29,12 @@ elif command -v "clang$2$3" > /dev/null
 elif command -v "clang-$2$3" > /dev/null
     then
         desired_llvm_version="-$2$3"
+elif command -v "clang-$2" > /dev/null
+    then
+        desired_llvm_version="-$2"
+elif command -v "clang$2" > /dev/null
+    then
+        desired_llvm_version="$2"
 elif command -v clang > /dev/null
     then
         desired_llvm_version=


### PR DESCRIPTION
TL;DR:
Version additions for LLVM/CLANG + fix typo. Should be low impact.

Overview:

`eng/build.sh`
- FreeBSD (and other BSD-like) return `amd64` for intel/amd 64bit from the `uname` command issued.
- I had to dig around on this one, but`$lowerI` appears to be left over from when some of the scripts were consolidated and a new function was made to lowercase things

`eng/common/native/find-native-compiler.sh`
- Add new cases for double digit compilers that don't use dot revision (e.g., 10, 11, 12)
- Added detection for the newer versions added in case

`eng/gen-buildsys-clang.sh`
- Same as second part of `find-native-compiler.sh`

Unnecessarily detailed stackexchange-like explanation: 

`uname` does not have many POSIX compliant options that can be passed to it. So trying to make the script use only POSIX complaint `uname` options and understand what is returned by them would be too much of a hassle;  output can be different from Linux distro to distro and even stranger outside the world of Linux even if the same `uname -option` is passed! The script tries to work around quirks in different Linux distros as it is. A simple `|amd64` is added to the `x86_64` case to cover how FreeBSD returns the `uname` issued to it. 

Before the changes noted above, the script would work under most environments without issue unless someone tried to pass `-clangx.y`. This would fail as `$lowerI` evaluated to, um, empty string(?)...empty variable(?)... NULL(?). Fallback would use `command -v clang`  and this is the compiler that ships with the base OS for most BSD-like (and the odd linux distro). This is unacceptable on FreeBSD (and likely other BSD) as the compiler that ships with the OS is for the OS and not for the user.  The update also handles cases like `clang11` or `clang-11` but the user still must use `-clangx.y`  (e.g.,`-clang11.0`). The fallback is maintained as this behavior was there originally and is likely acceptable on other OSes. The detection of newer non-dotted (typically double digit) LLVM/CLANG are placed at the end of the if/else block to respect preference for dotted revision LLVM/CLANG (e.g., 3.8, 3.9)


Finally, this does not fix actually building FOR FreeBSD as I thought it would be cleaner to separate the detection code from the FreeBSD work. That will, hopefully, be coming later.