### PR TITLE
Add thread adjustment reason for cooperative blocking

### DIFF
--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -9107,6 +9107,7 @@ DECLARE_API(ThreadPool)
                 "Stabilizing",
                 "Starvation",
                 "ThreadTimedOut",
+                "CooperativeBlocking",
                 "Undefined"
             };
 


### PR DESCRIPTION
The new adjustment reason was added to the runtime in https://github.com/dotnet/runtime/pull/53471