### PR TITLE
Change WarningsAsErrors elements to inherit

### DIFF
--- a/src/SOS/Strike/Strike.vcxproj
+++ b/src/SOS/Strike/Strike.vcxproj
@@ -108,7 +108,7 @@
       <StringPooling>true</StringPooling>
       <StructMemberAlignment>8Bytes</StructMemberAlignment>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <TreatSpecificWarningsAsErrors>4640</TreatSpecificWarningsAsErrors>
+      <TreatSpecificWarningsAsErrors>$(TreatSpecificWarningsAsErrors);4640</TreatSpecificWarningsAsErrors>
       <TreatWChar_tAsBuiltInType>false</TreatWChar_tAsBuiltInType>
       <TreatWarningAsError>true</TreatWarningAsError>
       <UndefinePreprocessorDefinitions>_MT</UndefinePreprocessorDefinitions>
@@ -184,7 +184,7 @@
       <StringPooling>true</StringPooling>
       <StructMemberAlignment>8Bytes</StructMemberAlignment>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <TreatSpecificWarningsAsErrors>4640</TreatSpecificWarningsAsErrors>
+      <TreatSpecificWarningsAsErrors>$(TreatSpecificWarningsAsErrors);4640</TreatSpecificWarningsAsErrors>
       <TreatWChar_tAsBuiltInType>false</TreatWChar_tAsBuiltInType>
       <TreatWarningAsError>true</TreatWarningAsError>
       <UndefinePreprocessorDefinitions>_MT</UndefinePreprocessorDefinitions>
@@ -258,7 +258,7 @@
       <StringPooling>true</StringPooling>
       <StructMemberAlignment>8Bytes</StructMemberAlignment>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <TreatSpecificWarningsAsErrors>4640</TreatSpecificWarningsAsErrors>
+      <TreatSpecificWarningsAsErrors>$(TreatSpecificWarningsAsErrors);4640</TreatSpecificWarningsAsErrors>
       <TreatWChar_tAsBuiltInType>false</TreatWChar_tAsBuiltInType>
       <TreatWarningAsError>true</TreatWarningAsError>
       <UndefinePreprocessorDefinitions>_MT</UndefinePreprocessorDefinitions>
@@ -334,7 +334,7 @@
       <StringPooling>true</StringPooling>
       <StructMemberAlignment>8Bytes</StructMemberAlignment>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <TreatSpecificWarningsAsErrors>4640</TreatSpecificWarningsAsErrors>
+      <TreatSpecificWarningsAsErrors>$(TreatSpecificWarningsAsErrors);4640</TreatSpecificWarningsAsErrors>
       <TreatWChar_tAsBuiltInType>false</TreatWChar_tAsBuiltInType>
       <TreatWarningAsError>true</TreatWarningAsError>
       <UndefinePreprocessorDefinitions>_MT</UndefinePreprocessorDefinitions>

--- a/src/SOS/extensions/extensions.vcxproj
+++ b/src/SOS/extensions/extensions.vcxproj
@@ -100,7 +100,7 @@
       <StringPooling>true</StringPooling>
       <StructMemberAlignment>8Bytes</StructMemberAlignment>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <TreatSpecificWarningsAsErrors>4640</TreatSpecificWarningsAsErrors>
+      <TreatSpecificWarningsAsErrors>$(TreatSpecificWarningsAsErrors);4640</TreatSpecificWarningsAsErrors>
       <TreatWChar_tAsBuiltInType>false</TreatWChar_tAsBuiltInType>
       <TreatWarningAsError>true</TreatWarningAsError>
       <UndefinePreprocessorDefinitions>_MT</UndefinePreprocessorDefinitions>
@@ -160,7 +160,7 @@
       <StringPooling>true</StringPooling>
       <StructMemberAlignment>8Bytes</StructMemberAlignment>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <TreatSpecificWarningsAsErrors>4640</TreatSpecificWarningsAsErrors>
+      <TreatSpecificWarningsAsErrors>$(TreatSpecificWarningsAsErrors);4640</TreatSpecificWarningsAsErrors>
       <TreatWChar_tAsBuiltInType>false</TreatWChar_tAsBuiltInType>
       <TreatWarningAsError>true</TreatWarningAsError>
       <UndefinePreprocessorDefinitions>_MT</UndefinePreprocessorDefinitions>
