### PR TITLE
Add dotnet-trace report stat command

### DIFF
--- a/src/Tools/dotnet-trace/CommandLine/Commands/ReportCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/ReportCommand.cs
@@ -1,101 +1,20 @@
 using Microsoft.Tools.Common;
 using System;
-using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Binding;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Diagnostics.Tracing.Etlx;
-using Microsoft.Diagnostics.Symbols;
-using Microsoft.Diagnostics.Tracing.Stacks;
-using Microsoft.Diagnostics.Tracing;
-using Diagnostics.Tracing.StackSources;
-using Microsoft.Diagnostics.Tools.Trace.CommandLine;
 
 namespace Microsoft.Diagnostics.Tools.Trace 
 {
     internal static class ReportCommandHandler 
     {
-        static List<string> unwantedMethodNames = new List<string>() { "ROOT", "Process"};
-
-        //Create an extension function to help 
-        public static List<CallTreeNodeBase> ByIDSortedInclusiveMetric(this CallTree callTree) 
-        {
-            var ret = new List<CallTreeNodeBase>(callTree.ByID);
-            ret.Sort((x, y) => Math.Abs(y.InclusiveMetric).CompareTo(Math.Abs(x.InclusiveMetric)));
-            return ret;
-        }
         delegate Task<int> ReportDelegate(CancellationToken ct, IConsole console, string traceFile);
         private static Task<int> Report(CancellationToken ct, IConsole console, string traceFile)
         {
             Console.Error.WriteLine("Error: subcommand was not provided. Available subcommands:");
             Console.Error.WriteLine("    topN: Finds the top N methods on the callstack the longest.");
             return Task.FromResult(-1);
-        }
-
-        delegate Task<int> TopNReportDelegate(CancellationToken ct, IConsole console, string traceFile, int n, bool inclusive, bool verbose);
-        private static async Task<int> TopNReport(CancellationToken ct, IConsole console, string traceFile, int number, bool inclusive, bool verbose) 
-        {          
-            try 
-            {
-                string tempEtlxFilename = TraceLog.CreateFromEventPipeDataFile(traceFile);
-                int count = 0;
-                int index = 0;
-                List<CallTreeNodeBase> nodesToReport = new List<CallTreeNodeBase>();
-                using (var symbolReader = new SymbolReader(System.IO.TextWriter.Null) { SymbolPath = SymbolPath.MicrosoftSymbolServerPath })
-                using (var eventLog = new TraceLog(tempEtlxFilename))
-                {
-                    var stackSource = new MutableTraceEventStackSource(eventLog)
-                    {
-                        OnlyManagedCodeStacks = true
-                    };
-
-                    var computer = new SampleProfilerThreadTimeComputer(eventLog,symbolReader);
-
-                    computer.GenerateThreadTimeStacks(stackSource);
-
-                    FilterParams filterParams = new FilterParams()
-                    {
-                        FoldRegExs = "CPU_TIME;UNMANAGED_CODE_TIME;{Thread (}",
-                    };
-                    FilterStackSource filterStack = new FilterStackSource(filterParams, stackSource, ScalingPolicyKind.ScaleToData);
-                    CallTree callTree = new(ScalingPolicyKind.ScaleToData);
-                    callTree.StackSource = filterStack;
-
-                    List<CallTreeNodeBase> callTreeNodes = null;
-
-                    if(!inclusive)
-                    {
-                        callTreeNodes = callTree.ByIDSortedExclusiveMetric();
-                    }
-                    else
-                    {
-                        callTreeNodes = callTree.ByIDSortedInclusiveMetric();
-                    }
-
-                    int totalElements = callTreeNodes.Count;
-                        while(count < number && index < totalElements)
-                        {
-                            CallTreeNodeBase node = callTreeNodes[index];
-                            index++;
-                            if(!unwantedMethodNames.Any(node.Name.Contains))
-                            {
-                                nodesToReport.Add(node);
-                                count++;
-                            }
-                        }
-
-                    PrintReportHelper.TopNWriteToStdOut(nodesToReport, inclusive, verbose);
-                }
-                return await Task.FromResult(0);
-            }
-            catch(Exception ex)
-            {
-                Console.Error.WriteLine($"[ERROR] {ex.ToString()}");
-            }
-
-            return await Task.FromResult(0);
         }
 
         public static Command ReportCommand() =>
@@ -107,19 +26,10 @@ namespace Microsoft.Diagnostics.Tools.Trace
                     HandlerDescriptor.FromDelegate((ReportDelegate)Report).GetCommandHandler(),
                     //Options
                     FileNameArgument(),
-                    new Command(
-                        name: "topN",
-                        description: "Finds the top N methods that have been on the callstack the longest.")
-                        {
-                            //Handler
-                            HandlerDescriptor.FromDelegate((TopNReportDelegate)TopNReport).GetCommandHandler(),
-                            TopNOption(),
-                            InclusiveOption(),
-                            VerboseOption(),
-                        }
+                    TopNReportHandler.TopNCommand
                 };
 
-        private static Argument<string> FileNameArgument() =>
+        public static Argument<string> FileNameArgument() =>
             new Argument<string>("trace_filename")
             {
                 Name = "tracefile",
@@ -127,25 +37,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 Arity = new ArgumentArity(1, 1)
             };
 
-        private static Option TopNOption()
-        {
-            return new Option(
-                aliases: new[] {"-n", "--number" },
-                description: $"Gives the top N methods on the callstack.")
-                {
-                    Argument = new Argument<int>(name: "n", getDefaultValue: () => 5)
-                };
-        }         
-
-        private static Option InclusiveOption() =>
-            new Option(
-                aliases: new[] { "--inclusive" },
-                description: $"Output the top N methods based on inclusive time. If not specified, exclusive time is used by default.")
-                {
-                    Argument = new Argument<bool>(name: "inclusive", getDefaultValue: () => false)
-                };
-
-        private static Option VerboseOption() =>
+        public static Option VerboseOption() =>
             new Option(
                 aliases: new[] {"-v", "--verbose"},
                 description: $"Output the parameters of each method in full. If not specified, parameters will be truncated.")

--- a/src/Tools/dotnet-trace/CommandLine/Commands/ReportCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/ReportCommand.cs
@@ -25,8 +25,9 @@ namespace Microsoft.Diagnostics.Tools.Trace
                     //Handler
                     HandlerDescriptor.FromDelegate((ReportDelegate)Report).GetCommandHandler(),
                     //Options
-                    FileNameArgument(),
-                    TopNReportHandler.TopNCommand
+                    // FileNameArgument(),
+                    TopNReportHandler.TopNCommand,
+                    StatReportHandler.StatCommand
                 };
 
         public static Argument<string> FileNameArgument() =>
