### PR TITLE
Disabling TestLogsAllCategoriesDefaultLevel on windows due to intermittent failures

### DIFF
--- a/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventLogsPipelineUnitTests.cs
+++ b/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventLogsPipelineUnitTests.cs
@@ -63,9 +63,14 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
         /// <summary>
         /// Test that log events at or above the default level are collected.
         /// </summary>
-        [Fact]
+        [SkippableFact]
         public async Task TestLogsAllCategoriesDefaultLevel()
         {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                throw new SkipTestException("https://github.com/dotnet/diagnostics/issues/2541");
+            }
+            
             using Stream outputStream = await GetLogsAsync(settings =>
             {
                 settings.UseAppFilters = false;


### PR DESCRIPTION
Please see https://github.com/dotnet/diagnostics/issues/2541#issuecomment-927223626