@@ -216,7 +216,7 @@
       <StringPooling>true</StringPooling>
       <StructMemberAlignment>8Bytes</StructMemberAlignment>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <TreatSpecificWarningsAsErrors>4640</TreatSpecificWarningsAsErrors>
+      <TreatSpecificWarningsAsErrors>$(TreatSpecificWarningsAsErrors);4640</TreatSpecificWarningsAsErrors>
       <TreatWChar_tAsBuiltInType>false</TreatWChar_tAsBuiltInType>
       <TreatWarningAsError>true</TreatWarningAsError>
       <UndefinePreprocessorDefinitions>_MT</UndefinePreprocessorDefinitions>
@@ -274,7 +274,7 @@
       <StringPooling>true</StringPooling>
       <StructMemberAlignment>8Bytes</StructMemberAlignment>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <TreatSpecificWarningsAsErrors>4640</TreatSpecificWarningsAsErrors>
+      <TreatSpecificWarningsAsErrors>$(TreatSpecificWarningsAsErrors);4640</TreatSpecificWarningsAsErrors>
       <TreatWChar_tAsBuiltInType>false</TreatWChar_tAsBuiltInType>
       <TreatWarningAsError>true</TreatWarningAsError>
       <UndefinePreprocessorDefinitions>_MT</UndefinePreprocessorDefinitions>

--- a/src/dbgshim/dbgshim.vcxproj
+++ b/src/dbgshim/dbgshim.vcxproj
@@ -111,7 +111,7 @@
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <StructMemberAlignment>8Bytes</StructMemberAlignment>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <TreatSpecificWarningsAsErrors>4007;4013;4102;4551;4700;4640;4806</TreatSpecificWarningsAsErrors>
+      <TreatSpecificWarningsAsErrors>$(TreatSpecificWarningsAsErrors);4007;4013;4102;4551;4700;4640;4806</TreatSpecificWarningsAsErrors>
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <TreatWarningAsError>true</TreatWarningAsError>
       <UseFullPaths>true</UseFullPaths>
@@ -180,7 +180,7 @@
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <StructMemberAlignment>8Bytes</StructMemberAlignment>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <TreatSpecificWarningsAsErrors>4007;4013;4102;4551;4700;4640;4806</TreatSpecificWarningsAsErrors>
+      <TreatSpecificWarningsAsErrors>$(TreatSpecificWarningsAsErrors);4007;4013;4102;4551;4700;4640;4806</TreatSpecificWarningsAsErrors>
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <TreatWarningAsError>true</TreatWarningAsError>
       <UseFullPaths>true</UseFullPaths>
@@ -248,7 +248,7 @@
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <StructMemberAlignment>8Bytes</StructMemberAlignment>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <TreatSpecificWarningsAsErrors>4007;4013;4102;4551;4700;4640;4806</TreatSpecificWarningsAsErrors>
+      <TreatSpecificWarningsAsErrors>$(TreatSpecificWarningsAsErrors);4007;4013;4102;4551;4700;4640;4806</TreatSpecificWarningsAsErrors>
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <TreatWarningAsError>true</TreatWarningAsError>
       <UseFullPaths>true</UseFullPaths>
@@ -318,7 +318,7 @@
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <StructMemberAlignment>8Bytes</StructMemberAlignment>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <TreatSpecificWarningsAsErrors>4007;4013;4102;4551;4700;4640;4806</TreatSpecificWarningsAsErrors>
+      <TreatSpecificWarningsAsErrors>$(TreatSpecificWarningsAsErrors);4007;4013;4102;4551;4700;4640;4806</TreatSpecificWarningsAsErrors>
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <TreatWarningAsError>true</TreatWarningAsError>
       <UseFullPaths>true</UseFullPaths>

--- a/src/shared/dbgutil/dbgutil.vcxproj
+++ b/src/shared/dbgutil/dbgutil.vcxproj
@@ -112,7 +112,7 @@
       <StringPooling>true</StringPooling>
       <StructMemberAlignment>8Bytes</StructMemberAlignment>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <TreatSpecificWarningsAsErrors>4640</TreatSpecificWarningsAsErrors>
