### PR TITLE
Revert "Update `ThreadCounts` usage based on a change (#2324)"

### DIFF
--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -8677,7 +8677,6 @@ DECLARE_API(ThreadPool)
     do // while (false)
     {
         UINT64 ui64Value = 0;
-        UINT32 ui32Value = 0;
 
         // Determine if the portable thread pool is enabled
         if (FAILED(
@@ -8774,12 +8773,12 @@ DECLARE_API(ThreadPool)
             accumulatedOffset += offset;
 
             offset = GetValueFieldOffset(vCountsField.MTOfType, W("_data"));
-            if (offset < 0 || FAILED(MOVE(ui32Value, cdaTpInstance + accumulatedOffset + offset)))
+            if (offset < 0 || FAILED(MOVE(ui64Value, cdaTpInstance + accumulatedOffset + offset)))
             {
                 ExtOut("    %s\n", "Failed to read PortableThreadPool._separated.counts._data");
                 break;
             }
-            UINT32 data = ui32Value;
+            UINT64 data = ui64Value;
 
             const UINT8 NumProcessingWorkShift = 0;
             const UINT8 NumExistingThreadsShift = 16;


### PR DESCRIPTION
- Depends on https://github.com/dotnet/runtime/pull/56346
- Reverted commit 3d57bee719e6db6b19dce4026bdc7c47b1c3519b from PR https://github.com/dotnet/diagnostics/pull/2324 since the relevant change to `ThreadCounts` was reverted in https://github.com/dotnet/runtime/pull/56346
- No functional change from before, as only the lower 32 bits of the 64-bit value are used, just changing back to match the size of the field