### PR TITLE
Add error message to WriteDump response

### DIFF
--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
@@ -602,7 +602,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
                     }
                     if (string.IsNullOrWhiteSpace(message))
                     {
-                        message = $"{operationName} - HRESULT: 0x{hr:X8}.";
+                        message = $"{operationName} failed - HRESULT: 0x{hr:X8}.";
                     }
                     throw new ServerErrorException(message);
 

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
@@ -589,7 +589,8 @@ namespace Microsoft.Diagnostics.NETCore.Client
                             throw new UnsupportedCommandException($"{operationName} failed - Invalid command argument.");
 
                         case (uint)DiagnosticsIpcError.NotSupported:
-                            throw new NotSupportedException($"{operationName} - Not supported by this runtime.");
+                            message = $"{operationName} - Not supported by this runtime.";
+                            break;
 
                         default:
                             break;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
@@ -591,16 +591,14 @@ namespace Microsoft.Diagnostics.NETCore.Client
                         case (uint)DiagnosticsIpcError.NotSupported:
                             throw new NotSupportedException($"{operationName} - Not supported by this runtime.");
 
-                        // Only this error code (E_FAIL) can have a error message
-                        case (uint)DiagnosticsIpcError.Fail:
-                            if (options.HasFlag(ValidateResponseOptions.ErrorMessageReturned))
-                            {
-                                message = IpcHelpers.ReadString(responseMessage.Payload, ref index);
-                            }
-                            break;
-
                         default:
                             break;