+      <TreatSpecificWarningsAsErrors>$(TreatSpecificWarningsAsErrors);4640</TreatSpecificWarningsAsErrors>
       <TreatWChar_tAsBuiltInType>false</TreatWChar_tAsBuiltInType>
       <TreatWarningAsError>true</TreatWarningAsError>
       <UndefinePreprocessorDefinitions>_MT</UndefinePreprocessorDefinitions>
@@ -172,7 +172,7 @@
       <StringPooling>true</StringPooling>
       <StructMemberAlignment>8Bytes</StructMemberAlignment>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <TreatSpecificWarningsAsErrors>4640</TreatSpecificWarningsAsErrors>
+      <TreatSpecificWarningsAsErrors>$(TreatSpecificWarningsAsErrors);4640</TreatSpecificWarningsAsErrors>
       <TreatWChar_tAsBuiltInType>false</TreatWChar_tAsBuiltInType>
       <TreatWarningAsError>true</TreatWarningAsError>
       <UndefinePreprocessorDefinitions>_MT</UndefinePreprocessorDefinitions>
@@ -228,7 +228,7 @@
       <StringPooling>true</StringPooling>
       <StructMemberAlignment>8Bytes</StructMemberAlignment>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <TreatSpecificWarningsAsErrors>4640</TreatSpecificWarningsAsErrors>
+      <TreatSpecificWarningsAsErrors>$(TreatSpecificWarningsAsErrors);4640</TreatSpecificWarningsAsErrors>
       <TreatWChar_tAsBuiltInType>false</TreatWChar_tAsBuiltInType>
       <TreatWarningAsError>true</TreatWarningAsError>
       <UndefinePreprocessorDefinitions>_MT</UndefinePreprocessorDefinitions>
@@ -286,7 +286,7 @@
       <StringPooling>true</StringPooling>
       <StructMemberAlignment>8Bytes</StructMemberAlignment>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <TreatSpecificWarningsAsErrors>4640</TreatSpecificWarningsAsErrors>
+      <TreatSpecificWarningsAsErrors>$(TreatSpecificWarningsAsErrors);4640</TreatSpecificWarningsAsErrors>
       <TreatWChar_tAsBuiltInType>false</TreatWChar_tAsBuiltInType>
       <TreatWarningAsError>true</TreatWarningAsError>
       <UndefinePreprocessorDefinitions>_MT</UndefinePreprocessorDefinitions>

--- a/src/shared/gcdump/gcdump.vcxproj
+++ b/src/shared/gcdump/gcdump.vcxproj
@@ -107,7 +107,7 @@
       <StringPooling>true</StringPooling>
       <StructMemberAlignment>8Bytes</StructMemberAlignment>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <TreatSpecificWarningsAsErrors>4640</TreatSpecificWarningsAsErrors>
+      <TreatSpecificWarningsAsErrors>$(TreatSpecificWarningsAsErrors);4640</TreatSpecificWarningsAsErrors>
       <TreatWChar_tAsBuiltInType>false</TreatWChar_tAsBuiltInType>
       <TreatWarningAsError>true</TreatWarningAsError>
       <UndefinePreprocessorDefinitions>_MT</UndefinePreprocessorDefinitions>
@@ -167,7 +167,7 @@
       <StringPooling>true</StringPooling>
       <StructMemberAlignment>8Bytes</StructMemberAlignment>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <TreatSpecificWarningsAsErrors>4640</TreatSpecificWarningsAsErrors>
+      <TreatSpecificWarningsAsErrors>$(TreatSpecificWarningsAsErrors);4640</TreatSpecificWarningsAsErrors>
       <TreatWChar_tAsBuiltInType>false</TreatWChar_tAsBuiltInType>
       <TreatWarningAsError>true</TreatWarningAsError>
       <UndefinePreprocessorDefinitions>_MT</UndefinePreprocessorDefinitions>
@@ -223,7 +223,7 @@
       <StringPooling>true</StringPooling>
       <StructMemberAlignment>8Bytes</StructMemberAlignment>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <TreatSpecificWarningsAsErrors>4640</TreatSpecificWarningsAsErrors>
