### PR TITLE
Use Environment.GetFolderPath to obtain home directory

### DIFF
--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/SymbolService.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/SymbolService.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
                     }
                     else
                     {
-                        _defaultSymbolCache = Path.Combine(Environment.GetEnvironmentVariable("HOME"), ".dotnet", "symbolcache");
+                        _defaultSymbolCache = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".dotnet", "symbolcache");
                     }
                 }
                 return _defaultSymbolCache;

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/SymbolService.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/SymbolService.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
                 }
                 return _defaultSymbolCache;
             }
-            set 
+            set
             {
                 _defaultSymbolCache = value;
             }
@@ -182,7 +182,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
                                             symbolCachePaths.Add(DefaultSymbolCache);
                                         }
                                     }
-                                    else 
+                                    else
                                     {
                                         symbolCachePaths.Add(parts[i]);
                                     }
@@ -461,10 +461,10 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
                     }
                 }
             }
-            catch (Exception ex) when 
-                (ex is UnauthorizedAccessException || 
-                 ex is BadImageFormatException || 
-                 ex is InvalidVirtualAddressException || 
+            catch (Exception ex) when
+                (ex is UnauthorizedAccessException ||
+                 ex is BadImageFormatException ||
+                 ex is InvalidVirtualAddressException ||
                  ex is IOException)
             {
                 Trace.TraceError($"GetMetaData: {ex.Message}");
@@ -493,7 +493,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
                 peStream = Utilities.TryOpenFile(assemblyPath);
                 if (peStream == null)
                     return null;
-                
+
                 options = PEStreamOptions.Default;
             }
 
@@ -606,7 +606,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
                     Trace.TraceWarning($"DownLoadPE: no key generated for module {fileName} ");
                     return null;
                 }
-            } 
+            }
             else if ((flags & KeyTypeFlags.SymbolKey) != 0)
             {
                 IEnumerable<PdbFileInfo> pdbInfos = module.GetPdbFileInfos();
@@ -647,7 +647,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
                     return null;
                 }
             }
-            else 
+            else
             {
                 throw new ArgumentException($"Key flag not supported {flags}");
             }
@@ -829,7 +829,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
                 string pdbPath = data.Path;
                 Stream pdbStream = null;
 
