### PR TITLE
In dotnet-trace/counters disposed of the server when we received ctrl+C while waiting for clients to connect. closes #2426

### DIFF
--- a/src/Tools/Common/ReversedServerHelpers/ReversedServerHelpers.cs
+++ b/src/Tools/Common/ReversedServerHelpers/ReversedServerHelpers.cs
@@ -162,10 +162,6 @@ namespace Microsoft.Internal.Common.Utils
 
         public async void Dispose()
         {
-            if (!string.IsNullOrEmpty(_port) && File.Exists(_port))
-            {
-                File.Delete(_port);
-            }
             ProcessLauncher.Launcher.Cleanup();
             if (_server != null)
             {
@@ -246,10 +242,6 @@ namespace Microsoft.Internal.Common.Utils
                 catch (TaskCanceledException)
                 {
                     //clean up the server
-                    if (!string.IsNullOrEmpty(fullPort) && File.Exists(fullPort))
-                    {
-                        File.Delete(fullPort);
-                    }
                     await server.DisposeAsync();
                     if (!ct.IsCancellationRequested)
                     {

--- a/src/Tools/Common/ReversedServerHelpers/ReversedServerHelpers.cs
+++ b/src/Tools/Common/ReversedServerHelpers/ReversedServerHelpers.cs
@@ -245,6 +245,12 @@ namespace Microsoft.Internal.Common.Utils
                 }
                 catch (TaskCanceledException)
                 {
+                    //clean up the server
+                    if (!string.IsNullOrEmpty(fullPort) && File.Exists(fullPort))
+                    {
+                        File.Delete(fullPort);
+                    }
+                    await server.DisposeAsync();
                     if (!ct.IsCancellationRequested)
                     {
                         throw;


### PR DESCRIPTION
Using the command dotnet-trace collect --diagnostic-port foo.sock, and pressing ctrl+C before the client connects used to leave a Unix Domain Socket file, this now cleans up the file to allow restart.

closes #2426