+                    }
+                    // Check if the command can return an error message and if the payload is big enough to contain the
+                    // error code (uint) and the string length (uint).
+                    if (options.HasFlag(ValidateResponseOptions.ErrorMessageReturned) && responseMessage.Payload.Length >= (sizeof(uint) * 2))
+                    {
+                        message = IpcHelpers.ReadString(responseMessage.Payload, ref index);
                     }
                     if (string.IsNullOrWhiteSpace(message))
                     {

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
@@ -121,9 +121,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
         /// <param name="logDumpGeneration">When set to true, display the dump generation debug log to the console.</param>
         public void WriteDump(DumpType dumpType, string dumpPath, bool logDumpGeneration = false)
         {
-            IpcMessage request = CreateWriteDumpMessage(dumpType, dumpPath, logDumpGeneration);
-            IpcMessage response = IpcClient.SendMessage(_endpoint, request);
-            ValidateResponseMessage(response, nameof(WriteDump));
+            WriteDump(dumpType, dumpPath, logDumpGeneration ? WriteDumpFlags.LoggingEnabled : WriteDumpFlags.None);
         }
 
         /// <summary>
@@ -134,15 +132,25 @@ namespace Microsoft.Diagnostics.NETCore.Client
         /// <param name="flags">logging and crash report flags. On runtimes less than 6.0, only LoggingEnabled is supported.</param>
         public void WriteDump(DumpType dumpType, string dumpPath, WriteDumpFlags flags)
         {
-            IpcMessage request = CreateWriteDumpMessage2(dumpType, dumpPath, flags);
+            IpcMessage request = CreateWriteDumpMessage(DumpCommandId.GenerateCoreDump3, dumpType, dumpPath, flags);
             IpcMessage response = IpcClient.SendMessage(_endpoint, request);
-            if (!ValidateResponseMessage(response, nameof(WriteDump), ValidateResponseOptions.UnknownCommandReturnsFalse))
+            if (!ValidateWriteDumpResponseMessage(response, errorMessage: true))
             {
-                if ((flags & ~WriteDumpFlags.LoggingEnabled) != 0)
+                request = CreateWriteDumpMessage(DumpCommandId.GenerateCoreDump2, dumpType, dumpPath, flags);
+                response = IpcClient.SendMessage(_endpoint, request);
+                if (!ValidateWriteDumpResponseMessage(response, errorMessage: false))
                 {
-                    throw new ArgumentException($"Only {nameof(WriteDumpFlags.LoggingEnabled)} flag is supported by this runtime version", nameof(flags));
+                    if ((flags & ~WriteDumpFlags.LoggingEnabled) != 0)
+                    {
+                        throw new ArgumentException($"Only {nameof(WriteDumpFlags.LoggingEnabled)} flag is supported by this runtime version", nameof(flags));
+                    }
+                    request = CreateWriteDumpMessage(dumpType, dumpPath, logDumpGeneration: (flags & WriteDumpFlags.LoggingEnabled) != 0);
+                    response = IpcClient.SendMessage(_endpoint, request);
+                    if (!ValidateWriteDumpResponseMessage(response, errorMessage: false))
+                    {
+                        throw new UnsupportedCommandException($"Write dump failed - command is not supported.");
+                    }
                 }
-                WriteDump(dumpType, dumpPath, logDumpGeneration: (flags & WriteDumpFlags.LoggingEnabled) != 0);
             }
         }
 
@@ -153,11 +161,9 @@ namespace Microsoft.Diagnostics.NETCore.Client
         /// <param name="dumpPath">Full path to the dump to be generated. By default it is /tmp/coredump.{pid}</param>
         /// <param name="logDumpGeneration">When set to true, display the dump generation debug log to the console.</param>
         /// <param name="token">The token to monitor for cancellation requests.</param>
-        public async Task WriteDumpAsync(DumpType dumpType, string dumpPath, bool logDumpGeneration, CancellationToken token)
+        public Task WriteDumpAsync(DumpType dumpType, string dumpPath, bool logDumpGeneration, CancellationToken token)
         {
-            IpcMessage request = CreateWriteDumpMessage(dumpType, dumpPath, logDumpGeneration);
-            IpcMessage response = await IpcClient.SendMessageAsync(_endpoint, request, token).ConfigureAwait(false);
-            ValidateResponseMessage(response, nameof(WriteDumpAsync));
+            return WriteDumpAsync(dumpType, dumpPath, logDumpGeneration ? WriteDumpFlags.LoggingEnabled : WriteDumpFlags.None, token);
         }
 
         /// <summary>
@@ -169,15 +175,70 @@ namespace Microsoft.Diagnostics.NETCore.Client
         /// <param name="token">The token to monitor for cancellation requests.</param>
         public async Task WriteDumpAsync(DumpType dumpType, string dumpPath, WriteDumpFlags flags, CancellationToken token)
         {
-            IpcMessage request = CreateWriteDumpMessage2(dumpType, dumpPath, flags);
+            IpcMessage request = CreateWriteDumpMessage(DumpCommandId.GenerateCoreDump3, dumpType, dumpPath, flags);
             IpcMessage response = await IpcClient.SendMessageAsync(_endpoint, request, token).ConfigureAwait(false);
-            if (!ValidateResponseMessage(response, nameof(WriteDumpAsync), ValidateResponseOptions.UnknownCommandReturnsFalse))
+            if (!ValidateWriteDumpResponseMessage(response, errorMessage: true))
             {
-                if ((flags & ~WriteDumpFlags.LoggingEnabled) != 0)
+                request = CreateWriteDumpMessage(DumpCommandId.GenerateCoreDump2, dumpType, dumpPath, flags);
+                response = await IpcClient.SendMessageAsync(_endpoint, request, token).ConfigureAwait(false);
+                if (!ValidateWriteDumpResponseMessage(response, errorMessage: false))
                 {
-                    throw new ArgumentException($"Only {nameof(WriteDumpFlags.LoggingEnabled)} flag is supported by this runtime version", nameof(flags));
+                    if ((flags & ~WriteDumpFlags.LoggingEnabled) != 0)
+                    {
+                        throw new ArgumentException($"Only {nameof(WriteDumpFlags.LoggingEnabled)} flag is supported by this runtime version", nameof(flags));
+                    }
+                    request = CreateWriteDumpMessage(dumpType, dumpPath, logDumpGeneration: (flags & WriteDumpFlags.LoggingEnabled) != 0);
+                    response = await IpcClient.SendMessageAsync(_endpoint, request, token).ConfigureAwait(false);
+                    if (!ValidateWriteDumpResponseMessage(response, errorMessage: false))
+                    {
+                        throw new UnsupportedCommandException($"Write dump failed - command is not supported.");
+                    }
                 }
-                await WriteDumpAsync(dumpType, dumpPath, logDumpGeneration: (flags & WriteDumpFlags.LoggingEnabled) != 0, token);
+            }
+        }
+
+        private static bool ValidateWriteDumpResponseMessage(IpcMessage response, bool errorMessage)
+        {
+            switch ((DiagnosticsServerResponseId)response.Header.CommandId)
+            {
+                case DiagnosticsServerResponseId.OK:
+                    return true;
+
+                case DiagnosticsServerResponseId.Error:
+                    int index = 0;
+                    uint hr = BitConverter.ToUInt32(response.Payload, index);
+                    index += sizeof(UInt32);
+                    string message = null;
+                    switch (hr)
+                    {
+                        case (uint)DiagnosticsIpcError.UnknownCommand:
+                            return false;
+
+                        case (uint)DiagnosticsIpcError.InvalidArgument:
+                            throw new UnsupportedCommandException("Write dump failed - Invalid command argument.");
+
+                        case (uint)DiagnosticsIpcError.NotSupported:
+                            throw new NotSupportedException("Write dump failed - Not supported by this runtime.");
+
+                        // Only this error code (E_FAIL) can have a error message
+                        case (uint)DiagnosticsIpcError.Fail:
+                            if (errorMessage)
+                            {
+                                message = IpcHelpers.ReadString(response.Payload, ref index);
+                            }
+                            break;
+
+                        default:
+                            break;
+                    }
+                    if (string.IsNullOrWhiteSpace(message))
+                    {
+                        message = $"Write dump failed - HRESULT: 0x{hr:X8}.";
+                    }
+                    throw new ServerErrorException(message);
+
+                default:
+                    throw new ServerErrorException("Write dump failed - Server responded with unknown response.");
             }
         }
 
@@ -522,13 +583,13 @@ namespace Microsoft.Diagnostics.NETCore.Client
             return new IpcMessage(DiagnosticsServerCommandSet.Dump, (byte)DumpCommandId.GenerateCoreDump, payload);
         }
 
