### PR TITLE
Standardize on new two-line license header

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,192 @@
+# editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Default settings:
+# A newline ending every file
+# Use 4 spaces as indentation
+[*]
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[project.json]
+indent_size = 2
+
+# Generated code
+[*{_AssemblyInfo.cs,.notsupported.cs}]
+generated_code = true
+
+# C# files
+[*.cs]
+# New line preferences
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+
+# Indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = one_less_than_current
+
+# Modifier preferences
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
+
+# avoid this. unless absolutely necessary
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+
+# Types: use keywords instead of BCL types, and permit var only when the type is clear
+csharp_style_var_for_built_in_types = false:suggestion
+csharp_style_var_when_type_is_apparent = false:none
+csharp_style_var_elsewhere = false:suggestion
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+# name all constant fields using PascalCase
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
+dotnet_naming_symbols.constant_fields.applicable_kinds   = field
+dotnet_naming_symbols.constant_fields.required_modifiers = const
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+
+# static fields should have s_ prefix
+dotnet_naming_rule.static_fields_should_have_prefix.severity = suggestion
+dotnet_naming_rule.static_fields_should_have_prefix.symbols  = static_fields
+dotnet_naming_rule.static_fields_should_have_prefix.style    = static_prefix_style
+dotnet_naming_symbols.static_fields.applicable_kinds   = field
+dotnet_naming_symbols.static_fields.required_modifiers = static
+dotnet_naming_symbols.static_fields.applicable_accessibilities = private, internal, private_protected
+dotnet_naming_style.static_prefix_style.required_prefix = s_
+dotnet_naming_style.static_prefix_style.capitalization = camel_case
+
+# internal and private fields should be _camelCase
+dotnet_naming_rule.camel_case_for_private_internal_fields.severity = suggestion
+dotnet_naming_rule.camel_case_for_private_internal_fields.symbols  = private_internal_fields
+dotnet_naming_rule.camel_case_for_private_internal_fields.style    = camel_case_underscore_style
+dotnet_naming_symbols.private_internal_fields.applicable_kinds = field
+dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = private, internal
+dotnet_naming_style.camel_case_underscore_style.required_prefix = _
+dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case
+
+# Code style defaults
+csharp_using_directive_placement = outside_namespace:suggestion
+dotnet_sort_system_directives_first = true
+csharp_prefer_braces = true:silent
+csharp_preserve_single_line_blocks = true:none
+csharp_preserve_single_line_statements = false:none
+csharp_prefer_static_local_function = true:suggestion
+csharp_prefer_simple_using_statement = false:none
+csharp_style_prefer_switch_expression = true:suggestion
+dotnet_style_readonly_field = true:suggestion
+
+# Expression-level preferences
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_auto_properties = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+csharp_prefer_simple_default_expression = true:suggestion
+
+# Expression-bodied members
+csharp_style_expression_bodied_methods = true:silent
+csharp_style_expression_bodied_constructors = true:silent
+csharp_style_expression_bodied_operators = true:silent
+csharp_style_expression_bodied_properties = true:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_accessors = true:silent
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_expression_bodied_local_functions = true:silent
+
+# Pattern matching
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+
+# Null checking preferences
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Other features
+csharp_style_prefer_index_operator = false:none
+csharp_style_prefer_range_operator = false:none
+csharp_style_pattern_local_over_anonymous_function = false:none
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = do_not_ignore
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false
+
+# License header
+file_header_template = Licensed to the .NET Foundation under one or more agreements.\nThe .NET Foundation licenses this file to you under the MIT license.
+
+# C++ Files
+[*.{cpp,h,in}]
+curly_bracket_next_line = true
+indent_brace_style = Allman
+
+# Xml project files
+[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,nativeproj,locproj}]
+indent_size = 2
+
+[*.{csproj,vbproj,proj,nativeproj,locproj}]
+charset = utf-8
+
+# Xml build files
+[*.builds]
+indent_size = 2
+
+# Xml files
+[*.{xml,stylecop,resx,ruleset}]
+indent_size = 2
+
+# Xml config files
+[*.{props,targets,config,nuspec}]
+indent_size = 2
+
+# YAML config files
+[*.{yml,yaml}]
+indent_size = 2
+
+# Shell scripts
+[*.sh]
+end_of_line = lf
+[*.{cmd,bat}]
+end_of_line = crlf

--- a/documentation/tutorial/src/triggerdump/CounterPayload.cs
+++ b/documentation/tutorial/src/triggerdump/CounterPayload.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/documentation/tutorial/src/triggerdump/Program.cs
+++ b/documentation/tutorial/src/triggerdump/Program.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/eng/CreateVersionFile.csproj
+++ b/eng/CreateVersionFile.csproj
@@ -1,4 +1,4 @@
-<!-- All Rights Reserved. Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- All Rights Reserved. Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>

