### PR TITLE
Allow dotnet-sos install parameter to use --arch

### DIFF
--- a/src/Tools/dotnet-sos/Program.cs
+++ b/src/Tools/dotnet-sos/Program.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Diagnostics.Tools.SOS
 
         private static Option ArchitectureOption() =>
             new Option(
-                alias: "--architecture",
+                aliases: new[] { "-a", "--arch", "--architecture" }, 
                 description: "The processor architecture to install.")
             {
                 Argument = new Argument<Architecture>(name: "architecture")


### PR DESCRIPTION
This aligns us better with the usage in `dotnet tool install`