### PR TITLE
Set shouldExit on the default scheduler

### DIFF
--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
@@ -276,7 +276,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
 
                             var fileInfo = new FileInfo(output.FullName);
                             Task copyTask = session.EventStream.CopyToAsync(fs);
-                            Task shouldExitTask = copyTask.ContinueWith((task) => shouldExit.Set());
+                            Task shouldExitTask = copyTask.ContinueWith((task) => shouldExit.Set(), TaskScheduler.Default);
 
                             if (printStatusOverTime)
                             {


### PR DESCRIPTION
Prevents deadlock that has been observed with `dotnet trace collect` on macOS when tracing Visual Studio for Mac.

The CopyAsync task does not finish before the blocking Wait call is done, so it deadlocks, as `CopyAsync.ContinueWith()` runs on `TaskScheduler.Current` by default.

https://gist.github.com/Therzok/bb19cd97fcb88f4dc70f157cd96b32dc