-        private static IpcMessage CreateWriteDumpMessage2(DumpType dumpType, string dumpPath, WriteDumpFlags flags)
+        private static IpcMessage CreateWriteDumpMessage(DumpCommandId command, DumpType dumpType, string dumpPath, WriteDumpFlags flags)
         {
             if (string.IsNullOrEmpty(dumpPath))
                 throw new ArgumentNullException($"{nameof(dumpPath)} required");
 
             byte[] payload = SerializePayload(dumpPath, (uint)dumpType, (uint)flags);
-            return new IpcMessage(DiagnosticsServerCommandSet.Dump, (byte)DumpCommandId.GenerateCoreDump2, payload);
+            return new IpcMessage(DiagnosticsServerCommandSet.Dump, (byte)command, payload);
         }
 
         private static ProcessInfo GetProcessInfoFromResponse(IpcResponse response, string operationName)

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcCommands.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcCommands.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
     {
         GenerateCoreDump = 0x01,
         GenerateCoreDump2 = 0x02,
+        GenerateCoreDump3 = 0x03,
     }
 
     internal enum ProfilerCommandId : byte

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcMessage.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcMessage.cs
@@ -16,7 +16,9 @@ namespace Microsoft.Diagnostics.NETCore.Client
     /// </summary>
     internal enum DiagnosticsIpcError : uint
     {
+        Fail                  = 0x80004005,
         InvalidArgument       = 0x80070057,
+        NotSupported          = 0x80131515,
         ProfilerAlreadyActive = 0x8013136A,
         BadEncoding           = 0x80131384,
         UnknownCommand        = 0x80131385,

--- a/src/Tools/dotnet-dump/Dumper.Windows.cs
+++ b/src/Tools/dotnet-dump/Dumper.Windows.cs
@@ -4,7 +4,7 @@
 
 using Microsoft.Win32.SafeHandles;
 using System;
-using System.Diagnostics;
+using System.ComponentModel;
 using System.IO;
 using System.Runtime.InteropServices;
 
@@ -21,7 +21,9 @@ namespace Microsoft.Diagnostics.Tools.Dump
                 using SafeProcessHandle processHandle = NativeMethods.OpenProcess(NativeMethods.PROCESS_QUERY_INFORMATION | NativeMethods.PROCESS_VM_READ, false, processId);
                 if (processHandle.IsInvalid)
                 {
-                    throw new ArgumentException($"Invalid process id {processId} error: {Marshal.GetLastWin32Error()}");
+                    int error = Marshal.GetLastWin32Error();
+                    string errorText = new Win32Exception(error).Message;
+                    throw new ArgumentException($"Invalid process id {processId} - {errorText} ({error})");
                 }
 
                 // Open the file for writing
@@ -77,7 +79,7 @@ namespace Microsoft.Diagnostics.Tools.Dump
                         else
                         {
                             int err = Marshal.GetHRForLastWin32Error();
-                            if (err != NativeMethods.ERROR_PARTIAL_COPY)
+                            if (err != NativeMethods.HR_ERROR_PARTIAL_COPY)
                             {
                                 Marshal.ThrowExceptionForHR(err);
                             }
@@ -88,7 +90,7 @@ namespace Microsoft.Diagnostics.Tools.Dump
 
             private static class NativeMethods
             {
-                public const int ERROR_PARTIAL_COPY = unchecked((int)0x8007012b);
+                public const int HR_ERROR_PARTIAL_COPY = unchecked((int)0x8007012b);
 
                 public const int PROCESS_VM_READ = 0x0010;
                 public const int PROCESS_QUERY_INFORMATION = 0x0400;

--- a/src/Tools/dotnet-dump/Dumper.cs
+++ b/src/Tools/dotnet-dump/Dumper.cs
@@ -84,17 +84,17 @@ namespace Microsoft.Diagnostics.Tools.Dump
                 }
                 console.Out.WriteLine($"Writing {dumpTypeMessage} to {output}");
 
-                //if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                //{
-                //    if (crashreport)
-                //    {
-                //        Console.WriteLine("Crash reports not supported on Windows.");
-                //        return 0;
-                //    }
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    if (crashreport)
+                    {
+                        Console.WriteLine("Crash reports not supported on Windows.");
+                        return 0;
+                    }
 
-                //    Windows.CollectDump(processId, output, type);
-                //}
-                //else
+                    Windows.CollectDump(processId, output, type);
+                }
+                else
                 {
                     var client = new DiagnosticsClient(processId);
 

--- a/src/Tools/dotnet-dump/Dumper.cs
+++ b/src/Tools/dotnet-dump/Dumper.cs
@@ -84,17 +84,17 @@ namespace Microsoft.Diagnostics.Tools.Dump
                 }
                 console.Out.WriteLine($"Writing {dumpTypeMessage} to {output}");
 
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                {
-                    if (crashreport)
-                    {
-                        Console.WriteLine("Crash reports not supported on Windows.");
-                        return 0;
-                    }
+                //if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                //{
+                //    if (crashreport)
+                //    {
+                //        Console.WriteLine("Crash reports not supported on Windows.");
+                //        return 0;
+                //    }
 
-                    Windows.CollectDump(processId, output, type);
-                }
-                else
+                //    Windows.CollectDump(processId, output, type);
+                //}
+                //else
                 {
                     var client = new DiagnosticsClient(processId);
 


### PR DESCRIPTION
Add the new generate core dump command that can receive error text on failure.