### PR TITLE
Remove old IVTs and add new one for dotnet-monitor.

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Microsoft.Diagnostics.Monitoring.EventPipe.csproj
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Microsoft.Diagnostics.Monitoring.EventPipe.csproj
@@ -39,8 +39,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="DotnetMonitor.UnitTests" />
-    <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.RestServer" />
+    <InternalsVisibleTo Include="dotnet-monitor" />
     <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.WebApi" />
   </ItemGroup>

--- a/src/Microsoft.Diagnostics.Monitoring/Microsoft.Diagnostics.Monitoring.csproj
+++ b/src/Microsoft.Diagnostics.Monitoring/Microsoft.Diagnostics.Monitoring.csproj
@@ -27,10 +27,8 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="dotnet-monitor" />
-    <!-- This is temporary until IEndpointInfoSourceInternal becomes public-->
     <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.EventPipe" />
     <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests" />
-    <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.RestServer" />
     <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.WebApi" />
   </ItemGroup>

--- a/src/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj
+++ b/src/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj
@@ -19,15 +19,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="dotnet-monitor" />
+    <InternalsVisibleTo Include="dotnet-counters" />
     <InternalsVisibleTo Include="dotnet-dsrouter" />
-    <InternalsVisibleTo Include="DotnetMonitor.UnitTests" />
+    <InternalsVisibleTo Include="dotnet-monitor" />
+    <InternalsVisibleTo Include="dotnet-trace" />
     <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring" />
     <!-- Temporary until Diagnostic Apis are finalized-->
-    <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.RestServer" />
     <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.WebApi" />
     <InternalsVisibleTo Include="Microsoft.Diagnostics.NETCore.Client.UnitTests" />
-    <InternalsVisibleTo Include="dotnet-counters" />
-    <InternalsVisibleTo Include="dotnet-trace" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This change removes IVTs for assemblies that no longer exist and adds a new one for dotnet-monitor to the Microsoft.Diagnostics.Monitoring.EventPipe assembly so that dotnet-monitor is not force to put all code that has internal dependencies into the Microsoft.Diagnostics.Monitoring.WebApi assembly.

Verified changes work with local build and test run in dotnet-monitor repository.