### PR TITLE
Fix clrstack -i crash

### DIFF
--- a/src/SOS/SOS.Hosting/CorDebugDataTargetWrapper.cs
+++ b/src/SOS/SOS.Hosting/CorDebugDataTargetWrapper.cs
@@ -55,6 +55,8 @@ namespace SOS.Hosting
             builder = AddInterface(IID_ICorDebugMetaDataLocator, validate: false);
             builder.AddMethod(new GetMetaDataDelegate(GetMetaData));
             builder.Complete();
+
+            AddRef();
         }
 
         protected override void Destroy()

--- a/src/SOS/SOS.Hosting/DataTargetWrapper.cs
+++ b/src/SOS/SOS.Hosting/DataTargetWrapper.cs
@@ -68,6 +68,8 @@ namespace SOS.Hosting
             builder = AddInterface(IID_ICLRRuntimeLocator, false);
             builder.AddMethod(new GetRuntimeBaseDelegate(GetRuntimeBase));
             builder.Complete();
+
+            AddRef();
         }
 
         void AddDataTarget(VTableBuilder builder)


### PR DESCRIPTION
The DataTargetWrapper (data target for DAC) and CorDebugDataTargetWrapper (data target for DBI) didn't increment the reference count initially. Normally this wasn't a problem because DAC/DBI don't release a reference except some debug/checked code in the DBI OpenVirtualProcess path that QI'ed for the data target interface and released as an assert.  The release would set the count back to zero which causes the wrappers to tear down the COM wrappers internals so when the next QI happened it failed. I don't know exactly why it seg faults because was running on Windows with the cross-DAC and got an assert in DBI instead.