### PR TITLE
Use minipal in more places

### DIFF
--- a/src/SOS/Strike/ExpressionNode.cpp
+++ b/src/SOS/Strike/ExpressionNode.cpp
@@ -2153,23 +2153,23 @@ HRESULT ExpressionNode::IsTokenValueTypeOrEnum(mdToken token, IMetaDataImport* p
     {
         ULONG chTypeDef;
         pMetadata->GetTypeRefProps(token, NULL, NULL, 0, &chTypeDef);
-        if(chTypeDef > _countof(nameBuffer))
+        if(chTypeDef > ARRAY_SIZE(nameBuffer))
         {
             *pResult = FALSE;
             return Status;
         }
-        IfFailRet(pMetadata->GetTypeRefProps(token, NULL, nameBuffer, _countof(nameBuffer), &chTypeDef));
+        IfFailRet(pMetadata->GetTypeRefProps(token, NULL, nameBuffer, ARRAY_SIZE(nameBuffer), &chTypeDef));
     }
     else if(type == mdtTypeDef)
     {
         ULONG chTypeDef;
         pMetadata->GetTypeDefProps(token, NULL, 0, &chTypeDef, NULL, NULL);
-        if(chTypeDef > _countof(nameBuffer))
+        if(chTypeDef > ARRAY_SIZE(nameBuffer))
         {
             *pResult = FALSE;
             return Status;
         }
-        IfFailRet(pMetadata->GetTypeDefProps(token, nameBuffer, _countof(nameBuffer), &chTypeDef, NULL, NULL));
+        IfFailRet(pMetadata->GetTypeDefProps(token, nameBuffer, ARRAY_SIZE(nameBuffer), &chTypeDef, NULL, NULL));
     }
 
     if(_wcscmp(nameBuffer, L"System.ValueType") == 0 ||

--- a/src/SOS/Strike/disasm.cpp
+++ b/src/SOS/Strike/disasm.cpp
@@ -188,7 +188,7 @@ char* PrintOneLine (__in_z char *begin, __in_z char *limit)
                 if (n > 127) {
                     n = 127;
                 }
-                strncpy_s (line,_countof(line), begin, n);
+                strncpy_s (line,ARRAY_SIZE(line), begin, n);
                 line[n] = '\0';
                 ExtOut ("%s", line);
                 begin += n;
@@ -839,7 +839,7 @@ void PrintNativeStack(DWORD_PTR ip, BOOL bSuppressLines)
     char symbol[1024];
     ULONG64 displacement;
 
-    HRESULT hr = g_ExtSymbols->GetNameByOffset(TO_CDADDR(ip), symbol, _countof(symbol), NULL, &displacement);
+    HRESULT hr = g_ExtSymbols->GetNameByOffset(TO_CDADDR(ip), symbol, ARRAY_SIZE(symbol), NULL, &displacement);
     if (SUCCEEDED(hr) && symbol[0] != '\0')
     {
         ExtOut("%s", symbol);
@@ -852,7 +852,7 @@ void PrintNativeStack(DWORD_PTR ip, BOOL bSuppressLines)
         if (!bSuppressLines)
         {
             ULONG line;
-            hr = g_ExtSymbols->GetLineByOffset(TO_CDADDR(ip), &line, filename, _countof(filename), NULL, NULL);
+            hr = g_ExtSymbols->GetLineByOffset(TO_CDADDR(ip), &line, filename, ARRAY_SIZE(filename), NULL, NULL);
             if (SUCCEEDED(hr))
             {
                 ExtOut(" [%s:%d]", filename, line);

--- a/src/SOS/Strike/disasm.h
+++ b/src/SOS/Strike/disasm.h
@@ -175,7 +175,7 @@ public:
     virtual LPCSTR GetDumpStackObjectsHeading() const   { return s_DSOHeading; }
     virtual LPCSTR GetSPName() const                    { return s_SPName; }
     virtual void GetGCRegisters(LPCSTR** regNames, unsigned int* cntRegs) const
-    { _ASSERTE(cntRegs != NULL); *regNames = s_GCRegs; *cntRegs = _countof(s_GCRegs); }
+    { _ASSERTE(cntRegs != NULL); *regNames = s_GCRegs; *cntRegs = ARRAY_SIZE(s_GCRegs); }
 
     virtual void DumpGCInfo(GCInfoToken gcInfoToken, unsigned methodSize, printfFtn gcPrintf, bool encBytes, bool bPrintHeader) const;
 
@@ -247,7 +247,7 @@ public:
     virtual LPCSTR GetDumpStackObjectsHeading() const   { return s_DSOHeading; }
     virtual LPCSTR GetSPName() const                    { return s_SPName; }
     virtual void GetGCRegisters(LPCSTR** regNames, unsigned int* cntRegs) const
-    { _ASSERTE(cntRegs != NULL); *regNames = s_GCRegs; *cntRegs = _countof(s_GCRegs); }
+    { _ASSERTE(cntRegs != NULL); *regNames = s_GCRegs; *cntRegs = ARRAY_SIZE(s_GCRegs); }
 
     virtual void DumpGCInfo(GCInfoToken gcInfoToken, unsigned methodSize, printfFtn gcPrintf, bool encBytes, bool bPrintHeader) const;
 
@@ -320,7 +320,7 @@ public:
     virtual LPCSTR GetDumpStackObjectsHeading() const   { return s_DSOHeading; }
     virtual LPCSTR GetSPName() const                    { return s_SPName; }
     virtual void GetGCRegisters(LPCSTR** regNames, unsigned int* cntRegs) const
-    { _ASSERTE(cntRegs != NULL); *regNames = s_GCRegs; *cntRegs = _countof(s_GCRegs); }
+    { _ASSERTE(cntRegs != NULL); *regNames = s_GCRegs; *cntRegs = ARRAY_SIZE(s_GCRegs); }
 
     virtual void DumpGCInfo(GCInfoToken gcInfoToken, unsigned methodSize, printfFtn gcPrintf, bool encBytes, bool bPrintHeader) const;
 
@@ -390,7 +390,7 @@ public:
     virtual LPCSTR GetDumpStackObjectsHeading() const   { return s_DSOHeading; }
     virtual LPCSTR GetSPName() const                    { return s_SPName; }
     virtual void GetGCRegisters(LPCSTR** regNames, unsigned int* cntRegs) const
-    { _ASSERTE(cntRegs != NULL); *regNames = s_GCRegs; *cntRegs = _countof(s_GCRegs);}
+    { _ASSERTE(cntRegs != NULL); *regNames = s_GCRegs; *cntRegs = ARRAY_SIZE(s_GCRegs);}
 
     virtual void DumpGCInfo(GCInfoToken gcInfoToken, unsigned methodSize, printfFtn gcPrintf, bool encBytes, bool bPrintHeader) const;
 

--- a/src/SOS/Strike/disasmARM.cpp
+++ b/src/SOS/Strike/disasmARM.cpp
@@ -419,7 +419,7 @@ void ARMMachine::Unassembly (
         }
 
         ULONG_PTR prevPC = PC;
-        DisasmAndClean (PC, line, _countof(line));
+        DisasmAndClean (PC, line, ARRAY_SIZE(line));
 
         // look at the disassembled bytes
         ptr = line;
@@ -451,7 +451,7 @@ void ARMMachine::Unassembly (
             ULONG_PTR OrigInstrAddr = GCStressCodeCopy + (InstrAddr - PCBegin);
             ULONG_PTR OrigPC = OrigInstrAddr;
 
-            DisasmAndClean(OrigPC, line, _countof(line));
+            DisasmAndClean(OrigPC, line, ARRAY_SIZE(line));
 
             //
             // Increment the real PC based on the size of the unmodifed

--- a/src/SOS/Strike/disasmARM64.cpp
+++ b/src/SOS/Strike/disasmARM64.cpp
@@ -163,7 +163,7 @@ void ARM64Machine::Unassembly (
     while(PC < PCEnd)
     {
         ULONG_PTR currentPC = PC;
-        DisasmAndClean (PC, line, _countof(line));
+        DisasmAndClean (PC, line, ARRAY_SIZE(line));
 
         // This is the closing of the previous run. 
         // Check the next instruction. if it's not a the last movk, handle the accumulated value
@@ -265,7 +265,7 @@ void ARM64Machine::Unassembly (
             ULONG_PTR OrigInstrAddr = GCStressCodeCopy + (InstrAddr - PCBegin);
             ULONG_PTR OrigPC = OrigInstrAddr;
 
-            DisasmAndClean(OrigPC, line, _countof(line));
+            DisasmAndClean(OrigPC, line, ARRAY_SIZE(line));
 
             //
             // Increment the real PC based on the size of the unmodifed

--- a/src/SOS/Strike/disasmX86.cpp
+++ b/src/SOS/Strike/disasmX86.cpp
@@ -150,7 +150,7 @@ inline RegIndex FindReg (___in __in_z char *ptr, __out_opt int *plen = NULL, __o
 
     };
 
-    for (size_t i = 0; i < sizeof(rgRegNames)/sizeof(rgRegNames[0]); i++)
+    for (size_t i = 0; i < ARRAY_SIZE(rgRegNames); i++)
     {
         if (!strncmp(ptr, rgRegNames[i].pszName, rgRegNames[i].cchName))
         {
@@ -577,7 +577,7 @@ void
 
         ULONG_PTR InstrAddr = IP;
 
-        DisasmAndClean (IP, line, _countof(line));
+        DisasmAndClean (IP, line, ARRAY_SIZE(line));
 
         // look at key word
         ptr = line;
@@ -605,7 +605,7 @@ void
             ULONG_PTR OrigInstrAddr = GCStressCodeCopy + (InstrAddr - IPBegin);
             ULONG_PTR OrigIP = OrigInstrAddr;
 
-            DisasmAndClean(OrigIP, line, _countof(line));
+            DisasmAndClean(OrigIP, line, ARRAY_SIZE(line));
 
             //
             // Increment the real IP based on the size of the unmodifed

--- a/src/SOS/Strike/eeheap.cpp
+++ b/src/SOS/Strike/eeheap.cpp
@@ -1922,7 +1922,7 @@ BOOL GCHeapSnapshot::AddSegments(const GCHeapDetails& details)
     // this loop will get information for all the heap segments in this heap. The outer loop iterates once
     // for the "normal" generation segments and once for the large object heap. The inner loop follows the chain
     // of segments rooted at AddrSegs[i]
-    for (unsigned int i = 0; i < sizeof(AddrSegs)/sizeof(AddrSegs[0]); ++i)
+    for (unsigned int i = 0; i < ARRAY_SIZE(AddrSegs); ++i)
     {
         if (AddrSegs[i] == NULL)
         {

--- a/src/SOS/Strike/gchist.cpp
+++ b/src/SOS/Strike/gchist.cpp
@@ -348,7 +348,7 @@ DECLARE_API(HistRoot)
         {&rootstr.data, COSTRING},
     };
 
-    if (!GetCMDOption(args, NULL, 0, arg, _countof(arg), &nArg))
+    if (!GetCMDOption(args, NULL, 0, arg, ARRAY_SIZE(arg), &nArg))
         return Status;
 
     if (nArg != 1)
@@ -463,7 +463,7 @@ DECLARE_API(HistObjFind)
         {&objstr.data, COSTRING},
     };
 
-    if (!GetCMDOption(args, NULL, 0, arg, _countof(arg), &nArg))
+    if (!GetCMDOption(args, NULL, 0, arg, ARRAY_SIZE(arg), &nArg))
         return Status;
 
     if (nArg != 1)
@@ -542,7 +542,7 @@ DECLARE_API(HistObj)
         {&objstr.data, COSTRING},
     };
 
-    if (!GetCMDOption(args, NULL, 0, arg, _countof(arg), &nArg))
+    if (!GetCMDOption(args, NULL, 0, arg, ARRAY_SIZE(arg), &nArg))
         return Status;
 
     if (nArg != 1)

--- a/src/SOS/Strike/gcroot.cpp
+++ b/src/SOS/Strike/gcroot.cpp
@@ -220,7 +220,7 @@ void GCRootImpl::GetDependentHandleMap(std::unordered_map<TADDR, std::list<TADDR
 
     do
     {
-        hr = handles->Next(_countof(data), data, &fetched);
+        hr = handles->Next(ARRAY_SIZE(data), data, &fetched);
 
         if (FAILED(hr))
         {
@@ -240,7 +240,7 @@ void GCRootImpl::GetDependentHandleMap(std::unordered_map<TADDR, std::list<TADDR
                 map[obj].push_back(target);
             }
         }
-    } while (fetched == _countof(data));
+    } while (fetched == ARRAY_SIZE(data));
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -791,7 +791,7 @@ int GCRootImpl::PrintRootsOnHandleTable(int gen)
     do
     {
         // Fetch more handles
-        hr = pEnum->Next(_countof(handles), handles, &fetched);
+        hr = pEnum->Next(ARRAY_SIZE(handles), handles, &fetched);
         if (FAILED(hr))
         {
             ExtOut("Failed to request more handles.\n");
@@ -833,7 +833,7 @@ int GCRootImpl::PrintRootsOnHandleTable(int gen)
             }
         }
     }
-    while (_countof(handles) == fetched);
+    while (ARRAY_SIZE(handles) == fetched);
 
     return total;
 }
@@ -1244,7 +1244,7 @@ UINT FindAllPinnedAndStrong(DWORD_PTR handlearray[], UINT arraySize)
 
     do
     {
-        hr = handles->Next(_countof(data), data, &fetched);
+        hr = handles->Next(ARRAY_SIZE(data), data, &fetched);
 
         if (FAILED(hr))
         {
@@ -1265,7 +1265,7 @@ UINT FindAllPinnedAndStrong(DWORD_PTR handlearray[], UINT arraySize)
                 handlearray[pos++] = (DWORD_PTR)data[i].Handle;
             }
         }
-    } while (fetched == _countof(data));
+    } while (fetched == ARRAY_SIZE(data));
 
     return pos;
 }
@@ -2190,14 +2190,14 @@ void HeapTraverser::TraceHandles()
 
     do
     {
-        hr = handles->Next(_countof(data), data, &fetched);
+        hr = handles->Next(ARRAY_SIZE(data), data, &fetched);
 
         if (FAILED(hr))
             break;
 
         for (unsigned int i = 0; i < fetched; ++i)
             PrintRoot(W("handle"), (size_t)data[i].Handle);
-    } while (fetched == _countof(data));
+    } while (fetched == ARRAY_SIZE(data));
 }
 
 /* static */ void HeapTraverser::GatherTypes(DWORD_PTR objAddr,size_t Size,

--- a/src/SOS/Strike/metadata.cpp
+++ b/src/SOS/Strike/metadata.cpp
@@ -382,7 +382,7 @@ void MDInfo::GetMethodName(mdTypeDef token, CQuickBytes *fullName)
     WCHAR szFunctionName[1024];
 
     hr = m_pImport->GetMethodProps(token, &memTypeDef, 
-                                   szFunctionName, _countof(szFunctionName), &nameLen, 
+                                   szFunctionName, ARRAY_SIZE(szFunctionName), &nameLen, 
                                    &flags, &pbSigBlob, &ulSigBlob, &ulCodeRVA, &ulImplFlags);
     if (FAILED (hr))
     {
@@ -393,12 +393,12 @@ void MDInfo::GetMethodName(mdTypeDef token, CQuickBytes *fullName)
     m_szName[0] = L'\0';
     if (memTypeDef != mdTypeDefNil)
     {
-        hr = NameForTypeDef_s (memTypeDef, m_pImport, m_szName, _countof(m_szName));
+        hr = NameForTypeDef_s (memTypeDef, m_pImport, m_szName, ARRAY_SIZE(m_szName));
         if (SUCCEEDED (hr)) {
-            wcscat_s (m_szName, _countof(m_szName), W("."));
+            wcscat_s (m_szName, ARRAY_SIZE(m_szName), W("."));
         }
     }
-    wcscat_s (m_szName, _countof(m_szName), szFunctionName);
+    wcscat_s (m_szName, ARRAY_SIZE(m_szName), szFunctionName);
 
     LONG lSigBlobRemaining;
     hr = GetFullNameForMD(pbSigBlob, ulSigBlob, &lSigBlobRemaining);

--- a/src/SOS/Strike/platform/targetimpl.cpp
+++ b/src/SOS/Strike/platform/targetimpl.cpp
@@ -264,7 +264,7 @@ LPCSTR Target::GetTempDirectory()
             pid = ::GetCurrentProcessId();
         }
         char pidstr[128];
-        sprintf_s(pidstr, _countof(pidstr), "sos%d", pid);
+        sprintf_s(pidstr, ARRAY_SIZE(pidstr), "sos%d", pid);
         strcat_s(tmpPath, MAX_LONGPATH, pidstr);
         strcat_s(tmpPath, MAX_LONGPATH, DIRECTORY_SEPARATOR_STR_A);
 

--- a/src/SOS/Strike/sildasm.cpp
+++ b/src/SOS/Strike/sildasm.cpp
@@ -182,7 +182,7 @@ void DisassembleToken(IMetaDataImport *i,
             hr = i->GetTypeDefProps(token, szName, 49, &cLen, NULL, NULL);
 
             if (FAILED(hr))
-                StringCchCopyW(szName, COUNTOF(szName), W("<unknown type def>"));
+                StringCchCopyW(szName, ARRAY_SIZE(szName), W("<unknown type def>"));
 
             printf("%S", szName);
         }
@@ -196,7 +196,7 @@ void DisassembleToken(IMetaDataImport *i,
             hr = i->GetTypeRefProps(token, NULL, szName, 49, &cLen);
 
             if (FAILED(hr))
-                StringCchCopyW(szName, COUNTOF(szName), W("<unknown type ref>"));
+                StringCchCopyW(szName, ARRAY_SIZE(szName), W("<unknown type ref>"));
 
             printf("%S", szName);
         }
@@ -213,13 +213,13 @@ void DisassembleToken(IMetaDataImport *i,
                                   NULL, NULL, NULL, NULL, NULL, NULL);
 
             if (FAILED(hr))
-                StringCchCopyW(szFieldName, COUNTOF(szFieldName), W("<unknown field def>"));
+                StringCchCopyW(szFieldName, ARRAY_SIZE(szFieldName), W("<unknown field def>"));
 
             hr = i->GetTypeDefProps(mdClass, szClassName, 49, &cLen,
                                     NULL, NULL);
 
             if (FAILED(hr))
-                StringCchCopyW(szClassName, COUNTOF(szClassName), W("<unknown type def>"));
+                StringCchCopyW(szClassName, ARRAY_SIZE(szClassName), W("<unknown type def>"));
 
             printf("%S::%S", szClassName, szFieldName);
         }
@@ -240,7 +240,7 @@ void DisassembleToken(IMetaDataImport *i,
             MethodSigArgPrettyPrinter methodPrettyPrinter(sig, cbSigBlob, i);
 
             if (FAILED(hr))
-                StringCchCopyW(szFieldName, COUNTOF(szFieldName), W("<unknown method def>"));
+                StringCchCopyW(szFieldName, ARRAY_SIZE(szFieldName), W("<unknown method def>"));
             else
                 methodPrettyPrinter.HandleReturnType();
 
@@ -248,7 +248,7 @@ void DisassembleToken(IMetaDataImport *i,
                                     NULL, NULL);
 
             if (FAILED(hr))
-                StringCchCopyW(szClassName, COUNTOF(szClassName), W("<unknown type def>"));
+                StringCchCopyW(szClassName, ARRAY_SIZE(szClassName), W("<unknown type def>"));
 
             printf("%S::%S", szClassName, szFieldName);
             methodPrettyPrinter.HandleArguments(); // Safe to call in all cases if HandleReturnType hasn't been called. Will do nothing.
@@ -286,7 +286,7 @@ void DisassembleToken(IMetaDataImport *i,
             {
                 if (FAILED(i->GetTypeRefProps(cr, NULL, szName, 50, &cLen)))
                 {
-                    StringCchCopyW(szName, COUNTOF(szName), W("<unknown type ref>"));
+                    StringCchCopyW(szName, ARRAY_SIZE(szName), W("<unknown type ref>"));
                 }
             }
             else if (TypeFromToken(cr) == mdtTypeDef)
@@ -294,7 +294,7 @@ void DisassembleToken(IMetaDataImport *i,
                 if (FAILED(i->GetTypeDefProps(cr, szName, 49, &cLen,
                     NULL, NULL)))
                 {
-                    StringCchCopyW(szName, COUNTOF(szName), W("<unknown type def>"));
+                    StringCchCopyW(szName, ARRAY_SIZE(szName), W("<unknown type def>"));
                 }
             }
             else if (TypeFromToken(cr) == mdtTypeSpec)
@@ -304,7 +304,7 @@ void DisassembleToken(IMetaDataImport *i,
                 PCCOR_SIGNATURE sig;
                 if (FAILED(i->GetTypeSpecFromToken(cr, &sig, &cSig)))
                 {
-                    StringCchCopyW(szName, COUNTOF(szName), W("<Invalid record>"));
+                    StringCchCopyW(szName, ARRAY_SIZE(szName), W("<Invalid record>"));
                 }
                 else
                 {
@@ -314,7 +314,7 @@ void DisassembleToken(IMetaDataImport *i,
             }
             else
             {
-                StringCchCopyW(szName, COUNTOF(szName), W("<unknown type token>"));
+                StringCchCopyW(szName, ARRAY_SIZE(szName), W("<unknown type token>"));
             }
 
             printf("%S::%S", szName, pMemberName);
@@ -708,7 +708,7 @@ static void insertStr(CQuickBytes *out, const char* str) {
 
 static void appendStrNum(CQuickBytes *out, int num) {
     char buff[16];  
-    sprintf_s(buff, COUNTOF(buff), "%d", num);   
+    sprintf_s(buff, ARRAY_SIZE(buff), "%d", num);   
     appendStr(out, buff);   
 }
 
@@ -944,7 +944,7 @@ PCCOR_SIGNATURE PrettyPrintType(
                 if(typ)
                 {
                     char sz[64];
-                    sprintf_s(sz,COUNTOF(sz),"/* UNKNOWN TYPE (0x%X)*/",typ);
+                    sprintf_s(sz,ARRAY_SIZE(sz),"/* UNKNOWN TYPE (0x%X)*/",typ);
                     appendStr(out, sz);
                 }
                 break;  
@@ -979,7 +979,7 @@ const char* PrettyPrintClass(
     if (!pIMD->IsValidToken(tk))
     {
         char str[1024];
-        sprintf_s(str,COUNTOF(str)," [ERROR: INVALID TOKEN 0x%8.8X] ",tk);
+        sprintf_s(str,ARRAY_SIZE(str)," [ERROR: INVALID TOKEN 0x%8.8X] ",tk);
         appendStr(out, str);
         return(asString(out));
     }
@@ -997,7 +997,7 @@ const char* PrettyPrintClass(
                     if (((formatFlags & FormatAssembly) && FAILED(pIMD->GetTypeRefProps(tk, &tkEncloser, nameComplete, MAX_TYPE_NAME_LEN, &unused))))
                     {
                         char str[1024];
-                        sprintf_s(str, COUNTOF(str), " [ERROR: Invalid TypeRef record 0x%8.8X] ", tk);
+                        sprintf_s(str, ARRAY_SIZE(str), " [ERROR: Invalid TypeRef record 0x%8.8X] ", tk);
                         appendStr(out, str);
                         return asString(out);
                     }
@@ -1010,7 +1010,7 @@ const char* PrettyPrintClass(
                     if (FAILED(pIMD->GetTypeDefProps(tk, nameComplete, MAX_TYPE_NAME_LEN, &unused, &typeDefFlags, &tkExtends)))
                     {
                         char str[1024];
-                        sprintf_s(str, COUNTOF(str), " [ERROR: Invalid TypeDef record 0x%8.8X] ", tk);
+                        sprintf_s(str, ARRAY_SIZE(str), " [ERROR: Invalid TypeDef record 0x%8.8X] ", tk);
                         appendStr(out, str);
                         return asString(out);
                     }
@@ -1115,7 +1115,7 @@ const char* PrettyPrintClass(
                 if (FAILED(pIMD->GetTypeSpecFromToken(tk, &sig, &cSig)))
                 {
                     char str[128];
-                    sprintf_s(str, COUNTOF(str), " [ERROR: Invalid token 0x%8.8X] ", tk);
+                    sprintf_s(str, ARRAY_SIZE(str), " [ERROR: Invalid token 0x%8.8X] ", tk);
                     appendStr(out, str);
                 }
                 else
@@ -1131,7 +1131,7 @@ const char* PrettyPrintClass(
         default:
             {
                 char str[128];
-                sprintf_s(str,COUNTOF(str)," [ERROR: INVALID TOKEN TYPE 0x%8.8X] ",tk);
+                sprintf_s(str,ARRAY_SIZE(str)," [ERROR: INVALID TOKEN TYPE 0x%8.8X] ",tk);
                 appendStr(out, str);
             }
     }

--- a/src/SOS/Strike/sos.cpp
+++ b/src/SOS/Strike/sos.cpp
@@ -976,7 +976,7 @@ namespace sos
             else if (isString)
             {
                 WCHAR str[32];
-                obj.GetStringData(str, _countof(str));
+                obj.GetStringData(str, ARRAY_SIZE(str));
 
                 _snwprintf_s(buffer, size, _TRUNCATE, W("%s: \"%s\""), mt.GetName(), str);
             }

--- a/src/SOS/Strike/sos.h
+++ b/src/SOS/Strike/sos.h
@@ -46,7 +46,7 @@ namespace sos
     public:
         Exception(const char *format, va_list args)
         {
-            vsprintf_s(mMsg, _countof(mMsg), format, args);
+            vsprintf_s(mMsg, ARRAY_SIZE(mMsg), format, args);
 
             va_end(args);
         }

--- a/src/SOS/Strike/stressLogDump.cpp
+++ b/src/SOS/Strike/stressLogDump.cpp
@@ -92,8 +92,8 @@ const char *getFacilityName(DWORD_PTR lf)
         {
             if ( lf & 0x1 )
             {
-                strcat_s ( buff, _countof(buff), &(facilities[i].lfName[3]) );
-                strcat_s ( buff, _countof(buff), "`" );
+                strcat_s ( buff, ARRAY_SIZE(buff), &(facilities[i].lfName[3]) );
+                strcat_s ( buff, ARRAY_SIZE(buff), "`" );
             }
             lf >>= 1;
         }
@@ -121,7 +121,7 @@ void formatOutput(struct IDebugDataSpaces* memCallBack, ___in FILE* file, __inou
     
     int iArgCount = 0;
     
-    strcpy_s(formatCopy, _countof(formatCopy), format);
+    strcpy_s(formatCopy, ARRAY_SIZE(formatCopy), format);
     for(;;) 
     {
         char c = *ptr++;
@@ -178,7 +178,7 @@ void formatOutput(struct IDebugDataSpaces* memCallBack, ___in FILE* file, __inou
                                     static WCHAR wszNameBuffer[1024]; // should be large enough
                                     if (g_sos->GetMethodDescName(arg, 1024, wszNameBuffer, NULL) != S_OK)
                                     {
-                                        wcscpy_s(wszNameBuffer, _countof(wszNameBuffer), W("UNKNOWN METHODDESC"));
+                                        wcscpy_s(wszNameBuffer, ARRAY_SIZE(wszNameBuffer), W("UNKNOWN METHODDESC"));
                                     }
 
                                     wcscpy_s(buff, capacity_buff, wszNameBuffer);
@@ -513,7 +513,7 @@ HRESULT StressLog::Dump(ULONG64 outProcLog, const char* fileName, struct IDebugD
             TADDR taFmt = GetFormatAddr(inProcLog, latestMsg->formatOffset, bHasModuleTable);
             hr = memCallBack->ReadVirtual(TO_CDADDR(taFmt), format, 256, 0);
             if (hr != S_OK) 
-                strcpy_s(format, _countof(format), "Could not read address of format string");
+                strcpy_s(format, ARRAY_SIZE(format), "Could not read address of format string");
 
             double deltaTime = ((double) (latestMsg->timeStamp - inProcLog.startTimeStamp)) / inProcLog.tickFrequency;
             if (bDoGcHist)

--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -234,7 +234,7 @@ DECLARE_API (MinidumpMode)
     };
 
     size_t nArg;
-    if (!GetCMDOption(args, NULL, 0, arg, _countof(arg), &nArg))
+    if (!GetCMDOption(args, NULL, 0, arg, ARRAY_SIZE(arg), &nArg))
     {
         return Status;
     }
@@ -286,7 +286,7 @@ DECLARE_API(IP2MD)
     };
     size_t nArg;
 
-    if (!GetCMDOption(args, option, _countof(option), arg, _countof(arg), &nArg))
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), arg, ARRAY_SIZE(arg), &nArg))
     {
         return Status;
     }
@@ -321,7 +321,7 @@ DECLARE_API(IP2MD)
     }
 
     if (symlines != 0 &&
-        SUCCEEDED(GetLineByOffset(TO_CDADDR(IP), &linenum, filename, _countof(filename))))
+        SUCCEEDED(GetLineByOffset(TO_CDADDR(IP), &linenum, filename, ARRAY_SIZE(filename))))
     {
         ExtOut("Source file:  %S @ %d\n", filename, linenum);
     }
@@ -465,7 +465,7 @@ DECLARE_API(DumpStack)
         {&DSFlag.end, COHEX}
     };
     size_t nArg;
-    if (!GetCMDOption(args, option, _countof(option), arg, _countof(arg), &nArg))
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), arg, ARRAY_SIZE(arg), &nArg))
         return Status;
 
     // symlines will be non-zero only if SYMOPT_LOAD_LINES was set in the symbol options
@@ -518,7 +518,7 @@ DECLARE_API (EEStack)
         {"/d", &dml, COBOOL, FALSE}
     };
 
-    if (!GetCMDOption(args, option, _countof(option), NULL, 0, NULL))
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), NULL, 0, NULL))
     {
         return Status;
     }
@@ -703,7 +703,7 @@ DECLARE_API(DumpStackObjects)
     };
     size_t nArg;
 
-    if (!GetCMDOption(args, option, _countof(option), arg, _countof(arg), &nArg))
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), arg, ARRAY_SIZE(arg), &nArg))
     {
         return Status;
     }
