### PR TITLE
Add ProcessInfo command line validation to tests.

### DIFF
--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/CommonHelper.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/CommonHelper.cs
@@ -16,11 +16,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
                 "..\\..\\..\\..\\..\\.dotnet\\dotnet.exe") : 
             "../../../../../.dotnet/dotnet";
         
-        /// <summary>
-        /// gets the tracee path, with args for the dotnet host for finding the correct version of the runtime.!--
-        /// example: "--fx-version 5.0.0-rc.1.12345.12 /path/to/tracee"
-        /// </summary>
-        public static string GetTraceePathWithArgs(string traceeName = "Tracee", string targetFramework = "netcoreapp3.1")
+        public static string GetTraceePath(string traceeName = "Tracee", string targetFramework = "netcoreapp3.1")
         {
             var curPath = Directory.GetCurrentDirectory();
 
@@ -28,8 +24,16 @@ namespace Microsoft.Diagnostics.NETCore.Client
                 .Replace(System.Reflection.Assembly.GetCallingAssembly().GetName().Name, traceeName)
                 .Replace("netcoreapp3.1", targetFramework);
 
-            traceePath = Path.Combine(traceePath, Path.ChangeExtension(traceeName, ".dll"));
+            return Path.Combine(traceePath, Path.ChangeExtension(traceeName, ".dll"));
+        }
 
+        /// <summary>
+        /// gets the tracee path, with args for the dotnet host for finding the correct version of the runtime.!--
+        /// example: "--fx-version 5.0.0-rc.1.12345.12 /path/to/tracee"
+        /// </summary>
+        public static string GetTraceePathWithArgs(string traceeName = "Tracee", string targetFramework = "netcoreapp3.1")
+        {
+            string traceePath = GetTraceePath(traceeName, targetFramework);
 
             // CurrentDARCVersion is generated at build time by Microsoft.Diagnostics.NETCore.Client.UnitTests.csproj
             // This value will be set to whatever the value for the newest runtime in eng/Versions.Props is


### PR DESCRIPTION
Update ProcessInfo tests to ensure that the host executable and entrypoint assembly are in the command line at some reasonable point.

cc @josalem