### PR TITLE
Fix dotnet-dump collect on half exited process

### DIFF
--- a/src/Tools/dotnet-dump/Dumper.Windows.cs
+++ b/src/Tools/dotnet-dump/Dumper.Windows.cs
@@ -16,6 +16,8 @@ namespace Microsoft.Diagnostics.Tools.Dump
         {
             internal static void CollectDump(int processId, string outputFile, DumpTypeOption type)
             {
+                // The managed Process (via Process.GetProcessById) type can not be used to get the handle for a process that is in the middle of exiting such
+                // that it has set an exit code, but not actually exited. This is because for compat reasons the Process class will throw in these circumstances.
                 using SafeProcessHandle processHandle = NativeMethods.OpenProcess(NativeMethods.PROCESS_QUERY_INFORMATION | NativeMethods.PROCESS_VM_READ, false, processId);
                 if (processHandle.IsInvalid)
                 {

--- a/src/Tools/dotnet-dump/Dumper.cs
+++ b/src/Tools/dotnet-dump/Dumper.cs
@@ -92,10 +92,7 @@ namespace Microsoft.Diagnostics.Tools.Dump
                         return 0;
                     }
 
-                    // Get the process
-                    Process process = Process.GetProcessById(processId);
-
-                    Windows.CollectDump(process, output, type);
+                    Windows.CollectDump(processId, output, type);
                 }
                 else
                 {
@@ -133,6 +130,7 @@ namespace Microsoft.Diagnostics.Tools.Dump
             }
             catch (Exception ex) when 
                 (ex is FileNotFoundException || 
+                 ex is ArgumentException || 
                  ex is DirectoryNotFoundException || 
                  ex is UnauthorizedAccessException || 
                  ex is PlatformNotSupportedException || 


### PR DESCRIPTION
Issue: https://github.com/dotnet/diagnostics/issues/2950

Changed to pinvoke directly to OpenProcess to get the process handle for MiniDumpWriteDump.