@@ -738,7 +738,7 @@ DECLARE_API(DumpMD)
     };
     size_t nArg;
 
-    if (!GetCMDOption(args, option, _countof(option), arg, _countof(arg), &nArg))
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), arg, ARRAY_SIZE(arg), &nArg))
     {
         return Status;
     }
@@ -857,7 +857,7 @@ DECLARE_API(DumpIL)
     };
     size_t nArg;
 
-    if (!GetCMDOption(args, option, _countof(option), arg, _countof(arg), &nArg))
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), arg, ARRAY_SIZE(arg), &nArg))
     {
         return Status;
     }
@@ -1058,7 +1058,7 @@ DECLARE_API(DumpSig)
         {&moduleExpr.data, COSTRING}
     };
     size_t nArg;
-    if (!GetCMDOption(args, NULL, 0, arg, _countof(arg), &nArg))
+    if (!GetCMDOption(args, NULL, 0, arg, ARRAY_SIZE(arg), &nArg))
     {
         return Status;
     }
@@ -1106,7 +1106,7 @@ DECLARE_API(DumpSigElem)
         {&moduleExpr.data, COSTRING}
     };
     size_t nArg;
-    if (!GetCMDOption(args, NULL, 0, arg, _countof(arg), &nArg))
+    if (!GetCMDOption(args, NULL, 0, arg, ARRAY_SIZE(arg), &nArg))
     {
         return Status;
     }
