### PR TITLE
Misc dbgshim and SOS fixes

### DIFF
--- a/src/Microsoft.Diagnostics.DebugServices/MemoryServiceExtensions.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/MemoryServiceExtensions.cs
@@ -125,6 +125,7 @@ namespace Microsoft.Diagnostics.DebugServices
         {
             Debug.Assert(address != 0);
             Debug.Assert(size != 0);
+            Debug.Assert((address & ~memoryService.SignExtensionMask()) == 0);
             return new TargetStream(memoryService, address, size);
         }
 

--- a/src/SOS/SOS.Hosting/SymbolServiceWrapper.cs
+++ b/src/SOS/SOS.Hosting/SymbolServiceWrapper.cs
@@ -53,6 +53,7 @@ namespace SOS.Hosting
 
         private readonly ISymbolService _symbolService;
         private readonly IMemoryService _memoryService;
+        private readonly ulong _ignoreAddressBitsMask;
 
         public SymbolServiceWrapper(ISymbolService symbolService, IMemoryService memoryService)
         {
@@ -60,6 +61,7 @@ namespace SOS.Hosting
             Debug.Assert(memoryService != null);
             _symbolService = symbolService;
             _memoryService = memoryService;
+            _ignoreAddressBitsMask = memoryService.SignExtensionMask();
             Debug.Assert(_symbolService != null);
 
             VTableBuilder builder = AddInterface(IID_ISymbolService, validate: false);
@@ -147,11 +149,13 @@ namespace SOS.Hosting
                 ISymbolFile symbolFile = null;
                 if (loadedPeAddress != 0)
                 {
+                    loadedPeAddress &= _ignoreAddressBitsMask;
                     Stream peStream = _memoryService.CreateMemoryStream(loadedPeAddress, loadedPeSize);
                     symbolFile = _symbolService.OpenSymbolFile(assemblyPath, isFileLayout, peStream);
                 }
                 if (inMemoryPdbAddress != 0)
                 {
+                    inMemoryPdbAddress &= _ignoreAddressBitsMask;
                     Stream pdbStream = _memoryService.CreateMemoryStream(inMemoryPdbAddress, inMemoryPdbSize);
                     symbolFile = _symbolService.OpenSymbolFile(pdbStream);
                 }

--- a/src/dbgshim/dbgshim.cpp
+++ b/src/dbgshim/dbgshim.cpp
@@ -598,12 +598,9 @@ public:
                 SetEvent(clrRuntimeInfo.ContinueStartupEvent);
             }
         }
-        if (FAILED(hr))
+        if (FAILED(hr) && (pCordb != NULL))
         {
-            if (pCordb != NULL)
-            {
-                pCordb->Release();
-            }
+            pCordb->Release();
         }
         return hr;
     }

--- a/src/dbgshim/dbgshim.cpp
+++ b/src/dbgshim/dbgshim.cpp
@@ -98,7 +98,11 @@ struct ClrRuntimeInfo
     ClrRuntimeInfo()
     {
         ModuleHandle = NULL;
+#ifdef TARGET_UNIX
+        ContinueStartupEvent = NULL;
+#else
         ContinueStartupEvent = INVALID_HANDLE_VALUE;
+#endif
 
         EngineMetrics.cbSize = sizeof(EngineMetrics);
         EngineMetrics.dwDbiVersion = CorDebugLatestVersion;
@@ -396,8 +400,10 @@ public:
     exit:
         if (FAILED(hr))
         {
-            _ASSERTE(pCordb == NULL);
-
+            if (pCordb != NULL)
+            {
+                pCordb->Release();
+            }
             // Invoke the callback on error
             m_callback(NULL, m_parameter, hr);
         }
@@ -502,19 +508,19 @@ public:
         // Don't need to wake up and wait for the worker thread if called on it
         if (m_threadId != GetCurrentThreadId())
         {
-            // Wait for work thread to exit
-            WaitForSingleObject(m_threadHandle, INFINITE);
+            // Wait for work thread to exit for 60 seconds
+            WaitForSingleObject(m_threadHandle, 60 * 1000);
         }
     }
 
     HRESULT InvokeStartupCallback(bool *pCoreClrExists)
     {
         ClrRuntimeInfo clrRuntimeInfo;
+        IUnknown *pCordb = NULL;
         HRESULT hr = S_OK;
 
         PAL_CPP_TRY
         {
-            IUnknown *pCordb = NULL;
 
             *pCoreClrExists = FALSE;
 
@@ -592,7 +598,13 @@ public:
                 SetEvent(clrRuntimeInfo.ContinueStartupEvent);
             }
         }
-
+        if (FAILED(hr))
+        {
+            if (pCordb != NULL)
+            {
+                pCordb->Release();
+            }
+        }
         return hr;
     }
 

--- a/src/shared/pal/src/thread/process.cpp
+++ b/src/shared/pal/src/thread/process.cpp
@@ -1441,11 +1441,8 @@ public:
         // Don't need to wait for the worker thread if unregister called on it
         if (m_threadId != (DWORD)THREADSilentGetCurrentThreadId())
         {
-            // Wait for work thread to exit
-            if (WaitForSingleObject(m_threadHandle, INFINITE) != WAIT_OBJECT_0)
-            {
-                ASSERT("WaitForSingleObject\n");
-            }
+            // Wait for work thread to exit for 60 seconds
+            WaitForSingleObject(m_threadHandle, 60 * 1000);
         }
     }
 


### PR DESCRIPTION
Fixed some dbgshim issues found with Samsung's netcoredbg managed debugger.

Fix some sign-extension issues on alpine arm32 in SOS. Found investigating https://github.com/dotnet/diagnostics/issues/3003.

Fix DbgShim.UnitTest's Microsoft.Diagnostics.DbgShimAPI+NativeRuntimeStartupCallbackDelegate being called after collected by the GC