+      <TreatSpecificWarningsAsErrors>$(TreatSpecificWarningsAsErrors);4640</TreatSpecificWarningsAsErrors>
       <TreatWChar_tAsBuiltInType>false</TreatWChar_tAsBuiltInType>
       <TreatWarningAsError>true</TreatWarningAsError>
       <UndefinePreprocessorDefinitions>_MT</UndefinePreprocessorDefinitions>
@@ -281,7 +281,7 @@
       <StringPooling>true</StringPooling>
       <StructMemberAlignment>8Bytes</StructMemberAlignment>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <TreatSpecificWarningsAsErrors>4640</TreatSpecificWarningsAsErrors>
+      <TreatSpecificWarningsAsErrors>$(TreatSpecificWarningsAsErrors);4640</TreatSpecificWarningsAsErrors>
       <TreatWChar_tAsBuiltInType>false</TreatWChar_tAsBuiltInType>
       <TreatWarningAsError>true</TreatWarningAsError>
       <UndefinePreprocessorDefinitions>_MT</UndefinePreprocessorDefinitions>

--- a/src/shared/utilcode/utilcode.vcxproj
+++ b/src/shared/utilcode/utilcode.vcxproj
@@ -102,7 +102,7 @@
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <StructMemberAlignment>8Bytes</StructMemberAlignment>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <TreatSpecificWarningsAsErrors>4007;4013;4102;4551;4700;4640;4806</TreatSpecificWarningsAsErrors>
+      <TreatSpecificWarningsAsErrors>$(TreatSpecificWarningsAsErrors);4007;4013;4102;4551;4700;4640;4806</TreatSpecificWarningsAsErrors>
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <TreatWarningAsError>true</TreatWarningAsError>
       <UseFullPaths>true</UseFullPaths>
@@ -158,7 +158,7 @@
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <StructMemberAlignment>8Bytes</StructMemberAlignment>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <TreatSpecificWarningsAsErrors>4007;4013;4102;4551;4700;4640;4806</TreatSpecificWarningsAsErrors>
+      <TreatSpecificWarningsAsErrors>$(TreatSpecificWarningsAsErrors);4007;4013;4102;4551;4700;4640;4806</TreatSpecificWarningsAsErrors>
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <TreatWarningAsError>true</TreatWarningAsError>
       <UseFullPaths>true</UseFullPaths>
@@ -211,7 +211,7 @@
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <StructMemberAlignment>8Bytes</StructMemberAlignment>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <TreatSpecificWarningsAsErrors>4007;4013;4102;4551;4700;4640;4806</TreatSpecificWarningsAsErrors>
+      <TreatSpecificWarningsAsErrors>$(TreatSpecificWarningsAsErrors);4007;4013;4102;4551;4700;4640;4806</TreatSpecificWarningsAsErrors>
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <TreatWarningAsError>true</TreatWarningAsError>
       <UseFullPaths>true</UseFullPaths>
@@ -266,7 +266,7 @@
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <StructMemberAlignment>8Bytes</StructMemberAlignment>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <TreatSpecificWarningsAsErrors>4007;4013;4102;4551;4700;4640;4806</TreatSpecificWarningsAsErrors>
+      <TreatSpecificWarningsAsErrors>$(TreatSpecificWarningsAsErrors);4007;4013;4102;4551;4700;4640;4806</TreatSpecificWarningsAsErrors>
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <TreatWarningAsError>true</TreatWarningAsError>
       <UseFullPaths>true</UseFullPaths>


### PR DESCRIPTION
Using the below syntax performs a complete replacement of warning codes which should be treated as errors.

```xml
<TreatSpecificWarningsAsErrors>aaaaa;bbbbb;ccccc;...</TreatSpecificWarningsAsErrors>
```

Instead, the following syntax should be used, which inherits the base list coming from the SDK (or a higher level props file) and augments the list with your desired warning codes.

```xml
<TreatSpecificWarningsAsErrors>$(TreatSpecificWarningsAsErrors);aaaaa;bbbbb;ccccc;...</TreatSpecificWarningsAsErrors>
```

> Exception: If you're intentionally trying to suppress the inherited list, please ignore this rule.