### PR TITLE
We should check against alloc_allocated instead of heap_segment_allocated for ephemeral segment

### DIFF
--- a/src/SOS/Strike/eeheap.cpp
+++ b/src/SOS/Strike/eeheap.cpp
@@ -700,7 +700,12 @@ BOOL GCObjInSegment(TADDR taddrObj, const GCHeapDetails &heap,
                     ExtOut("Error requesting heap segment %p\n", SOS_PTR(taddrSeg));
                     return FALSE;
                 }
-                if (taddrObj >= TO_TADDR(dacpSeg.mem) && taddrObj && taddrObj < TO_TADDR(dacpSeg.allocated))
+                TADDR allocated = TO_TADDR(dacpSeg.allocated);
+                if (taddrSeg == TO_TADDR(heap.ephemeral_heap_segment))
+                {
+                    allocated = TO_TADDR(heap.alloc_allocated);
+                }
+                if (taddrObj >= TO_TADDR(dacpSeg.mem) && taddrObj && taddrObj < allocated)
                 {
                     rngSeg.segAddr = (TADDR)dacpSeg.segmentAddr;
                     rngSeg.start = (TADDR)dacpSeg.mem;

--- a/src/SOS/Strike/eeheap.cpp
+++ b/src/SOS/Strike/eeheap.cpp
@@ -705,7 +705,7 @@ BOOL GCObjInSegment(TADDR taddrObj, const GCHeapDetails &heap,
                 {
                     allocated = TO_TADDR(heap.alloc_allocated);
                 }
-                if (taddrObj >= TO_TADDR(dacpSeg.mem) && taddrObj && taddrObj < allocated)
+                if (taddrObj >= TO_TADDR(dacpSeg.mem) && taddrObj < allocated)
                 {
                     rngSeg.segAddr = (TADDR)dacpSeg.segmentAddr;
                     rngSeg.start = (TADDR)dacpSeg.mem;
@@ -781,7 +781,7 @@ BOOL GCObjInLargeSegment(TADDR taddrObj, const GCHeapDetails &heap, TADDR_SEGINF
             ExtOut("Error requesting heap segment %p\n", SOS_PTR(taddrSeg));
             return FALSE;
         }
-        if (taddrObj >= TO_TADDR(dacpSeg.mem) && taddrObj && taddrObj < TO_TADDR(dacpSeg.allocated))
+        if (taddrObj >= TO_TADDR(dacpSeg.mem) && taddrObj < TO_TADDR(dacpSeg.allocated))
         {
             rngSeg.segAddr = (TADDR)dacpSeg.segmentAddr;
             rngSeg.start   = (TADDR)dacpSeg.mem;
@@ -814,7 +814,7 @@ BOOL GCObjInPinnedObjectSegment(TADDR taddrObj, const GCHeapDetails &heap, TADDR
             ExtOut("Error requesting heap segment %p\n", SOS_PTR(taddrSeg));
             return FALSE;
         }
-        if (taddrObj >= TO_TADDR(dacpSeg.mem) && taddrObj && taddrObj < TO_TADDR(dacpSeg.allocated))
+        if (taddrObj >= TO_TADDR(dacpSeg.mem) && taddrObj < TO_TADDR(dacpSeg.allocated))
         {
             rngSeg.segAddr = (TADDR)dacpSeg.segmentAddr;
             rngSeg.start   = (TADDR)dacpSeg.mem;


### PR DESCRIPTION
This fixes a test failure for the SOS unit test named [GCTests](https://github.com/dotnet/diagnostics/blob/main/src/SOS/SOS.UnitTests/Scripts/GCTests.script) when the test is run under `USE_REGIONS`.

The problem is that `GCWhere` failed to locate a freshly allocated object because `heap_segment_allocated` is not updated yet.

@dotnet/gc