### PR TITLE
Fix reverse named pipe server start collect -> resume hang.

### DIFF
--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcServerTransport.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcServerTransport.cs
@@ -149,7 +149,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
 
         private NamedPipeServerStream CreateNewNamedPipeServer(string pipeName, int maxInstances)
         {
-            var stream = new NamedPipeServerStream(pipeName, PipeDirection.InOut, maxInstances, PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
+            var stream = new NamedPipeServerStream(pipeName, PipeDirection.InOut, maxInstances, PipeTransmissionMode.Byte, PipeOptions.Asynchronous, 16 * 1024, 16 * 1024);
             OnCreateNewServer(null);
             return stream;
         }


### PR DESCRIPTION
Running reverse connect (--diagnostic-port) against a runtime running with nosuspend, hangs/deadlocks IPC client and IPC server thread on start collect -> resume command sequence. Doing the same against a runtime using suspend will hang any trace session created after runtime has started up.

Happens since runtime IPC server thread will write out initial header data into session stream (when streaming is enabled) but client only waits for session id and will then issue a resume command. If the reverse server is not setup with any buffering this will cause IPC server thread to block when writing into session, runtime server thread won’t be able to handle incoming resume command, and client won’t read anything from session unblocking server thread, since its waiting on completion of resume command.

This is not an issue on Unix domain, TCP/IP sockets since it by default will allocate smaller in/out buffers, preventing server thread to block. It’s not an issue on runtime IPC named pipe listener port’s either, since they are allocated with 16 KB in/out buffers. It is however an issue on reverse servers created by IpcWindowsNamedPipeServerTransport since those will default to 0 byte in/out buffers, triggering the issue.

Fix increase the default size of in/out buffers in sync with default named pipe in/out buffers used by runtime, 16KB.

Not an issue on CI since CI uses its own implementation of reverse named pipe server, using 16 KB as in/out buffers as well.

Keeping Unix Domain, TCP/IP sockets as is, since runtime also uses the same defaults in its implementation. CI on the other hand uses 16 KB for Unix Domain Socket in/out buffers, something IpcTcpSocketServerTransport could do as well, but could be adjusted if ever needed. The number of bytes written into stream when starting up streaming into session is small (32 bytes) and should fit into the default buffer sizes used by Unix Domain, TCP/IP sockets.

This fix is however just fixing the symptom of the underlying issue, that the runtime IPC server thread writes into a session stream that it expects reader to consume or it might block from processing other IPC commands.

One alternative runtime fix would be to move the write of stream init data into runtime streaming thread, but since we also write all rundown data on runtime IPC server thread as part of stop collect command, it won’t solve the complete problem. If client doesn’t have a consumer reading the data on the stopped session stream, while client is stopping the session, it will block waiting for stop command to finish, but runtime server thread will block on consumer reading written session data. Changing this behaviour in runtime requires some re-architecture of current IPC infrastructure moving all writes into trace session away from runtime server thread.