-                if (assemblyPath != null) 
+                if (assemblyPath != null)
                 {
                     try
                     {
@@ -916,7 +916,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder();
-            ForEachSymbolStore<Microsoft.SymbolStore.SymbolStores.SymbolStore>((symbolStore) => 
+            ForEachSymbolStore<Microsoft.SymbolStore.SymbolStores.SymbolStore>((symbolStore) =>
             {
                 if (symbolStore is HttpSymbolStore httpSymbolStore)
                 {
@@ -962,7 +962,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
             }
         }
 
-        private bool IsDuplicateSymbolStore<T>(Microsoft.SymbolStore.SymbolStores.SymbolStore symbolStore, Func<T, bool> match) 
+        private bool IsDuplicateSymbolStore<T>(Microsoft.SymbolStore.SymbolStores.SymbolStore symbolStore, Func<T, bool> match)
             where T : Microsoft.SymbolStore.SymbolStores.SymbolStore
         {
             while (symbolStore != null)
@@ -1006,7 +1006,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
         /// <returns>Last component of path</returns>
         internal static string GetFileName(string pathName)
         {
-            int pos = pathName.LastIndexOfAny(new char[] { '/', '\\'});
+            int pos = pathName.LastIndexOfAny(new char[] { '/', '\\' });
             if (pos < 0)
             {
                 return pathName;
@@ -1019,11 +1019,11 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
         /// </summary>
         private static bool IsPathEqual(string path1, string path2)
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) 
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 return StringComparer.OrdinalIgnoreCase.Equals(path1, path2);
             }
-            else 
+            else
             {
                 return string.Equals(path1, path2);
             }

--- a/src/SOS/SOS.InstallHelper/InstallHelper.cs
+++ b/src/SOS/SOS.InstallHelper/InstallHelper.cs
@@ -59,7 +59,7 @@ namespace SOS
             string rid = GetRid(architecture);
             string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
 
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) 
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 LLDBInitFile = Path.Combine(home, ".lldbinit");
             }
@@ -76,16 +76,20 @@ namespace SOS
         {
             WriteLine("Installing SOS to {0}", InstallLocation);
 
-            if (string.IsNullOrEmpty(SOSNativeSourcePath) || string.IsNullOrEmpty(SOSManagedSourcePath)) {
+            if (string.IsNullOrEmpty(SOSNativeSourcePath) || string.IsNullOrEmpty(SOSManagedSourcePath))
+            {
                 throw new SOSInstallerException("SOS source path not valid");
             }
-            if (!Directory.Exists(SOSNativeSourcePath)) {
+            if (!Directory.Exists(SOSNativeSourcePath))
+            {
                 throw new SOSInstallerException($"Operating system or architecture not supported: installing from {SOSNativeSourcePath}");
             }
-            if (!Directory.Exists(SOSManagedSourcePath)) {
+            if (!Directory.Exists(SOSManagedSourcePath))
+            {
                 throw new SOSInstallerException($"Invalid SOS source directory {SOSManagedSourcePath}");
             }
-            if (string.IsNullOrEmpty(InstallLocation)) {
+            if (string.IsNullOrEmpty(InstallLocation))
+            {
                 throw new SOSInstallerException($"Installation path {InstallLocation} not valid");
             }
 
@@ -128,10 +132,12 @@ namespace SOS
                 });
 
                 // Configure lldb 
-                if (LLDBInitFile != null) {
+                if (LLDBInitFile != null)
+                {
                     Configure();
                 }
-                else {
+                else
+                {
                     WriteLine($"Execute '.load {InstallLocation}\\sos.dll' to load SOS in your Windows debugger.");
                 }
 
@@ -196,7 +202,8 @@ namespace SOS
         /// <exception cref="SOSInstallerException"></exception>
         public void Configure(bool remove = false)
         {
-            if (string.IsNullOrEmpty(LLDBInitFile)) {
+            if (string.IsNullOrEmpty(LLDBInitFile))
+            {
                 throw new SOSInstallerException("No lldb configuration file path");
             }
             bool changed = false;
@@ -232,7 +239,8 @@ namespace SOS
                     }
                 }
 
-                if (markerFound) {
+                if (markerFound)
+                {
                     throw new SOSInstallerException(".lldbinit file end marker not found");
                 }
             }
@@ -245,7 +253,8 @@ namespace SOS
                 string extension = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? ".dylib" : ".so";
                 lines.Add($"plugin load {plugin}{extension}");
 
-                if (EnableSymbolServer) {
+                if (EnableSymbolServer)
+                {
                     lines.Add(string.Format("setsymbolserver -ms"));
                 }
                 lines.Add(InitFileEnd);
@@ -255,10 +264,12 @@ namespace SOS
             // If there is anything to write, write the lldb init file
             if (changed)
             {
-                if (remove) {
+                if (remove)
+                {
                     WriteLine("Reverting {0} file - LLDB will no longer load SOS at startup", LLDBInitFile);
                 }
-                else {
+                else
+                {
                     WriteLine("{0} {1} file - LLDB will load SOS automatically at startup", existing ? "Updating existing" : "Creating new", LLDBInitFile);
                 }
                 RetryOperation($"Problem writing lldb init file {LLDBInitFile}", () => File.WriteAllLines(LLDBInitFile, lines.ToArray()));
@@ -292,7 +303,8 @@ namespace SOS
                 }
                 catch (Exception ex) when (ex is ArgumentException || ex is UnauthorizedAccessException || ex is SecurityException)
                 {
-                    if (errorMessage == null) {
+                    if (errorMessage == null)
+                    {
                         return;
                     }
                     throw new SOSInstallerException($"{errorMessage}: {ex.Message}", ex);
@@ -301,7 +313,8 @@ namespace SOS
 
             if (lastfailure != null)
             {
-                if (errorMessage == null) {
+                if (errorMessage == null)
+                {
                     return;
                 }
                 throw new SOSInstallerException($"{errorMessage}: {lastfailure.Message}", lastfailure);

--- a/src/SOS/SOS.InstallHelper/InstallHelper.cs
+++ b/src/SOS/SOS.InstallHelper/InstallHelper.cs
@@ -57,21 +57,10 @@ namespace SOS
         {
             m_writeLine = writeLine;
             string rid = GetRid(architecture);
-            string home;
+            string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) 
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) 
             {
-                home = Environment.GetEnvironmentVariable("USERPROFILE");
-                if (string.IsNullOrEmpty(home)) {
-                    throw new SOSInstallerException("USERPROFILE environment variable not found");
-                }
-            }
-            else
-            {
-                home = Environment.GetEnvironmentVariable("HOME");
-                if (string.IsNullOrEmpty(home)) {
-                    throw new SOSInstallerException("HOME environment variable not found");
-                }
                 LLDBInitFile = Path.Combine(home, ".lldbinit");
             }
             InstallLocation = Path.GetFullPath(Path.Combine(home, ".dotnet", "sos"));

--- a/src/Tools/dotnet-dump/Analyzer.cs
+++ b/src/Tools/dotnet-dump/Analyzer.cs
@@ -64,13 +64,7 @@ namespace Microsoft.Diagnostics.Tools.Dump
             _consoleProvider.WriteLine($"Loading core dump: {dump_path} ...");
 
             // Attempt to load the persisted command history
-            string dotnetHome;
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
-                dotnetHome = Path.Combine(Environment.GetEnvironmentVariable("USERPROFILE"), ".dotnet");
-            }
-            else { 
-                dotnetHome = Path.Combine(Environment.GetEnvironmentVariable("HOME"), ".dotnet");
-            }
+            string dotnetHome = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".dotnet");
             string historyFileName = Path.Combine(dotnetHome, "dotnet-dump.history");
             try
             {

--- a/src/Tools/dotnet-dump/Analyzer.cs
+++ b/src/Tools/dotnet-dump/Analyzer.cs
@@ -47,7 +47,8 @@ namespace Microsoft.Diagnostics.Tools.Dump
             _serviceProvider.AddService<IContextService>(_contextService);
             _serviceProvider.AddServiceFactory<SOSLibrary>(() => SOSLibrary.Create(this));
 
-            _contextService.ServiceProvider.AddServiceFactory<ClrMDHelper>(() => {
+            _contextService.ServiceProvider.AddServiceFactory<ClrMDHelper>(() =>
+            {
                 ClrRuntime clrRuntime = _contextService.Services.GetService<ClrRuntime>();
                 return clrRuntime != null ? new ClrMDHelper(clrRuntime) : null;
             });
@@ -71,10 +72,10 @@ namespace Microsoft.Diagnostics.Tools.Dump
                 string[] history = File.ReadAllLines(historyFileName);
                 _consoleProvider.AddCommandHistory(history);
             }
-            catch (Exception ex) when 
-                (ex is IOException || 
-                 ex is UnauthorizedAccessException || 
-                 ex is NotSupportedException || 
+            catch (Exception ex) when
+                (ex is IOException ||
+                 ex is UnauthorizedAccessException ||
+                 ex is NotSupportedException ||
                  ex is SecurityException)
             {
             }
@@ -83,11 +84,12 @@ namespace Microsoft.Diagnostics.Tools.Dump
             LoadExtensions();
 
             try
-            { 
+            {
                 using DataTarget dataTarget = DataTarget.LoadDump(dump_path.FullName);
 
                 OSPlatform targetPlatform = dataTarget.DataReader.TargetPlatform;
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) || dataTarget.DataReader.EnumerateModules().Any((module) => Path.GetExtension(module.FileName) == ".dylib")) {
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) || dataTarget.DataReader.EnumerateModules().Any((module) => Path.GetExtension(module.FileName) == ".dylib"))
+                {
                     targetPlatform = OSPlatform.OSX;
                 }
                 _target = new TargetFromDataReader(dataTarget.DataReader, targetPlatform, this, _targetIdFactory++, dump_path.FullName);
@@ -106,7 +108,8 @@ namespace Microsoft.Diagnostics.Tools.Dump
                     foreach (string cmd in command)
                     {
                         _commandService.Execute(cmd, _contextService.Services);
-                        if (_consoleProvider.Shutdown) {
+                        if (_consoleProvider.Shutdown)
+                        {
                             break;
                         }
                     }
@@ -117,7 +120,8 @@ namespace Microsoft.Diagnostics.Tools.Dump
                     _consoleProvider.WriteLine("Ready to process analysis commands. Type 'help' to list available commands or 'help [command]' to get detailed help on a command.");
                     _consoleProvider.WriteLine("Type 'quit' or 'exit' to exit the session.");
 
-                    _consoleProvider.Start((string commandLine, CancellationToken cancellation) => {
+                    _consoleProvider.Start((string commandLine, CancellationToken cancellation) =>
+                    {
                         _commandService.Execute(commandLine, _contextService.Services);
                     });
                 }
@@ -146,10 +150,10 @@ namespace Microsoft.Diagnostics.Tools.Dump
                 {
                     File.WriteAllLines(historyFileName, _consoleProvider.GetCommandHistory());
                 }
-                catch (Exception ex) when 
-                    (ex is IOException || 
-                     ex is UnauthorizedAccessException || 
-                     ex is NotSupportedException || 
+                catch (Exception ex) when
+                    (ex is IOException ||
+                     ex is UnauthorizedAccessException ||
+                     ex is NotSupportedException ||
                      ex is SecurityException)
                 {
                 }
@@ -171,14 +175,16 @@ namespace Microsoft.Diagnostics.Tools.Dump
 
         public void DestroyTarget(ITarget target)
         {
-            if (target == null) {
+            if (target == null)
+            {
                 throw new ArgumentNullException(nameof(target));
             }
             if (target == _target)
             {
                 _target = null;
                 _contextService.ClearCurrentTarget();
-                if (target is IDisposable disposable) {
+                if (target is IDisposable disposable)
+                {
                     disposable.Dispose();
                 }
             }
@@ -215,7 +221,7 @@ namespace Microsoft.Diagnostics.Tools.Dump
             {
                 assembly = Assembly.LoadFrom(extensionPath);
             }
-            catch (Exception ex) when (ex is IOException || ex is ArgumentException  || ex is BadImageFormatException || ex is System.Security.SecurityException)
+            catch (Exception ex) when (ex is IOException || ex is ArgumentException || ex is BadImageFormatException || ex is System.Security.SecurityException)
             {
                 _consoleProvider.WriteLineError($"Extension load {extensionPath} FAILED {ex.Message}");
             }


### PR DESCRIPTION
The BCL API `Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)` (returns non-nullable and non-empty string) provides fallback in case environment variable, corresponding to platform-specific home directory, is not set. e.g. on Unix it fallback to `getpwuid_r` call and similarly on Windows it calls a similar Win32 API. Using this API aligns dotnet tools with other popular utilities like `git`, which do not give up in $HOME-less scenarios.

Prior art: https://github.com/dotnet/runtime/commit/cef245d28ae8d50f3bf0ad7adedc461cd45b085c and https://github.com/dotnet/sdk/commit/e0456aaf3d9df757b76af6f055eedcca3b51e4da

Second commit runs dotnet-format on the files changed in the first commit.