### PR TITLE
Fix SOS for SVR GC using regions

### DIFF
--- a/src/SOS/Strike/util.h
+++ b/src/SOS/Strike/util.h
@@ -484,7 +484,7 @@ public:
         lowest_address = dacGCDetails.lowest_address;
         highest_address = dacGCDetails.highest_address;
         card_table = dacGCDetails.card_table;
-        has_regions = saved_sweep_ephemeral_seg == -1;
+        has_regions = generation_table[0].start_segment != generation_table[1].start_segment;
     }
 
     DacpGcHeapDetails original_heap_details;


### PR DESCRIPTION
Use a different way of recognizing a GC build using regions that works for SVR GC.

As it turns out, SOS didn't yet work for SVR GC because the DAC logic sets saved_sweep_ephemeral_seg to 0 always.

This may need fixing as well (see issue https://github.com/dotnet/runtime/issues/54368), but the simple change below at least enables SOS for SVR GC using regions.
