### PR TITLE
Fix fallback for resumeruntime

### DIFF
--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
@@ -316,9 +316,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
                     var hr = BitConverter.ToUInt32(response.Payload, 0);
                     if (hr == (uint)DiagnosticsIpcError.UnknownCommand)
                     {
-                        // We attempted to resume a 3.1 runtime, which doesn't support suspension.
-                        // noop
-                        return;
+                        throw new UnsupportedCommandException($"Resume runtime command is unknown by target runtime.");
                     }
                     throw new ServerErrorException($"Resume runtime failed (HRESULT: 0x{hr:X8})");
                 case DiagnosticsServerResponseId.OK:

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
@@ -313,7 +313,13 @@ namespace Microsoft.Diagnostics.NETCore.Client
             switch ((DiagnosticsServerResponseId)response.Header.CommandId)
             {
                 case DiagnosticsServerResponseId.Error:
-                    var hr = BitConverter.ToInt32(response.Payload, 0);
+                    var hr = BitConverter.ToUInt32(response.Payload, 0);
+                    if (hr == (uint)DiagnosticsIpcError.UnknownCommand)
+                    {
+                        // We attempted to resume a 3.1 runtime, which doesn't support suspension.
+                        // noop
+                        return;
+                    }
                     throw new ServerErrorException($"Resume runtime failed (HRESULT: 0x{hr:X8})");
                 case DiagnosticsServerResponseId.OK:
                     return;

--- a/src/Tools/dotnet-counters/CounterMonitor.cs
+++ b/src/Tools/dotnet-counters/CounterMonitor.cs
@@ -343,7 +343,14 @@ namespace Microsoft.Diagnostics.Tools.Counters
                     _session = _diagnosticsClient.StartEventPipeSession(Trace.Extensions.ToProviders(providerString), false, 10);
                     if (_resumeRuntime)
                     {
-                        _diagnosticsClient.ResumeRuntime();
+                        try
+                        {
+                            _diagnosticsClient.ResumeRuntime();
+                        }
+                        catch (UnsupportedCommandException)
+                        {
+                            // Noop if the command is unknown since the target process is most likely a 3.1 app.
+                        }
                     }
                     var source = new EventPipeEventSource(_session.EventStream);
                     source.Dynamic.All += DynamicAllMonitor;

--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
@@ -222,7 +222,14 @@ namespace Microsoft.Diagnostics.Tools.Trace
                             session = diagnosticsClient.StartEventPipeSession(providerCollection, true, (int)buffersize);
                             if (resumeRuntime)
                             {
-                                diagnosticsClient.ResumeRuntime();
+                                try
+                                {
+                                    diagnosticsClient.ResumeRuntime();
+                                }
+                                catch (UnsupportedCommandException)
+                                {
+                                    // Noop if command is unsupported, since the target is most likely a 3.1 app.
+                                }
                             }
                         }
                         catch (DiagnosticsClientException e)


### PR DESCRIPTION
The fallback for the internal ResumeRuntime IPC command was erroring if it was used with a 3.1 runtime which doesn't support suspension. It should silently fail if the client receives an UnknownCommand error.

@hoyosjs can we get this merged in before we branch for release?

CC @lateralusX 