### PR TITLE
Fix unknown type/methods in core dumps.

### DIFF
--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/MetadataMappingMemoryService.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/MetadataMappingMemoryService.cs
@@ -3,13 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Runtime;
-using System.Linq;
+using Microsoft.Diagnostics.Runtime.Utilities;
 using System;
 using System.Collections.Immutable;
-using System.IO;
-using Microsoft.Diagnostics.Runtime.Utilities;
 using System.Diagnostics;
-using System.Diagnostics.Contracts;
+using System.IO;
+using System.Linq;
 
 namespace Microsoft.Diagnostics.DebugServices.Implementation
 {

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/ModuleServiceFromDataReader.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/ModuleServiceFromDataReader.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
             private readonly IExportReader _exportReader;
             private readonly ModuleInfo _moduleInfo;
             private readonly ulong _imageSize;
+            private VersionData _versionData;
             private string _versionString;
 
             public ModuleFromDataReader(ModuleServiceFromDataReader moduleService, IExportReader exportReader, int moduleIndex, ModuleInfo moduleInfo, ulong imageSize)
@@ -65,17 +66,17 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
                     {
                         if (_moduleInfo.Version != EmptyVersionInfo)
                         {
-                            base.VersionData = _moduleInfo.Version.ToVersionData();
+                            _versionData = _moduleInfo.Version.ToVersionData();
                         }
                         else
                         {
                             if (_moduleService.Target.OperatingSystem != OSPlatform.Windows)
                             {
-                                GetVersionFromVersionString();
+                                _versionData = GetVersion();
                             }
                         }
                     }
-                    return base.VersionData;
+                    return _versionData;
                 }
             }
 

--- a/src/SOS/SOS.Extensions/ModuleServiceFromDebuggerServices.cs
+++ b/src/SOS/SOS.Extensions/ModuleServiceFromDebuggerServices.cs
@@ -4,13 +4,10 @@
 
 using Microsoft.Diagnostics.DebugServices;
 using Microsoft.Diagnostics.DebugServices.Implementation;
-using Microsoft.Diagnostics.Runtime;
 using Microsoft.Diagnostics.Runtime.Interop;
 using Microsoft.Diagnostics.Runtime.Utilities;
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Runtime.InteropServices;
 
 namespace SOS.Extensions
@@ -26,6 +23,7 @@ namespace SOS.Extensions
             private const uint InvalidTimeStamp = 0xFFFFFFFE;
 
             private readonly ModuleServiceFromDebuggerServices _moduleService;
+            private VersionData _versionData;
             private string _versionString;
 
             public ModuleFromDebuggerServices(
@@ -77,17 +75,17 @@ namespace SOS.Extensions
                             int minor = (int)fileInfo.dwFileVersionMS & 0xffff;
                             int revision = (int)fileInfo.dwFileVersionLS >> 16;
                             int patch = (int)fileInfo.dwFileVersionLS & 0xffff;
-                            base.VersionData = new VersionData(major, minor, revision, patch);
+                            _versionData = new VersionData(major, minor, revision, patch);
                         }
                         else
                         {
                             if (_moduleService.Target.OperatingSystem != OSPlatform.Windows)
                             {
-                                GetVersionFromVersionString();
+                                _versionData = GetVersion();
                             }
                         }
                     }
-                    return base.VersionData;
+                    return _versionData;
                 }
             }
 


### PR DESCRIPTION
Fixes some of the issues in https://github.com/dotnet/diagnostics/issues/2375

The problem is that the image mapping memory service didn't convert the rva from a
loaded layout calculated from the in-memory module to the file layout (the PEReader
with the downloaded image).

On Windows, images (native or managed) are always loaded layout so return false in
IModule.IsFileLayout without calling GetPEInfo() to avoid the recursion that broken
getting the info about coreclr.dll. It turns out that the heap dumps generated on
Windows don't have the image in-memory.

Don't get module version in GetPEInfo() to determine the layout. Cleanup.

Skip relocations that span cache blocks. This happens very rarely and should not affect
anything unless we get really really unlucky.