### PR TITLE
Extend diagnostics to handle tcpip diagnostics client option

### DIFF
--- a/src/Microsoft.Diagnostics.NETCore.Client/AssemblyInfo.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 #if DIAGNOSTICS_RUNTIME
+// As of https://github.com/dotnet/runtime/pull/64358, InternalsVisibleTo MSBuild Item does not seem to work in Dotnet/Runtime like it does on Dotnet/Diagnostics
 using System;
 using System.IO;
 using System.Runtime.CompilerServices;

--- a/src/Microsoft.Diagnostics.NETCore.Client/AssemblyInfo.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+#if DIAGNOSTICS_RUNTIME
+using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("common")]
+#endif

--- a/src/Microsoft.Diagnostics.NETCore.Client/BinaryWriterExtensions.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/BinaryWriterExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClientExceptions.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClientExceptions.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DumpType.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DumpType.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.NETCore.Client
 {

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/EventPipeProvider.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/EventPipeProvider.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/EventPipeSession.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/EventPipeSession.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/EventPipeSessionConfiguration.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/EventPipeSessionConfiguration.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/WriteDumpFlags.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/WriteDumpFlags.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.Diagnostics.NETCore.Client
 {

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/ExposedSocketNetworkStream.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/ExposedSocketNetworkStream.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Net.Sockets;
 

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcAdvertise.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcAdvertise.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Linq;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcClient.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcClient.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcCommands.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcCommands.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcEndpointConfig.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcEndpointConfig.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcEndpointConfig.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcEndpointConfig.cs
@@ -18,13 +18,17 @@ namespace Microsoft.Diagnostics.NETCore.Client
         public enum TransportType
         {
             NamedPipe,
-            UnixDomainSocket
+            UnixDomainSocket,
+#if DIAGNOSTICS_RUNTIME
+            TcpSocket
+#endif
         }
 
         PortType _portType;
 
         TransportType _transportType;
 
+        // For TcpSocket TransportType, the address format will be <hostname_or_ip>:<port>
         public string Address { get; }
 
         public bool IsConnectConfig => _portType == PortType.Connect;
@@ -57,6 +61,12 @@ namespace Microsoft.Diagnostics.NETCore.Client
                         throw new PlatformNotSupportedException($"{UnixDomainSocketSchema} is not supported on Windows, use {NamedPipeSchema}.");
                     break;
                 }
+#if DIAGNOSTICS_RUNTIME
+                case TransportType.TcpSocket:
+                {
+                    break;
+                }
+#endif
                 default:
                 {
                     throw new NotSupportedException($"{transportType} not supported.");

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcHeader.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcHeader.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcMessage.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcMessage.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcResponse.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcResponse.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcServerTransport.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcServerTransport.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcSocket.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcSocket.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcSocket.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcSocket.cs
@@ -23,6 +23,8 @@ namespace Microsoft.Diagnostics.NETCore.Client
         {
         }
 
+// .NET 6 implements this method directly on Socket, but for earlier runtimes we need a polyfill
+#if !NET6_0
         public async Task<Socket> AcceptAsync(CancellationToken token)
         {
             using (token.Register(() => Close(0)))
@@ -44,6 +46,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
                 }
             }
         }
+#endif
 
         public virtual void Connect(EndPoint remoteEP, TimeSpan timeout)
         {
@@ -60,6 +63,8 @@ namespace Microsoft.Diagnostics.NETCore.Client
             }
         }
 
+// .NET 6 implements this method directly on Socket, but for earlier runtimes we need a polyfill
+#if !NET6_0
         public async Task ConnectAsync(EndPoint remoteEP, CancellationToken token)
         {
             using (token.Register(() => Close(0)))
@@ -82,6 +87,6 @@ namespace Microsoft.Diagnostics.NETCore.Client
                 }
             }
         }
-
+#endif
     }
 }

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcTcpSocketEndPoint.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcTcpSocketEndPoint.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Net;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcTransport.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcTransport.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcTransport.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcTransport.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.IO;
 using System.IO.Pipes;
 using System.Linq;
+using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using System.Security.Principal;
 using System.Threading;
@@ -69,6 +70,15 @@ namespace Microsoft.Diagnostics.NETCore.Client
                 socket.Connect(new IpcUnixDomainSocketEndPoint(config.Address), timeout);
                 return new ExposedSocketNetworkStream(socket, ownsSocket: true);
             }