--- a/eng/InstallRuntimes.proj
+++ b/eng/InstallRuntimes.proj
@@ -1,4 +1,4 @@
-<!-- All Rights Reserved. Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<!-- All Rights Reserved. Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <!--
      $(BuildArch) - architecture to test (x64, x86, arm, arm64). Defaults to x64.

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/ContextService.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/ContextService.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/ImageMappingMemoryService.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/ImageMappingMemoryService.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Runtime.Utilities;
 using Microsoft.FileFormats;

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/LinkedListNode.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/LinkedListNode.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections;

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/MemoryCache.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/MemoryCache.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/MemoryServiceFromDataReader.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/MemoryServiceFromDataReader.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Runtime;
 using System;

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/MetadataMappingMemoryService.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/MetadataMappingMemoryService.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Runtime;
 using Microsoft.Diagnostics.Runtime.Utilities;

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/Module.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/Module.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Runtime.Utilities;
 using Microsoft.FileFormats;

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/ModuleService.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/ModuleService.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Runtime.Utilities;
 using Microsoft.FileFormats;

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/ModuleServiceFromDataReader.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/ModuleServiceFromDataReader.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Runtime;
 using System;

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/Runtime.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/Runtime.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Runtime;
 using Microsoft.SymbolStore;

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/RuntimeService.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/RuntimeService.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Runtime;
 using System;

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/ServiceEvent.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/ServiceEvent.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/ServiceProvider.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/ServiceProvider.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/SymbolService.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/SymbolService.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.FileFormats;
 using Microsoft.SymbolStore;

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/Target.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/Target.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/TargetFromDataReader.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/TargetFromDataReader.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Runtime;
 using System;

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/Thread.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/Thread.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/ThreadService.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/ThreadService.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Runtime;
 using System;

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/ThreadServiceFromDataReader.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/ThreadServiceFromDataReader.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Runtime;
 using Microsoft.Diagnostics.Runtime.DataReaders.Implementation;

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/Utilities.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/Utilities.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.DebugServices.Implementation
 {

--- a/src/Microsoft.Diagnostics.DebugServices/CommandAttributes.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/CommandAttributes.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.Diagnostics.DebugServices/CommandBase.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/CommandBase.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.Diagnostics.DebugServices/CommandServiceExtensions.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/CommandServiceExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.DebugServices/ConsoleServiceExtensions.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/ConsoleServiceExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.Diagnostics.DebugServices/ContextServiceExtensions.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/ContextServiceExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.Diagnostics.DebugServices/DiagnosticsException.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/DiagnosticsException.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.Diagnostics.DebugServices/ICommandService.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/ICommandService.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.DebugServices/IConsoleService.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/IConsoleService.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Threading;
 

--- a/src/Microsoft.Diagnostics.DebugServices/IContextService.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/IContextService.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/Microsoft.Diagnostics.DebugServices/IDumpTargetFactory.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/IDumpTargetFactory.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/Microsoft.Diagnostics.DebugServices/IExportSymbols.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/IExportSymbols.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.Diagnostics.DebugServices/IHost.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/IHost.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections;

--- a/src/Microsoft.Diagnostics.DebugServices/IMemoryService.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/IMemoryService.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.Diagnostics.DebugServices/IModule.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/IModule.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Immutable;

--- a/src/Microsoft.Diagnostics.DebugServices/IModuleService.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/IModuleService.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 

--- a/src/Microsoft.Diagnostics.DebugServices/IModuleSymbols.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/IModuleSymbols.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.Diagnostics.DebugServices/IRemoteMemoryService.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/IRemoteMemoryService.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.Diagnostics.DebugServices/IRuntime.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/IRuntime.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.Diagnostics.DebugServices/IRuntimeService.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/IRuntimeService.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.DebugServices/IServiceEvent.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/IServiceEvent.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.Diagnostics.DebugServices/ISymbolService.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/ISymbolService.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.SymbolStore;
 using System.Collections.Immutable;

--- a/src/Microsoft.Diagnostics.DebugServices/ITarget.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/ITarget.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/Microsoft.Diagnostics.DebugServices/IThread.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/IThread.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.Diagnostics.DebugServices/IThreadService.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/IThreadService.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System;

--- a/src/Microsoft.Diagnostics.DebugServices/IThreadUnwindService.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/IThreadUnwindService.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.Diagnostics.DebugServices/MemoryServiceExtensions.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/MemoryServiceExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.FileFormats;
 using Microsoft.FileFormats.ELF;

--- a/src/Microsoft.Diagnostics.DebugServices/PdbFileInfo.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/PdbFileInfo.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.Diagnostics.DebugServices/RegisterInfo.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/RegisterInfo.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.DebugServices
 {

--- a/src/Microsoft.Diagnostics.DebugServices/ServiceProviderExtensions.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/ServiceProviderExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.DebugServices/TargetExtensions.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/TargetExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/Microsoft.Diagnostics.DebugServices/Tracer.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/Tracer.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
 

--- a/src/Microsoft.Diagnostics.DebugServices/VersionData.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/VersionData.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.Diagnostics.ExtensionCommands/ClrMDHelper.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/ClrMDHelper.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.DebugServices;
 using Microsoft.Diagnostics.Runtime;

--- a/src/Microsoft.Diagnostics.ExtensionCommands/ClrModulesCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/ClrModulesCommand.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.DebugServices;
 using Microsoft.Diagnostics.Runtime;

--- a/src/Microsoft.Diagnostics.ExtensionCommands/DumpConcurrentDictionaryCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/DumpConcurrentDictionaryCommand.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.DebugServices;
 using Microsoft.Diagnostics.Runtime;

--- a/src/Microsoft.Diagnostics.ExtensionCommands/DumpConcurrentQueueCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/DumpConcurrentQueueCommand.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.DebugServices;
 using Microsoft.Diagnostics.Runtime;

--- a/src/Microsoft.Diagnostics.ExtensionCommands/DumpGen.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/DumpGen.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.ExtensionCommands/DumpGenCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/DumpGenCommand.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.DebugServices;
 using Microsoft.Diagnostics.Runtime;

--- a/src/Microsoft.Diagnostics.ExtensionCommands/DumpGenStats.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/DumpGenStats.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Runtime;
 

--- a/src/Microsoft.Diagnostics.ExtensionCommands/ExtensionCommandBase.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/ExtensionCommandBase.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.DebugServices;
 

--- a/src/Microsoft.Diagnostics.ExtensionCommands/GCGeneration.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/GCGeneration.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.ExtensionCommands
 {

--- a/src/Microsoft.Diagnostics.ExtensionCommands/Host/LoggingCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/Host/LoggingCommand.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.DebugServices;
 using System;

--- a/src/Microsoft.Diagnostics.ExtensionCommands/Host/ModulesCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/Host/ModulesCommand.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.DebugServices;
 using Microsoft.FileFormats;

--- a/src/Microsoft.Diagnostics.ExtensionCommands/Host/RegistersCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/Host/RegistersCommand.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.DebugServices;
 using System;

--- a/src/Microsoft.Diagnostics.ExtensionCommands/Host/RuntimesCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/Host/RuntimesCommand.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.DebugServices;
 using System.Linq;

--- a/src/Microsoft.Diagnostics.ExtensionCommands/Host/SetClrPathCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/Host/SetClrPathCommand.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.DebugServices;
 using System.IO;

--- a/src/Microsoft.Diagnostics.ExtensionCommands/Host/StatusCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/Host/StatusCommand.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.DebugServices;
 

--- a/src/Microsoft.Diagnostics.ExtensionCommands/Host/ThreadsCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/Host/ThreadsCommand.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.DebugServices;
 

--- a/src/Microsoft.Diagnostics.ExtensionCommands/MonoColorConsoleRenderer.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/MonoColorConsoleRenderer.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.DebugServices;
 using ParallelStacks.Runtime;

--- a/src/Microsoft.Diagnostics.ExtensionCommands/ParallelStacks.Runtime/IRenderer.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/ParallelStacks.Runtime/IRenderer.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace ParallelStacks.Runtime
 {

--- a/src/Microsoft.Diagnostics.ExtensionCommands/ParallelStacks.Runtime/ParallelStack.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/ParallelStacks.Runtime/ParallelStack.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.ExtensionCommands/ParallelStacks.Runtime/RendererBase.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/ParallelStacks.Runtime/RendererBase.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace ParallelStacks.Runtime
 {

--- a/src/Microsoft.Diagnostics.ExtensionCommands/ParallelStacks.Runtime/RendererHelpers.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/ParallelStacks.Runtime/RendererHelpers.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.ExtensionCommands/ParallelStacks.Runtime/StackFrame.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/ParallelStacks.Runtime/StackFrame.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/Microsoft.Diagnostics.ExtensionCommands/ParallelStacksCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/ParallelStacksCommand.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.DebugServices;
 using Microsoft.Diagnostics.Runtime;

--- a/src/Microsoft.Diagnostics.ExtensionCommands/TaskStateCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/TaskStateCommand.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.DebugServices;
 using System;

--- a/src/Microsoft.Diagnostics.ExtensionCommands/ThreadPoolItem.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/ThreadPoolItem.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.ExtensionCommands
 {

--- a/src/Microsoft.Diagnostics.ExtensionCommands/ThreadPoolQueueCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/ThreadPoolQueueCommand.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.DebugServices;
 using System;

--- a/src/Microsoft.Diagnostics.ExtensionCommands/ThreadRoot.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/ThreadRoot.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.ExtensionCommands
 {

--- a/src/Microsoft.Diagnostics.ExtensionCommands/TimerInfo.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/TimerInfo.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.ExtensionCommands
 {

--- a/src/Microsoft.Diagnostics.ExtensionCommands/TimersCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/TimersCommand.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.DebugServices;
 using System;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/AggregateSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/AggregateSourceConfiguration.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/AspNetTriggerSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/AspNetTriggerSourceConfiguration.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/CpuProfileConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/CpuProfileConfiguration.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.NETCore.Client;
 using System;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/EventPipeProviderSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/EventPipeProviderSourceConfiguration.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/GCDumpSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/GCDumpSourceConfiguration.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.NETCore.Client;
 using Microsoft.Diagnostics.Tracing.Parsers;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/HttpRequestSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/HttpRequestSourceConfiguration.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Diagnostics.Tracing;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/LogMessageType.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/LogMessageType.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/LoggingSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/LoggingSourceConfiguration.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/MetricSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/MetricSourceConfiguration.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.NETCore.Client;
 using Microsoft.Diagnostics.Tracing.Parsers;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/MonitoringSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/MonitoringSourceConfiguration.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using Microsoft.Diagnostics.NETCore.Client;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/SampleProfilerConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/SampleProfilerConfiguration.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.NETCore.Client;
 using System;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/CounterFilter.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/CounterFilter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/CounterPayload.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/CounterPayload.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/CounterPayloadExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/CounterPayloadExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/EventCounterPipeline.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/EventCounterPipeline.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.NETCore.Client;
 using Microsoft.Diagnostics.Tracing;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/EventPipeCounterPipelineSettings.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/EventPipeCounterPipelineSettings.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/ICounterPayload.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/ICounterPayload.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/ICountersLogger.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/ICountersLogger.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/TraceEventExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/TraceEventExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Tracing;
 using System;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/DiagnosticsEventPipeProcessor.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/DiagnosticsEventPipeProcessor.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.NETCore.Client;
 using Microsoft.Diagnostics.Tracing;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/EventPipeStreamProvider.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/EventPipeStreamProvider.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/EventSourcePipeline.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/EventSourcePipeline.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.NETCore.Client;
 using Microsoft.Diagnostics.Tracing;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/EventSourcePipelineSettings.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/EventSourcePipelineSettings.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/EventTaskSource.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/EventTaskSource.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/GCDump/EventGCDumpPipeline.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/GCDump/EventGCDumpPipeline.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Graphs;
 using Microsoft.Diagnostics.NETCore.Client;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/GCDump/EventGCPipelineSettings.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/GCDump/EventGCPipelineSettings.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/EventLogsPipeline.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/EventLogsPipeline.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.NETCore.Client;
 using Microsoft.Diagnostics.Tracing;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/EventLogsPipelineSettings.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/EventLogsPipelineSettings.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Logging;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/FormattedLogValues.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/FormattedLogValues.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/IStateWithTimestamp.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/IStateWithTimestamp.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/LogObject.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/LogObject.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/LogValuesFormatter.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/LogValuesFormatter.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/LoggerException.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/LoggerException.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/ProcessInfo/EventProcessInfoPipeline.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/ProcessInfo/EventProcessInfoPipeline.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Trace/EventTracePipeline.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Trace/EventTracePipeline.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.NETCore.Client;
 using System;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Trace/EventTracePipelineSettings.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Trace/EventTracePipelineSettings.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/AspNet/AspNetRequestCountTrigger.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/AspNet/AspNetRequestCountTrigger.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Tracing;
 using System;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/AspNet/AspNetRequestCountTriggerSettings.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/AspNet/AspNetRequestCountTriggerSettings.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/AspNet/AspNetRequestDurationTrigger.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/AspNet/AspNetRequestDurationTrigger.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Tracing;
 using System;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/AspNet/AspNetRequestDurationTriggerSettings.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/AspNet/AspNetRequestDurationTriggerSettings.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/AspNet/AspNetRequestStatusTrigger.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/AspNet/AspNetRequestStatusTrigger.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Tracing;
 using System;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/AspNet/AspNetRequestStatusTriggerSettings.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/AspNet/AspNetRequestStatusTriggerSettings.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/AspNet/AspNetTrigger.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/AspNet/AspNetTrigger.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Tracing;
 using System;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/AspNet/AspNetTriggerFactories.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/AspNet/AspNetTriggerFactories.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/AspNet/AspNetTriggerSettings.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/AspNet/AspNetTriggerSettings.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/AspNet/GlobMatcher.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/AspNet/GlobMatcher.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/EventCounter/EventCounterTrigger.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/EventCounter/EventCounterTrigger.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Tracing;
 using System;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/EventCounter/EventCounterTriggerFactory.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/EventCounter/EventCounterTriggerFactory.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Runtime;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/EventCounter/EventCounterTriggerImpl.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/EventCounter/EventCounterTriggerImpl.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/EventCounter/EventCounterTriggerSettings.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/EventCounter/EventCounterTriggerSettings.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/ITraceEventTrigger.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/ITraceEventTrigger.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Tracing;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/ITraceEventTriggerFactory.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/ITraceEventTriggerFactory.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Monitoring.EventPipe.Triggers
 {

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/Pipelines/EventPipeTriggerPipeline.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/Pipelines/EventPipeTriggerPipeline.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.NETCore.Client;
 using Microsoft.Diagnostics.Tracing;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/Pipelines/EventPipeTriggerPipelineSettings.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/Pipelines/EventPipeTriggerPipelineSettings.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Monitoring.EventPipe.Triggers.Pipelines
 {

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/Pipelines/TraceEventTriggerPipeline.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/Pipelines/TraceEventTriggerPipeline.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Tracing;
 using System;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/SlidingWindow.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/SlidingWindow.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.Monitoring/MonitoringException.cs
+++ b/src/Microsoft.Diagnostics.Monitoring/MonitoringException.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.Diagnostics.Monitoring/Pipeline.cs
+++ b/src/Microsoft.Diagnostics.Monitoring/Pipeline.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Concurrent;

--- a/src/Microsoft.Diagnostics.Monitoring/PipelineException.cs
+++ b/src/Microsoft.Diagnostics.Monitoring/PipelineException.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.Diagnostics.Monitoring/PipelineExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring/PipelineExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.NETCore.Client/BinaryWriterExtensions.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/BinaryWriterExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClientExceptions.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClientExceptions.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DumpType.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DumpType.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.NETCore.Client
 {

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/EventPipeProvider.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/EventPipeProvider.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/EventPipeSession.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/EventPipeSession.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/EventPipeSessionConfiguration.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/EventPipeSessionConfiguration.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/WriteDumpFlags.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/WriteDumpFlags.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.NETCore.Client
 {

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/ExposedSocketNetworkStream.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/ExposedSocketNetworkStream.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Net.Sockets;
 

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcAdvertise.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcAdvertise.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Linq;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcClient.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcClient.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcCommands.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcCommands.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcEndpointConfig.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcEndpointConfig.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcHeader.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcHeader.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcMessage.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcMessage.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcResponse.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcResponse.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcServerTransport.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcServerTransport.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcSocket.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcSocket.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcTcpSocketEndPoint.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcTcpSocketEndPoint.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Net;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcTransport.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcTransport.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcUnixDomainSocket.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcUnixDomainSocket.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcUnixDomainSocketEndPoint.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcUnixDomainSocketEndPoint.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/ProcessEnvironment.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/ProcessEnvironment.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/ProcessInfo.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/ProcessInfo.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Text;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsServerRouter/DiagnosticsServerRouterFactory.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsServerRouter/DiagnosticsServerRouterFactory.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsServerRouter/DiagnosticsServerRouterRunner.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsServerRouter/DiagnosticsServerRouterRunner.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Net;

--- a/src/Microsoft.Diagnostics.NETCore.Client/HandleableCollection.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/HandleableCollection.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections;

--- a/src/Microsoft.Diagnostics.NETCore.Client/NativeMethods.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/NativeMethods.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/Microsoft.Diagnostics.NETCore.Client/ReversedServer/IpcEndpointInfo.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/ReversedServer/IpcEndpointInfo.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/Microsoft.Diagnostics.NETCore.Client/ReversedServer/ReversedDiagnosticsServer.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/ReversedServer/ReversedDiagnosticsServer.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Concurrent;

--- a/src/Microsoft.Diagnostics.NETCore.Client/StreamExtensions.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/StreamExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.IO;
 using System.Threading;

--- a/src/Microsoft.Diagnostics.Repl/Command/CommandProcessor.cs
+++ b/src/Microsoft.Diagnostics.Repl/Command/CommandProcessor.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.DebugServices;
 using System;

--- a/src/Microsoft.Diagnostics.Repl/Command/HelpCommand.cs
+++ b/src/Microsoft.Diagnostics.Repl/Command/HelpCommand.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.DebugServices;
 using System;

--- a/src/Microsoft.Diagnostics.Repl/Console/CharToLineConverter.cs
+++ b/src/Microsoft.Diagnostics.Repl/Console/CharToLineConverter.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Text;

--- a/src/Microsoft.Diagnostics.Repl/Console/ConsoleProvider.cs
+++ b/src/Microsoft.Diagnostics.Repl/Console/ConsoleProvider.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.DebugServices;
 using System;

--- a/src/Microsoft.Diagnostics.Repl/Console/ExitCommand.cs
+++ b/src/Microsoft.Diagnostics.Repl/Console/ExitCommand.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.DebugServices;
 using System;

--- a/src/Microsoft.Diagnostics.Repl/Console/OutputType.cs
+++ b/src/Microsoft.Diagnostics.Repl/Console/OutputType.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Repl
 {

--- a/src/Microsoft.Diagnostics.TestHelpers/AcquireDotNetTestStep.cs
+++ b/src/Microsoft.Diagnostics.TestHelpers/AcquireDotNetTestStep.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Microsoft.Diagnostics.TestHelpers/AssertX.cs
+++ b/src/Microsoft.Diagnostics.TestHelpers/AssertX.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Microsoft.Diagnostics.TestHelpers/BaseDebuggeeCompiler.cs
+++ b/src/Microsoft.Diagnostics.TestHelpers/BaseDebuggeeCompiler.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.TestHelpers/CliDebuggeeCompiler.cs
+++ b/src/Microsoft.Diagnostics.TestHelpers/CliDebuggeeCompiler.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/Microsoft.Diagnostics.TestHelpers/ConsoleTestOutputHelper.cs
+++ b/src/Microsoft.Diagnostics.TestHelpers/ConsoleTestOutputHelper.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Xunit.Abstractions;

--- a/src/Microsoft.Diagnostics.TestHelpers/CsprojBuildDebuggeeTestStep.cs
+++ b/src/Microsoft.Diagnostics.TestHelpers/CsprojBuildDebuggeeTestStep.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.IO;

--- a/src/Microsoft.Diagnostics.TestHelpers/DebuggeeCompiler.cs
+++ b/src/Microsoft.Diagnostics.TestHelpers/DebuggeeCompiler.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading.Tasks;

--- a/src/Microsoft.Diagnostics.TestHelpers/DotNetBuildDebuggeeTestStep.cs
+++ b/src/Microsoft.Diagnostics.TestHelpers/DotNetBuildDebuggeeTestStep.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.TestHelpers/FileTestOutputHelper.cs
+++ b/src/Microsoft.Diagnostics.TestHelpers/FileTestOutputHelper.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Microsoft.Diagnostics.TestHelpers/IProcessLogger.cs
+++ b/src/Microsoft.Diagnostics.TestHelpers/IProcessLogger.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.TestHelpers
 {

--- a/src/Microsoft.Diagnostics.TestHelpers/IndentedTestOutputHelper.cs
+++ b/src/Microsoft.Diagnostics.TestHelpers/IndentedTestOutputHelper.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Xunit.Abstractions;
 

--- a/src/Microsoft.Diagnostics.TestHelpers/MultiplexTestOutputHelper.cs
+++ b/src/Microsoft.Diagnostics.TestHelpers/MultiplexTestOutputHelper.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Xunit.Abstractions;
 

--- a/src/Microsoft.Diagnostics.TestHelpers/PrebuiltDebuggeeCompiler.cs
+++ b/src/Microsoft.Diagnostics.TestHelpers/PrebuiltDebuggeeCompiler.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.IO;
 using System.Threading.Tasks;

--- a/src/Microsoft.Diagnostics.TestHelpers/ProcessRunner.cs
+++ b/src/Microsoft.Diagnostics.TestHelpers/ProcessRunner.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.TestHelpers/SdkPrebuiltDebuggeeCompiler.cs
+++ b/src/Microsoft.Diagnostics.TestHelpers/SdkPrebuiltDebuggeeCompiler.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.IO;
 using System.Threading.Tasks;

--- a/src/Microsoft.Diagnostics.TestHelpers/TestConfiguration.cs
+++ b/src/Microsoft.Diagnostics.TestHelpers/TestConfiguration.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.TestHelpers/TestOutputProcessLogger.cs
+++ b/src/Microsoft.Diagnostics.TestHelpers/TestOutputProcessLogger.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.TestHelpers/TestRunner.cs
+++ b/src/Microsoft.Diagnostics.TestHelpers/TestRunner.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.TestHelpers/TestStep.cs
+++ b/src/Microsoft.Diagnostics.TestHelpers/TestStep.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/SOS/SOS.Extensions/AssemblyResolver.cs
+++ b/src/SOS/SOS.Extensions/AssemblyResolver.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/SOS/SOS.Extensions/ContextServiceFromDebuggerServices.cs
+++ b/src/SOS/SOS.Extensions/ContextServiceFromDebuggerServices.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.DebugServices;
 using Microsoft.Diagnostics.DebugServices.Implementation;

--- a/src/SOS/SOS.Extensions/DebuggerServices.cs
+++ b/src/SOS/SOS.Extensions/DebuggerServices.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.DebugServices;
 using Microsoft.Diagnostics.Runtime;

--- a/src/SOS/SOS.Extensions/HostServices.cs
+++ b/src/SOS/SOS.Extensions/HostServices.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.DebugServices;
 using Microsoft.Diagnostics.DebugServices.Implementation;

--- a/src/SOS/SOS.Extensions/MemoryServiceFromDebuggerServices.cs
+++ b/src/SOS/SOS.Extensions/MemoryServiceFromDebuggerServices.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.DebugServices;
 using Microsoft.Diagnostics.Runtime.Utilities;

--- a/src/SOS/SOS.Extensions/ModuleServiceFromDebuggerServices.cs
+++ b/src/SOS/SOS.Extensions/ModuleServiceFromDebuggerServices.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.DebugServices;
 using Microsoft.Diagnostics.DebugServices.Implementation;

--- a/src/SOS/SOS.Extensions/RemoteMemoryService.cs
+++ b/src/SOS/SOS.Extensions/RemoteMemoryService.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.DebugServices;
 using Microsoft.Diagnostics.Runtime;

--- a/src/SOS/SOS.Extensions/TargetFromFromDebuggerServices.cs
+++ b/src/SOS/SOS.Extensions/TargetFromFromDebuggerServices.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.DebugServices;
 using Microsoft.Diagnostics.DebugServices.Implementation;

--- a/src/SOS/SOS.Extensions/ThreadServiceFromDebuggerServices.cs
+++ b/src/SOS/SOS.Extensions/ThreadServiceFromDebuggerServices.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.DebugServices;
 using Microsoft.Diagnostics.DebugServices.Implementation;

--- a/src/SOS/SOS.Extensions/ThreadUnwindServiceFromDebuggerServices.cs
+++ b/src/SOS/SOS.Extensions/ThreadUnwindServiceFromDebuggerServices.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.DebugServices;
 

--- a/src/SOS/SOS.Hosting/ClrDebuggingProcessFlags.cs
+++ b/src/SOS/SOS.Hosting/ClrDebuggingProcessFlags.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace SOS.Hosting
 {

--- a/src/SOS/SOS.Hosting/ClrDebuggingVersion.cs
+++ b/src/SOS/SOS.Hosting/ClrDebuggingVersion.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace SOS.Hosting
 {

--- a/src/SOS/SOS.Hosting/Commands/SOSCommand.cs
+++ b/src/SOS/SOS.Hosting/Commands/SOSCommand.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.DebugServices;
 using System;

--- a/src/SOS/SOS.Hosting/CorDebugDataTargetWrapper.cs
+++ b/src/SOS/SOS.Hosting/CorDebugDataTargetWrapper.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.DebugServices;
 using Microsoft.Diagnostics.Runtime.Utilities;

--- a/src/SOS/SOS.Hosting/CorDebugPlatform.cs
+++ b/src/SOS/SOS.Hosting/CorDebugPlatform.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace SOS.Hosting
 {

--- a/src/SOS/SOS.Hosting/DataTargetWrapper.cs
+++ b/src/SOS/SOS.Hosting/DataTargetWrapper.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.DebugServices;
 using Microsoft.Diagnostics.Runtime.Interop;

--- a/src/SOS/SOS.Hosting/HostWrapper.cs
+++ b/src/SOS/SOS.Hosting/HostWrapper.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.DebugServices;
 using Microsoft.Diagnostics.Runtime.Utilities;

--- a/src/SOS/SOS.Hosting/LLDBServices.cs
+++ b/src/SOS/SOS.Hosting/LLDBServices.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.DebugServices;
 using Microsoft.Diagnostics.Runtime;

--- a/src/SOS/SOS.Hosting/RuntimeWrapper.cs
+++ b/src/SOS/SOS.Hosting/RuntimeWrapper.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.DebugServices;
 using Microsoft.Diagnostics.Runtime;

--- a/src/SOS/SOS.Hosting/SOSHost.cs
+++ b/src/SOS/SOS.Hosting/SOSHost.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.DebugServices;
 using Microsoft.Diagnostics.Runtime;

--- a/src/SOS/SOS.Hosting/SOSLibrary.cs
+++ b/src/SOS/SOS.Hosting/SOSLibrary.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.DebugServices;
 using Microsoft.Diagnostics.Runtime.Utilities;

--- a/src/SOS/SOS.Hosting/SymbolServiceExtensions.cs
+++ b/src/SOS/SOS.Hosting/SymbolServiceExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.DebugServices;
 using Microsoft.Diagnostics.Runtime.Utilities;

--- a/src/SOS/SOS.Hosting/SymbolServiceWrapper.cs
+++ b/src/SOS/SOS.Hosting/SymbolServiceWrapper.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.DebugServices;
 using Microsoft.Diagnostics.Runtime.Utilities;

--- a/src/SOS/SOS.Hosting/TargetWrapper.cs
+++ b/src/SOS/SOS.Hosting/TargetWrapper.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.DebugServices;
 using Microsoft.Diagnostics.Runtime.Utilities;

--- a/src/SOS/SOS.Hosting/dbgeng/DebugAdvanced.cs
+++ b/src/SOS/SOS.Hosting/dbgeng/DebugAdvanced.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Runtime.Interop;
 using Microsoft.Diagnostics.Runtime.Utilities;

--- a/src/SOS/SOS.Hosting/dbgeng/DebugClient.cs
+++ b/src/SOS/SOS.Hosting/dbgeng/DebugClient.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Runtime.Interop;
 using Microsoft.Diagnostics.Runtime.Utilities;

--- a/src/SOS/SOS.Hosting/dbgeng/DebugControl.cs
+++ b/src/SOS/SOS.Hosting/dbgeng/DebugControl.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Runtime.Interop;
 using Microsoft.Diagnostics.Runtime.Utilities;

--- a/src/SOS/SOS.Hosting/dbgeng/DebugDataSpaces.cs
+++ b/src/SOS/SOS.Hosting/dbgeng/DebugDataSpaces.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Runtime.Interop;
 using Microsoft.Diagnostics.Runtime.Utilities;

--- a/src/SOS/SOS.Hosting/dbgeng/DebugRegisters.cs
+++ b/src/SOS/SOS.Hosting/dbgeng/DebugRegisters.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Runtime.Interop;
 using Microsoft.Diagnostics.Runtime.Utilities;

--- a/src/SOS/SOS.Hosting/dbgeng/DebugSymbols.cs
+++ b/src/SOS/SOS.Hosting/dbgeng/DebugSymbols.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Runtime.Interop;
 using Microsoft.Diagnostics.Runtime.Utilities;

--- a/src/SOS/SOS.Hosting/dbgeng/DebugSystemObjects.cs
+++ b/src/SOS/SOS.Hosting/dbgeng/DebugSystemObjects.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Runtime.Interop;
 using Microsoft.Diagnostics.Runtime.Utilities;

--- a/src/SOS/SOS.InstallHelper/InstallHelper.cs
+++ b/src/SOS/SOS.InstallHelper/InstallHelper.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/SOS/SOS.UnitTests/Debuggees/DesktopClrHost/DesktopClrHost.cpp
+++ b/src/SOS/SOS.UnitTests/Debuggees/DesktopClrHost/DesktopClrHost.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 // Windows Header Files
 #include <windows.h>

--- a/src/SOS/SOS.UnitTests/SOS.cs
+++ b/src/SOS/SOS.UnitTests/SOS.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.TestHelpers;
 using Newtonsoft.Json;

--- a/src/SOS/SOS.UnitTests/SOSRunner.cs
+++ b/src/SOS/SOS.UnitTests/SOSRunner.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.TestHelpers;
 using System;

--- a/src/SOS/Strike/ExpressionNode.cpp
+++ b/src/SOS/Strike/ExpressionNode.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #include "ExpressionNode.h"
 

--- a/src/SOS/Strike/ExpressionNode.h
+++ b/src/SOS/Strike/ExpressionNode.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 
 #ifndef _EXPRESSION_NODE_

--- a/src/SOS/Strike/Native.rc
+++ b/src/SOS/Strike/Native.rc
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #define FX_VER_FILEDESCRIPTION_STR "Microsoft debugger extension for .NET Core\0"
 

--- a/src/SOS/Strike/UtilCode.h
+++ b/src/SOS/Strike/UtilCode.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 // ==++==
 // 

--- a/src/SOS/Strike/WatchCmd.cpp
+++ b/src/SOS/Strike/WatchCmd.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #include "WatchCmd.h"
 

--- a/src/SOS/Strike/WatchCmd.h
+++ b/src/SOS/Strike/WatchCmd.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #ifndef _WATCH_CMD_
 #define _WATCH_CMD_

--- a/src/SOS/Strike/data.h
+++ b/src/SOS/Strike/data.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 // ==++==
 // 

--- a/src/SOS/Strike/dbgengservices.cpp
+++ b/src/SOS/Strike/dbgengservices.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/SOS/Strike/dbgengservices.h
+++ b/src/SOS/Strike/dbgengservices.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #pragma once
 

--- a/src/SOS/Strike/disasm.cpp
+++ b/src/SOS/Strike/disasm.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 // ==++==
 // 

--- a/src/SOS/Strike/disasm.h
+++ b/src/SOS/Strike/disasm.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 // ==++==
 // 

--- a/src/SOS/Strike/disasmARM.cpp
+++ b/src/SOS/Strike/disasmARM.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 // ==++==
 // 

--- a/src/SOS/Strike/disasmARM64.cpp
+++ b/src/SOS/Strike/disasmARM64.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 // ==++==
 // 

--- a/src/SOS/Strike/disasmX86.cpp
+++ b/src/SOS/Strike/disasmX86.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 // ==++==
 // 

--- a/src/SOS/Strike/dllsext.cpp
+++ b/src/SOS/Strike/dllsext.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 // ==++==
 // 

--- a/src/SOS/Strike/eeheap.cpp
+++ b/src/SOS/Strike/eeheap.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 // ==++==
 //

--- a/src/SOS/Strike/exts.cpp
+++ b/src/SOS/Strike/exts.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 // ==++==
 // 

--- a/src/SOS/Strike/exts.h
+++ b/src/SOS/Strike/exts.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 // ==++==
 // 

--- a/src/SOS/Strike/gchist.cpp
+++ b/src/SOS/Strike/gchist.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 // ==++==
 // 

--- a/src/SOS/Strike/gcroot.cpp
+++ b/src/SOS/Strike/gcroot.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 // ==++==
 //

--- a/src/SOS/Strike/metadata.cpp
+++ b/src/SOS/Strike/metadata.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 // ==++==
 // 

--- a/src/SOS/Strike/ntinfo.h
+++ b/src/SOS/Strike/ntinfo.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 // ==++==
 // 

--- a/src/SOS/Strike/platform/cordebugdatatarget.h
+++ b/src/SOS/Strike/platform/cordebugdatatarget.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #ifndef __cordebugdatatarget_h__
 #define __cordebugdatatarget_h__

--- a/src/SOS/Strike/platform/datatarget.cpp
+++ b/src/SOS/Strike/platform/datatarget.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #include "sos.h"
 #include "datatarget.h"

--- a/src/SOS/Strike/platform/datatarget.h
+++ b/src/SOS/Strike/platform/datatarget.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 class DataTarget : public ICLRDataTarget2, ICorDebugDataTarget4, ICLRMetadataLocator, ICLRRuntimeLocator
 {

--- a/src/SOS/Strike/platform/hostimpl.cpp
+++ b/src/SOS/Strike/platform/hostimpl.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #include "strike.h"
 #include "util.h"

--- a/src/SOS/Strike/platform/hostimpl.h
+++ b/src/SOS/Strike/platform/hostimpl.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #pragma once
 

--- a/src/SOS/Strike/platform/runtimeimpl.cpp
+++ b/src/SOS/Strike/platform/runtimeimpl.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #include "strike.h"
 #include "util.h"

--- a/src/SOS/Strike/platform/runtimeimpl.h
+++ b/src/SOS/Strike/platform/runtimeimpl.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #pragma once
 

--- a/src/SOS/Strike/platform/targetimpl.cpp
+++ b/src/SOS/Strike/platform/targetimpl.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #include "strike.h"
 #include "util.h"

--- a/src/SOS/Strike/platform/targetimpl.h
+++ b/src/SOS/Strike/platform/targetimpl.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #pragma once
 

--- a/src/SOS/Strike/platformspecific.h
+++ b/src/SOS/Strike/platformspecific.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 // ==++==
 // 

--- a/src/SOS/Strike/sigparser.cpp
+++ b/src/SOS/Strike/sigparser.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #ifndef FEATURE_PAL
 #include <tchar.h>

--- a/src/SOS/Strike/sigparser.h
+++ b/src/SOS/Strike/sigparser.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 // sigparser.h
 //

--- a/src/SOS/Strike/sildasm.cpp
+++ b/src/SOS/Strike/sildasm.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 // ==++==
 // 

--- a/src/SOS/Strike/sildasm.h
+++ b/src/SOS/Strike/sildasm.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 // ==++==
 // 

--- a/src/SOS/Strike/sos.cpp
+++ b/src/SOS/Strike/sos.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #include "strike.h"
 #include "util.h"

--- a/src/SOS/Strike/sos.def
+++ b/src/SOS/Strike/sos.def
@@ -1,6 +1,6 @@
 ; Licensed to the .NET Foundation under one or more agreements.
 ; The .NET Foundation licenses this file to you under the MIT license.
-; See the LICENSE file in the project root for more information.
+;
 ;
 LIBRARY STRIKE
 EXPORTS

--- a/src/SOS/Strike/sos.h
+++ b/src/SOS/Strike/sos.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #pragma once
 

--- a/src/SOS/Strike/sos_md.h
+++ b/src/SOS/Strike/sos_md.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 // ==++==
 // 

--- a/src/SOS/Strike/sos_stacktrace.h
+++ b/src/SOS/Strike/sos_stacktrace.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 // ==++==
 //

--- a/src/SOS/Strike/sos_unixexports.src
+++ b/src/SOS/Strike/sos_unixexports.src
@@ -1,6 +1,6 @@
 ; Licensed to the .NET Foundation under one or more agreements.
 ; The .NET Foundation licenses this file to you under the MIT license.
-; See the LICENSE file in the project root for more information.
+;
 
 bpmd
 clrmodules

--- a/src/SOS/Strike/stressLogDump.cpp
+++ b/src/SOS/Strike/stressLogDump.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 // ==++==
 // 

--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 // ==++==
 //

--- a/src/SOS/Strike/strike.h
+++ b/src/SOS/Strike/strike.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 // ==++==
 // 

--- a/src/SOS/Strike/symbols.cpp
+++ b/src/SOS/Strike/symbols.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #include "sos.h"
 #include "disasm.h"

--- a/src/SOS/Strike/symbols.h
+++ b/src/SOS/Strike/symbols.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #pragma once
 

--- a/src/SOS/Strike/util.cpp
+++ b/src/SOS/Strike/util.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 // ==++==
 // 

--- a/src/SOS/Strike/util.h
+++ b/src/SOS/Strike/util.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #ifndef __util_h__
 #define __util_h__

--- a/src/SOS/Strike/vm.cpp
+++ b/src/SOS/Strike/vm.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 // ==++==
 // 

--- a/src/SOS/Strike/xplat/dbgeng.h
+++ b/src/SOS/Strike/xplat/dbgeng.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 //----------------------------------------------------------------------------
 //

--- a/src/SOS/Strike/xplat/dbghelp.h
+++ b/src/SOS/Strike/xplat/dbghelp.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*
 

--- a/src/SOS/Strike/xplat/wdbgexts.h
+++ b/src/SOS/Strike/xplat/wdbgexts.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/SOS/dbgutil/dbgutil.cpp
+++ b/src/SOS/dbgutil/dbgutil.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //*****************************************************************************
 // dbgutil.cpp
 //

--- a/src/SOS/dbgutil/elfreader.cpp
+++ b/src/SOS/dbgutil/elfreader.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #include <windows.h>
 #define __STDC_FORMAT_MACROS

--- a/src/SOS/dbgutil/elfreader.h
+++ b/src/SOS/dbgutil/elfreader.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #include <elf.h>
 #ifdef HOST_UNIX

--- a/src/SOS/debugshim/debugshim.cpp
+++ b/src/SOS/debugshim/debugshim.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //*****************************************************************************
 // debugshim.cpp
 // 

--- a/src/SOS/debugshim/debugshim.h
+++ b/src/SOS/debugshim/debugshim.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //*****************************************************************************
 // debugshim.h
 // 

--- a/src/SOS/extensions/extensions.cpp
+++ b/src/SOS/extensions/extensions.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #include <windows.h>
 #include <psapi.h>

--- a/src/SOS/extensions/extensions.h
+++ b/src/SOS/extensions/extensions.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #pragma once
 

--- a/src/SOS/extensions/hostcoreclr.cpp
+++ b/src/SOS/extensions/hostcoreclr.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #include <config.h>
 #include <windows.h>

--- a/src/SOS/extensions/hostdesktop.cpp
+++ b/src/SOS/extensions/hostdesktop.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 // Windows Header Files
 #include <windows.h>

--- a/src/SOS/gcdump/gcdump.cpp
+++ b/src/SOS/gcdump/gcdump.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 /*****************************************************************************
  *                                  GCDump.cpp
  *

--- a/src/SOS/gcdump/gcdumpnonx86.cpp
+++ b/src/SOS/gcdump/gcdumpnonx86.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 /*****************************************************************************
  *                               GCDumpNonX86.cpp
  */

--- a/src/SOS/gcdump/gcinfodecoder.cpp
+++ b/src/SOS/gcdump/gcinfodecoder.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #include "gcinfodecoder.h"
 

--- a/src/SOS/gcdump/gcinfodumper.cpp
+++ b/src/SOS/gcdump/gcinfodumper.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #include "gcinfodumper.h"
 #include "gcinfodecoder.h"

--- a/src/SOS/gcdump/i386/gcdumpx86.cpp
+++ b/src/SOS/gcdump/i386/gcdumpx86.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 /*****************************************************************************
  *                               GCDumpX86.cpp
  */

--- a/src/SOS/inc/debuggerservices.h
+++ b/src/SOS/inc/debuggerservices.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #pragma once
 

--- a/src/SOS/inc/host.h
+++ b/src/SOS/inc/host.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #pragma once
 

--- a/src/SOS/inc/hostservices.h
+++ b/src/SOS/inc/hostservices.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #pragma once
 

--- a/src/SOS/inc/lldbservices.h
+++ b/src/SOS/inc/lldbservices.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 //----------------------------------------------------------------------------
 //

--- a/src/SOS/inc/remotememoryservice.h
+++ b/src/SOS/inc/remotememoryservice.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #pragma once
 

--- a/src/SOS/inc/runtime.h
+++ b/src/SOS/inc/runtime.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #pragma once
 

--- a/src/SOS/inc/symbolservice.h
+++ b/src/SOS/inc/symbolservice.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #pragma once
 

--- a/src/SOS/inc/target.h
+++ b/src/SOS/inc/target.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #pragma once
 

--- a/src/SOS/lldbplugin.tests/TestDebuggee/Test.cs
+++ b/src/SOS/lldbplugin.tests/TestDebuggee/Test.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/SOS/lldbplugin.tests/t_cmd_bpmd_clear.py
+++ b/src/SOS/lldbplugin.tests/t_cmd_bpmd_clear.py
@@ -1,6 +1,6 @@
 # Licensed to the .NET Foundation under one or more agreements.
 # The .NET Foundation licenses this file to you under the MIT license.
-# See the LICENSE file in the project root for more information.
+#
 
 import lldb
 import re

--- a/src/SOS/lldbplugin.tests/t_cmd_bpmd_clearall.py
+++ b/src/SOS/lldbplugin.tests/t_cmd_bpmd_clearall.py
@@ -1,6 +1,6 @@
 # Licensed to the .NET Foundation under one or more agreements.
 # The .NET Foundation licenses this file to you under the MIT license.
-# See the LICENSE file in the project root for more information.
+#
 
 import lldb
 import re

--- a/src/SOS/lldbplugin.tests/t_cmd_bpmd_methoddesc.py
+++ b/src/SOS/lldbplugin.tests/t_cmd_bpmd_methoddesc.py
@@ -1,6 +1,6 @@
 # Licensed to the .NET Foundation under one or more agreements.
 # The .NET Foundation licenses this file to you under the MIT license.
-# See the LICENSE file in the project root for more information.
+#
 
 import lldb
 import re

--- a/src/SOS/lldbplugin.tests/t_cmd_bpmd_module_function.py
+++ b/src/SOS/lldbplugin.tests/t_cmd_bpmd_module_function.py
@@ -1,6 +1,6 @@
 # Licensed to the .NET Foundation under one or more agreements.
 # The .NET Foundation licenses this file to you under the MIT license.
-# See the LICENSE file in the project root for more information.
+#
 
 import lldb
 import re

--- a/src/SOS/lldbplugin.tests/t_cmd_bpmd_module_function_iloffset.py
+++ b/src/SOS/lldbplugin.tests/t_cmd_bpmd_module_function_iloffset.py
@@ -1,6 +1,6 @@
 # Licensed to the .NET Foundation under one or more agreements.
 # The .NET Foundation licenses this file to you under the MIT license.
-# See the LICENSE file in the project root for more information.
+#
 
 import lldb
 import re

--- a/src/SOS/lldbplugin.tests/t_cmd_bpmd_nofuturemodule_module_function.py
+++ b/src/SOS/lldbplugin.tests/t_cmd_bpmd_nofuturemodule_module_function.py
@@ -1,6 +1,6 @@
 # Licensed to the .NET Foundation under one or more agreements.
 # The .NET Foundation licenses this file to you under the MIT license.
-# See the LICENSE file in the project root for more information.
+#
 
 import lldb
 import re

--- a/src/SOS/lldbplugin.tests/t_cmd_clrstack.py
+++ b/src/SOS/lldbplugin.tests/t_cmd_clrstack.py
@@ -1,6 +1,6 @@
 # Licensed to the .NET Foundation under one or more agreements.
 # The .NET Foundation licenses this file to you under the MIT license.
-# See the LICENSE file in the project root for more information.
+#
 
 import lldb
 import re

--- a/src/SOS/lldbplugin.tests/t_cmd_clrthreads.py
+++ b/src/SOS/lldbplugin.tests/t_cmd_clrthreads.py
@@ -1,6 +1,6 @@
 # Licensed to the .NET Foundation under one or more agreements.
 # The .NET Foundation licenses this file to you under the MIT license.
-# See the LICENSE file in the project root for more information.
+#
 
 import lldb
 import re

--- a/src/SOS/lldbplugin.tests/t_cmd_clru.py
+++ b/src/SOS/lldbplugin.tests/t_cmd_clru.py
@@ -1,6 +1,6 @@
 # Licensed to the .NET Foundation under one or more agreements.
 # The .NET Foundation licenses this file to you under the MIT license.
-# See the LICENSE file in the project root for more information.
+#
 
 import lldb
 import re

--- a/src/SOS/lldbplugin.tests/t_cmd_dso.py
+++ b/src/SOS/lldbplugin.tests/t_cmd_dso.py
@@ -1,6 +1,6 @@
 # Licensed to the .NET Foundation under one or more agreements.
 # The .NET Foundation licenses this file to you under the MIT license.
-# See the LICENSE file in the project root for more information.
+#
 
 import lldb
 import re

--- a/src/SOS/lldbplugin.tests/t_cmd_dumpclass.py
+++ b/src/SOS/lldbplugin.tests/t_cmd_dumpclass.py
@@ -1,6 +1,6 @@
 # Licensed to the .NET Foundation under one or more agreements.
 # The .NET Foundation licenses this file to you under the MIT license.
-# See the LICENSE file in the project root for more information.
+#
 
 import lldb
 import re

--- a/src/SOS/lldbplugin.tests/t_cmd_dumpheap.py
+++ b/src/SOS/lldbplugin.tests/t_cmd_dumpheap.py
@@ -1,6 +1,6 @@
 # Licensed to the .NET Foundation under one or more agreements.
 # The .NET Foundation licenses this file to you under the MIT license.
-# See the LICENSE file in the project root for more information.
+#
 
 import lldb
 import re

--- a/src/SOS/lldbplugin.tests/t_cmd_dumpil.py
+++ b/src/SOS/lldbplugin.tests/t_cmd_dumpil.py
@@ -1,6 +1,6 @@
 # Licensed to the .NET Foundation under one or more agreements.
 # The .NET Foundation licenses this file to you under the MIT license.
-# See the LICENSE file in the project root for more information.
+#
 
 import lldb
 import re

--- a/src/SOS/lldbplugin.tests/t_cmd_dumplog.py
+++ b/src/SOS/lldbplugin.tests/t_cmd_dumplog.py
@@ -1,6 +1,6 @@
 # Licensed to the .NET Foundation under one or more agreements.
 # The .NET Foundation licenses this file to you under the MIT license.
-# See the LICENSE file in the project root for more information.
+#
 
 import lldb
 import re

--- a/src/SOS/lldbplugin.tests/t_cmd_dumpmd.py
+++ b/src/SOS/lldbplugin.tests/t_cmd_dumpmd.py
@@ -1,6 +1,6 @@
 # Licensed to the .NET Foundation under one or more agreements.
 # The .NET Foundation licenses this file to you under the MIT license.
-# See the LICENSE file in the project root for more information.
+#
 
 import lldb
 import re

--- a/src/SOS/lldbplugin.tests/t_cmd_dumpmodule.py
+++ b/src/SOS/lldbplugin.tests/t_cmd_dumpmodule.py
@@ -1,6 +1,6 @@
 # Licensed to the .NET Foundation under one or more agreements.
 # The .NET Foundation licenses this file to you under the MIT license.
-# See the LICENSE file in the project root for more information.
+#
 
 import lldb
 import re

--- a/src/SOS/lldbplugin.tests/t_cmd_dumpmt.py
+++ b/src/SOS/lldbplugin.tests/t_cmd_dumpmt.py
@@ -1,6 +1,6 @@
 # Licensed to the .NET Foundation under one or more agreements.
 # The .NET Foundation licenses this file to you under the MIT license.
-# See the LICENSE file in the project root for more information.
+#
 
 import lldb
 import re

--- a/src/SOS/lldbplugin.tests/t_cmd_dumpobj.py
+++ b/src/SOS/lldbplugin.tests/t_cmd_dumpobj.py
@@ -1,6 +1,6 @@
 # Licensed to the .NET Foundation under one or more agreements.
 # The .NET Foundation licenses this file to you under the MIT license.
-# See the LICENSE file in the project root for more information.
+#
 
 import lldb
 import re

--- a/src/SOS/lldbplugin.tests/t_cmd_dumpstack.py
+++ b/src/SOS/lldbplugin.tests/t_cmd_dumpstack.py
@@ -1,6 +1,6 @@
 # Licensed to the .NET Foundation under one or more agreements.
 # The .NET Foundation licenses this file to you under the MIT license.
-# See the LICENSE file in the project root for more information.
+#
 
 import lldb
 import re

--- a/src/SOS/lldbplugin.tests/t_cmd_eeheap.py
+++ b/src/SOS/lldbplugin.tests/t_cmd_eeheap.py
@@ -1,6 +1,6 @@
 # Licensed to the .NET Foundation under one or more agreements.
 # The .NET Foundation licenses this file to you under the MIT license.
-# See the LICENSE file in the project root for more information.
+#
 
 import lldb
 import re

--- a/src/SOS/lldbplugin.tests/t_cmd_eestack.py
+++ b/src/SOS/lldbplugin.tests/t_cmd_eestack.py
@@ -1,6 +1,6 @@
 # Licensed to the .NET Foundation under one or more agreements.
 # The .NET Foundation licenses this file to you under the MIT license.
-# See the LICENSE file in the project root for more information.
+#
 
 import lldb
 import re

--- a/src/SOS/lldbplugin.tests/t_cmd_gcroot.py
+++ b/src/SOS/lldbplugin.tests/t_cmd_gcroot.py
@@ -1,6 +1,6 @@
 # Licensed to the .NET Foundation under one or more agreements.
 # The .NET Foundation licenses this file to you under the MIT license.
-# See the LICENSE file in the project root for more information.
+#
 
 import lldb
 import re

--- a/src/SOS/lldbplugin.tests/t_cmd_histclear.py
+++ b/src/SOS/lldbplugin.tests/t_cmd_histclear.py
@@ -1,6 +1,6 @@
 # Licensed to the .NET Foundation under one or more agreements.
 # The .NET Foundation licenses this file to you under the MIT license.
-# See the LICENSE file in the project root for more information.
+#
 
 import lldb
 import re

--- a/src/SOS/lldbplugin.tests/t_cmd_histinit.py
+++ b/src/SOS/lldbplugin.tests/t_cmd_histinit.py
@@ -1,6 +1,6 @@
 # Licensed to the .NET Foundation under one or more agreements.
 # The .NET Foundation licenses this file to you under the MIT license.
-# See the LICENSE file in the project root for more information.
+#
 
 import lldb
 import re

--- a/src/SOS/lldbplugin.tests/t_cmd_histobj.py
+++ b/src/SOS/lldbplugin.tests/t_cmd_histobj.py
@@ -1,6 +1,6 @@
 # Licensed to the .NET Foundation under one or more agreements.
 # The .NET Foundation licenses this file to you under the MIT license.
-# See the LICENSE file in the project root for more information.
+#
 
 import lldb
 import re

--- a/src/SOS/lldbplugin.tests/t_cmd_histobjfind.py
+++ b/src/SOS/lldbplugin.tests/t_cmd_histobjfind.py
@@ -1,6 +1,6 @@
 # Licensed to the .NET Foundation under one or more agreements.
 # The .NET Foundation licenses this file to you under the MIT license.
-# See the LICENSE file in the project root for more information.
+#
 
 import lldb
 import re

--- a/src/SOS/lldbplugin.tests/t_cmd_histroot.py
+++ b/src/SOS/lldbplugin.tests/t_cmd_histroot.py
@@ -1,6 +1,6 @@
 # Licensed to the .NET Foundation under one or more agreements.
 # The .NET Foundation licenses this file to you under the MIT license.
-# See the LICENSE file in the project root for more information.
+#
 
 import lldb
 import re

--- a/src/SOS/lldbplugin.tests/t_cmd_ip2md.py
+++ b/src/SOS/lldbplugin.tests/t_cmd_ip2md.py
@@ -1,6 +1,6 @@
 # Licensed to the .NET Foundation under one or more agreements.
 # The .NET Foundation licenses this file to you under the MIT license.
-# See the LICENSE file in the project root for more information.
+#
 
 import lldb
 import re

--- a/src/SOS/lldbplugin.tests/t_cmd_name2ee.py
+++ b/src/SOS/lldbplugin.tests/t_cmd_name2ee.py
@@ -1,6 +1,6 @@
 # Licensed to the .NET Foundation under one or more agreements.
 # The .NET Foundation licenses this file to you under the MIT license.
-# See the LICENSE file in the project root for more information.
+#
 
 import lldb
 import re

--- a/src/SOS/lldbplugin.tests/test_libsosplugin.py
+++ b/src/SOS/lldbplugin.tests/test_libsosplugin.py
@@ -1,6 +1,6 @@
 # Licensed to the .NET Foundation under one or more agreements.
 # The .NET Foundation licenses this file to you under the MIT license.
-# See the LICENSE file in the project root for more information.
+#
 
 from __future__ import print_function
 import unittest

--- a/src/SOS/lldbplugin.tests/testutils.py
+++ b/src/SOS/lldbplugin.tests/testutils.py
@@ -1,6 +1,6 @@
 # Licensed to the .NET Foundation under one or more agreements.
 # The .NET Foundation licenses this file to you under the MIT license.
-# See the LICENSE file in the project root for more information.
+#
 
 from __future__ import print_function
 import lldb

--- a/src/SOS/lldbplugin/mstypes.h
+++ b/src/SOS/lldbplugin/mstypes.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 // Contains some definitions duplicated from pal.h, palrt.h, rpc.h, 
 // etc. because they have various conflicits with the linux standard

--- a/src/SOS/lldbplugin/services.cpp
+++ b/src/SOS/lldbplugin/services.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #include <cstdarg>
 #include <cstdlib>

--- a/src/SOS/lldbplugin/services.h
+++ b/src/SOS/lldbplugin/services.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #include <cstdarg>
 #include <string>

--- a/src/SOS/lldbplugin/sethostruntimecommand.cpp
+++ b/src/SOS/lldbplugin/sethostruntimecommand.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #include "sosplugin.h"
 #include <dlfcn.h>

--- a/src/SOS/lldbplugin/setsostidcommand.cpp
+++ b/src/SOS/lldbplugin/setsostidcommand.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #include "sosplugin.h"
 #include <dlfcn.h>

--- a/src/SOS/lldbplugin/soscommand.cpp
+++ b/src/SOS/lldbplugin/soscommand.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #include "sosplugin.h"
 #include <dlfcn.h>

--- a/src/SOS/lldbplugin/sosplugin.cpp
+++ b/src/SOS/lldbplugin/sosplugin.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #include "sosplugin.h"
 

--- a/src/SOS/lldbplugin/sosplugin.h
+++ b/src/SOS/lldbplugin/sosplugin.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #pragma once
 

--- a/src/Tools/Common/CommandExtensions.cs
+++ b/src/Tools/Common/CommandExtensions.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.CommandLine;
 using System.CommandLine.Invocation;

--- a/src/Tools/Common/Commands/ProcessStatus.cs
+++ b/src/Tools/Common/Commands/ProcessStatus.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.NETCore.Client;
 using System;

--- a/src/Tools/Common/Commands/Utils.cs
+++ b/src/Tools/Common/Commands/Utils.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Tools/Common/ReversedServerHelpers/ReversedServerHelpers.cs
+++ b/src/Tools/Common/ReversedServerHelpers/ReversedServerHelpers.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.NETCore.Client;
 using System;

--- a/src/Tools/dotnet-counters/CounterMonitor.cs
+++ b/src/Tools/dotnet-counters/CounterMonitor.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.NETCore.Client;
 using Microsoft.Diagnostics.Tools.Counters.Exporters;

--- a/src/Tools/dotnet-counters/CounterPayload.cs
+++ b/src/Tools/dotnet-counters/CounterPayload.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Tools/dotnet-counters/CounterProvider.cs
+++ b/src/Tools/dotnet-counters/CounterProvider.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Tools/dotnet-counters/CounterSet.cs
+++ b/src/Tools/dotnet-counters/CounterSet.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Tools/dotnet-counters/Exporters/CSVExporter.cs
+++ b/src/Tools/dotnet-counters/Exporters/CSVExporter.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Globalization;

--- a/src/Tools/dotnet-counters/Exporters/ConsoleWriter.cs
+++ b/src/Tools/dotnet-counters/Exporters/ConsoleWriter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Tools/dotnet-counters/Exporters/ICounterRenderer.cs
+++ b/src/Tools/dotnet-counters/Exporters/ICounterRenderer.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Tools.Counters.Exporters
 {

--- a/src/Tools/dotnet-counters/Exporters/JSONExporter.cs
+++ b/src/Tools/dotnet-counters/Exporters/JSONExporter.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Globalization;

--- a/src/Tools/dotnet-counters/KnownData.cs
+++ b/src/Tools/dotnet-counters/KnownData.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Tools/dotnet-counters/Program.cs
+++ b/src/Tools/dotnet-counters/Program.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Internal.Common.Commands;
 using Microsoft.Internal.Common.Utils;

--- a/src/Tools/dotnet-dsrouter/DiagnosticsServerRouterCommands.cs
+++ b/src/Tools/dotnet-dsrouter/DiagnosticsServerRouterCommands.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.NETCore.Client;
 using Microsoft.Internal.Common.Utils;

--- a/src/Tools/dotnet-dsrouter/Program.cs
+++ b/src/Tools/dotnet-dsrouter/Program.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Text;

--- a/src/Tools/dotnet-dump/Analyzer.cs
+++ b/src/Tools/dotnet-dump/Analyzer.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.ExtensionCommands;
 using Microsoft.Diagnostics.DebugServices;

--- a/src/Tools/dotnet-dump/Commands/ReadMemoryCommand.cs
+++ b/src/Tools/dotnet-dump/Commands/ReadMemoryCommand.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.DebugServices;
 using System;

--- a/src/Tools/dotnet-dump/Dumper.Windows.cs
+++ b/src/Tools/dotnet-dump/Dumper.Windows.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Win32.SafeHandles;
 using System;

--- a/src/Tools/dotnet-dump/Dumper.cs
+++ b/src/Tools/dotnet-dump/Dumper.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.NETCore.Client;
 using Microsoft.Internal.Common.Utils;

--- a/src/Tools/dotnet-dump/Program.cs
+++ b/src/Tools/dotnet-dump/Program.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Internal.Common.Commands;
 using Microsoft.Tools.Common;

--- a/src/Tools/dotnet-gcdump/CommandLine/CollectCommandHandler.cs
+++ b/src/Tools/dotnet-gcdump/CommandLine/CollectCommandHandler.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Tools.Common;
 using Microsoft.Internal.Common.Utils;

--- a/src/Tools/dotnet-gcdump/DotNetHeapDump/EventPipeDotNetHeapDumper.cs
+++ b/src/Tools/dotnet-gcdump/DotNetHeapDump/EventPipeDotNetHeapDumper.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Graphs;
 using Microsoft.Diagnostics.NETCore.Client;

--- a/src/Tools/dotnet-gcdump/Program.cs
+++ b/src/Tools/dotnet-gcdump/Program.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Internal.Common.Commands;
 using System.CommandLine.Builder;

--- a/src/Tools/dotnet-sos/Program.cs
+++ b/src/Tools/dotnet-sos/Program.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Tools.Common;
 using SOS;

--- a/src/Tools/dotnet-stack/Program.cs
+++ b/src/Tools/dotnet-stack/Program.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Internal.Common.Commands;
 using System.CommandLine.Builder;

--- a/src/Tools/dotnet-stack/ReportCommand.cs
+++ b/src/Tools/dotnet-stack/ReportCommand.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Tools/dotnet-stack/Symbolicate.cs
+++ b/src/Tools/dotnet-stack/Symbolicate.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Tools.Common;
 using System;

--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.NETCore.Client;
 using Microsoft.Internal.Common.Utils;

--- a/src/Tools/dotnet-trace/CommandLine/Commands/ConvertCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/ConvertCommand.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Tools.Common;
 using System;

--- a/src/Tools/dotnet-trace/CommandLine/Commands/ErrorCode.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/ErrorCode.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Tools.Trace
 {

--- a/src/Tools/dotnet-trace/CommandLine/Commands/ListProfilesCommandHandler.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/ListProfilesCommandHandler.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.NETCore.Client;
 using Microsoft.Diagnostics.Tracing.Parsers;

--- a/src/Tools/dotnet-trace/CommandLine/Options/CommonOptions.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Options/CommonOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.CommandLine;
 

--- a/src/Tools/dotnet-trace/Extensions.cs
+++ b/src/Tools/dotnet-trace/Extensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.NETCore.Client;
 using System;

--- a/src/Tools/dotnet-trace/Profile.cs
+++ b/src/Tools/dotnet-trace/Profile.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.NETCore.Client;
 using System.Collections.Generic;

--- a/src/Tools/dotnet-trace/Program.cs
+++ b/src/Tools/dotnet-trace/Program.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Internal.Common.Commands;
 using Microsoft.Internal.Common.Utils;

--- a/src/Tools/dotnet-trace/TraceFileFormatConverter.cs
+++ b/src/Tools/dotnet-trace/TraceFileFormatConverter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/inc/MSCOREE.IDL
+++ b/src/inc/MSCOREE.IDL
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/inc/arrayholder.h
+++ b/src/inc/arrayholder.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #ifndef __ARRAYHOLDER_H__
 #define __ARRAYHOLDER_H__

--- a/src/inc/bitvector.h
+++ b/src/inc/bitvector.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 
 /***************************************************************************/

--- a/src/inc/clr_std/algorithm
+++ b/src/inc/clr_std/algorithm
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 //
 // clr_std/algorithm

--- a/src/inc/clr_std/string
+++ b/src/inc/clr_std/string
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 //
 // clr_std/string

--- a/src/inc/clr_std/type_traits
+++ b/src/inc/clr_std/type_traits
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 //
 // clr_std/utility

--- a/src/inc/clr_std/utility
+++ b/src/inc/clr_std/utility
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 //
 // clr_std/utility

--- a/src/inc/clr_std/vector
+++ b/src/inc/clr_std/vector
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 //
 // clr_std/vector

--- a/src/inc/clrdata.idl
+++ b/src/inc/clrdata.idl
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*****************************************************************************
  **                                                                         **

--- a/src/inc/clrinternal.idl
+++ b/src/inc/clrinternal.idl
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /**************************************************************************************
  **                                                                                  **

--- a/src/inc/clrprivappxhosting.idl
+++ b/src/inc/clrprivappxhosting.idl
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 import "unknwn.idl";
 

--- a/src/inc/clrprivbinding.idl
+++ b/src/inc/clrprivbinding.idl
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 import "unknwn.idl";
 import "objidl.idl";

--- a/src/inc/clrprivhosting.idl
+++ b/src/inc/clrprivhosting.idl
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 import "unknwn.idl";
 import "CLRPrivBinding.idl";

--- a/src/inc/clrprivruntimebinders.idl
+++ b/src/inc/clrprivruntimebinders.idl
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 import "CLRPrivBinding.idl";
 

--- a/src/inc/cor.h
+++ b/src/inc/cor.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*****************************************************************************
  **                                                                         **

--- a/src/inc/cordebug.idl
+++ b/src/inc/cordebug.idl
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*****************************************************************************
  **                                                                         **

--- a/src/inc/coreclrhost.h
+++ b/src/inc/coreclrhost.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 //
 // APIs for hosting CoreCLR

--- a/src/inc/corexcep.h
+++ b/src/inc/corexcep.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*********************************************************************
  **                                                                 **

--- a/src/inc/corhdr.h
+++ b/src/inc/corhdr.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*****************************************************************************
  **                                                                         **

--- a/src/inc/corhlpr.cpp
+++ b/src/inc/corhlpr.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /****************************************************************************
  **                                                                        **

--- a/src/inc/corhlpr.h
+++ b/src/inc/corhlpr.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*****************************************************************************
  **                                                                         **

--- a/src/inc/corjitflags.h
+++ b/src/inc/corjitflags.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////
 //

--- a/src/inc/corprof.idl
+++ b/src/inc/corprof.idl
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /**************************************************************************************
  **                                                                                  **

--- a/src/inc/corpub.idl
+++ b/src/inc/corpub.idl
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /* -------------------------------------------------------------------------- *
  * Common Language Runtime Process Publishing Interfaces

--- a/src/inc/corsym.idl
+++ b/src/inc/corsym.idl
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /* ------------------------------------------------------------------------- *
  * Common Language Runtime Debugging Symbol Reader/Writer/Binder Interfaces

--- a/src/inc/cortypeinfo.h
+++ b/src/inc/cortypeinfo.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 // This describes information about the COM+ primitive types
 

--- a/src/inc/crosscomp.h
+++ b/src/inc/crosscomp.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 // crosscomp.h - cross-compilation enablement structures.
 //

--- a/src/inc/daccess.h
+++ b/src/inc/daccess.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //*****************************************************************************
 // File: daccess.h
 // 

--- a/src/inc/dacprivate.h
+++ b/src/inc/dacprivate.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //*****************************************************************************
 //
 // Internal data access functionality.

--- a/src/inc/dbgportable.h
+++ b/src/inc/dbgportable.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #ifndef __DBG_PORTABLE_INCLUDED
 #define __DBG_PORTABLE_INCLUDED

--- a/src/inc/dbgtargetcontext.h
+++ b/src/inc/dbgtargetcontext.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #ifndef __DBG_TARGET_CONTEXT_INCLUDED
 #define __DBG_TARGET_CONTEXT_INCLUDED

--- a/src/inc/dbgutil.h
+++ b/src/inc/dbgutil.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //*****************************************************************************
 // dbgutil.h
 // 

--- a/src/inc/debugmacros.h
+++ b/src/inc/debugmacros.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //*****************************************************************************
 // DebugMacros.h
 //

--- a/src/inc/debugmacrosext.h
+++ b/src/inc/debugmacrosext.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //*****************************************************************************
 // DebugMacrosExt.h
 //

--- a/src/inc/fusion.idl
+++ b/src/inc/fusion.idl
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 //+---------------------------------------------------------------------------
 //

--- a/src/inc/gcdecoder.cpp
+++ b/src/inc/gcdecoder.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/src/inc/gcdesc.h
+++ b/src/inc/gcdesc.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 //
 // GC Object Pointer Location Series Stuff

--- a/src/inc/gcdump.h
+++ b/src/inc/gcdump.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*****************************************************************************
  *                                  GCDump.h

--- a/src/inc/gcinfo.h
+++ b/src/inc/gcinfo.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 
 // ******************************************************************************

--- a/src/inc/gcinfodecoder.h
+++ b/src/inc/gcinfodecoder.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*****************************************************************
  *

--- a/src/inc/gcinfodumper.h
+++ b/src/inc/gcinfodumper.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #ifndef __GCINFODUMPER_H__
 #define __GCINFODUMPER_H__

--- a/src/inc/gcinfotypes.h
+++ b/src/inc/gcinfotypes.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 
 #ifndef __GCINFOTYPES_H__

--- a/src/inc/genericstackprobe.h
+++ b/src/inc/genericstackprobe.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/inc/hillclimbing.h
+++ b/src/inc/hillclimbing.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 //=========================================================================
 

--- a/src/inc/iallocator.h
+++ b/src/inc/iallocator.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 // We would like to allow "util" collection classes to be usable both
 // from the VM and from the JIT.  The latter case presents a

--- a/src/inc/livedatatarget.h
+++ b/src/inc/livedatatarget.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //*****************************************************************************
 //
 // Define a Data-Target for a live process.

--- a/src/inc/llvm/Dwarf.def
+++ b/src/inc/llvm/Dwarf.def
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 // ==============================================================================
 // LLVM Release License

--- a/src/inc/llvm/Dwarf.h
+++ b/src/inc/llvm/Dwarf.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 // ==============================================================================
 // LLVM Release License

--- a/src/inc/llvm/ELF.h
+++ b/src/inc/llvm/ELF.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 // ==============================================================================
 // LLVM Release License

--- a/src/inc/log.h
+++ b/src/inc/log.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 //
 // Logging Facility

--- a/src/inc/loglf.h
+++ b/src/inc/loglf.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 // The code in sos.DumpLog depends on the first 32 facility codes 
 // being bit flags sorted in incresing order.
 

--- a/src/inc/longfilepathwrappers.h
+++ b/src/inc/longfilepathwrappers.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements. 
 // The .NET Foundation licenses this file to you under the MIT license. 
-// See the LICENSE file in the project root for more information. 
+// 
 
 #ifndef _WIN_PATH_APIS_WRAPPER_
 #define _WIN_PATH_APIS_WRAPPER_

--- a/src/inc/metahost.idl
+++ b/src/inc/metahost.idl
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /**************************************************************************************
  ** Motivation for redesigning the shim APIs:                                        **

--- a/src/inc/mscorsvc.idl
+++ b/src/inc/mscorsvc.idl
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 /* -------------------------------------------------------------------------- *
  * Microsoft .NET Framework Service
  * -------------------------------------------------------------------------- */

--- a/src/inc/msodw.h
+++ b/src/inc/msodw.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 #pragma once
 
 /****************************************************************************

--- a/src/inc/new.hpp
+++ b/src/inc/new.hpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/inc/opcode.def
+++ b/src/inc/opcode.def
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*****************************************************************************
  **                                                                         **

--- a/src/inc/openum.h
+++ b/src/inc/openum.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #ifndef __openum_h__
 #define __openum_h__

--- a/src/inc/palclr.h
+++ b/src/inc/palclr.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 // ===========================================================================
 // File: palclr.h
 //

--- a/src/inc/palclr_win.h
+++ b/src/inc/palclr_win.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 // ===========================================================================
 // File: palclr.h
 //

--- a/src/inc/predeftlsslot.h
+++ b/src/inc/predeftlsslot.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 
 

--- a/src/inc/random.h
+++ b/src/inc/random.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 // random.h
 // 

--- a/src/inc/regdisp.h
+++ b/src/inc/regdisp.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #ifndef __REGDISP_H
 #define __REGDISP_H

--- a/src/inc/runtimeinfo.h
+++ b/src/inc/runtimeinfo.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #pragma once
 

--- a/src/inc/safemath.h
+++ b/src/inc/safemath.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 // ---------------------------------------------------------------------------
 // safemath.h
 //

--- a/src/inc/stacktrace.h
+++ b/src/inc/stacktrace.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //----------------------------------------------------------------------------- 
 
 //----------------------------------------------------------------------------- 

--- a/src/inc/static_assert.h
+++ b/src/inc/static_assert.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 // ---------------------------------------------------------------------------
 // static_assert.h
 //

--- a/src/inc/staticcontract.h
+++ b/src/inc/staticcontract.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 // ---------------------------------------------------------------------------
 // StaticContract.h
 // ---------------------------------------------------------------------------

--- a/src/inc/stresslog.h
+++ b/src/inc/stresslog.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 
 /*************************************************************************************/

--- a/src/inc/switches.h
+++ b/src/inc/switches.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 // switches.h switch configuration of common runtime features
 //

--- a/src/inc/tls.h
+++ b/src/inc/tls.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 // TLS.H -
 //
 

--- a/src/inc/volatile.h
+++ b/src/inc/volatile.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 // Volatile.h
 // 

--- a/src/inc/warningcontrol.h
+++ b/src/inc/warningcontrol.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 // warningcontrol.h
 //

--- a/src/inc/xclrdata.idl
+++ b/src/inc/xclrdata.idl
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 /*****************************************************************************
  **                                                                         **
  ** clrdata.idl - Common Language Runtime data access interfaces for         **

--- a/src/inc/xcordebug.idl
+++ b/src/inc/xcordebug.idl
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 /*****************************************************************************
  **                                                                         **
  ** XCordebug.idl - Experimental (undocumented) Debugging interfaces.       **

--- a/src/pal/inc/mbusafecrt.h
+++ b/src/pal/inc/mbusafecrt.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /***
 *   mbusafecrt.h - public declarations for SafeCRT lib

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/inc/pal_assert.h
+++ b/src/pal/inc/pal_assert.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/inc/pal_char16.h
+++ b/src/pal/inc/pal_char16.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/inc/pal_endian.h
+++ b/src/pal/inc/pal_endian.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/inc/pal_error.h
+++ b/src/pal/inc/pal_error.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/inc/pal_mstypes.h
+++ b/src/pal/inc/pal_mstypes.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/inc/pal_safecrt.h
+++ b/src/pal/inc/pal_safecrt.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/inc/regdef_mips64.h
+++ b/src/pal/inc/regdef_mips64.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #ifndef _REGDEF_MIPS64_H
 #define _REGDEF_MIPS64_H

--- a/src/pal/inc/rt/accctrl.h
+++ b/src/pal/inc/rt/accctrl.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/aclapi.h
+++ b/src/pal/inc/rt/aclapi.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/assert.h
+++ b/src/pal/inc/rt/assert.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/atl.h
+++ b/src/pal/inc/rt/atl.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/atlcom.h
+++ b/src/pal/inc/rt/atlcom.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/atlwin.h
+++ b/src/pal/inc/rt/atlwin.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/commctrl.h
+++ b/src/pal/inc/rt/commctrl.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/commdlg.h
+++ b/src/pal/inc/rt/commdlg.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/common.ver
+++ b/src/pal/inc/rt/common.ver
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #include "fxver.h"
 

--- a/src/pal/inc/rt/conio.h
+++ b/src/pal/inc/rt/conio.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/cpp/cstdlib
+++ b/src/pal/inc/rt/cpp/cstdlib
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 //
 // <OWNER>clrosdev</OWNER>

--- a/src/pal/inc/rt/cpp/ctype.h
+++ b/src/pal/inc/rt/cpp/ctype.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/cpp/fcntl.h
+++ b/src/pal/inc/rt/cpp/fcntl.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/cpp/float.h
+++ b/src/pal/inc/rt/cpp/float.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/cpp/io.h
+++ b/src/pal/inc/rt/cpp/io.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/cpp/limits.h
+++ b/src/pal/inc/rt/cpp/limits.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/cpp/malloc.h
+++ b/src/pal/inc/rt/cpp/malloc.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/cpp/math.h
+++ b/src/pal/inc/rt/cpp/math.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/cpp/memory.h
+++ b/src/pal/inc/rt/cpp/memory.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/cpp/stdarg.h
+++ b/src/pal/inc/rt/cpp/stdarg.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/cpp/stddef.h
+++ b/src/pal/inc/rt/cpp/stddef.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/cpp/stdint.h
+++ b/src/pal/inc/rt/cpp/stdint.h
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #include "palrt.h"

--- a/src/pal/inc/rt/cpp/stdio.h
+++ b/src/pal/inc/rt/cpp/stdio.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/cpp/stdlib.h
+++ b/src/pal/inc/rt/cpp/stdlib.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/cpp/string.h
+++ b/src/pal/inc/rt/cpp/string.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/cpp/time.h
+++ b/src/pal/inc/rt/cpp/time.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/cpp/wchar.h
+++ b/src/pal/inc/rt/cpp/wchar.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/crtdbg.h
+++ b/src/pal/inc/rt/crtdbg.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/dbghelp.h
+++ b/src/pal/inc/rt/dbghelp.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++ BUILD Version: 0000     Increment this if a change has global effects
 

--- a/src/pal/inc/rt/eh.h
+++ b/src/pal/inc/rt/eh.h
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #include "palrt.h"

--- a/src/pal/inc/rt/emmintrin.h
+++ b/src/pal/inc/rt/emmintrin.h
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #include "palrt.h"

--- a/src/pal/inc/rt/errorrep.h
+++ b/src/pal/inc/rt/errorrep.h
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #include "palrt.h"

--- a/src/pal/inc/rt/guiddef.h
+++ b/src/pal/inc/rt/guiddef.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/hstring.h
+++ b/src/pal/inc/rt/hstring.h
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #include "palrt.h"

--- a/src/pal/inc/rt/htmlhelp.h
+++ b/src/pal/inc/rt/htmlhelp.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/imagehlp.h
+++ b/src/pal/inc/rt/imagehlp.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/inc/rt/intrin.h
+++ b/src/pal/inc/rt/intrin.h
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #include "palrt.h"

--- a/src/pal/inc/rt/intsafe.h
+++ b/src/pal/inc/rt/intsafe.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /******************************************************************
 *                                                                 *

--- a/src/pal/inc/rt/mbstring.h
+++ b/src/pal/inc/rt/mbstring.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/new.h
+++ b/src/pal/inc/rt/new.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/no_sal2.h
+++ b/src/pal/inc/rt/no_sal2.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
     
 /***

--- a/src/pal/inc/rt/ntimage.h
+++ b/src/pal/inc/rt/ntimage.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/oaidl.h
+++ b/src/pal/inc/rt/oaidl.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/objbase.h
+++ b/src/pal/inc/rt/objbase.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/objidl.h
+++ b/src/pal/inc/rt/objidl.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/ocidl.h
+++ b/src/pal/inc/rt/ocidl.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/ole2.h
+++ b/src/pal/inc/rt/ole2.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/oleauto.h
+++ b/src/pal/inc/rt/oleauto.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/olectl.h
+++ b/src/pal/inc/rt/olectl.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/oleidl.h
+++ b/src/pal/inc/rt/oleidl.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/palrt.h
+++ b/src/pal/inc/rt/palrt.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/poppack.h
+++ b/src/pal/inc/rt/poppack.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/process.h
+++ b/src/pal/inc/rt/process.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/psapi.h
+++ b/src/pal/inc/rt/psapi.h
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #include "palrt.h"

--- a/src/pal/inc/rt/pshpack1.h
+++ b/src/pal/inc/rt/pshpack1.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/pshpack2.h
+++ b/src/pal/inc/rt/pshpack2.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/pshpack4.h
+++ b/src/pal/inc/rt/pshpack4.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/pshpack8.h
+++ b/src/pal/inc/rt/pshpack8.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/pshpck16.h
+++ b/src/pal/inc/rt/pshpck16.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/richedit.h
+++ b/src/pal/inc/rt/richedit.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/rpc.h
+++ b/src/pal/inc/rt/rpc.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/rpcndr.h
+++ b/src/pal/inc/rt/rpcndr.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/safecrt.h
+++ b/src/pal/inc/rt/safecrt.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/sal.h
+++ b/src/pal/inc/rt/sal.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /***
 *sal.h - markers for documenting the semantics of APIs

--- a/src/pal/inc/rt/servprov.h
+++ b/src/pal/inc/rt/servprov.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/share.h
+++ b/src/pal/inc/rt/share.h
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #include "palrt.h"

--- a/src/pal/inc/rt/shellapi.h
+++ b/src/pal/inc/rt/shellapi.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/shlobj.h
+++ b/src/pal/inc/rt/shlobj.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/shlwapi.h
+++ b/src/pal/inc/rt/shlwapi.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/specstrings.h
+++ b/src/pal/inc/rt/specstrings.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 
 //

--- a/src/pal/inc/rt/specstrings_adt.h
+++ b/src/pal/inc/rt/specstrings_adt.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 //
 

--- a/src/pal/inc/rt/specstrings_strict.h
+++ b/src/pal/inc/rt/specstrings_strict.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /************************************************************************* 
 *  This file documents all the macros approved for use in windows source

--- a/src/pal/inc/rt/specstrings_undef.h
+++ b/src/pal/inc/rt/specstrings_undef.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*
 

--- a/src/pal/inc/rt/symcrypt.h
+++ b/src/pal/inc/rt/symcrypt.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/tchar.h
+++ b/src/pal/inc/rt/tchar.h
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #include "palrt.h"

--- a/src/pal/inc/rt/tlhelp32.h
+++ b/src/pal/inc/rt/tlhelp32.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/unknwn.h
+++ b/src/pal/inc/rt/unknwn.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/urlmon.h
+++ b/src/pal/inc/rt/urlmon.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/verrsrc.h
+++ b/src/pal/inc/rt/verrsrc.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/vsassert.h
+++ b/src/pal/inc/rt/vsassert.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/winapifamily.h
+++ b/src/pal/inc/rt/winapifamily.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/winbase.h
+++ b/src/pal/inc/rt/winbase.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/wincrypt.h
+++ b/src/pal/inc/rt/wincrypt.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/windef.h
+++ b/src/pal/inc/rt/windef.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/windows.h
+++ b/src/pal/inc/rt/windows.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/winerror.h
+++ b/src/pal/inc/rt/winerror.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/wininet.h
+++ b/src/pal/inc/rt/wininet.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/winnls.h
+++ b/src/pal/inc/rt/winnls.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/winnt.h
+++ b/src/pal/inc/rt/winnt.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/winresrc.h
+++ b/src/pal/inc/rt/winresrc.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/winternl.h
+++ b/src/pal/inc/rt/winternl.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/winuser.h
+++ b/src/pal/inc/rt/winuser.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/winver.h
+++ b/src/pal/inc/rt/winver.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/wtsapi32.h
+++ b/src/pal/inc/rt/wtsapi32.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/pal/inc/rt/xmmintrin.h
+++ b/src/pal/inc/rt/xmmintrin.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 // From llvm-3.9/clang-3.9.1 xmmintrin.h:
 

--- a/src/pal/inc/strsafe.h
+++ b/src/pal/inc/strsafe.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/inc/unixasmmacros.inc
+++ b/src/pal/inc/unixasmmacros.inc
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #define INVALIDGCVALUE 0CCCCCCCDh
 

--- a/src/pal/inc/unixasmmacrosamd64.inc
+++ b/src/pal/inc/unixasmmacrosamd64.inc
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 .macro NESTED_ENTRY Name, Section, Handler
         LEAF_ENTRY \Name, \Section

--- a/src/pal/inc/unixasmmacrosarm.inc
+++ b/src/pal/inc/unixasmmacrosarm.inc
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 .macro LEAF_ENTRY Name, Section
         .thumb_func

--- a/src/pal/inc/unixasmmacrosarm64.inc
+++ b/src/pal/inc/unixasmmacrosarm64.inc
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 .macro NESTED_ENTRY Name, Section, Handler
         LEAF_ENTRY \Name, \Section

--- a/src/pal/inc/unixasmmacrosmips64.inc
+++ b/src/pal/inc/unixasmmacrosmips64.inc
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 // Copyright (c) Loongson Technology. All rights reserved.
 

--- a/src/pal/inc/unixasmmacrosx86.inc
+++ b/src/pal/inc/unixasmmacrosx86.inc
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 .macro NESTED_ENTRY Name, Section, Handler
         LEAF_ENTRY \Name, \Section

--- a/src/pal/prebuilt/idl/clrdata_i.cpp
+++ b/src/pal/prebuilt/idl/clrdata_i.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /* this ALWAYS GENERATED file contains the IIDs and CLSIDs */
 

--- a/src/pal/prebuilt/idl/clrinternal_i.cpp
+++ b/src/pal/prebuilt/idl/clrinternal_i.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 
 

--- a/src/pal/prebuilt/idl/clrprivappxhosting_i.cpp
+++ b/src/pal/prebuilt/idl/clrprivappxhosting_i.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 
 

--- a/src/pal/prebuilt/idl/clrprivbinding_i.cpp
+++ b/src/pal/prebuilt/idl/clrprivbinding_i.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 
 

--- a/src/pal/prebuilt/idl/clrprivhosting_i.cpp
+++ b/src/pal/prebuilt/idl/clrprivhosting_i.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 
 

--- a/src/pal/prebuilt/idl/clrprivruntimebinders_i.cpp
+++ b/src/pal/prebuilt/idl/clrprivruntimebinders_i.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 
 

--- a/src/pal/prebuilt/idl/corprof_i.cpp
+++ b/src/pal/prebuilt/idl/corprof_i.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /* this ALWAYS GENERATED file contains the IIDs and CLSIDs */
 

--- a/src/pal/prebuilt/idl/corpub_i.cpp
+++ b/src/pal/prebuilt/idl/corpub_i.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 
 

--- a/src/pal/prebuilt/idl/corsym_i.cpp
+++ b/src/pal/prebuilt/idl/corsym_i.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 
 

--- a/src/pal/prebuilt/idl/mscorsvc_i.cpp
+++ b/src/pal/prebuilt/idl/mscorsvc_i.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 
 

--- a/src/pal/prebuilt/idl/xclrdata_i.cpp
+++ b/src/pal/prebuilt/idl/xclrdata_i.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 
 

--- a/src/pal/prebuilt/inc/buildnumber.h
+++ b/src/pal/prebuilt/inc/buildnumber.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #define BuildNumberMajor       30319
 #define BuildNumberMinor       0

--- a/src/pal/prebuilt/inc/clrdata.h
+++ b/src/pal/prebuilt/inc/clrdata.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /* this ALWAYS GENERATED file contains the definitions for the interfaces */
 

--- a/src/pal/prebuilt/inc/clrinternal.h
+++ b/src/pal/prebuilt/inc/clrinternal.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 
 

--- a/src/pal/prebuilt/inc/clrprivbinding.h
+++ b/src/pal/prebuilt/inc/clrprivbinding.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 
 

--- a/src/pal/prebuilt/inc/clrprivhosting.h
+++ b/src/pal/prebuilt/inc/clrprivhosting.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 
 

--- a/src/pal/prebuilt/inc/clrprivruntimebinders.h
+++ b/src/pal/prebuilt/inc/clrprivruntimebinders.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 
 

--- a/src/pal/prebuilt/inc/corerror.h
+++ b/src/pal/prebuilt/inc/corerror.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #ifndef __COMMON_LANGUAGE_RUNTIME_HRESULTS__
 #define __COMMON_LANGUAGE_RUNTIME_HRESULTS__

--- a/src/pal/prebuilt/inc/corpub.h
+++ b/src/pal/prebuilt/inc/corpub.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 
 

--- a/src/pal/prebuilt/inc/corsym.h
+++ b/src/pal/prebuilt/inc/corsym.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 
 

--- a/src/pal/prebuilt/inc/fusion.h
+++ b/src/pal/prebuilt/inc/fusion.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 
 

--- a/src/pal/prebuilt/inc/fxver.h
+++ b/src/pal/prebuilt/inc/fxver.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 //
 // Insert just the #defines in winver.h, so that the

--- a/src/pal/prebuilt/inc/fxver.rc
+++ b/src/pal/prebuilt/inc/fxver.rc
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*---------------------------------------------------------------*/
 /*                                                               */

--- a/src/pal/prebuilt/inc/fxverstrings.h
+++ b/src/pal/prebuilt/inc/fxverstrings.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #ifndef VER_PRODUCTNAME_STR
         #define VER_PRODUCTNAME_STR      L"Microsoft\256 .NET Core"

--- a/src/pal/prebuilt/inc/product_version.h
+++ b/src/pal/prebuilt/inc/product_version.h
@@ -4,7 +4,7 @@
    file due to some usage of this in the build process.
    // Licensed to the .NET Foundation under one or more agreements.
    // The .NET Foundation licenses this file to you under the MIT license.
-   // See the LICENSE file in the project root for more information.
+   //
 #endif 
 
 #ifdef CLR_MAJOR_VERSION

--- a/src/pal/prebuilt/inc/xclrdata.h
+++ b/src/pal/prebuilt/inc/xclrdata.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 
 /* this ALWAYS GENERATED file contains the definitions for the interfaces */

--- a/src/pal/src/arch/amd64/asmconstants.h
+++ b/src/pal/src/arch/amd64/asmconstants.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #ifdef BIT64
 

--- a/src/pal/src/arch/amd64/context.S
+++ b/src/pal/src/arch/amd64/context.S
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #if defined(_DEBUG)
     .text

--- a/src/pal/src/arch/amd64/debugbreak.S
+++ b/src/pal/src/arch/amd64/debugbreak.S
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 .intel_syntax noprefix
 #include "unixasmmacros.inc"

--- a/src/pal/src/arch/amd64/processor.cpp
+++ b/src/pal/src/arch/amd64/processor.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/arch/arm/asmconstants.h
+++ b/src/pal/src/arch/arm/asmconstants.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #ifndef __PAL_ARM_ASMCONSTANTS_H__
 #define __PAL_ARM_ASMCONSTANTS_H__

--- a/src/pal/src/arch/arm/debugbreak.S
+++ b/src/pal/src/arch/arm/debugbreak.S
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #include "unixasmmacros.inc"
 

--- a/src/pal/src/arch/arm/processor.cpp
+++ b/src/pal/src/arch/arm/processor.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/arch/arm64/asmconstants.h
+++ b/src/pal/src/arch/arm64/asmconstants.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #ifndef __PAL_ARM64_ASMCONSTANTS_H__
 #define __PAL_ARM64_ASMCONSTANTS_H__

--- a/src/pal/src/arch/arm64/debugbreak.S
+++ b/src/pal/src/arch/arm64/debugbreak.S
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #include "unixasmmacros.inc"
 

--- a/src/pal/src/arch/arm64/processor.cpp
+++ b/src/pal/src/arch/arm64/processor.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/arch/i386/asmconstants.h
+++ b/src/pal/src/arch/i386/asmconstants.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #define CONTEXT_ContextFlags 0
 #define CONTEXT_FLOATING_POINT 8

--- a/src/pal/src/arch/i386/debugbreak.S
+++ b/src/pal/src/arch/i386/debugbreak.S
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 .intel_syntax noprefix
 #include "unixasmmacros.inc"

--- a/src/pal/src/arch/i386/processor.cpp
+++ b/src/pal/src/arch/i386/processor.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/arch/mips64/asmconstants.h
+++ b/src/pal/src/arch/mips64/asmconstants.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #ifndef __PAL_MIPS64_ASMCONSTANTS_H__
 #define __PAL_MIPS64_ASMCONSTANTS_H__

--- a/src/pal/src/arch/mips64/debugbreak.S
+++ b/src/pal/src/arch/mips64/debugbreak.S
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #include "unixasmmacros.inc"
 

--- a/src/pal/src/arch/mips64/processor.cpp
+++ b/src/pal/src/arch/mips64/processor.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/cruntime/file.cpp
+++ b/src/pal/src/cruntime/file.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/cruntime/filecrt.cpp
+++ b/src/pal/src/cruntime/filecrt.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/cruntime/lstr.cpp
+++ b/src/pal/src/cruntime/lstr.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/cruntime/malloc.cpp
+++ b/src/pal/src/cruntime/malloc.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/cruntime/math.cpp
+++ b/src/pal/src/cruntime/math.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/cruntime/mbstring.cpp
+++ b/src/pal/src/cruntime/mbstring.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/cruntime/misc.cpp
+++ b/src/pal/src/cruntime/misc.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/cruntime/misctls.cpp
+++ b/src/pal/src/cruntime/misctls.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/cruntime/path.cpp
+++ b/src/pal/src/cruntime/path.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/cruntime/printf.cpp
+++ b/src/pal/src/cruntime/printf.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/cruntime/printfcpp.cpp
+++ b/src/pal/src/cruntime/printfcpp.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/cruntime/silent_printf.cpp
+++ b/src/pal/src/cruntime/silent_printf.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/cruntime/string.cpp
+++ b/src/pal/src/cruntime/string.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/cruntime/stringtls.cpp
+++ b/src/pal/src/cruntime/stringtls.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/cruntime/wchar.cpp
+++ b/src/pal/src/cruntime/wchar.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/cruntime/wchartls.cpp
+++ b/src/pal/src/cruntime/wchartls.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/debug/debug.cpp
+++ b/src/pal/src/debug/debug.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/file/directory.cpp
+++ b/src/pal/src/file/directory.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/file/file.cpp
+++ b/src/pal/src/file/file.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/file/filetime.cpp
+++ b/src/pal/src/file/filetime.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/file/find.cpp
+++ b/src/pal/src/file/find.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/file/path.cpp
+++ b/src/pal/src/file/path.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/handlemgr/handleapi.cpp
+++ b/src/pal/src/handlemgr/handleapi.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/handlemgr/handlemgr.cpp
+++ b/src/pal/src/handlemgr/handlemgr.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/include/pal/cert.hpp
+++ b/src/pal/src/include/pal/cert.hpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/include/pal/corunix.hpp
+++ b/src/pal/src/include/pal/corunix.hpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/include/pal/corunix.inl
+++ b/src/pal/src/include/pal/corunix.inl
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/include/pal/critsect.h
+++ b/src/pal/src/include/pal/critsect.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/include/pal/cruntime.h
+++ b/src/pal/src/include/pal/cruntime.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/include/pal/cs.hpp
+++ b/src/pal/src/include/pal/cs.hpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 ///////////////////////////////////////////////////////////////////////////////
 //

--- a/src/pal/src/include/pal/dbgmsg.h
+++ b/src/pal/src/include/pal/dbgmsg.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/include/pal/debug.h
+++ b/src/pal/src/include/pal/debug.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/include/pal/dtraceprotocol.h
+++ b/src/pal/src/include/pal/dtraceprotocol.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 // File: rotor/pal/corunix/include/pal/dtrace_protocal.h
 //

--- a/src/pal/src/include/pal/environ.h
+++ b/src/pal/src/include/pal/environ.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/include/pal/event.hpp
+++ b/src/pal/src/include/pal/event.hpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/include/pal/fakepoll.h
+++ b/src/pal/src/include/pal/fakepoll.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 // fakepoll.h
 // poll using select

--- a/src/pal/src/include/pal/file.h
+++ b/src/pal/src/include/pal/file.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/include/pal/file.hpp
+++ b/src/pal/src/include/pal/file.hpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/include/pal/filetime.h
+++ b/src/pal/src/include/pal/filetime.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/include/pal/handleapi.hpp
+++ b/src/pal/src/include/pal/handleapi.hpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/include/pal/handlemgr.hpp
+++ b/src/pal/src/include/pal/handlemgr.hpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/include/pal/init.h
+++ b/src/pal/src/include/pal/init.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/include/pal/list.h
+++ b/src/pal/src/include/pal/list.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/include/pal/locale.h
+++ b/src/pal/src/include/pal/locale.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/include/pal/malloc.hpp
+++ b/src/pal/src/include/pal/malloc.hpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/include/pal/map.h
+++ b/src/pal/src/include/pal/map.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/include/pal/map.hpp
+++ b/src/pal/src/include/pal/map.hpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/include/pal/module.h
+++ b/src/pal/src/include/pal/module.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/include/pal/modulename.h
+++ b/src/pal/src/include/pal/modulename.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/include/pal/palinternal.h
+++ b/src/pal/src/include/pal/palinternal.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/include/pal/perftrace.h
+++ b/src/pal/src/include/pal/perftrace.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/include/pal/printfcpp.hpp
+++ b/src/pal/src/include/pal/printfcpp.hpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/include/pal/process.h
+++ b/src/pal/src/include/pal/process.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/include/pal/shm.hpp
+++ b/src/pal/src/include/pal/shm.hpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/include/pal/shmemory.h
+++ b/src/pal/src/include/pal/shmemory.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/include/pal/stackstring.hpp
+++ b/src/pal/src/include/pal/stackstring.hpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #ifndef __STACKSTRING_H_
 #define __STACKSTRING_H_

--- a/src/pal/src/include/pal/thread.hpp
+++ b/src/pal/src/include/pal/thread.hpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/include/pal/threadinfo.hpp
+++ b/src/pal/src/include/pal/threadinfo.hpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/include/pal/unicode_data.h
+++ b/src/pal/src/include/pal/unicode_data.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/include/pal/utf8.h
+++ b/src/pal/src/include/pal/utf8.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/include/pal/utils.h
+++ b/src/pal/src/include/pal/utils.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/include/pal/virtual.h
+++ b/src/pal/src/include/pal/virtual.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/init/pal.cpp
+++ b/src/pal/src/init/pal.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/loader/module.cpp
+++ b/src/pal/src/loader/module.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/loader/modulename.cpp
+++ b/src/pal/src/loader/modulename.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/locale/unicode.cpp
+++ b/src/pal/src/locale/unicode.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/locale/unicode_data.cpp
+++ b/src/pal/src/locale/unicode_data.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/map/common.cpp
+++ b/src/pal/src/map/common.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/map/common.h
+++ b/src/pal/src/map/common.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/map/map.cpp
+++ b/src/pal/src/map/map.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/map/virtual.cpp
+++ b/src/pal/src/map/virtual.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/memory/heap.cpp
+++ b/src/pal/src/memory/heap.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/memory/local.cpp
+++ b/src/pal/src/memory/local.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/misc/cgroup.cpp
+++ b/src/pal/src/misc/cgroup.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/misc/dbgmsg.cpp
+++ b/src/pal/src/misc/dbgmsg.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/misc/environ.cpp
+++ b/src/pal/src/misc/environ.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/misc/error.cpp
+++ b/src/pal/src/misc/error.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/misc/errorstrings.cpp
+++ b/src/pal/src/misc/errorstrings.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/misc/errorstrings.h
+++ b/src/pal/src/misc/errorstrings.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 #ifndef _ERRORSTRINGS_H_
 #define _ERRORSTRINGS_H_

--- a/src/pal/src/misc/fmtmessage.cpp
+++ b/src/pal/src/misc/fmtmessage.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/misc/miscpalapi.cpp
+++ b/src/pal/src/misc/miscpalapi.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/misc/msgbox.cpp
+++ b/src/pal/src/misc/msgbox.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/misc/strutil.cpp
+++ b/src/pal/src/misc/strutil.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/misc/sysinfo.cpp
+++ b/src/pal/src/misc/sysinfo.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/misc/utils.cpp
+++ b/src/pal/src/misc/utils.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/objmgr/palobjbase.cpp
+++ b/src/pal/src/objmgr/palobjbase.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/objmgr/palobjbase.hpp
+++ b/src/pal/src/objmgr/palobjbase.hpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/objmgr/shmobject.cpp
+++ b/src/pal/src/objmgr/shmobject.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/objmgr/shmobject.hpp
+++ b/src/pal/src/objmgr/shmobject.hpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/objmgr/shmobjectmanager.cpp
+++ b/src/pal/src/objmgr/shmobjectmanager.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/objmgr/shmobjectmanager.hpp
+++ b/src/pal/src/objmgr/shmobjectmanager.hpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/poll/fakepoll.cpp
+++ b/src/pal/src/poll/fakepoll.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 // fakepoll.h
 // poll using select

--- a/src/pal/src/safecrt/cruntime.h
+++ b/src/pal/src/safecrt/cruntime.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /***
 *cruntime.h - definitions specific to the target operating system and hardware

--- a/src/pal/src/safecrt/input.inl
+++ b/src/pal/src/safecrt/input.inl
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /***
 *input.c - C formatted input, used by scanf, etc.

--- a/src/pal/src/safecrt/internal.h
+++ b/src/pal/src/safecrt/internal.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /***
 *internal.h - contains declarations of internal routines and variables

--- a/src/pal/src/safecrt/internal_securecrt.h
+++ b/src/pal/src/safecrt/internal_securecrt.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /***
 *internal_securecrt.h - contains declarations of internal routines and variables for securecrt

--- a/src/pal/src/safecrt/makepath_s.cpp
+++ b/src/pal/src/safecrt/makepath_s.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /***
 *makepath_s.c - create path name from components

--- a/src/pal/src/safecrt/mbusafecrt.cpp
+++ b/src/pal/src/safecrt/mbusafecrt.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /***
 *   mbusafecrt.c - implementaion of support functions and data for MBUSafeCRT

--- a/src/pal/src/safecrt/mbusafecrt_internal.h
+++ b/src/pal/src/safecrt/mbusafecrt_internal.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /***
 *   mbusafecrt_internal.h - internal declarations for SafeCRT functions

--- a/src/pal/src/safecrt/memcpy_s.cpp
+++ b/src/pal/src/safecrt/memcpy_s.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /***
 *memcpy_s.c - contains memcpy_s routine

--- a/src/pal/src/safecrt/memmove_s.cpp
+++ b/src/pal/src/safecrt/memmove_s.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /***
 *memmove_s.c - contains memmove_s routine

--- a/src/pal/src/safecrt/output.inl
+++ b/src/pal/src/safecrt/output.inl
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /***
 *output.c - printf style output to a FILE

--- a/src/pal/src/safecrt/safecrt_input_s.cpp
+++ b/src/pal/src/safecrt/safecrt_input_s.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /***
 *safecrt_input_s.c - implementation of the _input family for safecrt.lib

--- a/src/pal/src/safecrt/safecrt_output_l.cpp
+++ b/src/pal/src/safecrt/safecrt_output_l.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /***
 *safecrt_output_l.c - implementation of the _output family for safercrt.lib

--- a/src/pal/src/safecrt/safecrt_output_s.cpp
+++ b/src/pal/src/safecrt/safecrt_output_s.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /***
 *safecrt_output_s.c - implementation of the _output family for safercrt.lib

--- a/src/pal/src/safecrt/safecrt_winput_s.cpp
+++ b/src/pal/src/safecrt/safecrt_winput_s.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /***
 *safecrt_winput_s.c - implementation of the _winput family for safecrt.lib

--- a/src/pal/src/safecrt/safecrt_woutput_s.cpp
+++ b/src/pal/src/safecrt/safecrt_woutput_s.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /***
 *safecrt_woutput_s.c - implementation of the _woutput family for safercrt.lib

--- a/src/pal/src/safecrt/snprintf.cpp
+++ b/src/pal/src/safecrt/snprintf.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /***
 *snprintf.c - "Count" version of sprintf

--- a/src/pal/src/safecrt/splitpath_s.cpp
+++ b/src/pal/src/safecrt/splitpath_s.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /***
 *splitpath_s.c - break down path name into components

--- a/src/pal/src/safecrt/sprintf_s.cpp
+++ b/src/pal/src/safecrt/sprintf_s.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /***
 *sprintf_s.c - print formatted to string

--- a/src/pal/src/safecrt/sscanf_s.cpp
+++ b/src/pal/src/safecrt/sscanf_s.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /***
 *sscanf_s.c - read formatted data from string

--- a/src/pal/src/safecrt/strcat_s.cpp
+++ b/src/pal/src/safecrt/strcat_s.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /***
 *strcat_s.c - contains strcat_s()

--- a/src/pal/src/safecrt/strcpy_s.cpp
+++ b/src/pal/src/safecrt/strcpy_s.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /***
 *strcpy_s.c - contains strcpy_s()

--- a/src/pal/src/safecrt/strlen_s.cpp
+++ b/src/pal/src/safecrt/strlen_s.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /***
 *strlen_s.c - contains strnlen() routine

--- a/src/pal/src/safecrt/strncat_s.cpp
+++ b/src/pal/src/safecrt/strncat_s.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /***
 *strncat_s.c - append n chars of string to new string

--- a/src/pal/src/safecrt/strncpy_s.cpp
+++ b/src/pal/src/safecrt/strncpy_s.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /***
 *strncpy_s.c - copy at most n characters of string

--- a/src/pal/src/safecrt/strtok_s.cpp
+++ b/src/pal/src/safecrt/strtok_s.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /***
 *strtok_s.c - tokenize a string with given delimiters

--- a/src/pal/src/safecrt/swprintf.cpp
+++ b/src/pal/src/safecrt/swprintf.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /***
 *swprintf.c - print formatted to string

--- a/src/pal/src/safecrt/tcscat_s.inl
+++ b/src/pal/src/safecrt/tcscat_s.inl
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /***
 *tcscat_s.inl - general implementation of _tcscpy_s

--- a/src/pal/src/safecrt/tcscpy_s.inl
+++ b/src/pal/src/safecrt/tcscpy_s.inl
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /***
 *tcscpy_s.inl - general implementation of _tcscpy_s

--- a/src/pal/src/safecrt/tcsncat_s.inl
+++ b/src/pal/src/safecrt/tcsncat_s.inl
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /***
 *tcsncat_s.inl - general implementation of _tcscpy_s

--- a/src/pal/src/safecrt/tcsncpy_s.inl
+++ b/src/pal/src/safecrt/tcsncpy_s.inl
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /***
 *tcsncpy_s.inl - general implementation of _tcsncpy_s

--- a/src/pal/src/safecrt/tcstok_s.inl
+++ b/src/pal/src/safecrt/tcstok_s.inl
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /***
 *tcstok_s.inl - general implementation of _tcstok_s

--- a/src/pal/src/safecrt/tmakepath_s.inl
+++ b/src/pal/src/safecrt/tmakepath_s.inl
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /***
 *tmakepath_s.inl - general implementation of _tmakepath_s

--- a/src/pal/src/safecrt/tsplitpath_s.inl
+++ b/src/pal/src/safecrt/tsplitpath_s.inl
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /***
 *tsplitpath_s.inl - general implementation of _tsplitpath_s

--- a/src/pal/src/safecrt/vsprintf.cpp
+++ b/src/pal/src/safecrt/vsprintf.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /***
 *vsprintf.c - print formatted data into a string from var arg list

--- a/src/pal/src/safecrt/vswprint.cpp
+++ b/src/pal/src/safecrt/vswprint.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /***
 *vswprint.c - print formatted data into a string from var arg list

--- a/src/pal/src/safecrt/wcscat_s.cpp
+++ b/src/pal/src/safecrt/wcscat_s.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /***
 *wcscat_s.c - contains wcscat_s()

--- a/src/pal/src/safecrt/wcscpy_s.cpp
+++ b/src/pal/src/safecrt/wcscpy_s.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /***
 *strcpy_s.c - contains wcscpy_s()

--- a/src/pal/src/safecrt/wcslen_s.cpp
+++ b/src/pal/src/safecrt/wcslen_s.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /***
 *wcslen_s.c - contains wcsnlen() routine

--- a/src/pal/src/safecrt/wcsncat_s.cpp
+++ b/src/pal/src/safecrt/wcsncat_s.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /***
 *wcsncat_s.c - append n chars of string to new string

--- a/src/pal/src/safecrt/wcsncpy_s.cpp
+++ b/src/pal/src/safecrt/wcsncpy_s.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /***
 *wcsncpy_s.c - copy at most n characters of wide-character string

--- a/src/pal/src/safecrt/wcstok_s.cpp
+++ b/src/pal/src/safecrt/wcstok_s.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /***
 *wcstok_s.c - tokenize a wide-character string with given delimiters

--- a/src/pal/src/safecrt/wmakepath_s.cpp
+++ b/src/pal/src/safecrt/wmakepath_s.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /***
 *wmakepath_s.c - create path name from components

--- a/src/pal/src/safecrt/wsplitpath_s.cpp
+++ b/src/pal/src/safecrt/wsplitpath_s.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /***
 *wsplitpath_s.c - break down path name into components

--- a/src/pal/src/safecrt/xtoa_s.cpp
+++ b/src/pal/src/safecrt/xtoa_s.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /***
 *strtok_s.c - tokenize a string with given delimiters

--- a/src/pal/src/safecrt/xtow_s.cpp
+++ b/src/pal/src/safecrt/xtow_s.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /***
 *strtok_s.c - tokenize a string with given delimiters

--- a/src/pal/src/safecrt/xtox_s.inl
+++ b/src/pal/src/safecrt/xtox_s.inl
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /***
 *xtoa.c - convert integers/longs to ASCII string

--- a/src/pal/src/shmemory/shmemory.cpp
+++ b/src/pal/src/shmemory/shmemory.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/pal/src/sync/cs.cpp
+++ b/src/pal/src/sync/cs.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 ///////////////////////////////////////////////////////////////////////////////
 //

--- a/src/pal/src/thread/thread.cpp
+++ b/src/pal/src/thread/thread.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 
 /*++
 

--- a/src/palrt/bstr.cpp
+++ b/src/palrt/bstr.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/palrt/coguid.cpp
+++ b/src/palrt/coguid.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/palrt/comem.cpp
+++ b/src/palrt/comem.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/palrt/common.h
+++ b/src/palrt/common.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //*****************************************************************************
 // common.h
 //

--- a/src/palrt/convert.h
+++ b/src/palrt/convert.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/palrt/guid.cpp
+++ b/src/palrt/guid.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/palrt/memorystream.cpp
+++ b/src/palrt/memorystream.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/palrt/path.cpp
+++ b/src/palrt/path.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/palrt/shlwapip.h
+++ b/src/palrt/shlwapip.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/palrt/shstr.h
+++ b/src/palrt/shstr.h
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/palrt/unicode.cpp
+++ b/src/palrt/unicode.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 #include "common.h" 

--- a/src/palrt/urlpars.cpp
+++ b/src/palrt/urlpars.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/palrt/variant.cpp
+++ b/src/palrt/variant.cpp
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+//
 //
 
 //

--- a/src/tests/EventPipeTracee/Program.cs
+++ b/src/tests/EventPipeTracee/Program.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;

--- a/src/tests/ExitCodeTracee/Program.cs
+++ b/src/tests/ExitCodeTracee/Program.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/Grape/TestRunner.cs
+++ b/src/tests/Grape/TestRunner.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/tests/Microsoft.Diagnostics.DebugServices.UnitTests/RunTests.cs
+++ b/src/tests/Microsoft.Diagnostics.DebugServices.UnitTests/RunTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.TestHelpers;
 using System;

--- a/src/tests/Microsoft.Diagnostics.DebugServices.UnitTests/ServiceEventTests.cs
+++ b/src/tests/Microsoft.Diagnostics.DebugServices.UnitTests/ServiceEventTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.DebugServices.Implementation;
 using System;

--- a/src/tests/Microsoft.Diagnostics.DebugServices.UnitTests/SymbolServiceTests.cs
+++ b/src/tests/Microsoft.Diagnostics.DebugServices.UnitTests/SymbolServiceTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.DebugServices.Implementation;
 using System;

--- a/src/tests/Microsoft.Diagnostics.DebugServices.UnitTests/WriteTestData.cs
+++ b/src/tests/Microsoft.Diagnostics.DebugServices.UnitTests/WriteTestData.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.DebugServices;
 

--- a/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/AspNetTriggerUnitTests.cs
+++ b/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/AspNetTriggerUnitTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.EventPipe.Triggers.AspNet;
 using Microsoft.Diagnostics.Monitoring.EventPipe.Triggers.Pipelines;

--- a/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventCounterConstants.cs
+++ b/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventCounterConstants.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
 {

--- a/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventCounterPipelineUnitTests.cs
+++ b/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventCounterPipelineUnitTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.NETCore.Client;
 using Microsoft.Diagnostics.NETCore.Client.UnitTests;

--- a/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventCounterTriggerTests.cs
+++ b/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventCounterTriggerTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.EventPipe.Triggers.EventCounter;
 using Microsoft.Diagnostics.Monitoring.EventPipe.Triggers.Pipelines;

--- a/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventLogsPipelineUnitTests.cs
+++ b/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventLogsPipelineUnitTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.NETCore.Client;
 using Microsoft.Diagnostics.NETCore.Client.UnitTests;

--- a/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventTracePipelineUnitTests.cs
+++ b/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventTracePipelineUnitTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/GlobMatcherTests.cs
+++ b/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/GlobMatcherTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.EventPipe.Triggers.AspNet;
 using System;

--- a/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/PipelineTestUtilities.cs
+++ b/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/PipelineTestUtilities.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.NETCore.Client.UnitTests;
 using System;

--- a/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/SlidingWindowTests.cs
+++ b/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/SlidingWindowTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring.EventPipe.Triggers;
 using Microsoft.Diagnostics.Monitoring.EventPipe.Triggers.AspNet;

--- a/src/tests/Microsoft.Diagnostics.Monitoring/PipelineTests.cs
+++ b/src/tests/Microsoft.Diagnostics.Monitoring/PipelineTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Monitoring;
 using Microsoft.Diagnostics.Tracing.Parsers.Kernel;

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/CommonHelper.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/CommonHelper.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/DiagnosticPortsHelper.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/DiagnosticPortsHelper.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.IO;
 using System.Runtime.InteropServices;

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClientApiShim.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClientApiShim.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClientApiShimExtensions.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClientApiShimExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/EventPipeProviderTests.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/EventPipeProviderTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.NETCore.Client;
 using System;

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/EventPipeSessionTests.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/EventPipeSessionTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.Tracing;
 using System;

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/GetProcessEnvironmentTests.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/GetProcessEnvironmentTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/GetProcessInfoTests.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/GetProcessInfoTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading.Tasks;

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/GetPublishedProcessesTests.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/GetPublishedProcessesTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/HandleableCollectionTests.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/HandleableCollectionTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections;

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.UnitTests.csproj
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.UnitTests.csproj
@@ -18,7 +18,6 @@
 <![CDATA[
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 
 // THIS FILE IS AUTO-GENERATED DURING BUILD.  MODIFICATIONS _WILL_ BE OVERWRITTEN!

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/RemoteTestExecution.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/RemoteTestExecution.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/ReversedServerTests.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/ReversedServerTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/TestRunner.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/TestRunner.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 
 using System;

--- a/src/tests/StackTracee/Program.cs
+++ b/src/tests/StackTracee/Program.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/Tracee/Program.cs
+++ b/src/tests/Tracee/Program.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading;

--- a/src/tests/dotnet-counters/CSVExporterTests.cs
+++ b/src/tests/dotnet-counters/CSVExporterTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/tests/dotnet-counters/CounterMonitorTests.cs
+++ b/src/tests/dotnet-counters/CounterMonitorTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/tests/dotnet-counters/JSONExporterTests.cs
+++ b/src/tests/dotnet-counters/JSONExporterTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/tests/dotnet-counters/KnownProviderTests.cs
+++ b/src/tests/dotnet-counters/KnownProviderTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Xunit;

--- a/src/tests/dotnet-stack/StackTests.cs
+++ b/src/tests/dotnet-stack/StackTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.NETCore.Client;
 using System;

--- a/src/tests/dotnet-trace/CLRProviderParsing.cs
+++ b/src/tests/dotnet-trace/CLRProviderParsing.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.NETCore.Client;
 using System;

--- a/src/tests/dotnet-trace/ChildProcessTests.cs
+++ b/src/tests/dotnet-trace/ChildProcessTests.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.NETCore.Client;
 using System;

--- a/src/tests/dotnet-trace/ProfileProviderMerging.cs
+++ b/src/tests/dotnet-trace/ProfileProviderMerging.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 using Microsoft.Diagnostics.NETCore.Client;
 using System;
 using Xunit;

--- a/src/tests/dotnet-trace/ProviderParsing.cs
+++ b/src/tests/dotnet-trace/ProviderParsing.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.NETCore.Client;
 using System;

--- a/src/tests/eventpipe/ContentionEvents.cs
+++ b/src/tests/eventpipe/ContentionEvents.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Xunit;

--- a/src/tests/eventpipe/CustomEvents.cs
+++ b/src/tests/eventpipe/CustomEvents.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Xunit;

--- a/src/tests/eventpipe/GCEvents.cs
+++ b/src/tests/eventpipe/GCEvents.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Xunit;

--- a/src/tests/eventpipe/LoaderEvents.cs
+++ b/src/tests/eventpipe/LoaderEvents.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Xunit;

--- a/src/tests/eventpipe/MethodEvents.cs
+++ b/src/tests/eventpipe/MethodEvents.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Xunit;

--- a/src/tests/eventpipe/ThreadPoolEvents.cs
+++ b/src/tests/eventpipe/ThreadPoolEvents.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Xunit;

--- a/src/tests/eventpipe/common/IpcTraceTest.cs
+++ b/src/tests/eventpipe/common/IpcTraceTest.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/tests/eventpipe/common/RemoteTestExecutorHelper.cs
+++ b/src/tests/eventpipe/common/RemoteTestExecutorHelper.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.RemoteExecutor;
 using System;

--- a/src/tests/eventpipe/common/StreamProxy.cs
+++ b/src/tests/eventpipe/common/StreamProxy.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Buffers;

--- a/src/tests/eventpipe/providers.cs
+++ b/src/tests/eventpipe/providers.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using Xunit;


### PR DESCRIPTION
License header was standardized on two-lines in the runtime repo (https://github.com/dotnet/runtime/commit/6072e4d3a7a2a1493f514cdf4be75a3d56580e84). This PR syncs the header with runtime.

Script:
```sh
if uname 2>/devnull | grep -q Darwin; then
    space=" "
fi

# delete entire line containing the unwanted license third line in C# code, which are part of the whole repo
git ls-files :/*.cs |\
    xargs grep -l "See the LICENSE file in the project root for more information." |\
    xargs sed -i$space'' '/See the LICENSE file in the project root for more information/d'

# delete part of line containing license third line in rest of the files, which are part of the whole repo
git ls-files |\
    xargs grep -l "See the LICENSE file in the project root for more information." |\
    xargs sed -i$space'' 's/ See the LICENSE file in the project root for more information.//g'

# verify
git grep "See the LICENSE file in the project root for more information."
```