### PR TITLE
SOS crash fixes

### DIFF
--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/Module.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/Module.cs
@@ -90,8 +90,16 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
         {
             get
             {
-                GetPEInfo();
-                return (_flags & Flags.IsPEImage) != 0;
+                // For Windows targets, we can always assume that all the modules are PEs.
+                if (Target.OperatingSystem == OSPlatform.Windows)
+                {
+                    return true;
+                }
+                else
+                {
+                    GetPEInfo();
+                    return (_flags & Flags.IsPEImage) != 0;
+                }
             }
         }
 
@@ -172,7 +180,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
         {
             if (Target.OperatingSystem == OSPlatform.Windows)
             {
-                Stream stream = Target.Services.GetService<IMemoryService>().CreateMemoryStream(ImageBase, ImageSize);
+                Stream stream = ModuleService.RawMemoryService.CreateMemoryStream(ImageBase, ImageSize);
                 PEFile image = new(new StreamAddressSpace(stream), isDataSourceVirtualAddressSpace: true);
                 if (image.IsValid())
                 { 
@@ -189,7 +197,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
             {
                 try
                 {
-                    Stream stream = Target.Services.GetService<IMemoryService>().CreateMemoryStream(ImageBase, ImageSize);
+                    Stream stream = ModuleService.RawMemoryService.CreateMemoryStream(ImageBase, ImageSize);
                     ElfFile elfFile = new(stream, position: ImageBase, leaveOpen: false, isVirtual: true);
                     if (elfFile.Header.IsValid)
                     {

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/Module.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/Module.cs
@@ -180,7 +180,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
         {
             if (Target.OperatingSystem == OSPlatform.Windows)
             {
-                Stream stream = ModuleService.RawMemoryService.CreateMemoryStream(ImageBase, ImageSize);
+                Stream stream = ModuleService.MemoryService.CreateMemoryStream(ImageBase, ImageSize);
                 PEFile image = new(new StreamAddressSpace(stream), isDataSourceVirtualAddressSpace: true);
                 if (image.IsValid())
                 { 
@@ -197,7 +197,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
             {
                 try
                 {
-                    Stream stream = ModuleService.RawMemoryService.CreateMemoryStream(ImageBase, ImageSize);
+                    Stream stream = ModuleService.MemoryService.CreateMemoryStream(ImageBase, ImageSize);
                     ElfFile elfFile = new(stream, position: ImageBase, leaveOpen: false, isVirtual: true);
                     if (elfFile.Header.IsValid)
                     {

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/ModuleService.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/ModuleService.cs
@@ -40,6 +40,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
 
         internal protected readonly ITarget Target;
         internal protected IMemoryService RawMemoryService;
+        private IMemoryService _memoryService;
         private ISymbolService _symbolService;
         private ReadVirtualCache _versionCache;
         private Dictionary<ulong, IModule> _modules;
@@ -689,9 +690,11 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
             else {
                 return string.Equals(Path.GetFileName(module.FileName), moduleName);
             }
-        }
+        } 
 
-        protected ISymbolService SymbolService => _symbolService ??= Target.Services.GetService<ISymbolService>(); 
+        internal protected IMemoryService MemoryService => _memoryService ??= Target.Services.GetService<IMemoryService>();
+
+        internal protected ISymbolService SymbolService => _symbolService ??= Target.Services.GetService<ISymbolService>(); 
 
         /// <summary>
         /// Search memory helper class

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/ModuleServiceFromDataReader.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/ModuleServiceFromDataReader.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
                     {
                         ImmutableArray<byte> buildId = _moduleService._dataReader.GetBuildId(ImageBase);
                         // If the data reader can't get the build id, it returns a empty (instead of default) immutable array.
-                        _buildId = buildId.IsEmpty ? base.BuildId : buildId;
+                        _buildId = buildId.IsDefaultOrEmpty ? base.BuildId : buildId;
                     }
                     return _buildId;
                 }
@@ -122,8 +122,8 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
 
         private readonly IDataReader _dataReader;
 
-        public ModuleServiceFromDataReader(ITarget target, IDataReader dataReader)
-            : base(target)
+        public ModuleServiceFromDataReader(ITarget target, IMemoryService rawMemoryService, IDataReader dataReader)
+            : base(target, rawMemoryService)
         {
             _dataReader = dataReader;
         }

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/TargetFromDataReader.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/TargetFromDataReader.cs
@@ -47,10 +47,11 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
             }
 
             // Add the thread, memory, and module services
+            IMemoryService rawMemoryService = new MemoryServiceFromDataReader(_dataReader);
             ServiceProvider.AddServiceFactory<IThreadService>(() => new ThreadServiceFromDataReader(this, _dataReader));
-            ServiceProvider.AddServiceFactory<IModuleService>(() => new ModuleServiceFromDataReader(this, _dataReader));
+            ServiceProvider.AddServiceFactory<IModuleService>(() => new ModuleServiceFromDataReader(this, rawMemoryService, _dataReader));
             ServiceProvider.AddServiceFactory<IMemoryService>(() => {
-                IMemoryService memoryService = new MemoryServiceFromDataReader(_dataReader);
+                IMemoryService memoryService = rawMemoryService;
                 if (IsDump)
                 {
                     memoryService = new ImageMappingMemoryService(this, memoryService);

--- a/src/SOS/SOS.Extensions/HostServices.cs
+++ b/src/SOS/SOS.Extensions/HostServices.cs
@@ -302,9 +302,16 @@ namespace SOS.Extensions
             IntPtr self)
         {
             Trace.TraceInformation("HostServices.DestroyTarget #{0}", _target != null ? _target.Id : "<none>");
-            if (_target != null)
+            try
             {
-                DestroyTarget(_target);
+                if (_target != null)
+                {
+                    DestroyTarget(_target);
+                }
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceError(ex.ToString());
             }
         }
 
@@ -350,22 +357,29 @@ namespace SOS.Extensions
             IntPtr self)
         {
             Trace.TraceInformation("HostServices.Uninitialize");
-            DestroyTarget(self);
-
-            if (DebuggerServices != null)
+            try
             {
-                DebuggerServices.Release();
-                DebuggerServices = null;
+                DestroyTarget(self);
+
+                if (DebuggerServices != null)
+                {
+                    DebuggerServices.Release();
+                    DebuggerServices = null;
+                }
+
+                // Send shutdown event on exit
+                OnShutdownEvent.Fire();
+
+                // Release the host services wrapper
+                Release();
+
+                // Clear HostService instance
+                Instance = null;
             }
-
-            // Send shutdown event on exit
-            OnShutdownEvent.Fire();
-
-            // Release the host services wrapper
-            Release();
-
-            // Clear HostService instance
-            Instance = null;
+            catch (Exception ex)
+            {
+                Trace.TraceError(ex.ToString());
+            }
         }
 
         #endregion

--- a/src/SOS/SOS.Extensions/ModuleServiceFromDebuggerServices.cs
+++ b/src/SOS/SOS.Extensions/ModuleServiceFromDebuggerServices.cs
@@ -133,8 +133,8 @@ namespace SOS.Extensions
 
         private readonly DebuggerServices _debuggerServices;
 
-        internal ModuleServiceFromDebuggerServices(ITarget target, DebuggerServices debuggerServices)
-            : base(target)
+        internal ModuleServiceFromDebuggerServices(ITarget target, IMemoryService rawMemoryService, DebuggerServices debuggerServices)
+            : base(target, rawMemoryService)
         {
             Debug.Assert(debuggerServices != null);
             _debuggerServices = debuggerServices;


### PR DESCRIPTION
The exception in the service provider is caused by the recursion of the ImageMappingMemoryService memory
service. Remove the recursion by passing the "raw" memory service (the one without any "mapping" memory
service wrappers) to the module service to use to get the build id/PE reader, etc.

Fix Windows debugger SOS termination exception