+#if DIAGNOSTICS_RUNTIME
+            else if (config.Transport == IpcEndpointConfig.TransportType.TcpSocket)
+            {
+                var tcpClient = new TcpClient ();
+                var endPoint = new IpcTcpSocketEndPoint(config.Address);
+                tcpClient.Connect(endPoint.EndPoint);
+                return tcpClient.GetStream();
+            }
+#endif
             else
             {
                 throw new ArgumentException($"Unsupported IpcEndpointConfig transport type {config.Transport}");

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcUnixDomainSocket.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcUnixDomainSocket.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcUnixDomainSocketEndPoint.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcUnixDomainSocketEndPoint.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/ProcessEnvironment.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/ProcessEnvironment.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/ProcessInfo.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/ProcessInfo.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Text;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsServerRouter/DiagnosticsServerRouterFactory.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsServerRouter/DiagnosticsServerRouterFactory.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsServerRouter/DiagnosticsServerRouterRunner.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsServerRouter/DiagnosticsServerRouterRunner.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Net;

--- a/src/Microsoft.Diagnostics.NETCore.Client/HandleableCollection.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/HandleableCollection.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections;

--- a/src/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj
+++ b/src/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj
@@ -13,6 +13,11 @@
     <IsShipping>true</IsShipping>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(GitHubRepositoryName)' == 'runtime'">
+    <DefineConstants>$(DefineConstants);DIAGNOSTICS_RUNTIME</DefineConstants>
+    <NoWarn>CS1591,CS8073,CS0162</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="$(MicrosoftBclAsyncInterfacesVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingVersion)" />
@@ -28,5 +33,9 @@
     <!-- Temporary until Diagnostic Apis are finalized-->
     <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.WebApi" />
     <InternalsVisibleTo Include="Microsoft.Diagnostics.NETCore.Client.UnitTests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Condition="'$(GitHubRepositoryName)' == 'runtime'" Include="**/*.cs" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Diagnostics.NETCore.Client/NativeMethods.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/NativeMethods.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/Microsoft.Diagnostics.NETCore.Client/ReversedServer/IpcEndpointInfo.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/ReversedServer/IpcEndpointInfo.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/Microsoft.Diagnostics.NETCore.Client/ReversedServer/ReversedDiagnosticsServer.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/ReversedServer/ReversedDiagnosticsServer.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Concurrent;

--- a/src/Microsoft.Diagnostics.NETCore.Client/StreamExtensions.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/StreamExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.IO;
 using System.Threading;


### PR DESCRIPTION
In effort to enable diagnostics tests for mobile (specifically Android) in https://github.com/dotnet/runtime/pull/60879, it was realized that some changes to `Microsoft.Diagnostics.NETCore.Client` are needed in order for the eventpipe runtime tests to work (bigevent, buffersize, eventsourceerror). More specifically, DiagnosticsClient needed to handle a TCPIP option. With most of the functionality brought up by @lateralusX previously, just a new transport type is needed for the tests to work (without the new transport type, exceptions are thrown because the API only expects two type of transports)

The expectation for the shared code between this repository and `Dotnet/Runtime` is that any modifications to `src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client` in `Dotnet/Runtime` must first be made here in `Dotnet/Diagnostics` and once passed, will then be downstreamed to `Dotnet/Runtime`.

This pr accomplishes the following:
1. Introduces `Dotnet/Runtime`-specific PropertyGroup and ItemGroup into `Microsoft.Diagnostics.NETCore.Client.csproj` to define `DIAGNOSTICS_RUNTIME` constant, ignore compiler warnings, and compile the source code.
2. Adds a new transport type `TcpSocket` for TCP/IP case yet wraps it under a `DIAGNOSTICS_RUNTIME` #if directive to limit modifications to this repository. Also extends `IpcTransport.Connect` with TcpClient to handle the TCP/IP transport.
3. Adds a new file `AssemblyInfo.cs` completely wrapped under the above mentioned directive in order for internals to be visible on `dotnet/runtime/src/tests/tracing/eventpipe/common/`.
4. Wraps `IpcSocket.AcceptAsync` and `IpcSocket.ConnectAsync` in  a `#if !NET6_0` preprocessor directive because .NET 6 implements the methods directly and throws on `Dotnet/Runtime`
5. Adds a TCP/IP comment for the expectation of `IpcEndpointConfig.Address`