### PR TITLE
Update SOS to show thread pool work items from new queues

### DIFF
--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -8372,7 +8372,7 @@ DECLARE_API(ThreadPool)
                 }
 
                 // Enumerate assignable normal-priority work items.
-                offset = GetObjFieldOffset(itr->GetAddress(), itr->GetMT(), W("assignableWorkItemQueues"));
+                offset = GetObjFieldOffset(itr->GetAddress(), itr->GetMT(), W("_assignableWorkItemQueues"));
                 if (offset > 0)
                 {
                     DWORD_PTR workItemsConcurrentQueueArrayPtr;
@@ -8383,9 +8383,9 @@ DECLARE_API(ThreadPool)
                     {
                         for (int i = 0; i < workItemsConcurrentQueueArray.dwNumComponents; i++)
                         {
-                            CLRDATA_ADDRESS workItemsConcurrentQueuePtr;
-                            MOVE(workItemsConcurrentQueuePtr, TO_CDADDR(workItemsConcurrentQueueArray.ArrayDataPtr + (i * workItemsConcurrentQueueArray.dwComponentSize)));
-                            if (workItemsConcurrentQueuePtr != NULL && sos::IsObject(workItemsConcurrentQueuePtr, false))
+                            DWORD_PTR workItemsConcurrentQueuePtr;
+                            MOVE(workItemsConcurrentQueuePtr, workItemsConcurrentQueueArray.ArrayDataPtr + (i * workItemsConcurrentQueueArray.dwComponentSize));
+                            if (workItemsConcurrentQueuePtr != NULL && sos::IsObject(TO_CDADDR(workItemsConcurrentQueuePtr), false))
                             {
                                 // We got the ConcurrentQueue.  Enumerate it.
                                 EnumerateThreadPoolGlobalWorkItemConcurrentQueue(workItemsConcurrentQueuePtr, "[Global]", &stats);
@@ -8421,9 +8421,9 @@ DECLARE_API(ThreadPool)
                     {
                         for (int i = 0; i < workItemArray.dwNumComponents; i++)
                         {
-                            CLRDATA_ADDRESS workItemPtr;
-                            MOVE(workItemPtr, TO_CDADDR(workItemArray.ArrayDataPtr + (i * workItemArray.dwComponentSize)));
-                            if (workItemPtr != NULL && sos::IsObject(workItemPtr, false))
+                            DWORD_PTR workItemPtr;
+                            MOVE(workItemPtr, workItemArray.ArrayDataPtr + (i * workItemArray.dwComponentSize));
+                            if (workItemPtr != NULL && sos::IsObject(TO_CDADDR(workItemPtr), false))
                             {
                                 sos::Object workItem = TO_TADDR(workItemPtr);
                                 stats.Add((DWORD_PTR)workItem.GetMT(), (DWORD)workItem.GetSize());
@@ -8431,10 +8431,10 @@ DECLARE_API(ThreadPool)
                                 if ((offset = GetObjFieldOffset(workItem.GetAddress(), workItem.GetMT(), W("_callback"))) > 0 ||
                                     (offset = GetObjFieldOffset(workItem.GetAddress(), workItem.GetMT(), W("m_action"))) > 0)
                                 {
-                                    CLRDATA_ADDRESS delegatePtr;
+                                    DWORD_PTR delegatePtr;
                                     MOVE(delegatePtr, workItem.GetAddress() + offset);
                                     CLRDATA_ADDRESS md;
-                                    if (TryGetMethodDescriptorForDelegate(delegatePtr, &md))
+                                    if (TryGetMethodDescriptorForDelegate(TO_CDADDR(delegatePtr), &md))
                                     {
                                         NameForMD_s((DWORD_PTR)md, g_mdName, mdNameLen);
                                         ExtOut(" => %S", g_mdName);

--- a/src/SOS/Strike/util.cpp
+++ b/src/SOS/Strike/util.cpp
@@ -6035,9 +6035,9 @@ void EnumerateThreadPoolGlobalWorkItemConcurrentQueue(
         {
             for (int i = 0; i < slotsArray.dwNumComponents; i++)
             {
-                CLRDATA_ADDRESS workItemPtr;
-                MOVE(workItemPtr, TO_CDADDR(slotsArray.ArrayDataPtr + (i * slotsArray.dwComponentSize))); // the item object reference is at the beginning of the Slot
-                if (workItemPtr != NULL && sos::IsObject(workItemPtr, false))
+                DWORD_PTR workItemPtr;
+                MOVE(workItemPtr, slotsArray.ArrayDataPtr + (i * slotsArray.dwComponentSize)); // the item object reference is at the beginning of the Slot
+                if (workItemPtr != NULL && sos::IsObject(TO_CDADDR(workItemPtr), false))
                 {
                     sos::Object workItem = TO_TADDR(workItemPtr);
                     stats->Add((DWORD_PTR)workItem.GetMT(), (DWORD)workItem.GetSize());
@@ -6045,10 +6045,10 @@ void EnumerateThreadPoolGlobalWorkItemConcurrentQueue(
                     if ((offset = GetObjFieldOffset(workItem.GetAddress(), workItem.GetMT(), W("_callback"))) > 0 ||
                         (offset = GetObjFieldOffset(workItem.GetAddress(), workItem.GetMT(), W("m_action"))) > 0)
                     {
-                        CLRDATA_ADDRESS delegatePtr;
+                        DWORD_PTR delegatePtr;
                         MOVE(delegatePtr, workItem.GetAddress() + offset);
                         CLRDATA_ADDRESS md;
-                        if (TryGetMethodDescriptorForDelegate(delegatePtr, &md))
+                        if (TryGetMethodDescriptorForDelegate(TO_CDADDR(delegatePtr), &md))
                         {
                             NameForMD_s((DWORD_PTR)md, g_mdName, mdNameLen);
                             ExtOut(" => %S", g_mdName);


### PR DESCRIPTION
- Depends on https://github.com/dotnet/runtime/pull/69386
- The PR above added new queues of work items. This change updates the `ThreadPool -wi` command to include showing work items from those new queues.
- Verified that the updated SOS works with and without the above PR