### PR TITLE
Enable crash dump report generation in SOS tests

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -51,5 +51,6 @@
     <XUnitAbstractionsVersion>2.0.3</XUnitAbstractionsVersion>
     <MicrosoftDotNetRemoteExecutorVersion>7.0.0-beta.21453.2</MicrosoftDotNetRemoteExecutorVersion>
     <cdbsosversion>10.0.18362</cdbsosversion>
+    <NewtonSoftJsonVersion>12.0.2</NewtonSoftJsonVersion>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/ImageMappingMemoryService.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/ImageMappingMemoryService.cs
@@ -151,7 +151,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
                                     if ((rva + size) <= block.Length)
                                     {
                                         data = block.GetReader(rva, size).ReadBytes(size);
-                                        ApplyRelocations(module, reader, rva, data);
+                                        ApplyRelocations(module, reader, (int)(address - module.ImageBase), data);
                                     }
                                     else
                                     {
@@ -182,7 +182,9 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
                                 Debug.Assert(rva >= 0);
                                 try
                                 {
+#if TRACE_VERBOSE
                                     Trace.TraceInformation($"ReadMemoryFromModule: address {address:X16} rva {rva:X16} size {bytesRequested:X8} in ELF or MachO file {module.FileName}");
+#endif
                                     byte[] data = new byte[bytesRequested];
                                     uint read = virtualAddressReader.Read(rva, data, 0, (uint)bytesRequested);
                                     if (read == 0)

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/Module.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/Module.cs
@@ -183,6 +183,11 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
                 if (versionString != null)
                 {
                     int spaceIndex = versionString.IndexOf(' ');
+                    if (spaceIndex < 0)
+                    {
+                        // It is probably a private build version that doesn't end with a space (no commit id after)
+                        spaceIndex = versionString.Length;
+                    }
                     if (spaceIndex > 0)
                     {
                         if (versionString[spaceIndex - 1] == '.')

--- a/src/Microsoft.Diagnostics.DebugServices/CommandBase.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/CommandBase.cs
@@ -38,6 +38,7 @@ namespace Microsoft.Diagnostics.DebugServices
         protected void WriteLine(string message)
         {
             Console.Write(message + Environment.NewLine);
+            Console.CancellationToken.ThrowIfCancellationRequested();
         }
 
         /// <summary>
@@ -48,6 +49,7 @@ namespace Microsoft.Diagnostics.DebugServices
         protected void WriteLine(string format, params object[] args)
         {
             Console.Write(string.Format(format, args) + Environment.NewLine);
+            Console.CancellationToken.ThrowIfCancellationRequested();
         }
 
         /// <summary>
@@ -58,6 +60,7 @@ namespace Microsoft.Diagnostics.DebugServices
         protected void WriteLineWarning(string format, params object[] args)
         {
             Console.WriteWarning(string.Format(format, args) + Environment.NewLine);
+            Console.CancellationToken.ThrowIfCancellationRequested();
         }
 
         /// <summary>
@@ -68,6 +71,7 @@ namespace Microsoft.Diagnostics.DebugServices
         protected void WriteLineError(string format, params object[] args)
         {
             Console.WriteError(string.Format(format, args) + Environment.NewLine);
+            Console.CancellationToken.ThrowIfCancellationRequested();
         }
 
         /// <summary>

--- a/src/Microsoft.Diagnostics.DebugServices/Microsoft.Diagnostics.DebugServices.csproj
+++ b/src/Microsoft.Diagnostics.DebugServices/Microsoft.Diagnostics.DebugServices.csproj
@@ -13,7 +13,6 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
     <PackageReference Include="Microsoft.SymbolStore" Version="$(MicrosoftSymbolStoreVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Diagnostics.ExtensionCommands/DumpConcurrentDictionaryCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/DumpConcurrentDictionaryCommand.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Diagnostics.ExtensionCommands
 
             var heap = Runtime.Heap;
             var type = heap.GetObjectType(address);
-            if (type == null)
+            if (type == null || type.Name == null)
             {
                 WriteLine($"{Address:x16} is not referencing an object...");
                 return;

--- a/src/Microsoft.Diagnostics.ExtensionCommands/DumpConcurrentDictionaryCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/DumpConcurrentDictionaryCommand.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Diagnostics.ExtensionCommands
 
             var heap = Runtime.Heap;
             var type = heap.GetObjectType(address);
-            if (type == null || type.Name == null)
+            if (type?.Name is null)
             {
                 WriteLine($"{Address:x16} is not referencing an object...");
                 return;

--- a/src/Microsoft.Diagnostics.ExtensionCommands/DumpGen.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/DumpGen.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Diagnostics.ExtensionCommands
 
         private static bool IsTypeNameMatching(string typeName, string typeNameFilter)
         {
-            return typeName.IndexOf(typeNameFilter, StringComparison.OrdinalIgnoreCase) >= 0;
+            return typeName != null && typeName.IndexOf(typeNameFilter, StringComparison.OrdinalIgnoreCase) >= 0;
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Repl/Command/CommandProcessor.cs
+++ b/src/Microsoft.Diagnostics.Repl/Command/CommandProcessor.cs
@@ -240,14 +240,20 @@ namespace Microsoft.Diagnostics.Repl
 
         private void OnException(Exception ex, InvocationContext context)
         {
+            if (ex is TargetInvocationException)
+            {
+                ex = ex.InnerException;
+            }
             if (ex is NullReferenceException || 
                 ex is ArgumentException || 
                 ex is ArgumentNullException || 
                 ex is ArgumentOutOfRangeException || 
-                ex is NotImplementedException) {
+                ex is NotImplementedException) 
+            {
                 context.Console.Error.WriteLine(ex.ToString());
             }
-            else {
+            else 
+            {
                 context.Console.Error.WriteLine(ex.Message);
             }
             Trace.TraceError(ex.ToString());
@@ -368,18 +374,11 @@ namespace Microsoft.Diagnostics.Repl
 
             private void Invoke(MethodInfo methodInfo, InvocationContext context, Parser parser, IServiceProvider services)
             {
-                try
-                {
-                    object instance = _factory(services);
-                    SetProperties(context, parser, services, instance);
+                object instance = _factory(services);
+                SetProperties(context, parser, services, instance);
 
-                    object[] arguments = BuildArguments(methodInfo, services);
-                    methodInfo.Invoke(instance, arguments);
-                }
-                catch (TargetInvocationException ex)
-                {
-                    throw ex.InnerException;
-                }
+                object[] arguments = BuildArguments(methodInfo, services);
+                methodInfo.Invoke(instance, arguments);
             }
 
             private void SetProperties(InvocationContext context, Parser parser, IServiceProvider services, object instance)

--- a/src/SOS/SOS.Hosting/SOSLibrary.cs
+++ b/src/SOS/SOS.Hosting/SOSLibrary.cs
@@ -107,11 +107,11 @@ namespace SOS.Hosting
                     // This is a workaround for the Microsoft SDK docker images. Can fail when LoadLibrary uses libdl.so to load the SOS module.
                     if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                     {
-                        throw new DllNotFoundException("Problem loading SOS module. Try installing libc6-dev (apt-get install libc6-dev) to work around this problem.", ex);
+                        throw new DllNotFoundException($"Problem loading SOS module from {sosPath}. Try installing libc6-dev (apt-get install libc6-dev) to work around this problem.", ex);
                     }
                     else
                     {
-                        throw;
+                        throw new DllNotFoundException($"Problem loading SOS module from {sosPath}", ex);
                     }
                 }
                 if (_sosLibrary == IntPtr.Zero)

--- a/src/SOS/SOS.UnitTests/SOS.UnitTests.csproj
+++ b/src/SOS/SOS.UnitTests/SOS.UnitTests.csproj
@@ -32,6 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="NewtonSoft.Json" Version="$(NewtonSoftJsonVersion)" />
     <PackageReference Include="Microsoft.Win32.Primitives" Version="$(MicrosoftWin32PrimitivesVersion)" />
     <PackageReference Include="cdb-sos" Version="$(cdbsosversion)" Condition="'$(OS)' == 'Windows_NT'" />
   </ItemGroup>

--- a/src/SOS/Strike/dbgengservices.cpp
+++ b/src/SOS/Strike/dbgengservices.cpp
@@ -502,8 +502,6 @@ HRESULT DbgEngServices::ChangeEngineState(
     {
         if (((Argument & DEBUG_STATUS_MASK) == DEBUG_STATUS_BREAK) && ((Argument & DEBUG_STATUS_INSIDE_WAIT) == 0))
         {
-            m_control->Output(DEBUG_OUTPUT_NORMAL, "ChangeEngineState\n");
-
             // Flush the target when the debugger target breaks
             Extensions::GetInstance()->FlushTarget();
         }

--- a/src/SOS/Strike/platform/cordebugdatatarget.h
+++ b/src/SOS/Strike/platform/cordebugdatatarget.h
@@ -114,6 +114,7 @@ public:
         {
             return E_UNEXPECTED;
         }
+        address = CONVERT_FROM_SIGN_EXTENDED(address);
 #ifdef FEATURE_PAL
         if (g_sos != nullptr)
         {

--- a/src/SOS/Strike/platform/datatarget.cpp
+++ b/src/SOS/Strike/platform/datatarget.cpp
@@ -148,6 +148,7 @@ DataTarget::ReadVirtual(
     {
         return E_UNEXPECTED;
     }
+    address = CONVERT_FROM_SIGN_EXTENDED(address);
 #ifdef FEATURE_PAL
     if (g_sos != nullptr)
     {

--- a/src/SOS/Strike/util.h
+++ b/src/SOS/Strike/util.h
@@ -7,6 +7,8 @@
 
 #define LIMITED_METHOD_CONTRACT
 
+#define CONVERT_FROM_SIGN_EXTENDED(offset) ((ULONG_PTR)(offset))
+
 // So we can use the PAL_TRY_NAKED family of macros without dependencies on utilcode.
 inline void RestoreSOToleranceState() {}
 

--- a/src/Tools/dotnet-dump/Analyzer.cs
+++ b/src/Tools/dotnet-dump/Analyzer.cs
@@ -98,9 +98,10 @@ namespace Microsoft.Diagnostics.Tools.Dump
 
                 _target.ServiceProvider.AddServiceFactory<SOSHost>(() => new SOSHost(_contextService.Services));
 
-                // Automatically enable symbol server support
+                // Automatically enable symbol server support, default cache and search for symbols in the dump directory
                 _symbolService.AddSymbolServer(msdl: true, symweb: false, symbolServerPath: null, authToken: null, timeoutInMinutes: 0);
                 _symbolService.AddCachePath(_symbolService.DefaultSymbolCache);
+                _symbolService.AddDirectoryPath(Path.GetDirectoryName(dump_path.FullName));
 
                 // Run the commands from the dotnet-dump command line
                 if (command != null)

--- a/src/Tools/dotnet-dump/Dumper.Windows.cs
+++ b/src/Tools/dotnet-dump/Dumper.Windows.cs
@@ -42,7 +42,20 @@ namespace Microsoft.Diagnostics.Tools.Dump
                                        NativeMethods.MINIDUMP_TYPE.MiniDumpWithTokenInformation;
                             break;
                         case DumpTypeOption.Mini:
-                            dumpType = NativeMethods.MINIDUMP_TYPE.MiniDumpWithThreadInfo;
+                            dumpType = NativeMethods.MINIDUMP_TYPE.MiniDumpNormal |
+                                       NativeMethods.MINIDUMP_TYPE.MiniDumpWithDataSegs |
+                                       NativeMethods.MINIDUMP_TYPE.MiniDumpWithHandleData |
+                                       NativeMethods.MINIDUMP_TYPE.MiniDumpWithThreadInfo;
+                            break;
+                        case DumpTypeOption.Triage:
+                            dumpType = NativeMethods.MINIDUMP_TYPE.MiniDumpFilterTriage |
+                                       NativeMethods.MINIDUMP_TYPE.MiniDumpIgnoreInaccessibleMemory |
+                                       NativeMethods.MINIDUMP_TYPE.MiniDumpWithoutOptionalData |
+                                       NativeMethods.MINIDUMP_TYPE.MiniDumpWithProcessThreadData |
+                                       NativeMethods.MINIDUMP_TYPE.MiniDumpFilterModulePaths |
+                                       NativeMethods.MINIDUMP_TYPE.MiniDumpWithUnloadedModules |
+                                       NativeMethods.MINIDUMP_TYPE.MiniDumpFilterMemory |
+                                       NativeMethods.MINIDUMP_TYPE.MiniDumpWithHandleData;
                             break;
                     }
 

--- a/src/Tools/dotnet-dump/Dumper.cs
+++ b/src/Tools/dotnet-dump/Dumper.cs
@@ -26,6 +26,8 @@ namespace Microsoft.Diagnostics.Tools.Dump
                         // stacks, exception information, handle information, and all memory except for mapped images.
 
             Mini,       // A small dump containing module lists, thread lists, exception information and all stacks.
+
+            Triage      // A small dump containing module lists, thread lists, exception information, all stacks and PMI removed.
         }
 
         public Dumper()
@@ -104,6 +106,9 @@ namespace Microsoft.Diagnostics.Tools.Dump
                             break;
                         case DumpTypeOption.Mini:
                             dumpType = DumpType.Normal;
+                            break;
+                        case DumpTypeOption.Triage:
+                            dumpType = DumpType.Triage;
                             break;
                     }
 

--- a/src/tests/dotnet-counters/DotnetCounters.UnitTests.csproj
+++ b/src/tests/dotnet-counters/DotnetCounters.UnitTests.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NewtonSoft.Json" Version="12.0.2" />
+    <PackageReference Include="NewtonSoft.Json" Version="$(NewtonSoftJsonVersion)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Load crash report json file and check some common values.

Enable Windows triage and heap dump testing

Check for ctrl-c on console writelines

Fix arm32/x86 sign extensions problems in C++ data targets

Fix dotnet-dump collect dump type and the exception display in commands

Fix eeversion command when private build version like 42.42.42.42424

Add the directory of the dump to the symbol search path

Remove "ChangeEngineState" message on every stop in windbg.

Fix module relocations fixes. It was using the wrong rva. Needed the original rva not the
translated file layout one.

Better SOS module load failure message.