### PR TITLE
fix building native component for FreeBSD

### DIFF
--- a/compileoptions.cmake
+++ b/compileoptions.cmake
@@ -79,6 +79,11 @@ if(CLR_CMAKE_PLATFORM_UNIX_ARM)
    endif(ARM_SOFTFP)
 endif(CLR_CMAKE_PLATFORM_UNIX_ARM)
 
+if(CLR_CMAKE_PLATFORM_FREEBSD)
+  add_compile_options(-Wno-macro-redefined)
+  add_compile_options(-Wno-pointer-to-int-cast)
+endif(CLR_CMAKE_PLATFORM_FREEBSD)
+
 if (WIN32)
   # Compile options for targeting windows
 

--- a/src/SOS/dbgutil/elfreader.cpp
+++ b/src/SOS/dbgutil/elfreader.cpp
@@ -393,20 +393,11 @@ ElfReader::EnumerateLinkMapEntries(Elf_Dyn* dynamicAddr)
             for (; i < PATH_MAX; i++)
             {
                 char ch;
-		#ifdef __FreeBSD__
-		{
 		char* l_name = const_cast<char*>(map.l_name);
 		if (!ReadMemory(l_name + i, &ch, sizeof(ch))) {
 		    TRACE("DSO: ReadMemory link_map name %p + %d FAILED\n", map.l_name, i);
                     break;
 		}
-		}
-		#else
-                if (!ReadMemory(map.l_name + i, &ch, sizeof(ch))) {
-                    TRACE("DSO: ReadMemory link_map name %p + %d FAILED\n", map.l_name, i);
-                    break;
-                }
-		#endif
                 if (ch == '\0') {
                     break;
                 }

--- a/src/SOS/dbgutil/elfreader.cpp
+++ b/src/SOS/dbgutil/elfreader.cpp
@@ -393,10 +393,20 @@ ElfReader::EnumerateLinkMapEntries(Elf_Dyn* dynamicAddr)
             for (; i < PATH_MAX; i++)
             {
                 char ch;
+		#ifdef __FreeBSD__
+		{
+		char* l_name = const_cast<char*>(map.l_name);
+		if (!ReadMemory(l_name + i, &ch, sizeof(ch))) {
+		    TRACE("DSO: ReadMemory link_map name %p + %d FAILED\n", map.l_name, i);
+                    break;
+		}
+		}
+		#else
                 if (!ReadMemory(map.l_name + i, &ch, sizeof(ch))) {
                     TRACE("DSO: ReadMemory link_map name %p + %d FAILED\n", map.l_name, i);
                     break;
                 }
+		#endif
                 if (ch == '\0') {
                     break;
                 }

--- a/src/SOS/dbgutil/elfreader.h
+++ b/src/SOS/dbgutil/elfreader.h
@@ -63,7 +63,11 @@ private:
     bool EnumerateLinkMapEntries(ElfW(Dyn)* dynamicAddr);
 #endif
     bool EnumerateProgramHeaders(ElfW(Phdr)* phdrAddr, int phnum, uint64_t baseAddress, uint64_t* ploadbias, ElfW(Dyn)** pdynamicAddr);
+#ifdef __FreeBSD__
+    virtual void VisitModule(caddr_t baseAddress, std::string& moduleName) { };
+#else
     virtual void VisitModule(uint64_t baseAddress, std::string& moduleName) { };
+#endif
     virtual void VisitProgramHeader(uint64_t loadbias, uint64_t baseAddress, ElfW(Phdr)* phdr) { };
     virtual bool ReadMemory(void* address, void* buffer, size_t size) = 0;
     virtual void Trace(const char* format, ...) { };

--- a/src/SOS/extensions/hostcoreclr.cpp
+++ b/src/SOS/extensions/hostcoreclr.cpp
@@ -22,6 +22,11 @@
 #include <mach-o/dyld.h>
 #endif
 
+#if defined(__FreeBSD__)
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#endif
+
 #include "palclr.h"
 #include "arrayholder.h"
 #include "coreclrhost.h"
@@ -412,14 +417,15 @@ static HRESULT GetHostRuntime(std::string& coreClrPath, std::string& hostRuntime
         else 
         {
 #ifdef FEATURE_PAL
-#if defined (__FreeBSD__) || defined(__NetBSD__)
-            TraceError("Hosting on FreeBSD or NetBSD not supported\n");
+#if defined(__NetBSD__)
+            TraceError("Hosting on NetBSD not supported\n");
             return E_FAIL;
 #else
             char* line = nullptr;
             size_t lineLen = 0;
 
             // Start with Linux location file if exists
+	    // Note to self: Add a better location in FreeBSD for this
             FILE* locationFile = fopen("/etc/dotnet/install_location", "r");
             if (locationFile != nullptr)
             {
@@ -446,7 +452,7 @@ static HRESULT GetHostRuntime(std::string& coreClrPath, std::string& hostRuntime
                     }
                 }
             }
-#endif // defined (__FreeBSD__) || defined(__NetBSD__)
+#endif // defined(__NetBSD__)
 #else
             ArrayHolder<CHAR> programFiles = new CHAR[MAX_LONGPATH];
             if (GetEnvironmentVariableA("PROGRAMFILES", programFiles, MAX_LONGPATH) == 0)

--- a/src/SOS/extensions/hostcoreclr.cpp
+++ b/src/SOS/extensions/hostcoreclr.cpp
@@ -425,7 +425,6 @@ static HRESULT GetHostRuntime(std::string& coreClrPath, std::string& hostRuntime
             size_t lineLen = 0;
 
             // Start with Linux location file if exists
-	    // Note to self: Add a better location in FreeBSD for this
             FILE* locationFile = fopen("/etc/dotnet/install_location", "r");
             if (locationFile != nullptr)
             {

--- a/src/SOS/lldbplugin/CMakeLists.txt
+++ b/src/SOS/lldbplugin/CMakeLists.txt
@@ -114,6 +114,10 @@ else()
     #FreeBSD
     find_path(LLDB_H "lldb/API/LLDB.h" PATHS "/usr/local/llvm39/include")
     find_path(LLDB_H "lldb/API/LLDB.h" PATHS "/usr/local/llvm38/include")
+    find_path(LLDB_H "lldb/API/LLDB.h" PATHS "/usr/local/llvm12/include")
+    find_path(LLDB_H "lldb/API/LLDB.h" PATHS "/usr/local/llvm11/include")
+    find_path(LLDB_H "lldb/API/LLDB.h" PATHS "/usr/local/llvm10/include")
+    find_path(LLDB_H "lldb/API/LLDB.h" PATHS "/usr/local/llvm90/include")
 
     if(LLDB_H STREQUAL LLDB_H-NOTFOUND)
 	if(REQUIRE_LLDBPLUGIN)

--- a/src/pal/src/misc/sysinfo.cpp
+++ b/src/pal/src/misc/sysinfo.cpp
@@ -35,6 +35,10 @@ Revision History:
 #error Either sysctl or sysconf is required for GetSystemInfo.
 #endif
 
+#if defined(__FreeBSD__)
+#include <sys/sysctl.h>
+#endif
+
 #if HAVE_SYSINFO
 #include <sys/sysinfo.h>
 #endif


### PR DESCRIPTION
- ifdef's for `__FreeBSD__` for missing sys/types.h and sys/sysctl.h where needed
- elfreader: link_map under Linux is different than FreeBSD 
- while we are here: add newer LLVM version paths for `LLDB_H` and disable, only for FreeBSD, two new warnings that LLVM10/11 use