### PR TITLE
Fix default IPC port for IPC server, TCP client mode in dotnet-dsrouter.

### DIFF
--- a/src/Tools/dotnet-dsrouter/DiagnosticsServerRouterCommands.cs
+++ b/src/Tools/dotnet-dsrouter/DiagnosticsServerRouterCommands.cs
@@ -208,6 +208,9 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
                 }
             }
 
+            if (string.IsNullOrEmpty(ipcServer))
+                ipcServer = GetDefaultIpcServerPath(logger);
+
             var routerTask = DiagnosticsServerRouterRunner.runIpcServerTcpClientRouter(linkedCancelToken.Token, ipcServer, tcpClient, runtimeTimeout == Timeout.Infinite ? runtimeTimeout : runtimeTimeout * 1000, tcpClientRouterFactory, logger, Launcher);
 
             while (!linkedCancelToken.IsCancellationRequested)


### PR DESCRIPTION
Fallback using default ICP server port works for server-server mode in dsrouter, but was missing for server-client mode. PR adds same fallback into RunIpcServerTcpClientRouter, making sure default IPC server port gets setup, if no explicit IPC server port has been supplied using -ipcs argument.