@@ -36,13 +37,5 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 Description = "The file path for the trace being analyzed.",
                 Arity = new ArgumentArity(1, 1)
             };
-
-        public static Option VerboseOption() =>
-            new Option(
-                aliases: new[] {"-v", "--verbose"},
-                description: $"Output the parameters of each method in full. If not specified, parameters will be truncated.")
-                {
-                    Argument = new Argument<bool>(name: "verbose", getDefaultValue: () => false)
-                };
     }
 }

--- a/src/Tools/dotnet-trace/CommandLine/Commands/Reports/StatReport.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/Reports/StatReport.cs
@@ -1,0 +1,276 @@
+using Microsoft.Tools.Common;
+using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.Binding;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Diagnostics.Tracing.Etlx;
+using Microsoft.Diagnostics.Symbols;
+using Microsoft.Diagnostics.Tracing.Stacks;
+using Microsoft.Diagnostics.Tracing;
+using Diagnostics.Tracing.StackSources;
+using Microsoft.Diagnostics.Tools.Trace.CommandLine;
+using System.IO;
+using System.CommandLine.IO;
+using System.Text.RegularExpressions;
+
+#nullable enable
+
+namespace Microsoft.Diagnostics.Tools.Trace
+{
+    internal static class StatReportHandler
+    {
+        private class PredicateBuilder
+        {
+            private class ProviderPredicate
+            {
+                public string ProviderName { get; private set; }
+                private string eventNameInclude = "";
+                private long keywordInclude = 0;
+                private HashSet<int> eventIdInclude = new();
+
+                public ProviderPredicate(string providerName)
+                {
+                    ProviderName = providerName;
+                }
+
+                public void IncludeEventName(string pattern)
+                {
+                    eventNameInclude = $"{pattern}|{eventNameInclude}";
+                }
+
+                public void IncludeKeyword(long keyword)
+                {
+                    keywordInclude |= keyword;
+                }
+
+                public void IncludeEventId(int eventId)
+                {
+                    eventIdInclude.Add(eventId);
+                }
+
+                public Func<TraceEvent, bool> MakePredicate() => (TraceEvent data) =>
+                {
+                    bool ret = true;
+                    if (data.ProviderName.Equals(ProviderName, StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        if (!string.IsNullOrEmpty(eventNameInclude))
+                        {
+                            ret &= Regex.IsMatch(data.EventName.ToLowerInvariant(), eventNameInclude.ToLowerInvariant());
+                        }
+
+                        if (keywordInclude != 0)
+                        {
+                            ret &= ((long)data.Keywords & keywordInclude) != 0;
+                        }
+
+                        if (eventIdInclude.Count != 0)
+                        {
+                            ret &= eventIdInclude.Contains((int)data.ID);
+                        }
+                    }
+
+                    return ret;
+                };
+            }
+
+            private readonly Dictionary<string, ProviderPredicate> providerPredicates = new();
+            private string? providerNameIncludePattern;
+            private string? providerNameExcludePattern;
+
+            public PredicateBuilder() {}
+
+            public PredicateBuilder AddProviderPattern(string pattern, bool exclude = false) => exclude switch
+            {
+                true => ExcludeProviderPattern(pattern),
+                false => IncludeProviderPattern(pattern)
+            };
+
+            public PredicateBuilder ExcludeProviderPattern(string pattern)
+            {
+                providerNameExcludePattern = $"{pattern}|{providerNameExcludePattern}";
+                return this;
+            }
+
+            public PredicateBuilder IncludeProviderPattern(string pattern)
+            {
+                providerNameIncludePattern = $"{pattern}|{providerNameIncludePattern}";
+                return this;
+            }
+
+            public PredicateBuilder AddProviderFilter(string providerName, string eventNamePattern)
+            {
+                if (!providerPredicates.ContainsKey(providerName))
+                    providerPredicates[providerName] = new ProviderPredicate(providerName);
+
+                providerPredicates[providerName].IncludeEventName(eventNamePattern);
+                return this;
+            }
+
+            public PredicateBuilder AddProviderFilter(string providerName, int eventId)
+            {
+                if (!providerPredicates.ContainsKey(providerName))
+                    providerPredicates[providerName] = new ProviderPredicate(providerName);
+
+                providerPredicates[providerName].IncludeEventId(eventId);
+                return this;
+            }
+
+            public PredicateBuilder AddProviderFilter(string providerName, long keyword)
+            {
+                if (!providerPredicates.ContainsKey(providerName))
+                    providerPredicates[providerName] = new ProviderPredicate(providerName);
+
+                providerPredicates[providerName].IncludeKeyword(keyword);
+                return this;
+            }
+
+            public Func<TraceEvent, bool> Build()
+            {
+                Func<TraceEvent, bool> predicate = (_) => true;
+
+                if (string.IsNullOrEmpty(providerNameIncludePattern) && string.IsNullOrEmpty(providerNameExcludePattern) && providerPredicates.Count == 0)
+                    return predicate;
+
+                return predicate;
+            }
+        }
+
+        private delegate Task<int> StatReportDelegate(CancellationToken ct, IConsole console, string traceFile, string filter, bool verbose);
+        private static async Task<int> StatReport(CancellationToken ct, IConsole console, string traceFile, string filter, bool verbose) 
+        {
+            // Validate
+            if (!File.Exists(traceFile))
+            {
+                console.Error.WriteLine($"The file '{traceFile}' doesn't exist.");
+                return await Task.FromResult(-1);
+            }
+
+            // Parse the filter string
+            Func<TraceEvent, bool> predicate = ParseFilter(filter);
+
+            using EventPipeEventSource source = new(traceFile);
+
+            Dictionary<string, int> stats = CollectStats(source, predicate);
+
+            PrintStats(source, stats);
+            return await Task.FromResult(0);
+        }
+
+        private static Dictionary<string, int> CollectStats(EventPipeEventSource source, Func<TraceEvent, bool> predicate)
+        {
+            Dictionary<string, int> stats = new();
+
+            source.Dynamic.All += (TraceEvent data) =>
+            {
+                if (predicate(data))
+                {
+                    string key = $"{data.ProviderName}/{data.EventName}";
+                    if (stats.ContainsKey(key))
+                        stats[key]++;
+                    else
+                        stats[key] = 1;
+                }
+            };
+
+            source.Process();
+
+            return stats;
+        }
+
+        private static Func<TraceEvent, bool> ParseFilter(string filter)
+        {
+            // Filter ::= 𝞮 | <NameFilter> | <Name>:Subfilter | -Filter | Filter;Filter
+            // Subfilter ::= id=<Number> | name=<NameFilter> | keyword=<Number>
+            // NameFilter ::= [a-zA-Z0-9\*]+
+            // Name ::= [a-zA-Z0-9]+
+            // Number ::= [1-9]+[0-9]* | 0x[0-9a-fA-F]* | 0b[01]*
+
+            Func<TraceEvent, bool> predicate = (_) => true;
+            PredicateBuilder builder = new();
+
+            string[] filters = filter.Split(';', StringSplitOptions.RemoveEmptyEntries);
+
+            foreach (string f in filters)
+            {
+                bool exclude = false;
+                if (f.StartsWith('-'))
+                {
+                    exclude = true;
+                    f.TrimStart('-');
+                }
+
+                string[] filterParts = f.Split(':', StringSplitOptions.RemoveEmptyEntries);
+                if (filterParts[0].Contains('*'))
+                {
+                    builder.AddProviderPattern(filterParts[0], exclude);
+                }
+                else
+                {
+                    // Regular name
+                }
+
+
+            }
+
+            return builder.Build();
+        }
+
+        private static Func<TraceEvent, bool> MakeProviderNameWildcardPredicate(bool negate, string pattern, Func<TraceEvent, bool> previousPredicate) => negate switch
+        {
+            true => (TraceEvent data) => !Regex.IsMatch(data.ProviderName.ToLowerInvariant(), pattern.ToLowerInvariant()) && previousPredicate(data),
+            false => (TraceEvent data) => !Regex.IsMatch(data.ProviderName.ToLowerInvariant(), pattern) && previousPredicate(data)
+        };
+
+        private static void PrintStats(EventPipeEventSource source, Dictionary<string, int> stats)
+        {
+
+        }
+
+        private const string DescriptionString = @$"Filter the report output. Syntax:
+Filter ::= 𝞮 | <NameFilter> | <NameFilter>:Subfilter | -Filter | Filter;Filter
+Subfilter ::= id=<Number> | name=<NameFilter> | keyword=<Number>
+NameFilter ::= [a-zA-Z0-9\*]*
+Number ::= [1-9]+[0-9]* | 0x[0-9a-fA-F]* | 0b[01]*
+
+Examples:
+* 'Microsoft-Windows-DotNETRuntime' - only show stats for this provider
+* 'Microsoft-Windows-DotNETRuntime:name=Jit*' - only show stats for Jit events from this provider
+* 'Microsoft-Windows-DotNETRuntime:name=Jit*;MyProvider:keyword=0xFFF' - only show stats for Jit events from this provider and events with keyword 0xFFF from the other
+* '-ProviderA:name=Jit*' - don't show Jit events from ProviderA
+* '-Microsoft*' - don't show events from Microsoft* providers
+";
+
+        private static Option FilterOption()
+        {
+            return new Option(
+                aliases: new[] {"--filter" },
+                description: DescriptionString)
+                {
+                    Argument = new Argument<string>(name: "filter", getDefaultValue: () => "")
+                };
+        }         
+
+        private static Option InclusiveOption() =>
+            new Option(
+                aliases: new[] { "--inclusive" },
+                description: $"Output the top N methods based on inclusive time. If not specified, exclusive time is used by default.")
+                {
+                    Argument = new Argument<bool>(name: "inclusive", getDefaultValue: () => false)
+                };
+
+        public static Command StatCommand =>
+            new Command(
+                name: "topN",
+                description: "Finds the top N methods that have been on the callstack the longest.")
+                {
+                    //Handler
+                    HandlerDescriptor.FromDelegate((StatReportDelegate)StatReport).GetCommandHandler(),
+                    FilterOption(),
+                    InclusiveOption(),
+                    ReportCommandHandler.VerboseOption(),
+                };
+    }
+}

--- a/src/Tools/dotnet-trace/CommandLine/Commands/Reports/TopNReport.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/Reports/TopNReport.cs
@@ -1,0 +1,122 @@
+using Microsoft.Tools.Common;
+using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.Binding;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Diagnostics.Tracing.Etlx;
+using Microsoft.Diagnostics.Symbols;
+using Microsoft.Diagnostics.Tracing.Stacks;
+using Microsoft.Diagnostics.Tracing;
+using Diagnostics.Tracing.StackSources;
+using Microsoft.Diagnostics.Tools.Trace.CommandLine;
+
+namespace Microsoft.Diagnostics.Tools.Trace
+{
+    internal static class TopNReportHandler
+    {
+        private static readonly List<string> UnwantedMethodNames = new() { "ROOT", "Process"};
+
+        //Create an extension function to help 
+        private  static List<CallTreeNodeBase> ByIDSortedInclusiveMetric(this CallTree callTree) 
+        {
+            var ret = new List<CallTreeNodeBase>(callTree.ByID);
+            ret.Sort((x, y) => Math.Abs(y.InclusiveMetric).CompareTo(Math.Abs(x.InclusiveMetric)));
+            return ret;
+        }
+
+        private delegate Task<int> TopNReportDelegate(CancellationToken ct, IConsole console, string traceFile, int n, bool inclusive, bool verbose);
+        private static async Task<int> TopNReport(CancellationToken ct, IConsole console, string traceFile, int number, bool inclusive, bool verbose) 
+        {          
+            try 
+            {
+                string tempEtlxFilename = TraceLog.CreateFromEventPipeDataFile(traceFile);
+                int count = 0;
+                int index = 0;
+                List<CallTreeNodeBase> nodesToReport = new List<CallTreeNodeBase>();
+                using (var symbolReader = new SymbolReader(System.IO.TextWriter.Null) { SymbolPath = SymbolPath.MicrosoftSymbolServerPath })
+                using (var eventLog = new TraceLog(tempEtlxFilename))
+                {
+                    var stackSource = new MutableTraceEventStackSource(eventLog)
+                    {
+                        OnlyManagedCodeStacks = true
+                    };
+
+                    var computer = new SampleProfilerThreadTimeComputer(eventLog,symbolReader);
+
+                    computer.GenerateThreadTimeStacks(stackSource);
+
+                    FilterParams filterParams = new FilterParams()
+                    {
+                        FoldRegExs = "CPU_TIME;UNMANAGED_CODE_TIME;{Thread (}",
+                    };
+                    FilterStackSource filterStack = new FilterStackSource(filterParams, stackSource, ScalingPolicyKind.ScaleToData);
+                    CallTree callTree = new(ScalingPolicyKind.ScaleToData);
+                    callTree.StackSource = filterStack;
+
+                    List<CallTreeNodeBase> callTreeNodes = null;
+
+                    if(!inclusive)
+                    {
+                        callTreeNodes = callTree.ByIDSortedExclusiveMetric();
+                    }
+                    else
+                    {
+                        callTreeNodes = callTree.ByIDSortedInclusiveMetric();
+                    }
+
+                    int totalElements = callTreeNodes.Count;
+                        while(count < number && index < totalElements)
+                        {
+                            CallTreeNodeBase node = callTreeNodes[index];
+                            index++;
+                            if(!UnwantedMethodNames.Any(node.Name.Contains))
+                            {
+                                nodesToReport.Add(node);
+                                count++;
+                            }
+                        }
+
+                    PrintReportHelper.TopNWriteToStdOut(nodesToReport, inclusive, verbose);
+                }
+                return await Task.FromResult(0);
+            }
+            catch(Exception ex)
+            {
+                Console.Error.WriteLine($"[ERROR] {ex}");
+            }
+
+            return await Task.FromResult(0);
+        }
+
+        private static Option TopNOption() =>
+            new Option(
+                aliases: new[] {"-n", "--number" },
+                description: $"Gives the top N methods on the callstack.")
+                {
+                    Argument = new Argument<int>(name: "n", getDefaultValue: () => 5)
+                };
+
+        private static Option InclusiveOption() =>
+            new Option(
+                aliases: new[] { "--inclusive" },
+                description: $"Output the top N methods based on inclusive time. If not specified, exclusive time is used by default.")
+                {
+                    Argument = new Argument<bool>(name: "inclusive", getDefaultValue: () => false)
+                };
+
+        public static Command TopNCommand =>
+            new Command(
+                name: "topN",
+                description: "Finds the top N methods that have been on the callstack the longest.")
+                {
+                    //Handler
+                    HandlerDescriptor.FromDelegate((TopNReportDelegate)TopNReport).GetCommandHandler(),
+                    TopNOption(),
+                    InclusiveOption(),
+                    ReportCommandHandler.VerboseOption(),
+                };
+}
+}

--- a/src/Tools/dotnet-trace/CommandLine/Commands/Reports/TopNReport.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/Reports/TopNReport.cs
@@ -107,6 +107,14 @@ namespace Microsoft.Diagnostics.Tools.Trace
                     Argument = new Argument<bool>(name: "inclusive", getDefaultValue: () => false)
                 };
 
