### PR TITLE
Align TraceEvent Version with dotnet/runtime

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -49,7 +49,7 @@
     <MicrosoftBclAsyncInterfacesVersion>1.1.0</MicrosoftBclAsyncInterfacesVersion>
     <MicrosoftDiagnosticsRuntimeVersion>2.2.332302</MicrosoftDiagnosticsRuntimeVersion>
     <MicrosoftDiaSymReaderNativePackageVersion>16.9.0-beta1.21055.5</MicrosoftDiaSymReaderNativePackageVersion>
-    <MicrosoftDiagnosticsTracingTraceEventVersion>2.0.64</MicrosoftDiagnosticsTracingTraceEventVersion>
+    <MicrosoftDiagnosticsTracingTraceEventVersion>3.0.2</MicrosoftDiagnosticsTracingTraceEventVersion>
     <!-- Use pinned version to avoid picking up latest (which doesn't support netcoreapp3.1) during source-build -->
     <MicrosoftExtensionsLoggingPinnedVersion>2.1.1</MicrosoftExtensionsLoggingPinnedVersion>
     <!-- Need version that understands UseAppFilters sentinel. -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -49,7 +49,7 @@
     <MicrosoftBclAsyncInterfacesVersion>1.1.0</MicrosoftBclAsyncInterfacesVersion>
     <MicrosoftDiagnosticsRuntimeVersion>2.2.332302</MicrosoftDiagnosticsRuntimeVersion>
     <MicrosoftDiaSymReaderNativePackageVersion>16.9.0-beta1.21055.5</MicrosoftDiaSymReaderNativePackageVersion>
-    <MicrosoftDiagnosticsTracingTraceEventVersion>3.0.2</MicrosoftDiagnosticsTracingTraceEventVersion>
+    <MicrosoftDiagnosticsTracingTraceEventVersion>3.0.3</MicrosoftDiagnosticsTracingTraceEventVersion>
     <!-- Use pinned version to avoid picking up latest (which doesn't support netcoreapp3.1) during source-build -->
     <MicrosoftExtensionsLoggingPinnedVersion>2.1.1</MicrosoftExtensionsLoggingPinnedVersion>
     <!-- Need version that understands UseAppFilters sentinel. -->

--- a/src/Tools/dotnet-gcdump/DotNetHeapDump/Graph.cs
+++ b/src/Tools/dotnet-gcdump/DotNetHeapDump/Graph.cs
@@ -125,7 +125,7 @@ namespace Graphs
         /// <summary>
         /// Same as NodeIndexLimit, just cast to an integer.  
         /// </summary>
-        public int NodeCount { get { return m_nodes.Count; } }
+        public long NodeCount { get { return m_nodes.Count; } }
         /// <summary>
         /// It is expected that users will want additional information associated with TYPES of the nodes of the graph.  They can
         /// do this by allocating an array of code:NodeTypeIndexLimit and then indexing this by code:NodeTypeIndex


### PR DESCRIPTION
The TraceEvent versions here and in dotnet/runtime diverged. [Dotnet/Runtime is taking 3.0.3 ](https://github.com/dotnet/runtime/pull/71813) as it contains https://github.com/microsoft/perfview/pull/1658, necessary for RuntimeSku to show up as `Mono` in .mibc files instead of `4`.

Update Graph NodeCount type to long https://github.com/microsoft/perfview/pull/1486