@@ -1155,7 +1155,7 @@ DECLARE_API(DumpClass)
     };
 
     size_t nArg;
-    if (!GetCMDOption(args, option, _countof(option), arg, _countof(arg), &nArg))
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), arg, ARRAY_SIZE(arg), &nArg))
     {
         return Status;
     }
@@ -1275,7 +1275,7 @@ DECLARE_API(DumpMT)
         {&dwStartAddr, COHEX}
     };
     size_t nArg;
-    if (!GetCMDOption(args, option, _countof(option), arg, _countof(arg), &nArg))
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), arg, ARRAY_SIZE(arg), &nArg))
     {
         return Status;
     }
@@ -1914,7 +1914,7 @@ DECLARE_API(DumpArray)
         {&flags.strObject, COSTRING}
     };
     size_t nArg;
-    if (!GetCMDOption(args, option, _countof(option), arg, _countof(arg), &nArg))
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), arg, ARRAY_SIZE(arg), &nArg))
     {
         return Status;
     }
@@ -2130,7 +2130,7 @@ DECLARE_API(DumpObj)
         {&str_Object.data, COSTRING}
     };
     size_t nArg;
-    if (!GetCMDOption(args, option, _countof(option), arg, _countof(arg), &nArg))
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), arg, ARRAY_SIZE(arg), &nArg))
     {
         return Status;
     }
@@ -2188,7 +2188,7 @@ DECLARE_API(DumpALC)
         {&str_Object.data, COSTRING}
     };
     size_t nArg;
-    if (!GetCMDOption(args, option, _countof(option), arg, _countof(arg), &nArg))
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), arg, ARRAY_SIZE(arg), &nArg))
     {
         return Status;
     }
@@ -2241,7 +2241,7 @@ DECLARE_API(DumpDelegate)
             {&dwAddr, COHEX}
         };
         size_t nArg;
-        if (!GetCMDOption(args, option, _countof(option), arg, _countof(arg), &nArg))
+        if (!GetCMDOption(args, option, ARRAY_SIZE(option), arg, ARRAY_SIZE(arg), &nArg))
         {
             return Status;
         }
@@ -2512,7 +2512,7 @@ BOOL IsAsyncException(CLRDATA_ADDRESS taObj, CLRDATA_ADDRESS mtObj)
                 xcode = EXCEPTION_COMPLUS;
                 goto Done;
             }
-            for (size_t idx = 0; idx < _countof(AsyncHResultValues); ++idx)
+            for (size_t idx = 0; idx < ARRAY_SIZE(AsyncHResultValues); ++idx)
             {
                 if (ehr == AsyncHResultValues[idx])
                 {
@@ -2533,7 +2533,7 @@ BOOL IsAsyncException(const DacpExceptionObjectData & excData)
         return TRUE;
 
     HRESULT ehr = excData.HResult;
-    for (size_t idx = 0; idx < _countof(AsyncHResultValues); ++idx)
+    for (size_t idx = 0; idx < ARRAY_SIZE(AsyncHResultValues); ++idx)
     {
         if (ehr == AsyncHResultValues[idx])
         {
@@ -2653,13 +2653,13 @@ size_t FormatGeneratedException (DWORD_PTR dataPtr,
                 // The unmodified IP is displayed (above by DumpMDInfoBuffer) which points after the exception in most
                 // cases. This means that the printed IP and the printed line number often will not map to one another
                 // and this is intentional.
-                SUCCEEDED(GetLineByOffset(TO_CDADDR(ste.ip), &linenum, filename, _countof(filename), !bAsync || i > 0)))
+                SUCCEEDED(GetLineByOffset(TO_CDADDR(ste.ip), &linenum, filename, ARRAY_SIZE(filename), !bAsync || i > 0)))
             {
-                swprintf_s(wszLineBuffer, _countof(wszLineBuffer), W("    %s [%s @ %d]\n"), so.String(), filename, linenum);
+                swprintf_s(wszLineBuffer, ARRAY_SIZE(wszLineBuffer), W("    %s [%s @ %d]\n"), so.String(), filename, linenum);
             }
             else
             {
-                swprintf_s(wszLineBuffer, _countof(wszLineBuffer), W("    %s\n"), so.String());
+                swprintf_s(wszLineBuffer, ARRAY_SIZE(wszLineBuffer), W("    %s\n"), so.String());
             }
 
             Length += _wcslen(wszLineBuffer);
@@ -2960,7 +2960,7 @@ DECLARE_API(PrintException)
         {&strObject, COSTRING}
     };
     size_t nArg;
-    if (!GetCMDOption(args, option, _countof(option), arg, _countof(arg), &nArg))
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), arg, ARRAY_SIZE(arg), &nArg))
     {
         return Status;
     }
