### PR TITLE
Add enable crash report flag to WriteDump client API

### DIFF
--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
@@ -132,13 +132,17 @@ namespace Microsoft.Diagnostics.NETCore.Client
         /// </summary> 
         /// <param name="dumpType">Type of the dump to be generated</param>
         /// <param name="dumpPath">Full path to the dump to be generated. By default it is /tmp/coredump.{pid}</param>
-        /// <param name="flags">logging and crash report flags. On runtimes less than 6.0, only LoggingEnabled is supported. The rest are ignored</param>
+        /// <param name="flags">logging and crash report flags. On runtimes less than 6.0, only LoggingEnabled is supported.</param>
         public void WriteDump(DumpType dumpType, string dumpPath, WriteDumpFlags flags)
         {
             IpcMessage request = CreateWriteDumpMessage2(dumpType, dumpPath, flags);
             IpcMessage response = IpcClient.SendMessage(_endpoint, request);
             if (!ValidateResponseMessage(response, nameof(WriteDump), ValidateResponseOptions.UnknownCommandReturnsFalse))
             {
+                if ((flags & ~WriteDumpFlags.LoggingEnabled) != 0)
+                {
+                    throw new ArgumentException($"Only {nameof(WriteDumpFlags.LoggingEnabled)} flag is supported by this runtime version", nameof(flags));
+                }
                 WriteDump(dumpType, dumpPath, logDumpGeneration: (flags & WriteDumpFlags.LoggingEnabled) != 0);
             }
         }
@@ -162,7 +166,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
         /// </summary> 
         /// <param name="dumpType">Type of the dump to be generated</param>
         /// <param name="dumpPath">Full path to the dump to be generated. By default it is /tmp/coredump.{pid}</param>
-        /// <param name="flags">logging and crash report flags. On runtimes less than 6.0, only LoggingEnabled is supported. The rest are ignored</param>
+        /// <param name="flags">logging and crash report flags. On runtimes less than 6.0, only LoggingEnabled is supported.</param>
         /// <param name="token">The token to monitor for cancellation requests.</param>
         public async Task WriteDumpAsync(DumpType dumpType, string dumpPath, WriteDumpFlags flags, CancellationToken token)
         {
@@ -170,6 +174,10 @@ namespace Microsoft.Diagnostics.NETCore.Client
             IpcMessage response = await IpcClient.SendMessageAsync(_endpoint, request, token).ConfigureAwait(false);
             if (!ValidateResponseMessage(response, nameof(WriteDumpAsync), ValidateResponseOptions.UnknownCommandReturnsFalse))
             {
+                if ((flags & ~WriteDumpFlags.LoggingEnabled) != 0)
+                {
+                    throw new ArgumentException($"Only {nameof(WriteDumpFlags.LoggingEnabled)} flag is supported by this runtime version", nameof(flags));
+                }
                 await WriteDumpAsync(dumpType, dumpPath, logDumpGeneration: (flags & WriteDumpFlags.LoggingEnabled) != 0, token);
             }
         }

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/WriteDumpFlags.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/WriteDumpFlags.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Diagnostics.NETCore.Client
+{
+    public enum WriteDumpFlags
+    {
+        None = 0x00,
+        LoggingEnabled = 0x01,
+        VerboseLoggingEnabled = 0x02,
+        CrashReportEnabled = 0x04
+    }
+}

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcCommands.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcCommands.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
     internal enum DumpCommandId : byte
     {
         GenerateCoreDump = 0x01,
+        GenerateCoreDump2 = 0x02,
     }
 
     internal enum ProfilerCommandId : byte

--- a/src/Tools/dotnet-dump/Dumper.cs
+++ b/src/Tools/dotnet-dump/Dumper.cs
@@ -86,6 +86,12 @@ namespace Microsoft.Diagnostics.Tools.Dump
 
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
+                    if (crashreport)
+                    {
+                        Console.WriteLine("Crash reports not supported on Windows.");
+                        return 0;
+                    }
+
                     // Get the process
                     Process process = Process.GetProcessById(processId);
 

--- a/src/Tools/dotnet-dump/Dumper.cs
+++ b/src/Tools/dotnet-dump/Dumper.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Diagnostics.Tools.Dump
         {
         }
 
-        public int Collect(IConsole console, int processId, string output, bool diag, DumpTypeOption type, string name)
+        public int Collect(IConsole console, int processId, string output, bool diag, bool crashreport, DumpTypeOption type, string name)
         {
             Console.WriteLine(name);
             if (name != null)
@@ -112,8 +112,17 @@ namespace Microsoft.Diagnostics.Tools.Dump
                             break;
                     }
 
+                    WriteDumpFlags flags = WriteDumpFlags.None;
+                    if (diag)
+                    {
+                        flags |= WriteDumpFlags.LoggingEnabled;
+                    }
+                    if (crashreport)
+                    {
+                        flags |= WriteDumpFlags.CrashReportEnabled;
+                    }
                     // Send the command to the runtime to initiate the core dump
-                    client.WriteDump(dumpType, output, diag);
+                    client.WriteDump(dumpType, output, flags);
                 }
             }
             catch (Exception ex) when 

--- a/src/Tools/dotnet-dump/Program.cs
+++ b/src/Tools/dotnet-dump/Program.cs
@@ -32,9 +32,9 @@ namespace Microsoft.Diagnostics.Tools.Dump
             new Command( name: "collect", description: "Capture dumps from a process")
             {
                 // Handler
-                CommandHandler.Create<IConsole, int, string, bool, Dumper.DumpTypeOption, string>(new Dumper().Collect),
+                CommandHandler.Create<IConsole, int, string, bool, bool, Dumper.DumpTypeOption, string>(new Dumper().Collect),
                 // Options
-                ProcessIdOption(), OutputOption(), DiagnosticLoggingOption(), TypeOption(), ProcessNameOption()
+                ProcessIdOption(), OutputOption(), DiagnosticLoggingOption(), CrashReportOption(), TypeOption(), ProcessNameOption()
             };
 
         private static Option ProcessIdOption() =>
@@ -68,6 +68,14 @@ on Linux where YYYYMMDD is Year/Month/Day and HHMMSS is Hour/Minute/Second. Othe
                 description: "Enable dump collection diagnostic logging.") 
             {
                 Argument = new Argument<bool>(name: "diag")
+            };
+
+        private static Option CrashReportOption() =>
+            new Option(
+                alias: "--crashreport", 
+                description: "Enable crash report generation.") 
+            {
+                Argument = new Argument<bool>(name: "crashreport")
             };
 
         private static Option TypeOption() =>


### PR DESCRIPTION
Uses new write dump command supported by 6.0 runtime to pass a set of flags instead
of just the logging enabled bool.

Issue: https://github.com/dotnet/diagnostics/issues/2698