### PR TITLE
Add Guid Serialization to Diagnostics Client

### DIFF
--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
@@ -388,6 +388,11 @@ namespace Microsoft.Diagnostics.NETCore.Client
                 uint uiValue = bValue ? (uint)1 : 0;
                 writer.Write(uiValue);
             }
+            else if (typeof(T) == typeof(Guid))
+            {
+                Guid guidVal = (Guid)((object)obj);
+                writer.Write(guidVal.ToByteArray());
+            }
             else
             {
                 throw new ArgumentException($"Type {obj.GetType()} is not supported in SerializePayloadArgument, please add it.");


### PR DESCRIPTION
- Adds serialization for the type `Guid` when calling `SetStartupProfiler` on the diagnostic pipe