@@ -3126,7 +3126,7 @@ DECLARE_API(DumpVC)
         {&p_Object, COHEX},
     };
     size_t nArg;
-    if (!GetCMDOption(args, option, _countof(option), arg, _countof(arg), &nArg))
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), arg, ARRAY_SIZE(arg), &nArg))
     {
         return Status;
     }
@@ -3168,7 +3168,7 @@ DECLARE_API(DumpRCW)
         {&strObject, COSTRING}
     };
     size_t nArg;
-    if (!GetCMDOption(args, option, _countof(option), arg, _countof(arg), &nArg))
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), arg, ARRAY_SIZE(arg), &nArg))
     {
         return Status;
     }
@@ -3296,7 +3296,7 @@ DECLARE_API(DumpCCW)
         {&strObject, COSTRING}
     };
     size_t nArg;
-    if (!GetCMDOption(args, option, _countof(option), arg, _countof(arg), &nArg))
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), arg, ARRAY_SIZE(arg), &nArg))
     {
         return Status;
     }
@@ -3552,7 +3552,7 @@ DECLARE_API(DumpPermissionSet)
         {&p_Object, COHEX}
     };
     size_t nArg;
-    if (!GetCMDOption(args, NULL, 0, arg, _countof(arg), &nArg))
+    if (!GetCMDOption(args, NULL, 0, arg, ARRAY_SIZE(arg), &nArg))
     {
         return Status;
     }
@@ -3595,7 +3595,7 @@ DECLARE_API(EEHeap)
         {"/d", &dml, COBOOL, FALSE},
     };
 
-    if (!GetCMDOption(args, option, _countof(option), NULL, 0, NULL))
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), NULL, 0, NULL))
     {
         return Status;
     }
@@ -3641,7 +3641,7 @@ DECLARE_API(EEHeap)
                 break;
 
             char domain[16];
-            sprintf_s(domain, _countof(domain), "Domain %d", n+1);
+            sprintf_s(domain, ARRAY_SIZE(domain), "Domain %d", n+1);
 
             IfFailRet(PrintDomainHeapInfo(domain, pArray[n], &allHeapSize, &wasted));
 
@@ -3819,7 +3819,7 @@ DECLARE_API(TraverseHeap)
         {&Filename.data, COSTRING},
     };
     size_t nArg;
-    if (!GetCMDOption(args, option, _countof(option), arg, _countof(arg), &nArg))
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), arg, ARRAY_SIZE(arg), &nArg))
     {
         return Status;
     }
@@ -3949,7 +3949,7 @@ DECLARE_API(DumpRuntimeTypes)
         {"/d", &dml, COBOOL, FALSE},
     };
 
-    if (!GetCMDOption(args, option, _countof(option), NULL, 0, NULL))
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), NULL, 0, NULL))
         return Status;
 
     EnableDMLHolder dmlHolder(dml);
@@ -4038,7 +4038,7 @@ public:
         };
 
         size_t nArgs = 0;
-        if (!GetCMDOption(args, option, _countof(option), arg, _countof(arg), &nArgs))
+        if (!GetCMDOption(args, option, ARRAY_SIZE(option), arg, ARRAY_SIZE(arg), &nArgs))
             sos::Throw<sos::Exception>("Failed to parse command line arguments.");
 
         if (mStart == 0)
@@ -4171,7 +4171,7 @@ private:
         if (mVerify)
         {
             char buffer[1024];
-            if (!itr.Verify(buffer, _countof(buffer)))
+            if (!itr.Verify(buffer, ARRAY_SIZE(buffer)))
             {
                 ExtOut(buffer);
                 return false;
@@ -4327,7 +4327,7 @@ private:
 
                 // Don't bother calculating the size of the string, just read the full 64 characters of the buffer.  The null
                 // terminator we read will terminate the string.
-                HRESULT hr = g_ExtData->ReadVirtual(TO_CDADDR(addr+offset), tmp.str, sizeof(WCHAR)*(_countof(tmp.str)-1), &fetched);
+                HRESULT hr = g_ExtData->ReadVirtual(TO_CDADDR(addr+offset), tmp.str, sizeof(WCHAR)*(ARRAY_SIZE(tmp.str)-1), &fetched);
                 if (SUCCEEDED(hr))
                 {
                     // Ensure we null terminate the string.  Note that this will not overrun the buffer as we only
@@ -4512,7 +4512,7 @@ DECLARE_API(VerifyHeap)
 
         while (itr)
         {
-            if (itr.Verify(buffer, _countof(buffer)))
+            if (itr.Verify(buffer, ARRAY_SIZE(buffer)))
             {
                 ++itr;
             }
@@ -4727,7 +4727,7 @@ DECLARE_API(VerifyObj)
         {&taddrObj, COHEX}
     };
     size_t nArg;
-    if (!GetCMDOption(args, option, _countof(option), arg, _countof(arg), &nArg))
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), arg, ARRAY_SIZE(arg), &nArg))
     {
         return Status;
     }
@@ -4789,7 +4789,7 @@ DECLARE_API(ListNearObj)
         {&taddrArg, COHEX}
     };
     size_t nArg;
-    if (!GetCMDOption(args, option, _countof(option), arg, _countof(arg), &nArg) || nArg != 1)
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), arg, ARRAY_SIZE(arg), &nArg) || nArg != 1)
     {
         ExtOut("Usage: !ListNearObj <obj_address>\n");
         return Status;
@@ -4974,7 +4974,7 @@ DECLARE_API(GCHeapStat)
         {"/d",            &dml, COBOOL, FALSE}
     };
 
-    if (!GetCMDOption(args, option, _countof(option), NULL, 0, NULL))
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), NULL, 0, NULL))
     {
         return Status;
     }
@@ -5188,7 +5188,7 @@ DECLARE_API(SyncBlk)
         {&nbAsked, COSIZE_T}
     };
     size_t nArg;
-    if (!GetCMDOption(args, option, _countof(option), arg, _countof(arg), &nArg))
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), arg, ARRAY_SIZE(arg), &nArg))
     {
         return Status;
     }
@@ -5467,7 +5467,7 @@ DECLARE_API(FinalizeQueue)
         {"-mt",       &taddrMT,   COHEX,  TRUE},
     };
 
-    if (!GetCMDOption(args, option, _countof(option), NULL, 0, NULL))
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), NULL, 0, NULL))
     {
         return Status;
     }
@@ -5662,7 +5662,7 @@ DECLARE_API(DumpModule)
     };
 
     size_t nArg;
-    if (!GetCMDOption(args, option, _countof(option), arg, _countof(arg), &nArg))
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), arg, ARRAY_SIZE(arg), &nArg))
     {
         return Status;
     }
@@ -5833,7 +5833,7 @@ DECLARE_API(DumpDomain)
     };
     size_t nArg;
 
-    if (!GetCMDOption(args, option, _countof(option), arg, _countof(arg), &nArg))
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), arg, ARRAY_SIZE(arg), &nArg))
     {
         return Status;
     }
@@ -5954,7 +5954,7 @@ DECLARE_API(DumpAssembly)
     };
     size_t nArg;
 
-    if (!GetCMDOption(args, option, _countof(option), arg, _countof(arg), &nArg))
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), arg, ARRAY_SIZE(arg), &nArg))
     {
         return Status;
     }
@@ -6484,7 +6484,7 @@ DECLARE_API(ThreadState)
     if (state)
     {
 
-        for (unsigned int i = 0; i < _countof(ThreadStates); ++i)
+        for (unsigned int i = 0; i < ARRAY_SIZE(ThreadStates); ++i)
             if (state & ThreadStates[i].State)
             {
                 ExtOut("    %s\n", ThreadStates[i].Name);
@@ -6516,7 +6516,7 @@ DECLARE_API(Threads)
         {"-managedexception", &bSwitchToManagedExceptionThread, COBOOL, FALSE},
         {"/d", &dml, COBOOL, FALSE},
     };
-    if (!GetCMDOption(args, option, _countof(option), NULL, 0, NULL))
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), NULL, 0, NULL))
     {
         return Status;
     }
@@ -6690,13 +6690,13 @@ void IssueDebuggerBPCommand ( CLRDATA_ADDRESS addr )
         if (g_sos->GetMethodDescPtrFromIP(addr, &pMD) != S_OK
             || g_sos->GetMethodDescName(pMD, 1024, wszNameBuffer, NULL) != S_OK)
         {
-            wcscpy_s(wszNameBuffer, _countof(wszNameBuffer), W("UNKNOWN"));
+            wcscpy_s(wszNameBuffer, ARRAY_SIZE(wszNameBuffer), W("UNKNOWN"));
         }
 
 #ifndef FEATURE_PAL
-        sprintf_s(buffer, _countof(buffer), "bp %p", SOS_PTR(addr));
+        sprintf_s(buffer, ARRAY_SIZE(buffer), "bp %p", SOS_PTR(addr));
 #else
-        sprintf_s(buffer, _countof(buffer), "breakpoint set --address 0x%p", SOS_PTR(addr));
+        sprintf_s(buffer, ARRAY_SIZE(buffer), "breakpoint set --address 0x%p", SOS_PTR(addr));
 #endif
         ExtOut("Setting breakpoint: %s [%S]\n", buffer, wszNameBuffer);
         g_ExtControl->Execute(DEBUG_EXECUTE_NOT_LOGGED, buffer, 0);
@@ -7456,9 +7456,9 @@ public:
             {
                 CHAR buffer[100];
 #ifndef FEATURE_PAL
-                sprintf_s(buffer, _countof(buffer), "bp /1 %p", SOS_PTR(startAddr+catcherNativeOffset));
+                sprintf_s(buffer, ARRAY_SIZE(buffer), "bp /1 %p", SOS_PTR(startAddr+catcherNativeOffset));
 #else
-                sprintf_s(buffer, _countof(buffer), "breakpoint set --one-shot --address 0x%p", SOS_PTR(startAddr+catcherNativeOffset));
+                sprintf_s(buffer, ARRAY_SIZE(buffer), "breakpoint set --one-shot --address 0x%p", SOS_PTR(startAddr+catcherNativeOffset));
 #endif
                 g_ExtControl->Execute(DEBUG_EXECUTE_NOT_LOGGED, buffer, 0);
             }
@@ -7486,7 +7486,7 @@ BOOL CheckCLRNotificationEvent(DEBUG_LAST_EVENT_INFO_EXCEPTION* pdle)
 
     if (SUCCEEDED(Status = g_sos->QueryInterface(__uuidof(ISOSDacInterface4), (void**) &psos4)))
     {
-        int count = _countof(arguments);
+        int count = ARRAY_SIZE(arguments);
         int countNeeded = 0;
 
         Status = psos4->GetClrNotification(arguments, count, &countNeeded);
@@ -7677,7 +7677,7 @@ DECLARE_API(bpmd)
         {&Offset, COSIZE_T},
     };
     size_t nArg;
-    if (!GetCMDOption(args, option, _countof(option), arg, _countof(arg), &nArg))
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), arg, ARRAY_SIZE(arg), &nArg))
     {
         return Status;
     }
@@ -7963,7 +7963,7 @@ DECLARE_API(bpmd)
             ExtOut("This DynamicMethodDesc is not yet JITTED. Placing memory breakpoint at %p\n",
                 SOS_PTR(MethodDescData.AddressOfNativeCodeSlot));
 
-            sprintf_s(buffer, _countof(buffer),
+            sprintf_s(buffer, ARRAY_SIZE(buffer),
 #ifdef _TARGET_WIN64_
                 "ba w8"
 #else
@@ -8036,7 +8036,7 @@ DECLARE_API(ThreadPool)
         {"/d", &dml, COBOOL, FALSE},
     };
 
-    if (!GetCMDOption(args, option, _countof(option), NULL, 0, NULL))
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), NULL, 0, NULL))
     {
         return E_FAIL;
     }
@@ -8603,7 +8603,7 @@ DECLARE_API(FindAppDomain)
     };
     size_t nArg;
 