+        public static Option VerboseOption() =>
+            new Option(
+                aliases: new[] {"-v", "--verbose"},
+                description: $"Output the parameters of each method in full. If not specified, parameters will be truncated.")
+                {
+                    Argument = new Argument<bool>(name: "verbose", getDefaultValue: () => false)
+                };
+
         public static Command TopNCommand =>
             new Command(
                 name: "topN",
@@ -116,7 +124,8 @@ namespace Microsoft.Diagnostics.Tools.Trace
                     HandlerDescriptor.FromDelegate((TopNReportDelegate)TopNReport).GetCommandHandler(),
                     TopNOption(),
                     InclusiveOption(),
-                    ReportCommandHandler.VerboseOption(),
+                    VerboseOption(),
+                    ReportCommandHandler.FileNameArgument()
                 };
 }
 }


### PR DESCRIPTION
This patch adds the `stat` report to `dotnet-trace`. This report prints some metadata about a trace and then the counts of each type of event in the trace. The intent is to make this a bookkeeping report that will get followed by yet to be created `script` report that prints the event contents. I'm imagining we'll call it `script` after the equivalent report on `perf`, but we can call it whatever we want.

There's a simple filtering syntax parser included in this code. My intent is to reuse this logic when we add the `script` report. The syntax is as follows:
```
Filter     ::= 𝞮 
	 		 | <NameFilter> 
			 | <NameFilter>:Subfilter 
			 | -Filter 
			 | Filter;Filter

Subfilter  ::= id=<Number> 
			 | name=<NameFilter> 
			 | keyword=<Number>

NameFilter ::= [a-zA-Z0-9\*]*

Number     ::= [1-9]+[0-9]* 
			 | 0x[0-9a-fA-F]* 
			 | 0b[01]*
```


