### PR TITLE
Initial trace event trigger implementation and tests.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -45,6 +45,7 @@
     <MicrosoftExtensionsLoggingEventSourceVersion>5.0.1</MicrosoftExtensionsLoggingEventSourceVersion>
     <SystemCommandLineVersion>2.0.0-beta1.20468.1</SystemCommandLineVersion>
     <SystemCommandLineRenderingVersion>2.0.0-beta1.20074.1</SystemCommandLineRenderingVersion>
+    <SystemComponentModelAnnotationsVersion>5.0.0</SystemComponentModelAnnotationsVersion>
     <SystemMemoryVersion>4.5.4</SystemMemoryVersion>
     <SystemTextEncodingsWebVersion>4.7.2</SystemTextEncodingsWebVersion>
     <SystemTextJsonVersion>4.7.1</SystemTextJsonVersion>

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/CounterFilter.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/CounterFilter.cs
@@ -11,13 +11,16 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
     internal sealed class CounterFilter
     {
         private Dictionary<string, List<string>> _enabledCounters;
+        private int _intervalMilliseconds;
 
-        public static CounterFilter AllCounters { get; } = new CounterFilter();
+        public static CounterFilter AllCounters(int counterIntervalSeconds)
+            => new CounterFilter(counterIntervalSeconds);
 
-        public CounterFilter()
+        public CounterFilter(int intervalSeconds)
         {
             //Provider names are not case sensitive, but counter names are.
             _enabledCounters = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+            _intervalMilliseconds = intervalSeconds * 1000;
         }
 
         // Called when we want to enable all counters under a provider name.
@@ -33,8 +36,12 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
 
         public IEnumerable<string> GetProviders() => _enabledCounters.Keys;
 
-        public bool IsIncluded(string providerName, string counterName)
+        public bool IsIncluded(string providerName, string counterName, int interval)
         {
+            if (_intervalMilliseconds != interval)
+            {
+                return false;
+            }
             if (_enabledCounters.Count == 0)
             {
                 return true;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/TraceEventExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/TraceEventExtensions.cs
@@ -1,0 +1,78 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Tracing;
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Diagnostics.Monitoring.EventPipe
+{
+    internal static class TraceEventExtensions
+    {
+        public static bool TryGetCounterPayload(this TraceEvent traceEvent, CounterFilter filter, out ICounterPayload payload)
+        {
+            payload = null;
+
+            if ("EventCounters".Equals(traceEvent.EventName))
+            {
+                IDictionary<string, object> payloadVal = (IDictionary<string, object>)(traceEvent.PayloadValue(0));
+                IDictionary<string, object> payloadFields = (IDictionary<string, object>)(payloadVal["Payload"]);
+
+                //Make sure we are part of the requested series. If multiple clients request metrics, all of them get the metrics.
+                string series = payloadFields["Series"].ToString();
+                string counterName = payloadFields["Name"].ToString();
+                if (!filter.IsIncluded(traceEvent.ProviderName, counterName, GetInterval(series)))
+                {
+                    return false;
+                }
+
+                float intervalSec = (float)payloadFields["IntervalSec"];
+                string displayName = payloadFields["DisplayName"].ToString();
+                string displayUnits = payloadFields["DisplayUnits"].ToString();
+                double value = 0;
+                CounterType counterType = CounterType.Metric;
+
+                if (payloadFields["CounterType"].Equals("Mean"))
+                {
+                    value = (double)payloadFields["Mean"];
+                }
+                else if (payloadFields["CounterType"].Equals("Sum"))
+                {
+                    counterType = CounterType.Rate;
+                    value = (double)payloadFields["Increment"];
+                    if (string.IsNullOrEmpty(displayUnits))
+                    {
+                        displayUnits = "count";
+                    }
+                    //TODO Should we make these /sec like the dotnet-counters tool?
+                }
+
+                // Note that dimensional data such as pod and namespace are automatically added in prometheus and azure monitor scenarios.
+                // We no longer added it here.
+                payload = new CounterPayload(
+                    traceEvent.TimeStamp,
+                    traceEvent.ProviderName,
+                    counterName, displayName,
+                    displayUnits,
+                    value,
+                    counterType,
+                    intervalSec);
+                return true;
+            }
+
+            return false;
+        }
+
+        private static int GetInterval(string series)
+        {
+            const string comparison = "Interval=";
+            int interval = 0;
+            if (series.StartsWith(comparison, StringComparison.OrdinalIgnoreCase))
+            {
+                int.TryParse(series.Substring(comparison.Length), out interval);
+            }
+            return interval;
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Microsoft.Diagnostics.Monitoring.EventPipe.csproj
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Microsoft.Diagnostics.Monitoring.EventPipe.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="$(MicrosoftDiagnosticsTracingTraceEventVersion)" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="$(MicrosoftBclAsyncInterfacesVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingVersion)" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="$(SystemComponentModelAnnotationsVersion)" />
     <PackageReference Include="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWebVersion)" />
     <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
   </ItemGroup>

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/EventCounter/EventCounterTrigger.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/EventCounter/EventCounterTrigger.cs
@@ -1,0 +1,71 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Tracing;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace Microsoft.Diagnostics.Monitoring.EventPipe.Triggers.EventCounter
+{
+    /// <summary>
+    /// Trigger that detects when the specified event source counter value is held
+    /// above, below, or between threshold values for a specified duration of time.
+    /// </summary>
+    internal sealed class EventCounterTrigger :
+        ITraceEventTrigger
+    {
+        private readonly CounterFilter _filter;
+        private readonly EventCounterTriggerImpl _impl;
+        private readonly string _providerName;
+
+        public EventCounterTrigger(EventCounterTriggerSettings settings)
+        {
+            if (null == settings)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            Validate(settings);
+
+            _filter = new CounterFilter(settings.CounterIntervalSeconds);
+            _filter.AddFilter(settings.ProviderName, new string[] { settings.CounterName });
+            
+            _impl = new(settings);
+
+            _providerName = settings.ProviderName;
+        }
+
+        public IDictionary<string, IEnumerable<string>> GetProviderEventMap()
+        {
+            return new Dictionary<string, IEnumerable<string>>()
+            {
+                { _providerName, new string[] { "EventCounters" } }
+            };
+        }
+
+        public bool HasSatisfiedCondition(TraceEvent traceEvent)
+        {
+            // Filter to the counter of interest before forwarding to the implementation
+            if (traceEvent.TryGetCounterPayload(_filter, out ICounterPayload payload))
+            {
+                return _impl.HasSatisfiedCondition(payload);
+            }
+            return false;
+        }
+
+        public static MonitoringSourceConfiguration CreateConfiguration(EventCounterTriggerSettings settings)
+        {
+            Validate(settings);
+
+            return new MetricSourceConfiguration(settings.CounterIntervalSeconds, new string[] { settings.ProviderName });
+        }
+
+        private static void Validate(EventCounterTriggerSettings settings)
+        {
+            ValidationContext context = new(settings);
+            Validator.ValidateObject(settings, context, validateAllProperties: true);
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/EventCounter/EventCounterTriggerFactory.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/EventCounter/EventCounterTriggerFactory.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime;
+
+namespace Microsoft.Diagnostics.Monitoring.EventPipe.Triggers.EventCounter
+{
+    /// <summary>
+    /// The trigger factory for the <see cref="EventCounterTrigger"/>.
+    /// </summary>
+    internal sealed class EventCounterTriggerFactory :
+        ITraceEventTriggerFactory<EventCounterTriggerSettings>
+    {
+        public ITraceEventTrigger Create(EventCounterTriggerSettings settings)
+        {
+            return new EventCounterTrigger(settings);
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/EventCounter/EventCounterTriggerImpl.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/EventCounter/EventCounterTriggerImpl.cs
@@ -1,0 +1,92 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.Diagnostics.Monitoring.EventPipe.Triggers.EventCounter
+{
+    // The core implementation of the EventCounter trigger that processes
+    // the trigger settings and evaluates the counter payload. Primary motivation
+    // for the implementation is for unit testability separate from TraceEvent.
+    internal sealed class EventCounterTriggerImpl
+    {
+        private readonly long _intervalTicks;
+        private readonly Func<double, bool> _valueFilter;
+        private readonly long _windowTicks;
+
+        private long? _latestTicks;
+        private long? _targetTicks;
+
+        public EventCounterTriggerImpl(EventCounterTriggerSettings settings)
+        {
+            if (null == settings)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            if (settings.GreaterThan.HasValue)
+            {
+                double minValue = settings.GreaterThan.Value;
+                if (settings.LessThan.HasValue)
+                {
+                    double maxValue = settings.LessThan.Value;
+                    _valueFilter = value => value > minValue && value < maxValue;
+                }
+                else
+                {
+                    _valueFilter = value => value > minValue;
+                }
+            }
+            else if (settings.LessThan.HasValue)
+            {
+                double maxValue = settings.LessThan.Value;
+                _valueFilter = value => value < maxValue;
+            }
+
+            _intervalTicks = settings.CounterIntervalSeconds * TimeSpan.TicksPerSecond;
+            _windowTicks = settings.SlidingWindowDuration.Ticks;
+        }
+
+        public bool HasSatisfiedCondition(ICounterPayload payload)
+        {
+            long payloadTimestampTicks = payload.Timestamp.Ticks;
+            long payloadIntervalTicks = (long)(payload.Interval * TimeSpan.TicksPerSecond);
+
+            if (!_valueFilter(payload.Value))
+            {
+                // Series was broken; reset state.
+                _latestTicks = null;
+                _targetTicks = null;
+                return false;
+            }
+            else if (!_targetTicks.HasValue)
+            {
+                // This is the first event in the series. Record latest and target times.
+                _latestTicks = payloadTimestampTicks;
+                // The target time should be the start of the first passing interval + the requisite time window.
+                // The start of the first passing interval is the payload time stamp - the interval time.
+                _targetTicks = payloadTimestampTicks - payloadIntervalTicks + _windowTicks;
+            }
+            else if (_latestTicks.Value + (1.5 * _intervalTicks) < payloadTimestampTicks)
+            {
+                // Detected that an event was skipped/dropped because the time between the current
+                // event and the previous is more that 150% of the requested interval; consecutive
+                // counter events should not have that large of an interval. Reset for current
+                // event to be first event in series. Record latest and target times.
+                _latestTicks = payloadTimestampTicks;
+                // The target time should be the start of the first passing interval + the requisite time window.
+                // The start of the first passing interval is the payload time stamp - the interval time.
+                _targetTicks = payloadTimestampTicks - payloadIntervalTicks + _windowTicks;
+            }
+            else
+            {
+                // Update latest time to the current event time.
+                _latestTicks = payloadTimestampTicks;
+            }
+
+            // Trigger is satisfied when the latest time is larger than the targe time.
+            return _latestTicks >= _targetTicks;
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/EventCounter/EventCounterTriggerSettings.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/EventCounter/EventCounterTriggerSettings.cs
@@ -1,0 +1,95 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace Microsoft.Diagnostics.Monitoring.EventPipe.Triggers.EventCounter
+{
+    /// <summary>
+    /// The settings for the <see cref="EventCounterTrigger"/>.
+    /// </summary>
+    internal sealed class EventCounterTriggerSettings :
+        IValidatableObject
+    {
+        internal const int CounterIntervalSeconds_MaxValue = 24 * 60 * 60; // 1 day
+        internal const int CounterIntervalSeconds_MinValue = 1; // 1 second
+
+        internal const string EitherGreaterThanLessThanMessage = $"Either the {nameof(GreaterThan)} field or the {nameof(LessThan)} field are required.";
+
+        internal const string GreaterThanMustBeLessThanLessThanMessage = $"The {nameof(GreaterThan)} field must be less than the {nameof(LessThan)} field.";
+
+        internal const string SlidingWindowDuration_MaxValue = "1.00:00:00"; // 1 day
+        internal const string SlidingWindowDuration_MinValue = "00:00:01"; // 1 second
+
+        /// <summary>
+        /// The name of the event provider from which counters will be monitored.
+        /// </summary>
+        [Required]
+        public string ProviderName { get; set; }
+
+        /// <summary>
+        /// The name of the event counter from the event provider to monitor.
+        /// </summary>
+        [Required]
+        public string CounterName { get; set; }
+
+        /// <summary>
+        /// The lower bound threshold that the event counter value must hold for
+        /// the duration specified in <see cref="SlidingWindowDuration"/>.
+        /// </summary>
+        public double? GreaterThan { get; set; }
+
+        /// <summary>
+        /// The upper bound threshold that the event counter value must hold for
+        /// the duration specified in <see cref="SlidingWindowDuration"/>.
+        /// </summary>
+        public double? LessThan { get; set; }
+
+        /// <summary>
+        /// The sliding duration of time in which the event counter must maintain a value
+        /// above, below, or between the thresholds specified by <see cref="GreaterThan"/> and <see cref="LessThan"/>.
+        /// </summary>
+        [Range(typeof(TimeSpan), SlidingWindowDuration_MinValue, SlidingWindowDuration_MaxValue)]
+        public TimeSpan SlidingWindowDuration { get; set; }
+
+        /// <summary>
+        /// The sampling interval of the event counter.
+        /// </summary>
+        [Range(CounterIntervalSeconds_MinValue, CounterIntervalSeconds_MaxValue)]
+        public int CounterIntervalSeconds { get; set; }
+
+        IEnumerable<ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
+        {
+            List<ValidationResult> results = new();
+
+            if (!GreaterThan.HasValue && !LessThan.HasValue)
+            {
+                results.Add(new ValidationResult(
+                    EitherGreaterThanLessThanMessage,
+                    new[]
+                    {
+                        nameof(GreaterThan),
+                        nameof(LessThan)
+                    }));
+            }
+            else if (GreaterThan.HasValue && LessThan.HasValue)
+            {
+                if (GreaterThan.Value > LessThan.Value)
+                {
+                    results.Add(new ValidationResult(
+                        GreaterThanMustBeLessThanLessThanMessage,
+                        new[]
+                        {
+                            nameof(GreaterThan),
+                            nameof(LessThan)
+                        }));
+                }
+            }
+
+            return results;
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/ITraceEventTrigger.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/ITraceEventTrigger.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Tracing;
+using System.Collections.Generic;
+
+namespace Microsoft.Diagnostics.Monitoring.EventPipe.Triggers
+{
+    /// <summary>
+    /// Interface for all <see cref="TraceEvent"/>-based triggers.
+    /// </summary>
+    internal interface ITraceEventTrigger
+    {
+        /// <summary>
+        /// Mapping of event providers to event names in which the trigger has an interest.
+        /// </summary>
+        /// <remarks>
+        /// The method may return null to signify that all events can be forwarded to the trigger.
+        /// Each event provider entry also may have a null or empty list of event names to
+        /// signify that all events from the provider can be forwarded to the trigger.
+        /// </remarks>
+        IDictionary<string, IEnumerable<string>> GetProviderEventMap();
+
+        /// <summary>
+        /// Check if the given <see cref="TraceEvent"/> satisfies the condition
+        /// described by the trigger.
+        /// </summary>
+        bool HasSatisfiedCondition(TraceEvent traceEvent);
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/ITraceEventTriggerFactory.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/ITraceEventTriggerFactory.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Diagnostics.Monitoring.EventPipe.Triggers
+{
+    /// <summary>
+    /// Interface for creating a new instance of the associated
+    /// trigger from the specified settings.
+    /// </summary>
+    internal interface ITraceEventTriggerFactory<TSettings>
+    {
+        /// <summary>
+        /// Creates a new instance of the associated trigger from the <paramref name="settings"/>.
+        /// </summary>
+        ITraceEventTrigger Create(TSettings settings);
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/Pipelines/EventPipeTriggerPipeline.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/Pipelines/EventPipeTriggerPipeline.cs
@@ -1,0 +1,94 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.NETCore.Client;
+using Microsoft.Diagnostics.Tracing;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.Monitoring.EventPipe.Triggers.Pipelines
+{
+    /// <summary>
+    /// Starts an event pipe session using the specified configuration and 
+    /// </summary>
+    /// <typeparam name="TSettings">The settings type of the trace event trigger.</typeparam>
+    internal sealed class EventPipeTriggerPipeline<TSettings> :
+        EventSourcePipeline<EventPipeTriggerPipelineSettings<TSettings>>
+    {
+        // The callback as provided to the pipeline. Invoked when the trigger condition is satisfied.
+        // The trigger condition may be satisfied more than once (thus invoking the callback more than
+        // once) over the lifetime of the pipeline, depending on the implementation of the trigger.
+        private readonly Action<TraceEvent> _callback;
+
+        /// <summary>
+        /// The pipeline used to monitor the trace event source from the event pipe using the trigger
+        /// specified in the settings of the current pipeline.
+        /// </summary>
+        private TraceEventTriggerPipeline _pipeline;
+
+        // The trigger implementation used to detect a condition in the trace event source.
+        private ITraceEventTrigger _trigger;
+
+        public EventPipeTriggerPipeline(DiagnosticsClient client, EventPipeTriggerPipelineSettings<TSettings> settings, Action<TraceEvent> callback) :
+            base(client, settings)
+        {
+            if (null == Settings.Configuration)
+            {
+                throw new ArgumentException(FormattableString.Invariant($"The {nameof(settings.Configuration)} property on the settings must not be null."), nameof(settings));
+            }
+
+            if (null == Settings.TriggerFactory)
+            {
+                throw new ArgumentException(FormattableString.Invariant($"The {nameof(settings.TriggerFactory)} property on the settings must not be null."), nameof(settings));
+            }
+
+            _callback = callback;
+        }
+
+        protected override MonitoringSourceConfiguration CreateConfiguration()
+        {
+            return Settings.Configuration;
+        }
+
+        protected override async Task OnEventSourceAvailable(EventPipeEventSource eventSource, Func<Task> stopSessionAsync, CancellationToken token)
+        {
+            _trigger = Settings.TriggerFactory.Create(Settings.TriggerSettings);
+
+            _pipeline = new TraceEventTriggerPipeline(eventSource, _trigger, _callback);
+
+            await _pipeline.RunAsync(token).ConfigureAwait(false);
+        }
+
+        protected override async Task OnStop(CancellationToken token)
+        {
+            if (null != _pipeline)
+            {
+                await _pipeline.StopAsync(token).ConfigureAwait(false);
+            }
+            await base.OnStop(token);
+        }
+
+        protected override async Task OnCleanup()
+        {
+            if (null != _pipeline)
+            {
+                await _pipeline.DisposeAsync().ConfigureAwait(false);
+            }
+
+            // Disposal is not part of the ITraceEventTrigger interface; check the implementation
+            // of the trigger to see if it implements one of the disposal interfaces and call it.
+            if (_trigger is IAsyncDisposable asyncDisposableTrigger)
+            {
+                await asyncDisposableTrigger.DisposeAsync().ConfigureAwait(false);
+            }
+            else if (_trigger is IDisposable disposableTrigger)
+            {
+                disposableTrigger.Dispose();
+            }
+
+            await base.OnCleanup();
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/Pipelines/EventPipeTriggerPipelineSettings.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/Pipelines/EventPipeTriggerPipelineSettings.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Diagnostics.Monitoring.EventPipe.Triggers.Pipelines
+{
+    internal sealed class EventPipeTriggerPipelineSettings<TSettings> :
+        EventSourcePipelineSettings
+    {
+        /// <summary>
+        /// The event pipe configuration used to collect trace event information for the trigger
+        /// to use to determine if the trigger condition is satisfied.
+        /// </summary>
+        public MonitoringSourceConfiguration Configuration { get; set; }
+
+        /// <summary>
+        /// The factory that produces the trigger instantiation.
+        /// </summary>
+        public ITraceEventTriggerFactory<TSettings> TriggerFactory { get; set; }
+
+        /// <summary>
+        /// The settings to pass to the trigger factory when creating the trigger.
+        /// </summary>
+        public TSettings TriggerSettings { get; set; }
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/Pipelines/TraceEventTriggerPipeline.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/Pipelines/TraceEventTriggerPipeline.cs
@@ -1,0 +1,111 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Tracing;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.Monitoring.EventPipe.Triggers.Pipelines
+{
+    /// <summary>
+    /// A pipeline that detects a condition (as specified by the trigger) within the event stream
+    /// of the specified event source. The callback is invoked for each instance of the detected condition.
+    /// </summary>
+    internal sealed class TraceEventTriggerPipeline : Pipeline
+    {
+        // The callback as provided to the pipeline. Invoked when the trigger condition is satisfied.
+        // The trigger condition may be satisfied more than once (thus invoking the callback more than
+        // once) over the lifetime of the pipeline, depending on the implementation of the trigger.
+        private readonly Action<TraceEvent> _callback;
+
+        // Completion source to help coordinate running and stopping the pipeline.
+        private readonly TaskCompletionSource<object> _completionSource =
+            new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // The source of thr trace events to monitor.
+        private readonly TraceEventSource _eventSource;
+
+        // The trigger implementation used to detect a condition in the trace event source.
+        private readonly ITraceEventTrigger _trigger;
+
+        public TraceEventTriggerPipeline(TraceEventSource eventSource, ITraceEventTrigger trigger, Action<TraceEvent> callback)
+        {
+            _callback = callback ?? throw new ArgumentNullException(nameof(callback));
+            _eventSource = eventSource ?? throw new ArgumentNullException(nameof(eventSource));
+            _trigger = trigger ?? throw new ArgumentNullException(nameof(trigger));
+
+            IDictionary<string, IEnumerable<string>> providerEventMap = _trigger.GetProviderEventMap();
+            if (null == providerEventMap)
+            {
+                // Allow all events to be forwarded to the trigger
+                _eventSource.Dynamic.AddCallbackForProviderEvents(
+                    null,
+                    TraceEventCallback);
+            }
+            else
+            {
+                // Only allow events described in the mapping to be forwarded to the trigger.
+                // If a provider has no events specified, then all events from that provider are forwarded.
+                _eventSource.Dynamic.AddCallbackForProviderEvents(
+                    (string providerName, string eventName) =>
+                    {
+                        if (!providerEventMap.TryGetValue(providerName, out IEnumerable<string> eventNames))
+                        {
+                            return EventFilterResponse.RejectProvider;
+                        }
+                        else if (null == eventNames)
+                        {
+                            return EventFilterResponse.AcceptEvent;
+                        }
+                        else if (!eventNames.Contains(eventName, StringComparer.Ordinal))
+                        {
+                            return EventFilterResponse.RejectEvent;
+                        }
+                        return EventFilterResponse.AcceptEvent;
+                    },
+                    TraceEventCallback);
+            }
+        }
+
+        protected override async Task OnRun(CancellationToken token)
+        {
+            using var _ = token.Register(() => _completionSource.TrySetCanceled(token));
+
+            await _completionSource.Task.ConfigureAwait(false);
+        }
+
+        protected override Task OnStop(CancellationToken token)
+        {
+            _completionSource.TrySetResult(null);
+
+            return base.OnStop(token);
+        }
+
+        protected override Task OnCleanup()
+        {
+            _completionSource.TrySetCanceled();
+
+            _eventSource.Dynamic.RemoveCallback<TraceEvent>(TraceEventCallback);
+
+            return base.OnCleanup();
+        }
+
+        private void TraceEventCallback(TraceEvent obj)
+        {
+            // Check if processing of in-flight events should be ignored
+            // due to pipeline in the midst of stopping.
+            if (!_completionSource.Task.IsCompleted)
+            {
+                // If the trigger condition has been satified, invoke the callback
+                if (_trigger.HasSatisfiedCondition(obj))
+                {
+                    _callback(obj);
+                }
+            }
+        }
+    }
+}

--- a/src/tests/EventPipeTracee/Program.cs
+++ b/src/tests/EventPipeTracee/Program.cs
@@ -16,10 +16,11 @@ namespace EventPipeTracee
 
         static void Main(string[] args)
         {
-            TestBody(args[0]);
+            bool spinWait10 = args.Length > 1 && args[1] == "SpinWait";
+            TestBody(args[0], spinWait10);
         }
 
-        private static void TestBody(string loggerCategory)
+        private static void TestBody(string loggerCategory, bool spinWait)
         {
             Console.Error.WriteLine("Starting remote test process");
             Console.Error.Flush();
@@ -50,6 +51,21 @@ namespace EventPipeTracee
 
             //Signal end of test data
             Console.WriteLine("1");
+
+            if (spinWait)
+            {
+                DateTime targetDateTime = DateTime.UtcNow.AddSeconds(10);
+
+                long acc = 0;
+                while (DateTime.UtcNow < targetDateTime)
+                {
+                    acc++;
+                    if (acc % 1_000_000 == 0)
+                    {
+                        Console.Error.WriteLine("Spin waiting...");
+                    }
+                }
+            }
 
             Console.Error.WriteLine($"{DateTime.UtcNow} Awaiting end");
             Console.Error.Flush();

--- a/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventCounterConstants.cs
+++ b/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventCounterConstants.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
+{
+    internal static class EventCounterConstants
+    {
+        public const string RuntimeProviderName = "System.Runtime";
+
+        public const string EventCountersEventName = "EventCounters";
+
+        public const string CpuUsageCounterName = "cpu-usage";
+        public const string CpuUsageDisplayName = "CPU Usage";
+        public const string CpuUsageUnits = "%";
+    }
+}

--- a/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventCounterTriggerTests.cs
+++ b/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventCounterTriggerTests.cs
@@ -1,0 +1,489 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Monitoring.EventPipe.Triggers.EventCounter;
+using Microsoft.Diagnostics.Monitoring.EventPipe.Triggers.Pipelines;
+using Microsoft.Diagnostics.NETCore.Client;
+using Microsoft.Diagnostics.NETCore.Client.UnitTests;
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
+{
+    public class EventCounterTriggerTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public EventCounterTriggerTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        /// <summary>
+        /// Tests the validation of the fields of the trigger settings.
+        /// </summary>
+        [Fact]
+        public void EventCounterTriggerSettingsValidationTest()
+        {
+            EventCounterTriggerSettings settings = new();
+
+            // ProviderName is required.
+            ValidateRequiredFieldValidation(
+                settings,
+                nameof(EventCounterTriggerSettings.ProviderName));
+
+            settings.ProviderName = EventCounterConstants.RuntimeProviderName;
+
+            // CounterName is required.
+            ValidateRequiredFieldValidation(
+                settings,
+                nameof(EventCounterTriggerSettings.CounterName));
+
+            settings.CounterName = "exception-count";
+
+            // SlidingWindowDuration must be specified within valid range.
+            ValidateRangeFieldValidation<TimeSpan>(
+                settings,
+                nameof(EventCounterTriggerSettings.SlidingWindowDuration),
+                EventCounterTriggerSettings.SlidingWindowDuration_MinValue,
+                EventCounterTriggerSettings.SlidingWindowDuration_MaxValue);
+
+            settings.SlidingWindowDuration = TimeSpan.FromSeconds(15);
+
+            // CounterIntervalSeconds must be specified within valid range.
+            ValidateRangeFieldValidation<int>(
+                settings,
+                nameof(EventCounterTriggerSettings.CounterIntervalSeconds),
+                EventCounterTriggerSettings.CounterIntervalSeconds_MinValue.ToString(CultureInfo.InvariantCulture),
+                EventCounterTriggerSettings.CounterIntervalSeconds_MaxValue.ToString(CultureInfo.InvariantCulture));
+
+            settings.CounterIntervalSeconds = 2;
+
+            // Either GreaterThan or LessThan must be specified
+            ValidateFieldValidation(
+                settings,
+                EventCounterTriggerSettings.EitherGreaterThanLessThanMessage,
+                new[] { nameof(EventCounterTriggerSettings.GreaterThan), nameof(EventCounterTriggerSettings.LessThan) });
+
+            settings.GreaterThan = 10;
+
+            // Settings object should now pass validation
+            EventCounterTrigger trigger = new(settings);
+
+            // GreaterThan must be less than LessThan
+            settings.LessThan = 5;
+            ValidateFieldValidation(
+                settings,
+                EventCounterTriggerSettings.GreaterThanMustBeLessThanLessThanMessage,
+                new[] { nameof(EventCounterTriggerSettings.GreaterThan), nameof(EventCounterTriggerSettings.LessThan) });
+        }
+
+        /// <summary>
+        /// Validates that the usage of the settings will result in a ValidationException thrown
+        /// with the expected error message and member names.
+        /// </summary>
+        private void ValidateFieldValidation(EventCounterTriggerSettings settings, string expectedMessage, string[] expectedMemberNames)
+        {
+            var exception = Assert.Throws<ValidationException>(() => new EventCounterTrigger(settings));
+
+            Assert.NotNull(exception.ValidationResult);
+
+            Assert.Equal(expectedMessage, exception.ValidationResult.ErrorMessage);
+
+            Assert.Equal(expectedMemberNames, exception.ValidationResult.MemberNames);
+        }
+
+        /// <summary>
+        /// Validates that the given member name will yield a requiredness validation exception when not specified.
+        /// </summary>
+        private void ValidateRequiredFieldValidation(EventCounterTriggerSettings settings, string memberName)
+        {
+            RequiredAttribute requiredAttribute = new();
+            ValidateFieldValidation(settings, requiredAttribute.FormatErrorMessage(memberName), new[] { memberName });
+        }
+
+        /// <summary>
+        /// Validates that the given member name will yield a range validation exception when not in the valid range.
+        /// </summary>
+        private void ValidateRangeFieldValidation<T>(EventCounterTriggerSettings settings, string memberName, string min, string max)
+        {
+            RangeAttribute rangeAttribute = new(typeof(T), min, max);
+            ValidateFieldValidation(settings, rangeAttribute.FormatErrorMessage(memberName), new[] { memberName });
+        }
+
+        /// <summary>
+        /// Test that the trigger condition can be satisfied when detecting counter
+        /// values higher than the specified threshold for a duration of time.
+        /// </summary>
+        [Fact]
+        public void EventCounterTriggerGreaterThanTest()
+        {
+            // The counter value must be greater than 0.70 for at least 3 seconds.
+            const double Threshold = 70; // 70%
+            const int Interval = 1; // 1 second
+            TimeSpan WindowDuration = TimeSpan.FromSeconds(3);
+
+            CpuData[] data = new CpuData[]
+            {
+                new(65, false),
+                new(67, false),
+                new(71, false),
+                new(73, false),
+                new(74, null), // Unknown depending if sum of intervals is larger than window
+                new(72, true),
+                new(71, true),
+                new(70, false), // Value must be greater than threshold
+                new(68, false),
+                new(66, false),
+                new(70, false),
+                new(71, false),
+                new(74, false),
+                new(73, null), // Unknown depending if sum of intervals is larger than window
+                new(75, true),
+                new(72, true),
+                new(73, true),
+                new(71, true),
+                new(69, false),
+                new(67, false)
+            };
+
+            EventCounterTriggerSettings settings = new()
+            {
+                ProviderName = EventCounterConstants.RuntimeProviderName,
+                CounterName = EventCounterConstants.CpuUsageCounterName,
+                GreaterThan = Threshold,
+                CounterIntervalSeconds = Interval,
+                SlidingWindowDuration = WindowDuration
+            };
+
+            SimulateDataVerifyTrigger(settings, data);
+        }
+
+        /// <summary>
+        /// Test that the trigger condition can be satisfied when detecting counter
+        /// values lower than the specified threshold for a duration of time.
+        /// </summary>
+        [Fact]
+        public void EventCounterTriggerLessThanTest()
+        {
+            // The counter value must be less than 0.70 for at least 3 seconds.
+            const double Threshold = 70; // 70%
+            const int Interval = 1; // 1 second
+            TimeSpan WindowDuration = TimeSpan.FromSeconds(3);
+
+            CpuData[] data = new CpuData[]
+            {
+                new(65, false),
+                new(67, false),
+                new(66, null), // Unknown depending if sum of intervals is larger than window
+                new(68, true),
+                new(69, true),
+                new(70, false), // Value must be less than threshold
+                new(71, false),
+                new(68, false),
+                new(66, false),
+                new(68, null), // Unknown depending if sum of intervals is larger than window
+                new(67, true),
+                new(65, true),
+                new(64, true),
+                new(71, false),
+                new(73, false)
+            };
+
+            EventCounterTriggerSettings settings = new()
+            {
+                ProviderName = EventCounterConstants.RuntimeProviderName,
+                CounterName = EventCounterConstants.CpuUsageCounterName,
+                LessThan = Threshold,
+                CounterIntervalSeconds = Interval,
+                SlidingWindowDuration = WindowDuration
+            };
+
+            SimulateDataVerifyTrigger(settings, data);
+        }
+
+        /// <summary>
+        /// Test that the trigger condition can be satisfied when detecting counter
+        /// values that fall between two thresholds for a duration of time.
+        /// </summary>
+        [Fact]
+        public void EventCounterTriggerRangeTest()
+        {
+            // The counter value must be between 0.25 and 0.35 for at least 8 seconds.
+            const double LowerThreshold = 25; // 25%
+            const double UpperThreshold = 35; // 35%
+            const int Interval = 2; // 2 seconds
+            TimeSpan WindowDuration = TimeSpan.FromSeconds(8);
+
+            CpuData[] data = new CpuData[]
+            {
+                new(23, false),
+                new(25, false),
+                new(26, false),
+                new(27, false),
+                new(28, false),
+                new(29, null), // Unknown depending if sum of intervals is larger than window
+                new(30, true),
+                new(31, true),
+                new(33, true),
+                new(35, false),
+                new(37, false),
+                new(34, false),
+                new(33, false),
+                new(31, false),
+                new(30, null), // Unknown depending if sum of intervals is larger than window
+                new(29, true),
+                new(27, true),
+                new(26, true),
+                new(24, false)
+            };
+
+            EventCounterTriggerSettings settings = new()
+            {
+                ProviderName = EventCounterConstants.RuntimeProviderName,
+                CounterName = EventCounterConstants.CpuUsageCounterName,
+                GreaterThan = LowerThreshold,
+                LessThan = UpperThreshold,
+                CounterIntervalSeconds = Interval,
+                SlidingWindowDuration = WindowDuration
+            };
+
+            SimulateDataVerifyTrigger(settings, data);
+        }
+
+        /// <summary>
+        /// Test that the trigger condition will not be satisfied if successive
+        /// counter events are missing from the stream (e.g. events are dropped due
+        /// to event pipe buffer being filled).
+        /// </summary>
+        [Fact]
+        public void EventCounterTriggerDropTest()
+        {
+            // The counter value must be greater than 0.50 for at least 10 seconds.
+            const double Threshold = 50; // 50%
+            const int Interval = 2; // 2 second
+            TimeSpan WindowDuration = TimeSpan.FromSeconds(10);
+
+            CpuData[] data = new CpuData[]
+            {
+                new(53, false),
+                new(54, false),
+                new(51, false),
+                new(52, false),
+                new(54, null), // Unknown depending if sum of intervals is larger than window
+                new(53, true),
+                new(52, true, drop: true),
+                new(51, false),
+                new(54, false),
+                new(58, false),
+                new(53, false),
+                new(54, null), // Unknown depending if sum of intervals is larger than window
+                new(51, true),
+                new(54, true),
+                new(54, true, drop: true),
+                new(52, false),
+                new(57, false),
+                new(59, false),
+                new(54, false),
+                new(53, null), // Unknown depending if sum of intervals is larger than window
+                new(51, true),
+                new(53, true),
+                new(47, false)
+            };
+
+            EventCounterTriggerSettings settings = new()
+            {
+                ProviderName = EventCounterConstants.RuntimeProviderName,
+                CounterName = EventCounterConstants.CpuUsageCounterName,
+                GreaterThan = Threshold,
+                CounterIntervalSeconds = Interval,
+                SlidingWindowDuration = WindowDuration
+            };
+
+            SimulateDataVerifyTrigger(settings, data);
+        }
+
+        /// <summary>
+        /// Tests that the trigger condition can be detected on a live application
+        /// using the EventPipeTriggerPipeline.
+        /// </summary>
+        [Fact]
+        public async Task EventCounterTriggerWithEventPipePipelineTest()
+        {
+            EventCounterTriggerSettings settings = new()
+            {
+                ProviderName = EventCounterConstants.RuntimeProviderName,
+                CounterName = EventCounterConstants.CpuUsageCounterName,
+                GreaterThan = 5,
+                SlidingWindowDuration = TimeSpan.FromSeconds(3),
+                CounterIntervalSeconds = 1
+            };
+
+            await using (var testExecution = StartTraceeProcess("TriggerRemoteTest"))
+            {
+                //TestRunner should account for start delay to make sure that the diagnostic pipe is available.
+
+                DiagnosticsClient client = new(testExecution.TestRunner.Pid);
+
+                TaskCompletionSource<object> waitSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+                await using EventPipeTriggerPipeline<EventCounterTriggerSettings> pipeline = new(
+                    client,
+                    new EventPipeTriggerPipelineSettings<EventCounterTriggerSettings>
+                    {
+                        Configuration = EventCounterTrigger.CreateConfiguration(settings),
+                        TriggerFactory = new EventCounterTriggerFactory(),
+                        TriggerSettings = settings,
+                        Duration = Timeout.InfiniteTimeSpan
+                    },
+                    traceEvent =>
+                    {
+                        waitSource.TrySetResult(null);
+                    });
+
+                await PipelineTestUtilities.ExecutePipelineWithDebugee(
+                    _output,
+                    pipeline,
+                    testExecution,
+                    waitSource);
+
+                Assert.True(waitSource.Task.IsCompletedSuccessfully);
+            }
+        }
+
+        /// <summary>
+        /// Run the specified sample CPU data through a simple simulation to test the capabilities
+        /// of the event counter trigger. This uses a random number seed to generate random variations
+        /// in timestamp and interval data.
+        /// </summary>
+        private void SimulateDataVerifyTrigger(EventCounterTriggerSettings settings, CpuData[] cpuData)
+        {
+            Random random = new Random();
+            int seed = random.Next();
+            _output.WriteLine("Simulation seed: {0}", seed);
+            SimulateDataVerifyTrigger(settings, cpuData, seed);
+        }
+
+        /// <summary>
+        /// Run the specified sample CPU data through a simple simulation to test the capabilities
+        /// of the event counter trigger. This uses the specified seed value to seed the RNG that produces
+        /// random variations in timestamp and interval data; allows for replayability of generated variations.
+        /// </summary>
+        private void SimulateDataVerifyTrigger(EventCounterTriggerSettings settings, CpuData[] cpuData, int seed)
+        {
+            EventCounterTriggerImpl trigger = new(settings);
+
+            CpuUsagePayloadFactory payloadFactory = new(seed, settings.CounterIntervalSeconds);
+
+            for (int i = 0; i < cpuData.Length; i++)
+            {
+                ref CpuData data = ref cpuData[i];
+                _output.WriteLine("Data: Value={0}, Expected={1}, Drop={2}", data.Value, data.Result, data.Drop);
+                ICounterPayload payload = payloadFactory.CreateNext(data.Value);
+                if (data.Drop)
+                {
+                    continue;
+                }
+                bool actualResult = trigger.HasSatisfiedCondition(payload);
+                if (data.Result.HasValue)
+                {
+                    Assert.Equal(data.Result.Value, actualResult);
+                }
+            }
+        }
+
+        private RemoteTestExecution StartTraceeProcess(string loggerCategory)
+        {
+            return RemoteTestExecution.StartProcess(CommonHelper.GetTraceePathWithArgs("EventPipeTracee") + " " + loggerCategory + " SpinWait", _output);
+        }
+
+        private sealed class CpuData
+        {
+            public CpuData(double value, bool? result, bool drop = false)
+            {
+                Drop = drop;
+                Result = result;
+                Value = value;
+            }
+
+            /// <summary>
+            /// Specifies if the data should be "dropped" to simulate dropping of events.
+            /// </summary>
+            public bool Drop { get; }
+
+            /// <summary>
+            /// The expected result of evaluating the trigger on this data.
+            /// </summary>
+            public bool? Result { get;}
+
+            /// <summary>
+            /// The sample CPU value to be given to the trigger for evaluation.
+            /// </summary>
+            public double Value { get; }
+        }
+
+        /// <summary>
+        /// Creates CPU Usage payloads in successive order, simulating the data produced
+        /// for the cpu-usage counter from the runtime.
+        /// </summary>
+        private sealed class CpuUsagePayloadFactory
+        {
+            private readonly int _intervalSeconds;
+            private readonly Random _random;
+
+            private DateTime? _lastTimestamp;
+
+            public CpuUsagePayloadFactory(int seed, int intervalSeconds)
+            {
+                _intervalSeconds = intervalSeconds;
+                _random = new Random(seed);
+            }
+
+            /// <summary>
+            /// Creates the next counter payload based on the provided value.
+            /// </summary>
+            /// <remarks>
+            /// The timestamp is roughly incremented by the specified interval from the constructor
+            /// in order to simulate variations in the timestamp of counter events as seen in real
+            /// event data. The actual interval is also roughly generated from specified interval
+            /// from the constructor to simulate variations in the collection interval as seen in
+            /// real event data.
+            /// </remarks>
+            public ICounterPayload CreateNext(double value)
+            {
+                // Add some variance between -5 to 5 milliseconds to simulate "real" interval value.
+                float actualInterval = Convert.ToSingle(_intervalSeconds + (_random.NextDouble() / 100) - 0.005);
+
+                if (!_lastTimestamp.HasValue)
+                {
+                    // Start with the current time
+                    _lastTimestamp = DateTime.UtcNow;
+                }
+                else
+                {
+                    // Increment timestamp by one whole interval
+                    _lastTimestamp = _lastTimestamp.Value.AddSeconds(actualInterval);
+                }
+
+                // Add some variance between -5 and 5 milliseconds to simulate "real" timestamp
+                _lastTimestamp = _lastTimestamp.Value.AddMilliseconds((10 * _random.NextDouble()) - 5);
+
+                return new CounterPayload(
+                    _lastTimestamp.Value,
+                    EventCounterConstants.RuntimeProviderName,
+                    EventCounterConstants.CpuUsageCounterName,
+                    EventCounterConstants.CpuUsageDisplayName,
+                    EventCounterConstants.CpuUsageUnits,
+                    value,
+                    CounterType.Metric,
+                    actualInterval);
+            }
+        }
+    }
+}


### PR DESCRIPTION
These changes introduce the foundation of writing and executing trace event triggers (triggers that monitor for a condition based on trace event data). The current change contains:
- the interfaces for implementing these triggers (`ITraceEventTrigger<TSettings>` and `ITraceEventTriggerFactory<TSettings>`).
- pipeline implementations for executing these triggers over trace event source (`TraceEventTriggerPipeline`) and for executing these triggers using the events from an event pipe session (`EventPipeTriggerPipeline<TSettings>`).
- a single trigger implementation (`EventCounterTrigger`) demonstrating the capabilities
- some tests (`EventCounterTriggerTests`) for the trigger implementation to test the trigger settings, the trigger algorithm, and the usage of the trigger in the pipelines.

Refer to the `EventCounterTriggerTests.EventCounterTriggerWithEventPipePipelineTest` test on how to set up the pipeline with a trigger and execute it.

The current changes only allow for using one trigger on a single event pipe session (however, multiple `TraceEventTriggerPipeline` instances can be created and executed over a single `TraceEventSource`). This should be a sufficient starting point to allow trigger pipelines and collection mechanisms to start being developed.

In the near future (subsequent change), I would like to explore refactoring the EventPipeTriggerPipeline to allow for multiple triggers to be executed on a single event pipe session, which would allow minimizing some of the observability overhead by coalescing multiple sessions into one. This change has its unique challenges, such as how to deterministically merge multiple event pipe configurations together, allowing for suspension/restarting of individual triggers, and reporting of individual trigger callbacks.

cc @dotnet/dotnet-monitor, @noahfalk, @josalem, @WilliamXieMSFT, @delmyers