-    if (!GetCMDOption(args, option, _countof(option), arg, _countof(arg), &nArg))
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), arg, ARRAY_SIZE(arg), &nArg))
     {
         return Status;
     }
@@ -8873,7 +8873,7 @@ DECLARE_API(EHInfo)
     };
 
     size_t nArg;
-    if (!GetCMDOption(args, option, _countof(option), arg, _countof(arg), &nArg) || (0 == nArg))
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), arg, ARRAY_SIZE(arg), &nArg) || (0 == nArg))
     {
         return Status;
     }
@@ -8954,7 +8954,7 @@ DECLARE_API(GCInfo)
         {&taStartAddr, COHEX},
     };
     size_t nArg;
-    if (!GetCMDOption(args, option, _countof(option), arg, _countof(arg), &nArg) || (0 == nArg))
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), arg, ARRAY_SIZE(arg), &nArg) || (0 == nArg))
     {
         return Status;
     }
@@ -9261,7 +9261,7 @@ DECLARE_API(u)
     {   // vptr, type
         {&dwStartAddr, COHEX},
     };
-    if (!GetCMDOption(args, option, _countof(option), arg, _countof(arg), &nArg) || (nArg < 1))
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), arg, ARRAY_SIZE(arg), &nArg) || (nArg < 1))
     {
         return Status;
     }
@@ -9796,7 +9796,7 @@ DECLARE_API(DumpLog)
         {&sFileName.data, COSTRING}
     };
     size_t nArg;
-    if (!GetCMDOption(args, option, _countof(option), arg, _countof(arg), &nArg))
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), arg, ARRAY_SIZE(arg), &nArg))
     {
         return Status;
     }
@@ -10369,7 +10369,7 @@ DECLARE_API(SOSStatus)
             {"--reset", &bReset, COBOOL, FALSE},
             {"-r", &bReset, COBOOL, FALSE},
         };
-        if (!GetCMDOption(args, option, _countof(option), NULL, 0, NULL))
+        if (!GetCMDOption(args, option, ARRAY_SIZE(option), NULL, 0, NULL))
         {
             return Status;
         }
@@ -10494,7 +10494,7 @@ DECLARE_API (ProcInfo)
                 end = _wcschr (pt, L'\0');
                 if (end == NULL) {
                     char format[20];
-                    sprintf_s (format,_countof (format), "%dS", &buffer[DT_OS_PAGE_SIZE/2] - pt);
+                    sprintf_s (format, ARRAY_SIZE(format), "%dS", &buffer[DT_OS_PAGE_SIZE/2] - pt);
                     ExtOut(format, pt);
                     break;
                 }
@@ -10694,7 +10694,7 @@ DECLARE_API(Token2EE)
     };
 
     size_t nArg;
-    if (!GetCMDOption(args,option, _countof(option), arg, _countof(arg), &nArg))
+    if (!GetCMDOption(args,option, ARRAY_SIZE(option), arg, ARRAY_SIZE(arg), &nArg))
     {
         return Status;
     }
@@ -10786,7 +10786,7 @@ DECLARE_API(Name2EE)
     };
     size_t nArg;
 
-    if (!GetCMDOption(args, option, _countof(option), arg, _countof(arg), &nArg))
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), arg, ARRAY_SIZE(arg), &nArg))
     {
         return Status;
     }
@@ -10907,7 +10907,7 @@ DECLARE_API(PathTo)
         {&root, COHEX},
         {&target, COHEX},
     };
-    if (!GetCMDOption(args, option, _countof(option), arg, _countof(arg), &nArg))
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), arg, ARRAY_SIZE(arg), &nArg))
     {
         return Status;
     }
@@ -10957,7 +10957,7 @@ DECLARE_API(GCRoot)
     {   // vptr, type
         {&obj, COHEX}
     };
-    if (!GetCMDOption(args, option, _countof(option), arg, _countof(arg), &nArg))
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), arg, ARRAY_SIZE(arg), &nArg))
     {
         return Status;
     }
@@ -11003,7 +11003,7 @@ DECLARE_API(GCWhere)
     {   // vptr, type
         {&taddrObj, COHEX}
     };
-    if (!GetCMDOption(args, option, _countof(option), arg, _countof(arg), &nArg))
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), arg, ARRAY_SIZE(arg), &nArg))
     {
         return Status;
     }
@@ -11132,7 +11132,7 @@ DECLARE_API(FindRoots)
     {   // vptr, type
         {&taObj, COHEX}
     };
-    if (!GetCMDOption(args, option, _countof(option), arg, _countof(arg), &nArg))
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), arg, ARRAY_SIZE(arg), &nArg))
     {
         return Status;
     }
@@ -11355,7 +11355,7 @@ public:
             {"/d", &mDML, COBOOL, FALSE},
         };
 
-        if (!GetCMDOption(args,option,_countof(option),NULL,0,NULL))
+        if (!GetCMDOption(args,option,ARRAY_SIZE(option),NULL,0,NULL))
             sos::Throw<sos::Exception>("Failed to parse command line arguments.");
 
         if (type != NULL)
@@ -11453,14 +11453,14 @@ private:
         HRESULT hr = S_OK;
         do
         {
-            if (FAILED(hr = handles->Next(_countof(data), data, &fetched)))
+            if (FAILED(hr = handles->Next(ARRAY_SIZE(data), data, &fetched)))
             {
                 ExtOut("Error %x while walking the handle table.\n", hr);
                 break;
             }
 
             WalkHandles(data, fetched);
-        } while (_countof(data) == fetched);
+        } while (ARRAY_SIZE(data) == fetched);
     }
 
     void WalkHandles(SOSHandleData data[], unsigned int count)
@@ -11739,7 +11739,7 @@ DECLARE_API(GetCodeTypeFlags)
         {&PReg.data, COSTRING}
     };
     size_t nArg;
-    if (!GetCMDOption(args, NULL, 0, arg, _countof(arg), &nArg))
+    if (!GetCMDOption(args, NULL, 0, arg, ARRAY_SIZE(arg), &nArg))
     {
         return Status;
     }
@@ -11755,7 +11755,7 @@ DECLARE_API(GetCodeTypeFlags)
         }
     }
 
-    sprintf_s(buffer,_countof (buffer),
+    sprintf_s(buffer, ARRAY_SIZE(buffer),
         "r$t%d=0",
         preg);
     Status = g_ExtControl->Execute(DEBUG_EXECUTE_NOT_LOGGED, buffer ,0);
@@ -11806,7 +11806,7 @@ DECLARE_API(GetCodeTypeFlags)
         codeType = 16;
     }
 
-    sprintf_s(buffer,_countof (buffer),
+    sprintf_s(buffer, ARRAY_SIZE(buffer),
         "r$t%d=%x",
         preg, codeType);
     Status = g_ExtControl->Execute(DEBUG_EXECUTE_NOT_LOGGED, buffer, 0);
@@ -11847,7 +11847,7 @@ DECLARE_API(StopOnException)
         {&PReg.data, COSTRING}
     };
     size_t nArg;
-    if (!GetCMDOption(args, option, _countof(option), arg, _countof(arg), &nArg))
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), arg, ARRAY_SIZE(arg), &nArg))
     {
         return Status;
     }
@@ -11875,7 +11875,7 @@ DECLARE_API(StopOnException)
         }
     }
 
-    sprintf_s(buffer,_countof (buffer),
+    sprintf_s(buffer, ARRAY_SIZE(buffer),
         "r$t%d=0",
         preg);
     Status = g_ExtControl->Execute(DEBUG_EXECUTE_NOT_LOGGED, buffer, 0);
@@ -11887,7 +11887,7 @@ DECLARE_API(StopOnException)
 
     if (fCreate1 || fCreate2)
     {
-        sprintf_s(buffer,_countof (buffer),
+        sprintf_s(buffer, ARRAY_SIZE(buffer),
             "sxe %s \"!soe %s %s %d;.if(@$t%d==0) {g} .else {.echo '%s hit'}\" %x",
             fCreate1 ? "-c" : "-c2",
             fDerived ? "-derived" : "",
@@ -11941,7 +11941,7 @@ DECLARE_API(StopOnException)
             if ((_wcscmp(g_mdName,typeNameWide) == 0) ||
                 (fDerived && IsDerivedFrom(taMT, typeNameWide)))
             {
-                sprintf_s(buffer,_countof (buffer),
+                sprintf_s(buffer, ARRAY_SIZE(buffer),
                     "r$t%d=1",
                     preg);
                 Status = g_ExtControl->Execute(DEBUG_EXECUTE_NOT_LOGGED, buffer, 0);
@@ -11982,7 +11982,7 @@ DECLARE_API(ObjSize)
         {&str_Object.data, COSTRING}
     };
     size_t nArg;
-    if (!GetCMDOption(args, option, _countof(option), arg, _countof(arg), &nArg))
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), arg, ARRAY_SIZE(arg), &nArg))
     {
         return Status;
     }
@@ -12039,7 +12039,7 @@ DECLARE_API(GCHandleLeaks)
         {"/d", &dml, COBOOL, FALSE},
     };
 
-    if (!GetCMDOption(args, option, _countof(option), NULL, 0, NULL))
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), NULL, 0, NULL))
     {
         return Status;
     }
@@ -13264,7 +13264,7 @@ public:
 
                 WCHAR wszModuleName[MAX_LONGPATH];
                 ULONG32 cchModuleNameActual;
-                IfFailRet(pModule->GetName(_countof(wszModuleName), &cchModuleNameActual, wszModuleName));
+                IfFailRet(pModule->GetName(ARRAY_SIZE(wszModuleName), &cchModuleNameActual, wszModuleName));
 
                 ToRelease<IUnknown> pMDUnknown;
                 ToRelease<IMetaDataImport> pMD;
@@ -13311,7 +13311,7 @@ WString BuildRegisterOutput(const SOSStackRefData &ref, bool printObj)
     if (ref.HasRegisterInformation)
     {
         WCHAR reg[32];
-        HRESULT hr = g_sos->GetRegisterName(ref.Register, _countof(reg), reg, NULL);
+        HRESULT hr = g_sos->GetRegisterName(ref.Register, ARRAY_SIZE(reg), reg, NULL);
         if (SUCCEEDED(hr))
             res = reg;
         else
@@ -13367,7 +13367,7 @@ void PrintRef(const SOSStackRefData &ref, TableOutput &out)
     if (ref.Object && (ref.Flags & SOSRefInterior) == 0)
     {
         WCHAR type[128];
-        sos::BuildTypeWithExtraInfo(TO_TADDR(ref.Object), _countof(type), type);
+        sos::BuildTypeWithExtraInfo(TO_TADDR(ref.Object), ARRAY_SIZE(type), type);
 
         res += WString(W(" - ")) + type;
     }
@@ -13660,7 +13660,7 @@ public:
         out.WriteColumn(0, frame->StackOffset);
         out.WriteColumn(1, NativePtr(ip));
 
-        HRESULT hr = g_ExtSymbols->GetNameByOffset(TO_CDADDR(ip), symbol, _countof(symbol), NULL, &displacement);
+        HRESULT hr = g_ExtSymbols->GetNameByOffset(TO_CDADDR(ip), symbol, ARRAY_SIZE(symbol), NULL, &displacement);
         if (SUCCEEDED(hr) && symbol[0] != '\0')
         {
             String frameOutput;
@@ -13675,7 +13675,7 @@ public:
             if (!bSuppressLines)
             {
                 ULONG line;
-                hr = g_ExtSymbols->GetLineByOffset(TO_CDADDR(ip), &line, filename, _countof(filename), NULL, NULL);
+                hr = g_ExtSymbols->GetLineByOffset(TO_CDADDR(ip), &line, filename, ARRAY_SIZE(filename), NULL, NULL);
                 if (SUCCEEDED(hr))
                 {
                     frameOutput += " at ";
@@ -14045,7 +14045,7 @@ DECLARE_API(Watch)
     {   // vptr, type
         {&expression.data, COSTRING}
     };
-    if (!GetCMDOption(args, option, _countof(option), arg, _countof(arg), &nArg))
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), arg, ARRAY_SIZE(arg), &nArg))
     {
         return Status;
     }
@@ -14178,7 +14178,7 @@ DECLARE_API(ClrStack)
         {&cvariableName.data, COSTRING},
         {&frameToDumpVariablesFor, COSIZE_T},
     };
