### PR TITLE
Avoid checking for ephemeral heap segment in DumpGen

### DIFF
--- a/src/Microsoft.Diagnostics.ExtensionCommands/ClrMDHelper.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/ClrMDHelper.cs
@@ -721,18 +721,12 @@ namespace Microsoft.Diagnostics.ExtensionCommands
             switch (generation)
             {
                 case GCGeneration.Generation0:
-                    if (segment.IsEphemeralSegment)
-                    {
-                        start = segment.Generation0.Start;
-                        end = segment.Generation0.End;
-                    }
+                    start = segment.Generation0.Start;
+                    end = segment.Generation0.End;
                     return start != end;
                 case GCGeneration.Generation1:
-                    if (segment.IsEphemeralSegment)
-                    {
-                        start = segment.Generation1.Start;
-                        end = segment.Generation1.End;
-                    }
+                    start = segment.Generation1.Start;
+                    end = segment.Generation1.End;
                     return start != end;
                 case GCGeneration.Generation2:
                     if (!(segment.IsLargeObjectSegment || segment.IsPinnedObjectSegment))


### PR DESCRIPTION
This is an incomplete fix for https://github.com/dotnet/diagnostics/issues/2451.

The extra check if the segment is `ephemeral_heap_segment` is bogus. CLRMD would guarantee the generation range have length 0 anyway.

https://github.com/microsoft/clrmd/blob/124b189a2519c4f13610c6bf94e516243647af2e/src/Microsoft.Diagnostics.Runtime/src/Builders/SegmentBuilder.cs#L47-L49

With this change, together with https://github.com/microsoft/clrmd/pull/945, I have got the unit test working locally for `USE_REGIONS`.