### PR TITLE
Update alpine image that includes lldb python support and enable tests on 6.0

### DIFF
--- a/diagnostics.yml
+++ b/diagnostics.yml
@@ -142,7 +142,7 @@ stages:
       parameters:
         name: Alpine3_13
         osGroup: Linux
-        dockerImage: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.13-WithNode-20210720123506-ddfc481
+        dockerImage: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.13-WithNode-20210728123842-ddfc481
         artifactsTargetPath: bin/Linux-musl.x64.Release
         strategy:
           matrix:

--- a/diagnostics.yml
+++ b/diagnostics.yml
@@ -144,6 +144,7 @@ stages:
         osGroup: Linux
         dockerImage: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.13-WithNode-20210728123842-ddfc481
         artifactsTargetPath: bin/Linux-musl.x64.Release
+        requiresCapPtraceContainer: true
         strategy:
           matrix:
             Build_Release:

--- a/src/SOS/SOS.UnitTests/SOS.cs
+++ b/src/SOS/SOS.UnitTests/SOS.cs
@@ -41,9 +41,8 @@ public class SOS
     {
         information.OutputHelper = Output;
 
-        // TODO: enable when the Alpine images (we are currently using 3.13) have the py3-lldb package installed.
         // TODO: enable either when bpmd is fixed on Alpine or the bpmd tests are ifdef'ed out of the scripts for Alpine
-        if (testLive && !SOSRunner.IsAlpine())
+        if (testLive)
         {
             // Live
             using (SOSRunner runner = await SOSRunner.StartDebugger(information, SOSRunner.DebuggerAction.Live))
@@ -52,12 +51,10 @@ public class SOS
             }
         }
 
-        // TODO: enable for 6.0 when PR https://github.com/dotnet/runtime/pull/56272 is merged/released
-        if (testDump && !SOSRunner.IsAlpine())
+        if (testDump)
         {
-            // Create and test dumps on OSX only if the runtime is 6.0 or greater
-            // TODO: reenable for 5.0 when the MacOS createdump fixes make it into a service release (https://github.com/dotnet/diagnostics/issues/1749)
-            if (OS.Kind != OSKind.OSX || information.TestConfiguration.RuntimeFrameworkVersionMajor > 5)
+            // Create and test dumps on OSX or Alpine only if the runtime is 6.0 or greater
+            if (!(OS.Kind == OSKind.OSX || SOSRunner.IsAlpine()) || information.TestConfiguration.RuntimeFrameworkVersionMajor > 5)
             {
                 // Generate a crash dump.
                 if (information.TestConfiguration.DebuggeeDumpOutputRootDir() != null)

--- a/src/SOS/SOS.UnitTests/Scripts/NestedExceptionTest.script
+++ b/src/SOS/SOS.UnitTests/Scripts/NestedExceptionTest.script
@@ -9,6 +9,8 @@ LOADSOS
 # Verify that bpmd works
 IFDEF:LIVE
 !IFDEF:MAJOR_RUNTIME_VERSION_1
+# Issue: https://github.com/dotnet/diagnostics/issues/2459
+!IFDEF:ALPINE
 
 IFDEF:DESKTOP
 SOSCOMMAND:bpmd NestedExceptionTest.exe NestedExceptionTest.Program.Main
@@ -27,6 +29,7 @@ SOSCOMMAND:ClrStack
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+NestedExceptionTest\.Program\.Main(\(.*\))?\s*
 VERIFY:\[.*[\\|/]Debuggees[\\|/](dotnet.+[\\|/])?[Nn]ested[Ee]xception[Tt]est[\\|/][Nn]ested[Ee]xception[Tt]est\.cs @ 8\s*\]\s*
 
+ENDIF:ALPINE
 ENDIF:MAJOR_RUNTIME_VERSION_1
 ENDIF:LIVE
 

--- a/src/SOS/SOS.UnitTests/Scripts/OtherCommands.script
+++ b/src/SOS/SOS.UnitTests/Scripts/OtherCommands.script
@@ -7,6 +7,8 @@ LOADSOS
 # Verify that bpmd works
 IFDEF:LIVE
 !IFDEF:MAJOR_RUNTIME_VERSION_1
+# Issue: https://github.com/dotnet/diagnostics/issues/2459
+!IFDEF:ALPINE
 
 IFDEF:DESKTOP
 SOSCOMMAND:bpmd SymbolTestApp.exe SymbolTestApp.Program.Main
@@ -52,6 +54,7 @@ CONTINUE
 SOSCOMMAND:ClrStack
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.Program\.Foo4\(.*\)\s+\[(?i:.*[\\|/]SymbolTestApp\.cs) @ 34\]\s*
 
+ENDIF:ALPINE
 ENDIF:MAJOR_RUNTIME_VERSION_1
 ENDIF:LIVE
 

--- a/src/SOS/SOS.UnitTests/Scripts/StackAndOtherTests.script
+++ b/src/SOS/SOS.UnitTests/Scripts/StackAndOtherTests.script
@@ -9,6 +9,8 @@ LOADSOS
 # Verify that bpmd works
 IFDEF:LIVE
 !IFDEF:MAJOR_RUNTIME_VERSION_1
+# Issue: https://github.com/dotnet/diagnostics/issues/2459
+!IFDEF:ALPINE
 
 IFDEF:DESKTOP
 SOSCOMMAND:bpmd SymbolTestApp.exe SymbolTestApp.Program.Main
@@ -48,6 +50,7 @@ CONTINUE
 SOSCOMMAND:ClrStack
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.Program\.Foo4\(.*\)\s+\[(?i:.*[\\|/]SymbolTestApp\.cs) @ 34\]\s*
 
+ENDIF:ALPINE
 ENDIF:MAJOR_RUNTIME_VERSION_1
 ENDIF:LIVE
 


### PR DESCRIPTION
Update alpine image that includes lldb python support

Enable lldb and dump tests (for 6.0) on Alpine

Don't run the bpmd portions of the tests on Alpine (see issue #2459)