-    if (!GetCMDOption(args, option, _countof(option), arg, _countof(arg), &nArg))
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), arg, ARRAY_SIZE(arg), &nArg))
     {
         return Status;
     }
@@ -14319,7 +14319,7 @@ DECLARE_API(SaveModule)
         {&Location.data, COSTRING}
     };
     size_t nArg;
-    if (!GetCMDOption(args, NULL, 0, arg, _countof(arg), &nArg))
+    if (!GetCMDOption(args, NULL, 0, arg, ARRAY_SIZE(arg), &nArg))
     {
         return Status;
     }
@@ -14509,7 +14509,7 @@ DECLARE_API(dbgout)
         {"-off", &bOff, COBOOL, FALSE},
     };
 
-    if (!GetCMDOption(args, option, _countof(option), NULL, 0, NULL))
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), NULL, 0, NULL))
     {
         return Status;
     }
@@ -15045,7 +15045,7 @@ BOOL FormatFromRemoteString(DWORD_PTR strObjPointer, __out_ecount(cchString) PWS
     UINT Length = 0;
     while(1)
     {
-        if (_wcsncmp(pwszPointer, PSZSEP, _countof(PSZSEP)-1) != 0)
+        if (_wcsncmp(pwszPointer, PSZSEP, ARRAY_SIZE(PSZSEP)-1) != 0)
         {
             delete [] pwszBuf;
             return bRet;
@@ -15068,7 +15068,7 @@ BOOL FormatFromRemoteString(DWORD_PTR strObjPointer, __out_ecount(cchString) PWS
         WCHAR wszLineBuffer[mdNameLen + 8 + sizeof(size_t)*2];
 
         // Note that we don't add a newline because we have this embedded in wszLineBuffer
-        swprintf_s(wszLineBuffer, _countof(wszLineBuffer), W("    %p %p %s"), SOS_PTR(-1), SOS_PTR(-1), pwszPointer);
+        swprintf_s(wszLineBuffer, ARRAY_SIZE(wszLineBuffer), W("    %p %p %s"), SOS_PTR(-1), SOS_PTR(-1), pwszPointer);
         Length += (UINT)_wcslen(wszLineBuffer);
 
         if (wszBuffer)
@@ -15282,7 +15282,7 @@ DECLARE_API(VerifyStackTrace)
         {"-ManagedExcepStack", &bVerifyManagedExcepStack, COBOOL, FALSE},
     };
 
-    if (!GetCMDOption(args, option, _countof(option), NULL,0,NULL))
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), NULL,0,NULL))
     {
         return Status;
     }
@@ -15488,7 +15488,7 @@ DECLARE_API(SaveState)
         {&filePath.data, COSTRING},
     };
     size_t nArg;
-    if (!GetCMDOption(args, NULL, 0, arg, _countof(arg), &nArg))
+    if (!GetCMDOption(args, NULL, 0, arg, ARRAY_SIZE(arg), &nArg))
     {
         return E_FAIL;
     }
@@ -15528,7 +15528,7 @@ DECLARE_API(SuppressJitOptimization)
         {&onOff.data, COSTRING},
     };
     size_t nArg;
-    if (!GetCMDOption(args, NULL, 0, arg, _countof(arg), &nArg))
+    if (!GetCMDOption(args, NULL, 0, arg, ARRAY_SIZE(arg), &nArg))
     {
         return E_FAIL;
     }
@@ -15865,7 +15865,7 @@ DECLARE_API(VerifyGMT)
         };
         size_t nArg;
 
-        if (!GetCMDOption(args, NULL, 0, arg, _countof(arg), &nArg))
+        if (!GetCMDOption(args, NULL, 0, arg, ARRAY_SIZE(arg), &nArg))
         {
             return Status;
         }
@@ -15948,7 +15948,7 @@ DECLARE_API(SetHostRuntime)
         {&hostRuntimeDirectory.data, COSTRING},
     };
     size_t narg;
-    if (!GetCMDOption(args, option, _countof(option), arg, _countof(arg), &narg))
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), arg, ARRAY_SIZE(arg), &narg))
     {
         return E_FAIL;
     }
@@ -16049,7 +16049,7 @@ DECLARE_API(SetSymbolServer)
         {&symbolServer.data, COSTRING},
     };
     size_t narg;
-    if (!GetCMDOption(args, option, _countof(option), arg, _countof(arg), &narg))
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), arg, ARRAY_SIZE(arg), &narg))
     {
         return E_FAIL;
     }
@@ -16152,7 +16152,7 @@ DECLARE_API(SetClrPath)
             {&runtimeModulePath.data, COSTRING},
         };
         size_t narg;
-        if (!GetCMDOption(args, nullptr, 0, arg, _countof(arg), &narg))
+        if (!GetCMDOption(args, nullptr, 0, arg, ARRAY_SIZE(arg), &narg))
         {
             return E_FAIL;
         }
@@ -16197,7 +16197,7 @@ DECLARE_API(runtimes)
             {"-netfx", &bNetFx, COBOOL, FALSE},
             {"-netcore", &bNetCore, COBOOL, FALSE},
         };
-        if (!GetCMDOption(args, option, _countof(option), NULL, 0, NULL))
+        if (!GetCMDOption(args, option, ARRAY_SIZE(option), NULL, 0, NULL))
         {
             return Status;
         }
@@ -16316,8 +16316,8 @@ void PrintHelp (__in_z LPCSTR pszCmdName)
         }
 
         char lpFilename[MAX_LONGPATH + 12]; // + 12 to make enough room for strcat function.
-        strcpy_s(lpFilename, _countof(lpFilename), szSOSModulePath);
-        strcat_s(lpFilename, _countof(lpFilename), "sosdocsunix.txt");
+        strcpy_s(lpFilename, ARRAY_SIZE(lpFilename), szSOSModulePath);
+        strcat_s(lpFilename, ARRAY_SIZE(lpFilename), "sosdocsunix.txt");
 
         HANDLE hSosDocFile = CreateFileA(lpFilename, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, 0, NULL);
         if (hSosDocFile == INVALID_HANDLE_VALUE) {
@@ -16344,7 +16344,7 @@ void PrintHelp (__in_z LPCSTR pszCmdName)
 
     // Find our line in the text file
     char searchString[MAX_LONGPATH];
-    sprintf_s(searchString, _countof(searchString), "COMMAND: %s.", pszCmdName);
+    sprintf_s(searchString, ARRAY_SIZE(searchString), "COMMAND: %s.", pszCmdName);
 
     LPSTR pStart = strstr(pText, searchString);
     LPSTR pEnd = NULL;
@@ -16404,7 +16404,7 @@ DECLARE_API(Help)
         {&commandName.data, COSTRING}
     };
     size_t nArg;
-    if (!GetCMDOption(args, NULL, 0, arg, _countof(arg), &nArg))
+    if (!GetCMDOption(args, NULL, 0, arg, ARRAY_SIZE(arg), &nArg))
     {
         return Status;
     }

--- a/src/SOS/Strike/strike.h
+++ b/src/SOS/Strike/strike.h
@@ -10,9 +10,7 @@
 #ifndef __strike_h__
 #define __strike_h__
 
-#ifndef _countof
-#define _countof(x) (sizeof(x)/sizeof(x[0]))
-#endif
+#include <minipal/utils.h>
 
 #if defined(_MSC_VER)
 #pragma warning(disable:4245)   // signed/unsigned mismatch

--- a/src/SOS/Strike/util.cpp
+++ b/src/SOS/Strike/util.cpp
@@ -111,7 +111,7 @@ DWORD_PTR GetValueFromExpression(___in __in_z const char *const instr)
     else if (hr == S_FALSE && dwAddr)
         return (DWORD_PTR)dwAddr;
 
