### PR TITLE
Running dotnet-counters in the background fixes #1098

### DIFF
--- a/src/Tools/dotnet-counters/CounterMonitor.cs
+++ b/src/Tools/dotnet-counters/CounterMonitor.cs
@@ -527,7 +527,8 @@ namespace Microsoft.Diagnostics.Tools.Counters
             string diagnosticPort,
             bool resumeRuntime,
             int maxHistograms,
-            int maxTimeSeries)
+            int maxTimeSeries,
+            bool runInBackground)
         {
             try
             {
@@ -659,6 +660,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
 
             if (counters.IsEmpty)
             {
+                //TODO: fix something here, so this is only put into the file? 
                 _console.Out.WriteLine($"--counters is unspecified. Monitoring System.Runtime counters by default.");
                 counters.AddAllProviderCounters("System.Runtime");
             }
@@ -676,6 +678,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
         // parses a comma separated list of providers
         internal void ParseProviderList(string providerListText, CounterSet counters)
         {
+            //TODO: Something needs to be done here to allow the app to run in the background
             bool inParen = false;
             int startIdx = -1;
             int i = 0;
@@ -728,6 +731,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
         //   System.Runtime[exception-count,cpu-usage]
         void ParseCounterProvider(string providerText, CounterSet counters)
         {
+            //TODO: Something needs to be done here to let the app run in the background
             string[] tokens = providerText.Split('[');
             if(tokens.Length == 0)
             {

--- a/src/Tools/dotnet-counters/Program.cs
+++ b/src/Tools/dotnet-counters/Program.cs
@@ -35,7 +35,8 @@ namespace Microsoft.Diagnostics.Tools.Counters
             string port,
             bool resumeRuntime,
             int maxHistograms,
-            int maxTimeSeries);
+            int maxTimeSeries,
+            bool runInBackground);
         delegate Task<int> MonitorDelegate(
             CancellationToken ct,
             List<string> counter_list,
@@ -86,7 +87,8 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 DiagnosticPortOption(),
                 ResumeRuntimeOption(),
                 MaxHistogramOption(),
-                MaxTimeSeriesOption()
+                MaxTimeSeriesOption(),
+                RunInBackgroundOption()
             };
 
         private static Option NameOption() =>
@@ -194,6 +196,16 @@ namespace Microsoft.Diagnostics.Tools.Counters
             {
                 Argument = new Argument<int>(name: "maxTimeSeries", getDefaultValue: () => 1000)
             };
+
+        private static Option RunInBackgroundOption() =>
+            new Option(
+                alias: "--background",
+                description: "Whether or not dotnet-counters collect will run in the background. Simply prevents the app from interacting with the console so that it can" +
+                "safely run in the background, and then be brought to the foreground when needed by the user. Prevents the use of press p or q to pause or stop feature," + 
+                "but dotnet-counters should be able to be stopped using ctrl+C") 
+                {
+                    Argument = new Argument<bool>(name: "background", getDefaultValue: () => false)
+                };
 
         private static readonly string[] s_SupportedRuntimeVersions = new[] { "3.0", "3.1", "5.0" };
 


### PR DESCRIPTION
I started looking at this issue, here are my main thoughts. Does this seem to be on a right track? I assumed that part of what running in the background meant that there would not be anything printed to the Console, is this correct? 