Help text:
```
$ dotnet trace report stat -h
stat:
  Display information about number of events from each provider and metadata in the trace.

Usage:
  dotnet-trace report stat [options] <tracefile>

Arguments:
  <tracefile>    The file path for the trace being analyzed.

Options:
  --filter <filter>    Filter the report output. Syntax:
                       Filter ::= 𝞮 | <NameFilter> | <NameFilter>:Subfilter | -Filter | Filter;Filter
                       Subfilter ::= id=<Number> | name=<NameFilter> | keyword=<Number>
                       NameFilter ::= [a-zA-Z0-9\*]*
                       Number ::= [1-9]+[0-9]* | 0x[0-9a-fA-F]* | 0b[01]*
  
                       Examples:
                       * 'Microsoft-Windows-DotNETRuntime' - only show stats for this provider
                       * 'Microsoft-Windows-DotNETRuntime:name=Jit*' - only show stats for Jit events from this provider
                       * 'Microsoft-Windows-DotNETRuntime:name=Jit*;MyProvider:keyword=0xFFF' - only show stats for Jit events from this provider and events with keyword 0xFFF from the other
                       * '-ProviderA' - don't show events from ProviderA
                       * '-Microsoft*' - don't show events from Microsoft* providers
                        [default: ]
  -v, --verbose        Output additional information from filter parsing. [default: False]
  -?, -h, --help       Show help and usage information
```