-    strcpy_s (name, _countof(name), str);
+    strcpy_s (name, ARRAY_SIZE(name), str);
     char *ptr;
     if ((ptr = strstr (name, "__")) != NULL)
     {
@@ -866,7 +866,7 @@ const char * ElementTypeName(unsigned type)
         return "MVAR";
         break;
     default:
-        if ((type >= _countof(CorElementTypeName)) || (CorElementTypeName[type] == NULL))
+        if ((type >= ARRAY_SIZE(CorElementTypeName)) || (CorElementTypeName[type] == NULL))
         {
             return "";
         }
@@ -877,7 +877,7 @@ const char * ElementTypeName(unsigned type)
 
 const char * ElementTypeNamespace(unsigned type)
 {
-    if ((type >= _countof(CorElementTypeName)) || (CorElementTypeNamespace[type] == NULL))
+    if ((type >= ARRAY_SIZE(CorElementTypeName)) || (CorElementTypeNamespace[type] == NULL))
     {
         return "";
     }
@@ -1017,7 +1017,7 @@ void DisplayFields(CLRDATA_ADDRESS cdaMT, DacpMethodTableData *pMTD, DacpMethodT
                 // If ET type from signature is different from fielddesc, then the signature one is more descriptive.
                 // For example, E_T_STRING in field desc will be E_T_CLASS. In minidump's case, we won't have
                 // the method table for it.
-                ComposeName_s(vFieldDesc.Type != vFieldDesc.sigType ? vFieldDesc.sigType : vFieldDesc.Type, ElementName, sizeof(ElementName)/sizeof(ElementName[0]));
+                ComposeName_s(vFieldDesc.Type != vFieldDesc.sigType ? vFieldDesc.sigType : vFieldDesc.Type, ElementName, ARRAY_SIZE(ElementName));
                 ExtOut("%20.20s ", ElementName);
             }
         }
@@ -3179,7 +3179,7 @@ void DumpMDInfoFromMethodDescData(DacpMethodDescData * pMethodDescData, DacpReJi
     BOOL bFailed = FALSE;
     if (g_sos->GetMethodDescName(pMethodDescData->MethodDescPtr, 1024, wszNameBuffer, NULL) != S_OK)
     {
-        wcscpy_s(wszNameBuffer, _countof(wszNameBuffer), W("UNKNOWN"));
+        wcscpy_s(wszNameBuffer, ARRAY_SIZE(wszNameBuffer), W("UNKNOWN"));
         bFailed = TRUE;
     }
 
@@ -3272,7 +3272,7 @@ void DumpMDInfo(DWORD_PTR dwMethodDescAddr, CLRDATA_ADDRESS dwRequestedIP /* = 0
         TO_CDADDR(dwMethodDescAddr),
         dwRequestedIP,
         &MethodDescData,
-        _countof(revertedRejitData),
+        ARRAY_SIZE(revertedRejitData),
         revertedRejitData,
         &cNeededRevertedRejitData) != S_OK)
     {
@@ -3593,7 +3593,7 @@ BOOL GetSOSVersion(VS_FIXEDFILEINFO *pFileInfo)
     _ASSERTE(pFileInfo);
 
     WCHAR wszFullPath[MAX_LONGPATH];
-    DWORD cchFullPath = GetModuleFileNameW(g_hInstance, wszFullPath, _countof(wszFullPath));
+    DWORD cchFullPath = GetModuleFileNameW(g_hInstance, wszFullPath, ARRAY_SIZE(wszFullPath));
 
     DWORD dwHandle = 0;
     DWORD infoSize = GetFileVersionInfoSizeW(wszFullPath, &dwHandle);
@@ -3744,7 +3744,7 @@ void StringObjectContent(size_t obj, BOOL fLiteral, const int length)
                 toRead = count;
 
             ULONG bytesRead;
-            wcsncpy_s(buffer,_countof(buffer),(LPWSTR) dwAddr, toRead);
+            wcsncpy_s(buffer,ARRAY_SIZE(buffer),(LPWSTR) dwAddr, toRead);
             bytesRead = toRead*sizeof(WCHAR);
             DWORD wcharsRead = bytesRead/2;
             buffer[wcharsRead] = L'\0';
@@ -4042,7 +4042,7 @@ BOOL GetCMDOption(const char *string, CMDOption *option, size_t nOption,
                 ExtOut ("Invalid option %s\n", ptr);
                 return FALSE;
             }
-            strncpy_s (buffer,_countof(buffer), ptr, end-ptr);
+            strncpy_s (buffer,ARRAY_SIZE(buffer), ptr, end-ptr);
 
             size_t n;
             for (n = 0; n < nOption; n ++)
@@ -4860,10 +4860,10 @@ CachedString Output::BuildHexValue(CLRDATA_ADDRESS disp, CLRDATA_ADDRESS addr, F
         char hex2[POINTERSIZE_BYTES*2 + 1];
         char* d = hex1;
         char* a = hex1;
-        GetHex(addr, hex1, _countof(hex1), fill);
+        GetHex(addr, hex1, ARRAY_SIZE(hex1), fill);
         if (disp != addr)
         {
-            GetHex(disp, hex2, _countof(hex2), fill);
+            GetHex(disp, hex2, ARRAY_SIZE(hex2), fill);
             d = hex2;
         }
 
@@ -4889,7 +4889,7 @@ CachedString Output::BuildHexValueWithLength(CLRDATA_ADDRESS addr, size_t len, F
     if (IsDMLEnabled())
     {
         char hex[POINTERSIZE_BYTES*2 + 1];
-        GetHex(addr, hex, _countof(hex), fill);
+        GetHex(addr, hex, ARRAY_SIZE(hex), fill);
         sprintf_s(ret, ret.GetStrLen(), DMLFormats[type], hex, len, hex);
     }
     else
@@ -4918,13 +4918,13 @@ CachedString Output::BuildVCValue(CLRDATA_ADDRESS disp, CLRDATA_ADDRESS mt, CLRD
         char* d = hexaddr1;
         char* a = hexaddr1;
 
-        GetHex(addr, hexaddr1, _countof(hexaddr1), fill);
+        GetHex(addr, hexaddr1, ARRAY_SIZE(hexaddr1), fill);
         if (disp != addr)
         {
-            GetHex(disp, hexaddr2, _countof(hexaddr2), fill);
+            GetHex(disp, hexaddr2, ARRAY_SIZE(hexaddr2), fill);
             d = hexaddr2;
         }
-        GetHex(mt, hexmt, _countof(hexmt), fill);
+        GetHex(mt, hexmt, ARRAY_SIZE(hexmt), fill);
 
         sprintf_s(ret, ret.GetStrLen(), DMLFormats[type], hexmt, a, d);
     }
@@ -4988,7 +4988,7 @@ CachedString Output::BuildManagedVarValue(__in_z LPCWSTR expansionName, ULONG fr
 CachedString Output::BuildManagedVarValue(__in_z LPCWSTR expansionName, ULONG frame, int indexInArray, FormatType type)
 {
     WCHAR indexString[24];
-    swprintf_s(indexString, _countof(indexString), W("[%d]"), indexInArray);
+    swprintf_s(indexString, ARRAY_SIZE(indexString), W("[%d]"), indexInArray);
     return BuildManagedVarValue(expansionName, frame, indexString, type);
 }
 
@@ -5079,7 +5079,7 @@ GetLastMethodIlOffset(
     HRESULT Status;
     CLRDATA_IL_ADDRESS_MAP MapLocal[16];
     CLRDATA_IL_ADDRESS_MAP* Map = MapLocal;
-    ULONG32 MapCount = _countof(MapLocal);
+    ULONG32 MapCount = ARRAY_SIZE(MapLocal);
     ULONG32 MapNeeded;
     ULONG32 HighestOffset;
 
@@ -5342,7 +5342,7 @@ const char *TableOutput::GetWhitespace(int amount)
 
     if (count == 0)
     {
-        count = _countof(WhiteSpace);
+        count = ARRAY_SIZE(WhiteSpace);
         for (int i = 0; i < count-1; ++i)
             WhiteSpace[i] = ' ';
         WhiteSpace[count-1] = 0;
@@ -5612,7 +5612,7 @@ WString MethodNameFromIP(CLRDATA_ADDRESS ip, BOOL bSuppressLines, BOOL bAssembly
 
                 if (SUCCEEDED(g_ExtSymbols->GetModuleNames(Index, moduleBase, NULL, 0, NULL, szModuleName, MAX_LONGPATH, NULL, NULL, 0, NULL)))
                 {
-                    MultiByteToWideChar (CP_ACP, 0, szModuleName, MAX_LONGPATH, g_mdName, _countof(g_mdName));
+                    MultiByteToWideChar (CP_ACP, 0, szModuleName, MAX_LONGPATH, g_mdName, ARRAY_SIZE(g_mdName));
                     methodOutput += g_mdName;
                     methodOutput += W("!");
                 }
@@ -5700,7 +5700,7 @@ HRESULT InternalFrameManager::Init(ICorDebugThread3 * pThread3)
     _ASSERTE(pThread3 != NULL);
 
     return pThread3->GetActiveInternalFrames(
-        _countof(m_rgpInternalFrame2),
+        ARRAY_SIZE(m_rgpInternalFrame2),
         &m_cInternalFramesActual,
         &(m_rgpInternalFrame2[0]));
 }

--- a/src/SOS/Strike/util.h
+++ b/src/SOS/Strike/util.h
@@ -41,10 +41,6 @@ inline void RestoreSOToleranceState() {}
 #include "runtimeimpl.h"
 #include "symbols.h"
 
-#ifndef COUNTOF
-#define COUNTOF(a) (sizeof(a) / sizeof(*a))
-#endif
-
 typedef LPCSTR  LPCUTF8;
 typedef LPSTR   LPUTF8;
 
@@ -1025,8 +1021,8 @@ namespace Output
                 char buffer[64];
                 if (mFormat == Formats::Default || mFormat == Formats::Pointer)
                 {
-                    sprintf_s(buffer, _countof(buffer), "%p", (int *)(SIZE_T)mValue);
-                    ConvertToLower(buffer, _countof(buffer));
+                    sprintf_s(buffer, ARRAY_SIZE(buffer), "%p", (int *)(SIZE_T)mValue);
+                    ConvertToLower(buffer, ARRAY_SIZE(buffer));
                 }
                 else
                 {
@@ -1038,8 +1034,8 @@ namespace Output
                     else if (mFormat == Formats::Decimal)
                         format = "%d";
 
-                    sprintf_s(buffer, _countof(buffer), format, (__int32)mValue);
-                    ConvertToLower(buffer, _countof(buffer));
+                    sprintf_s(buffer, ARRAY_SIZE(buffer), format, (__int32)mValue);
+                    ConvertToLower(buffer, ARRAY_SIZE(buffer));
                 }
 
                 return buffer;
@@ -1095,7 +1091,7 @@ namespace Output
         static void BuildDMLCol(__out_ecount(len) char *result, int len, CLRDATA_ADDRESS value, Formats::Format format, Output::FormatType dmlType, bool leftAlign, int width)
         {
             char hex[64];
-            int count = GetHex(value, hex, _countof(hex), format != Formats::Hex);
+            int count = GetHex(value, hex, ARRAY_SIZE(hex), format != Formats::Hex);
             int i = 0;
 
             if (!leftAlign)
@@ -1534,7 +1530,7 @@ public:
 
         va_list list;
         va_start(list, fmt);
-        vsprintf_s(result, _countof(result), fmt, list);
+        vsprintf_s(result, ARRAY_SIZE(result), fmt, list);
         va_end(list);
 
         WriteColumn(col, result);
@@ -1546,7 +1542,7 @@ public:
 
         va_list list;
         va_start(list, fmt);
-        vswprintf_s(result, _countof(result), fmt, list);
+        vswprintf_s(result, ARRAY_SIZE(result), fmt, list);
         va_end(list);
 
         WriteColumn(col, result);
@@ -2890,7 +2886,7 @@ public:
     {
 #ifdef _DEBUG
         char buffer[1024];
-        sprintf_s(buffer, _countof(buffer), "Cache (%s): %d reads (%2.1f%% hits), %d misses (%2.1f%%), %d misaligned (%2.1f%%).\n",
+        sprintf_s(buffer, ARRAY_SIZE(buffer), "Cache (%s): %d reads (%2.1f%% hits), %d misses (%2.1f%%), %d misaligned (%2.1f%%).\n",
                                              func, mReads, 100*(mReads-mMisses)/(float)(mReads+mMisaligned), mMisses,
                                              100*mMisses/(float)(mReads+mMisaligned), mMisaligned, 100*mMisaligned/(float)(mReads+mMisaligned));
         OutputDebugStringA(buffer);

--- a/src/SOS/Strike/vm.cpp
+++ b/src/SOS/Strike/vm.cpp
@@ -52,7 +52,7 @@ Revision History:
 #define PRINTF_FORMAT_HEAD  "%-7s  %*s  %*s  %*s %*s  %*s\n"
 #define PRINTF_FORMAT       "%-7s %*sK %*sK %*sK %*s %*sK\n"
 
-#define CCH_ULONGLONG_COMMAS   _countof("18,446,744,073,709,551,616")
+#define CCH_ULONGLONG_COMMAS   ARRAY_SIZE("18,446,744,073,709,551,616")
 #define CCH_ULONGLONG_MINIMUM_COMMAS (CCH_ULONGLONG_COMMAS - 3)
 #define CCH_ULONGLONG_BLOCKCOUNT_COMMAS    sizeof("1,000,000")
 
@@ -144,12 +144,9 @@ PROTECT_MASK ProtectMasks[] =
         }
     };
 
-#define NUM_PROTECT_MASKS (sizeof(ProtectMasks) / sizeof(ProtectMasks[0]))
-
 //
 // Private functions.
 //
-
 
 PSTR
 ULongLongToString(
@@ -157,7 +154,6 @@ ULongLongToString(
     __out_ecount (CCH_ULONGLONG_COMMAS) OUT PSTR Buffer
     )
 {
-
     PSTR p1;
     PSTR p2;
     CHAR ch;
@@ -407,7 +403,7 @@ VmProtectToString(
     Buffer[0] = '\0';
 
     for( i = 0, mask = &ProtectMasks[0] ;
-        (i < NUM_PROTECT_MASKS) && (Protect != 0) ;
+        (i < ARRAY_SIZE(ProtectMasks)) && (Protect != 0) ;
         i++, mask++ ) {
         if( mask->Bit & Protect ) {
             Protect &= ~mask->Bit;
@@ -461,7 +457,7 @@ VmStateToString(
         break;
 
     default:
-        sprintf_s(invalidStr,_countof(invalidStr), "%08lx", State );
+        sprintf_s(invalidStr,ARRAY_SIZE(invalidStr), "%08lx", State );
         result = invalidStr;
         break;
     }
@@ -500,7 +496,7 @@ VmTypeToString(
         break;
 
     default:
-        sprintf_s(invalidStr,_countof(invalidStr), "%08lx", Type );
+        sprintf_s(invalidStr,ARRAY_SIZE(invalidStr), "%08lx", Type );
         result = invalidStr;
         break;
     }
@@ -698,10 +694,10 @@ Return Value:
             SOS_PTR(memInfo.BaseAddress),
             SOS_PTR(((ULONG_PTR)memInfo.BaseAddress + memInfo.RegionSize - 1)),
             SOS_PTR(memInfo.RegionSize),
-            VmProtectToString( memInfo.AllocationProtect, aprotectStr, _countof(aprotectStr) ),
-            VmProtectToString( memInfo.Protect, protectStr, _countof(protectStr)  ),
-            VmStateToString( memInfo.State, stateStr, _countof(stateStr) ),
-            VmTypeToString( memInfo.Type, typeStr , _countof(typeStr))
+            VmProtectToString( memInfo.AllocationProtect, aprotectStr, ARRAY_SIZE(aprotectStr) ),
+            VmProtectToString( memInfo.Protect, protectStr, ARRAY_SIZE(protectStr)  ),
+            VmStateToString( memInfo.State, stateStr, ARRAY_SIZE(stateStr) ),
+            VmTypeToString( memInfo.Type, typeStr , ARRAY_SIZE(typeStr))
             );
 
         //

--- a/src/SOS/extensions/config.h.in
+++ b/src/SOS/extensions/config.h.in
@@ -5,5 +5,6 @@
 #define __CONFIG_H__
 
 #cmakedefine01 HAVE_DIRENT_D_TYPE
+#cmakedefine01 HAVE_GETAUXVAL
 
 #endif // __CONFIG_H__

--- a/src/SOS/extensions/configure.cmake
+++ b/src/SOS/extensions/configure.cmake
@@ -1,5 +1,5 @@
 include(CheckStructHasMember)
-include(CheckCXXSymbolExists)
+include(CheckIncludeFiles)
 
 check_struct_has_member ("struct dirent" d_type dirent.h HAVE_DIRENT_D_TYPE)
 check_include_files("sys/auxv.h;asm/hwcap.h" HAVE_AUXV_HWCAP_H)

--- a/src/SOS/extensions/configure.cmake
+++ b/src/SOS/extensions/configure.cmake
@@ -1,5 +1,7 @@
 include(CheckStructHasMember)
+include(CheckCXXSymbolExists)
 
 check_struct_has_member ("struct dirent" d_type dirent.h HAVE_DIRENT_D_TYPE)
+check_include_files("sys/auxv.h;asm/hwcap.h" HAVE_AUXV_HWCAP_H)
 
 configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/config.h.in ${CMAKE_CURRENT_BINARY_DIR}/config.h)

--- a/src/SOS/extensions/hostcoreclr.cpp
+++ b/src/SOS/extensions/hostcoreclr.cpp
@@ -25,10 +25,8 @@
 #include "coreclrhost.h"
 #include "extensions.h"
 
-#ifndef _countof
-#define _countof(x) (sizeof(x)/sizeof(x[0]))
-#endif
 #include <minipal/getexepath.h>
+#include <minipal/utils.h>
 
 #ifndef IfFailRet
 #define IfFailRet(EXPR) do { Status = (EXPR); if(FAILED(Status)) { return (Status); } } while (0)
@@ -478,7 +476,7 @@ static HRESULT GetHostRuntime(std::string& coreClrPath, std::string& hostRuntime
         };
 
 #if defined(HOST_UNIX)
-        for (int i = 0; i < _countof(RuntimeHostingConstants::UnixInstallPaths); i++)
+        for (int i = 0; i < ARRAY_SIZE(RuntimeHostingConstants::UnixInstallPaths); i++)
         {
             strategyList.push_back({ ProbeInstallationDir, RuntimeHostingConstants::UnixInstallPaths[i] });
         }
@@ -644,8 +642,7 @@ static HRESULT InitializeNetCoreHost()
 
         void* hostHandle;
         unsigned int domainId;
-        hr = initializeCoreCLR(exePath, "sos",
-            sizeof(propertyKeys) / sizeof(propertyKeys[0]), propertyKeys, propertyValues, &hostHandle, &domainId);
+        hr = initializeCoreCLR(exePath, "sos", ARRAY_SIZE(propertyKeys), propertyKeys, propertyValues, &hostHandle, &domainId);
 
         free(exePath);
         if (FAILED(hr))

--- a/src/shared/gcdump/gcinfodumper.cpp
+++ b/src/shared/gcdump/gcinfodumper.cpp
@@ -191,14 +191,10 @@ PORTABILITY_ASSERT("GcInfoDumper::ReportPointerRecord is not implemented on this
 
     };
 
-    const UINT nCONTEXTRegisters = sizeof(rgRegisters)/sizeof(rgRegisters[0]);
-
     UINT iFirstRegister;
     UINT iSPRegister;
-    UINT nRegisters;
 
     iFirstRegister = 0;
-    nRegisters = nCONTEXTRegisters;
 #ifdef TARGET_AMD64
     iSPRegister = (FIELD_OFFSET(CONTEXT, Rsp) - FIELD_OFFSET(CONTEXT, Rax)) / sizeof(ULONGLONG);
 #elif defined(TARGET_ARM64)
@@ -218,7 +214,7 @@ PORTABILITY_ASSERT("GcInfoDumper::ReportPointerRecord is not implemented on this
     {
         SIZE_T *pReg = NULL;
 
-        for (UINT iReg = 0; iReg < nRegisters; iReg++)
+        for (UINT iReg = 0; iReg < ARRAY_SIZE(rgRegisters); iReg++)
         {
             UINT iEncodedReg = iFirstRegister + iReg;
 #ifdef TARGET_ARM
@@ -278,7 +274,7 @@ PORTABILITY_ASSERT("GcInfoDumper::ReportPointerRecord is not implemented on this
             }
 #endif
             {
-                _ASSERTE(iReg < nCONTEXTRegisters);
+                _ASSERTE(iReg < ARRAY_SIZE(rgRegisters));
 #ifdef TARGET_ARM
                 pReg = *(SIZE_T**)(pContext + rgRegisters[iReg].cbContextOffset);
                 if (iEncodedReg == 12)

--- a/src/shared/gcdump/i386/gcdumpx86.cpp
+++ b/src/shared/gcdump/i386/gcdumpx86.cpp
@@ -36,7 +36,7 @@ const char *        RegName(unsigned reg)
         "EDI"
     };
 
-    _ASSERTE(reg < (sizeof(regNames)/sizeof(regNames[0])));
+    _ASSERTE(reg < ARRAY_SIZE(regNames));
 
     return regNames[reg];
 }
@@ -51,7 +51,7 @@ const char *        CalleeSavedRegName(unsigned reg)
         "EBP"
     };
 
-    _ASSERTE(reg < (sizeof(regNames)/sizeof(regNames[0])));
+    _ASSERTE(reg < ARRAY_SIZE(regNames));
 
     return regNames[reg];
 }

--- a/src/shared/minipal/getexepath.h
+++ b/src/shared/minipal/getexepath.h
@@ -1,0 +1,100 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#ifndef HAVE_MINIPAL_GETEXEPATH_H
+#define HAVE_MINIPAL_GETEXEPATH_H
+
+#include <errno.h>
+#include <limits.h>
+#include <stdlib.h>
+
+#if defined(__APPLE__)
+#include <mach-o/dyld.h>
+#elif defined(__FreeBSD__)
+#include <string.h>
+#include <sys/types.h>
+#include <sys/param.h>
+#include <sys/sysctl.h>
+#elif defined(_WIN32)
+#include <windows.h>
+#elif HAVE_GETAUXVAL
+#include <sys/auxv.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Returns the full path to the executable for the current process, resolving symbolic links.
+// The caller is responsible for releasing the buffer. Returns null on error.
+static inline char* minipal_getexepath(void)
+{
+#if defined(__APPLE__)
+    uint32_t path_length = 0;
+    if (_NSGetExecutablePath(NULL, &path_length) != -1)
+    {
+        errno = EINVAL;
+        return NULL;
+    }
+
+    char path_buf[path_length];
+    if (_NSGetExecutablePath(path_buf, &path_length) != 0)
+    {
+        errno = EINVAL;
+        return NULL;
+    }
+
+    return realpath(path_buf, NULL);
+#elif defined(__FreeBSD__)
+    static const int name[] = { CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1 };
+    char path[PATH_MAX];
+    size_t len = sizeof(path);
+    if (sysctl(name, 4, path, &len, NULL, 0) != 0)
+    {
+        return NULL;
+    }
+
+    return strdup(path);
+#elif defined(__sun)
+    const char* path = getexecname();
+    if (path == NULL)
+    {
+        return NULL;
+    }
+
+    return realpath(path, NULL);
+#elif defined(_WIN32)
+    char path[MAX_PATH];
+    if (GetModuleFileNameA(NULL, path, MAX_PATH) == 0)
+    {
+        return NULL;
+    }
+
+    return strdup(path);
+#elif defined(TARGET_WASM)
+    // This is a packaging convention that our tooling should enforce.
+    return strdup("/managed");
+#else
+#if HAVE_GETAUXVAL && defined(AT_EXECFN)
+    const char* path = (const char *)(getauxval(AT_EXECFN));
+    if (path && !errno)
+    {
+        return realpath(path, NULL);
+    }
+#endif // HAVE_GETAUXVAL && defined(AT_EXECFN)
+#ifdef __linux__
+    const char* symlinkEntrypointExecutable = "/proc/self/exe";
+#else
+    const char* symlinkEntrypointExecutable = "/proc/curproc/exe";
+#endif
+
+    // Resolve the symlink to the executable from /proc
+    return realpath(symlinkEntrypointExecutable, NULL);
+#endif // defined(__APPLE__)
+}
+
+#ifdef __cplusplus
+}
+#endif // extern "C"
+
+#endif // HAVE_MINIPAL_GETEXEPATH_H

--- a/src/shared/minipal/getexepath.h
+++ b/src/shared/minipal/getexepath.h
@@ -70,7 +70,7 @@ static inline char* minipal_getexepath(void)
         return NULL;
     }
 
-    return strdup(path);
+    return _strdup(path);
 #elif defined(TARGET_WASM)
     // This is a packaging convention that our tooling should enforce.
     return strdup("/managed");

--- a/src/shared/pal/src/include/pal/palinternal.h
+++ b/src/shared/pal/src/include/pal/palinternal.h
@@ -145,6 +145,7 @@ function_name() to call the system's implementation
 /* Include our configuration information so it's always present when
    compiling PAL implementation files. */
 #include "config.h"
+#include <minipal/utils.h>
 
 #ifdef DEBUG
 #define _ENABLE_DEBUG_MESSAGES_ 1

--- a/src/shared/pal/src/misc/errorstrings.cpp
+++ b/src/shared/pal/src/misc/errorstrings.cpp
@@ -163,7 +163,7 @@ LPCWSTR GetPalErrorString(DWORD code)
     ErrorString *stringEntry = (ErrorString *)bsearch(
         &searchEntry,
         palErrorStrings,
-        sizeof(palErrorStrings) / sizeof(palErrorStrings[0]),
+        ARRAY_SIZE(palErrorStrings),
         sizeof(ErrorString),
         CompareErrorStrings);
 

--- a/src/shared/pal/src/safecrt/input.inl
+++ b/src/shared/pal/src/safecrt/input.inl
@@ -220,10 +220,10 @@ static int __check_float_string(size_t nFloatStrUsed,
 #endif  /* _UNICODE */
 {
     _TCHAR floatstring[_CVTBUFSIZE + 1];
-    _TCHAR *pFloatStr=floatstring;
-    size_t nFloatStrUsed=0;
-    size_t nFloatStrSz=sizeof(floatstring)/sizeof(floatstring[0]);
-    int malloc_FloatStrFlag=0;
+    _TCHAR *pFloatStr = floatstring;
+    size_t nFloatStrUsed = 0;
+    size_t nFloatStrSz = ARRAY_SIZE(floatstring);
+    int malloc_FloatStrFlag = 0;
 
     unsigned long number;               /* temp hold-value                   */
 #if ALLOC_TABLE

--- a/src/shared/pal/src/synchmgr/wait.cpp
+++ b/src/shared/pal/src/synchmgr/wait.cpp
@@ -33,13 +33,8 @@ SET_DEFAULT_DEBUG_CHANNEL(SYNC);
 
 using namespace CorUnix;
 
-static PalObjectTypeId sg_rgWaitObjectsIds[] =
-    {
-        otiProcess,
-        otiThread
-    };
-static CAllowedObjectTypes sg_aotWaitObject(sg_rgWaitObjectsIds,
-    sizeof(sg_rgWaitObjectsIds)/sizeof(sg_rgWaitObjectsIds[0]));
+static PalObjectTypeId sg_rgWaitObjectsIds[] = { otiProcess, otiThread };
+static CAllowedObjectTypes sg_aotWaitObject(sg_rgWaitObjectsIds, ARRAY_SIZE(sg_rgWaitObjectsIds));
 
 /*++
 Function:


### PR DESCRIPTION
First commit: port https://github.com/dotnet/runtime/blob/f865423/src/native/minipal/getexepath.h, a self-dependent header, covers handful of corner cases to get executable path in a cross-platform manner. It is used throughout the runtime repo (clr, tests, corehost, mono and `Environment.ProcessPath` .NET API).

Second commit: use `ARRAY_SIZE` macro from the previously copied `minipal/utils.h` in more places and delete three redundant macros computing the same thing.