### PR TITLE
Better rundown defaults and parameterization

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/AggregateSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/AggregateSourceConfiguration.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Diagnostics.NETCore.Client;
@@ -21,6 +22,12 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
         {
             // CONSIDER: Might have to deduplicate providers and merge them together.
             return _configurations.SelectMany(c => c.GetProviders()).ToList();
+        }
+
+        public override bool RequestRundown
+        {
+            get => _configurations.Any(c => c.RequestRundown);
+            set => throw new NotSupportedException();
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/AspNetTriggerSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/AspNetTriggerSourceConfiguration.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
 
         public AspNetTriggerSourceConfiguration(float? heartbeatIntervalSeconds = null)
         {
+            RequestRundown = false;
             _heartbeatIntervalSeconds = heartbeatIntervalSeconds;
         }
 

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/EventPipeProviderSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/EventPipeProviderSourceConfiguration.cs
@@ -11,13 +11,12 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
     public sealed class EventPipeProviderSourceConfiguration : MonitoringSourceConfiguration
     {
         private readonly IEnumerable<EventPipeProvider> _providers;
-        private readonly bool _requestRundown;
         private readonly int _bufferSizeInMB;
 
         public EventPipeProviderSourceConfiguration(bool requestRundown = true, int bufferSizeInMB = 256, params EventPipeProvider[] providers)
         {
             _providers = providers;
-            _requestRundown = requestRundown;
+            RequestRundown = requestRundown;
             _bufferSizeInMB = bufferSizeInMB;
         }
 
@@ -25,8 +24,6 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
         {
             return _providers.ToList();
         }
-
-        public override bool RequestRundown => _requestRundown;
 
         public override int BufferSizeInMB => _bufferSizeInMB;
     }

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/GCDumpSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/GCDumpSourceConfiguration.cs
@@ -11,6 +11,11 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
 {
     public sealed class GCDumpSourceConfiguration : MonitoringSourceConfiguration
     {
+        public GCDumpSourceConfiguration()
+        {
+            RequestRundown = false;
+        }
+
         public override IList<EventPipeProvider> GetProviders()
         {
             var providers = new List<EventPipeProvider>()

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/HttpRequestSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/HttpRequestSourceConfiguration.cs
@@ -12,7 +12,8 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
     {
         public HttpRequestSourceConfiguration()
         {
-            RequestRundown = false;
+            //CONSIDER removing rundown for this scenario.
+            RequestRundown = true;
         }
 
         private const string DiagnosticFilterString =

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/HttpRequestSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/HttpRequestSourceConfiguration.cs
@@ -10,6 +10,11 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
 {
     public sealed class HttpRequestSourceConfiguration : MonitoringSourceConfiguration
     {
+        public HttpRequestSourceConfiguration()
+        {
+            RequestRundown = false;
+        }
+
         private const string DiagnosticFilterString =
                 "Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.HttpRequestIn.Start@Activity1Start:-" +
                     "Request.Scheme" +

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/LoggingSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/LoggingSourceConfiguration.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
         /// </summary>
         public LoggingSourceConfiguration(LogLevel level, LogMessageType messageType, IDictionary<string, LogLevel?> filterSpecs, bool useAppFilters)
         {
+            RequestRundown = false;
             _filterSpecs = ToFilterSpecsString(filterSpecs, useAppFilters);
             _keywords = (long)ToKeywords(messageType);
             _level = ToEventLevel(level);

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/MetricSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/MetricSourceConfiguration.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
 
         public MetricSourceConfiguration(float metricIntervalSeconds, IEnumerable<string> customProviderNames)
         {
+            RequestRundown = false;
             if (customProviderNames == null)
             {
                 throw new ArgumentNullException(nameof(customProviderNames));

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/MonitoringSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/MonitoringSourceConfiguration.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
 
         public abstract IList<EventPipeProvider> GetProviders();
 
-        public virtual bool RequestRundown => true;
+        public virtual bool RequestRundown { get; set; } = true;
 
         public virtual int BufferSizeInMB => 256;
     }

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/SampleProfilerConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/SampleProfilerConfiguration.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.NETCore.Client;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.Tracing;
 
@@ -18,6 +19,10 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
 
         public override int BufferSizeInMB => 1;
 
-        public override bool RequestRundown => false;
+        public override bool RequestRundown
+        {
+            get => false;
+            set => throw new NotSupportedException();
+        }
     }
 }


### PR DESCRIPTION
Note that I wanted to accomplish the following:
- Although these types are not really a public API, I didn't want to make a breaking Api change
- Reasonable defaults for each particular configuration.
- The ability to further customize the property externally should it be necessary in the future.