Examples:
```
$ dotnet run trace stat ./dotnet_20220407_033645.nettrace
Trace name:                                                                            ./dotnet_20220407_033645.nettrace
Commandline:                  /workspaces/diagnostics/.dotnet/dotnet /workspaces/diagnostics/.dotnet/sdk/7.0.100-preview.2.22153.17/MSBuild.dll /nologo /nodemode:1 /nodeReuse:true /low:false
OS:                                                                                                                Linux
Architecture:                                                                                                        x64
Trace start time:                                                                                    4/7/2022 3:36:45 AM
Trace Duration:                                                                                         00:00:13.6796252
Number of processors:                                                                                                 16
Events Lost:                                                                                                           0
Total Events:                                                                                                     200822
Filtered Events:                                                                                                  200822
------------------------------------------------------------------------------------------------------------------------

Microsoft-Windows-DotNETRuntime/EventID(58):                                                                          11
Microsoft-Windows-DotNETRuntime/AppDomainResourceManagement/ThreadCreated:                                             3
Microsoft-Windows-DotNETRuntime/GC/SuspendEEStart:                                                                 12027
Microsoft-Windows-DotNETRuntime/GC/SuspendEEStop:                                                                  12027
Microsoft-DotNETCore-SampleProfiler/EventWriteString:                                                             132303
Microsoft-Windows-DotNETRuntime/GC/RestartEEStart:                                                                 12027
Microsoft-Windows-DotNETRuntime/GC/RestartEEStop:                                                                  12027
Microsoft-Windows-DotNETRuntime/TieredCompilation/Pause:                                                               1
Microsoft-Windows-DotNETRuntime/TieredCompilation/Resume:                                                              1
Microsoft-Windows-DotNETRuntime/TieredCompilation/BackgroundJitStart:                                                  1
Microsoft-Windows-DotNETRuntime/TieredCompilation/BackgroundJitStop:                                                   1
Microsoft-Windows-DotNETRuntime/GC/FinalizersStart:                                                                    3
Microsoft-Windows-DotNETRuntime/GC/FinalizersStop:                                                                     3
Microsoft-DotNETCore-EventPipe/ProcessInfo:                                                                            1
Microsoft-Windows-DotNETRuntimeRundown/Runtime/Start:                                                                  1
Microsoft-Windows-DotNETRuntimeRundown/Method/DCStopInit:                                                              1
Microsoft-Windows-DotNETRuntimeRundown/Method/ILToNativeMapDCStop:                                                  6263
Microsoft-Windows-DotNETRuntimeRundown/Method/DCStopVerbose:                                                       13897
Microsoft-Windows-DotNETRuntimeRundown/Loader/ModuleDCStop:                                                           74
Microsoft-Windows-DotNETRuntimeRundown/Loader/DomainModuleDCStop:                                                     74
Microsoft-Windows-DotNETRuntimeRundown/Loader/AssemblyDCStop:                                                         74
Microsoft-Windows-DotNETRuntimeRundown/Loader/AppDomainDCStop:                                                         1
Microsoft-Windows-DotNETRuntimeRundown/Method/DCStopComplete:                                                          1
```

