### PR TITLE
Change GetCurrentTarget and GetService ret type from HResult to int

### DIFF
--- a/src/SOS/SOS.Hosting/HostWrapper.cs
+++ b/src/SOS/SOS.Hosting/HostWrapper.cs
@@ -48,7 +48,7 @@ namespace SOS.Hosting
         /// </summary>
         /// <param name="targetWrapper">target wrapper address returned</param>
         /// <returns>S_OK</returns>
-        private HResult GetCurrentTarget(IntPtr self, out IntPtr targetWrapper)
+        private int GetCurrentTarget(IntPtr self, out IntPtr targetWrapper)
         {
             TargetWrapper wrapper = _getTarget();
             if (wrapper == null)
@@ -70,13 +70,13 @@ namespace SOS.Hosting
             [In] IntPtr self);
 
         [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        internal delegate HResult GetServiceDelegate(
+        internal delegate int GetServiceDelegate(
             [In] IntPtr self,
             [In] in Guid guid,
             [Out] out IntPtr ptr);
 
         [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate HResult GetCurrentTargetDelegate(
+        private delegate int GetCurrentTargetDelegate(
             [In] IntPtr self,
             [Out] out IntPtr target);
 

--- a/src/SOS/SOS.Hosting/ServiceWrapper.cs
+++ b/src/SOS/SOS.Hosting/ServiceWrapper.cs
@@ -87,7 +87,7 @@ namespace SOS.Hosting
         /// <param name="serviceId">guid of the service</param>
         /// <param name="service">pointer to return service instance</param>
         /// <returns>S_OK or E_NOINTERFACE</returns>
-        public HResult GetService(IntPtr self, in Guid guid, out IntPtr ptr)
+        public int GetService(IntPtr self, in Guid guid, out IntPtr ptr)
         {
             ptr = IntPtr.Zero;
 


### PR DESCRIPTION
Returning managed HResult {struct int} to native breaks diagnostics on x86 Linux.

Issue #3101