### PR TITLE
Update SOS to resolve first level byref fields

### DIFF
--- a/src/SOS/Strike/util.cpp
+++ b/src/SOS/Strike/util.cpp
@@ -373,7 +373,7 @@ static DWORD_PTR ResolveByRefField(DacpFieldDescData* pFD, DWORD_PTR dwAddr, CLR
     if (dwAddr == 0)
         return 0;
 
-    ToRelease<IMetaDataImport> pImport = MDImportForModule(pFD->ModuleOfType);
+    ToRelease<IMetaDataImport> pImport = MDImportForModule(TO_TADDR(pFD->ModuleOfType));
 
     PCCOR_SIGNATURE   pSignatureBlob = NULL;
     ULONG             sigBlobLength = 0;

--- a/src/SOS/Strike/util.h
+++ b/src/SOS/Strike/util.h
@@ -577,28 +577,29 @@ namespace Output
     * of addr.                                                             *
     *                                                                      *
     * Params:                                                              *
+    *   disp - the display address of the object                           *
     *   mt - the method table of the ValueClass                            *
     *   addr - the address of the ValueClass                               *
     *   type - the format type to use to output this object                *
     *   fill - whether or not to pad the hex value with zeros              *
     *                                                                      *
     \**********************************************************************/
-    CachedString BuildVCValue(CLRDATA_ADDRESS mt, CLRDATA_ADDRESS addr, FormatType type, bool fill = true);
-
+    CachedString BuildVCValue(CLRDATA_ADDRESS disp, CLRDATA_ADDRESS mt, CLRDATA_ADDRESS addr, FormatType type, bool fill = true);
 
     /**********************************************************************\
-    * This function builds a DML string for an object.  If DML is enabled, *
+    * This function builds a DML string with a display name.  If DML is enabled,  *
     * this function returns a DML string based on the format type.         *
     * Otherwise this returns a string containing only the hex value of     *
     * addr.                                                                *
     *                                                                      *
     * Params:                                                              *
+    *   disp - the display address of the object                           *
     *   addr - the address of the object                                   *
     *   type - the format type to use to output this object                *
     *   fill - whether or not to pad the hex value with zeros              *
     *                                                                      *
     \**********************************************************************/
-    CachedString BuildHexValue(CLRDATA_ADDRESS addr, FormatType type, bool fill = true);
+    CachedString BuildHexValue(CLRDATA_ADDRESS disp, CLRDATA_ADDRESS addr, FormatType type, bool fill = true);
 
     /**********************************************************************\
     * This function builds a DML string for an object.  If DML is enabled, *
@@ -671,25 +672,27 @@ inline void DecrementIndent()  { if (Output::g_Indent > 0) Output::g_Indent--; }
 inline void ExtOutIndent()  { WhitespaceOut(Output::g_Indent << 2); }
 
 // DML Generation Methods
-#define DMLListNearObj(addr) Output::BuildHexValue(addr, Output::DML_ListNearObj).GetPtr()
-#define DMLDumpHeapMT(addr) Output::BuildHexValue(addr, Output::DML_DumpHeapMT).GetPtr()
-#define DMLMethodTable(addr) Output::BuildHexValue(addr, Output::DML_MethodTable).GetPtr()
-#define DMLMethodDesc(addr) Output::BuildHexValue(addr, Output::DML_MethodDesc).GetPtr()
-#define DMLClass(addr) Output::BuildHexValue(addr, Output::DML_EEClass).GetPtr()
-#define DMLModule(addr) Output::BuildHexValue(addr, Output::DML_Module).GetPtr()
-#define DMLIP(ip) Output::BuildHexValue(ip, Output::DML_IP).GetPtr()
-#define DMLObject(addr) Output::BuildHexValue(addr, Output::DML_Object).GetPtr()
-#define DMLDomain(addr) Output::BuildHexValue(addr, Output::DML_Domain).GetPtr()
-#define DMLAssembly(addr) Output::BuildHexValue(addr, Output::DML_Assembly).GetPtr()
-#define DMLThreadID(id) Output::BuildHexValue(id, Output::DML_ThreadID, false).GetPtr()
-#define DMLValueClass(mt, addr) Output::BuildVCValue(mt, addr, Output::DML_ValueClass).GetPtr()
-#define DMLRCWrapper(addr) Output::BuildHexValue(addr, Output::DML_RCWrapper).GetPtr()
-#define DMLCCWrapper(addr) Output::BuildHexValue(addr, Output::DML_CCWrapper).GetPtr()
+#define DMLListNearObj(addr) Output::BuildHexValue(addr, addr, Output::DML_ListNearObj).GetPtr()
+#define DMLDumpHeapMT(addr) Output::BuildHexValue(addr, addr, Output::DML_DumpHeapMT).GetPtr()
+#define DMLMethodTable(addr) Output::BuildHexValue(addr, addr, Output::DML_MethodTable).GetPtr()
+#define DMLMethodDesc(addr) Output::BuildHexValue(addr, addr, Output::DML_MethodDesc).GetPtr()
+#define DMLClass(addr) Output::BuildHexValue(addr, addr, Output::DML_EEClass).GetPtr()
+#define DMLModule(addr) Output::BuildHexValue(addr, addr, Output::DML_Module).GetPtr()
+#define DMLIP(ip) Output::BuildHexValue(ip, ip, Output::DML_IP).GetPtr()
+#define DMLObject(addr) Output::BuildHexValue(addr, addr, Output::DML_Object).GetPtr()
+#define DMLByRefObject(byref, addr) Output::BuildHexValue(byref, addr, Output::DML_Object).GetPtr()
+#define DMLDomain(addr) Output::BuildHexValue(addr, addr, Output::DML_Domain).GetPtr()
+#define DMLAssembly(addr) Output::BuildHexValue(addr, addr, Output::DML_Assembly).GetPtr()
+#define DMLThreadID(id) Output::BuildHexValue(id, id, Output::DML_ThreadID, false).GetPtr()
+#define DMLValueClass(mt, addr) Output::BuildVCValue(addr, mt, addr, Output::DML_ValueClass).GetPtr()
+#define DMLByRefValueClass(byref, mt, addr) Output::BuildVCValue(byref, mt, addr, Output::DML_ValueClass).GetPtr()
+#define DMLRCWrapper(addr) Output::BuildHexValue(addr, addr, Output::DML_RCWrapper).GetPtr()
+#define DMLCCWrapper(addr) Output::BuildHexValue(addr, addr, Output::DML_CCWrapper).GetPtr()
 #define DMLManagedVar(expansionName,frame,simpleName) Output::BuildManagedVarValue(expansionName, frame, simpleName, Output::DML_ManagedVar).GetPtr()
-#define DMLAsync(addr) Output::BuildHexValue(addr, Output::DML_Async).GetPtr()
-#define DMLIL(addr) Output::BuildHexValue(addr, Output::DML_IL).GetPtr()
-#define DMLComWrapperRCW(addr) Output::BuildHexValue(addr, Output::DML_ComWrapperRCW).GetPtr()
-#define DMLComWrapperCCW(addr) Output::BuildHexValue(addr, Output::DML_ComWrapperCCW).GetPtr()
+#define DMLAsync(addr) Output::BuildHexValue(addr, addr, Output::DML_Async).GetPtr()
+#define DMLIL(addr) Output::BuildHexValue(addr, addr, Output::DML_IL).GetPtr()
+#define DMLComWrapperRCW(addr) Output::BuildHexValue(addr, addr, Output::DML_ComWrapperRCW).GetPtr()
+#define DMLComWrapperCCW(addr) Output::BuildHexValue(addr, addr, Output::DML_ComWrapperCCW).GetPtr()
 #define DMLTaggedMemory(addr, len) Output::BuildHexValueWithLength(addr, len, Output::DML_TaggedMemory).GetPtr()
 
 bool IsDMLEnabled();

--- a/src/inc/crosscomp.h
+++ b/src/inc/crosscomp.h
@@ -21,7 +21,10 @@
 #define ARM_MAX_BREAKPOINTS     8
 #define ARM_MAX_WATCHPOINTS     1
 
+// This is already set in winnt.h when building for Win-x86 or Win-ARM64
+#ifndef CONTEXT_UNWOUND_TO_CALL
 #define CONTEXT_UNWOUND_TO_CALL 0x20000000
+#endif
 
 typedef struct _NEON128 {
     ULONGLONG Low;
@@ -82,7 +85,7 @@ typedef struct DECLSPEC_ALIGN(8) _T_CONTEXT {
     DWORD Bcr[ARM_MAX_BREAKPOINTS];
     DWORD Wvr[ARM_MAX_WATCHPOINTS];
     DWORD Wcr[ARM_MAX_WATCHPOINTS];
-    
+
     DWORD Padding2[2];
 
 } T_CONTEXT, *PT_CONTEXT;
@@ -370,7 +373,7 @@ typedef struct _T_KNONVOLATILE_CONTEXT_POINTERS {
 #define T_RUNTIME_FUNCTION RUNTIME_FUNCTION
 #define PT_RUNTIME_FUNCTION PRUNTIME_FUNCTION
 
-#endif 
+#endif
 
 
 #ifdef CROSSGEN_COMPILE


### PR DESCRIPTION
This feature adds support for resolving byref fields via SOS. Used the [dotnet/runtime RefFields test](https://github.com/dotnet/runtime/tree/main/src/tests/Loader/classloader/RefFields) to validate. A design decision to retain the actual value was made in the display as opposed to resolving to the target and showing that in the pretty print.

There is a fair bit of whitespace change. Recommend using https://github.com/dotnet/diagnostics/pull/2829/files?diff=split&w=1 to view files.

Before:
```
0:000> !DumpVC 00007ff943c82c78 @rbp-10h
Name:        InvalidCSharp.WithRefField
MethodTable: 00007ff943c82c78
EEClass:     00007ff943c78938
Size:        24(0x18) bytes
File:        D:\runtime\artifacts\tests\coreclr\windows.x64.Release\Loader\classloader\RefFields\Validate\InvalidCSharp.dll
Fields:
              MT    Field   Offset                 Type VT     Attr            Value Name
0000000000000000  4000002        0                BYREF  0 instance 000000e9f5f7d1e8 Str
0:000> !DumpObj /d 000000e9f5f7d1e8
<Note: this object has an invalid CLASS field>
Invalid object
```

After:
```
0:000> !DumpVC 00007ff943c72c78 @rbp-10h
Name:        InvalidCSharp.WithRefField
MethodTable: 00007ff943c72c78
EEClass:     00007ff943c68938
Size:        24(0x18) bytes
File:        D:\runtime\artifacts\tests\coreclr\windows.x64.Release\Loader\classloader\RefFields\Validate\InvalidCSharp.dll
Fields:
              MT    Field   Offset                 Type VT     Attr            Value Name
0000000000000000  4000002        0                BYREF  0 instance 0000001833d7d2f8 Str
0:000> !DumpObj /d 00000177a0e73d68
Name:        System.String
MethodTable: 00007ff94393d710
EEClass:     00007ff943949050
Tracked Type: false
Size:        70(0x46) bytes
File:        D:\runtime\artifacts\tests\coreclr\windows.x64.Debug\Tests\Core_Root\System.Private.CoreLib.dll
String:      Validate_Create_RefField
Fields:
              MT    Field   Offset                 Type VT     Attr            Value Name
00007ff9438d2580  40002f7        8         System.Int32  1 instance               24 _stringLength
00007ff94388b2f8  40002f8        c          System.Char  1 instance               56 _firstChar
00007ff94393d710  40002f6       e8        System.String  0   static 00000177a0e61240 Empty
```

Contributes to https://github.com/dotnet/runtime/issues/63768