```
$ dotnet trace report stat ./dotnet_20220407_033645.nettrace --filter="Microsoft-Windows-DotNETRuntime:name=*gc*"
Trace name:                                                                            ./dotnet_20220407_033645.nettrace
Commandline:                  /workspaces/diagnostics/.dotnet/dotnet /workspaces/diagnostics/.dotnet/sdk/7.0.100-preview.2.22153.17/MSBuild.dll /nologo /nodemode:1 /nodeReuse:true /low:false
OS:                                                                                                                Linux
Architecture:                                                                                                        x64
Trace start time:                                                                                    4/7/2022 3:36:45 AM
Trace Duration:                                                                                         00:00:13.6796252
Number of processors:                                                                                                 16
Events Lost:                                                                                                           0
Total Events:                                                                                                     200822
Filtered Events:                                                                                                   48114
------------------------------------------------------------------------------------------------------------------------

Microsoft-Windows-DotNETRuntime/GC/SuspendEEStart:                                                                 12027
Microsoft-Windows-DotNETRuntime/GC/SuspendEEStop:                                                                  12027
Microsoft-Windows-DotNETRuntime/GC/RestartEEStart:                                                                 12027
Microsoft-Windows-DotNETRuntime/GC/RestartEEStop:                                                                  12027
Microsoft-Windows-DotNETRuntime/GC/FinalizersStart:                                                                    3
Microsoft-Windows-DotNETRuntime/GC/FinalizersStop:                                                                     3
```

It is worth pointing out that I refactored the `report` verb on `dotnet-trace` as well to reduce repeated code.

I'm intending to add tests to this change, but a rough set of scenarios have been run locally.