### PR TITLE
Make ReversedDiagnosticsServer.Start method throw if address is in use

### DIFF
--- a/src/Microsoft.Diagnostics.NETCore.Client/ReversedServer/ReversedDiagnosticsServer.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/ReversedServer/ReversedDiagnosticsServer.cs
@@ -29,8 +29,9 @@ namespace Microsoft.Diagnostics.NETCore.Client
         private readonly string _address;
 
         private bool _disposed = false;
-        private Task _listenTask;
+        private Task _acceptTransportTask;
         private bool _enableTcpIpProtocol = false;
+        private IpcServerTransport _transport;
 
         /// <summary>
         /// Constructs the <see cref="ReversedDiagnosticsServer"/> instance with an endpoint bound
@@ -72,13 +73,24 @@ namespace Microsoft.Diagnostics.NETCore.Client
         {
             if (!_disposed)
             {
+                // Dispose the server transport before signaling cancellation in order to prevent the
+                // AcceptAsync call on the server transport from recreating the server stream.
+                try
+                {
+                    _transport?.Dispose();
+                }
+                catch (Exception ex)
+                {
+                    Debug.Fail(ex.Message);
+                }
+
                 _disposalSource.Cancel();
 
-                if (null != _listenTask)
+                if (null != _acceptTransportTask)
                 {
                     try
                     {
-                        await _listenTask.ConfigureAwait(false);
+                        await _acceptTransportTask.ConfigureAwait(false);
                     }
                     catch (Exception ex)
                     {
@@ -122,9 +134,12 @@ namespace Microsoft.Diagnostics.NETCore.Client
                 throw new InvalidOperationException(nameof(ReversedDiagnosticsServer.Start) + " method can only be called once.");
             }
 
-            _listenTask = ListenAsync(maxConnections, _disposalSource.Token);
-            if (_listenTask.IsFaulted)
-                _listenTask.Wait(); // Rethrow aggregated exception.
+            _transport = IpcServerTransport.Create(_address, maxConnections, _enableTcpIpProtocol, TransportCallback);
+
+            _acceptTransportTask = AcceptTransportAsync(_transport, _disposalSource.Token);
+
+            if (_acceptTransportTask.IsFaulted)
+                _acceptTransportTask.Wait(); // Rethrow aggregated exception.
         }
 
         /// <summary>
@@ -188,19 +203,13 @@ namespace Microsoft.Diagnostics.NETCore.Client
         }
 
         /// <summary>
-        /// Listens at the address for new connections.
+        /// Accept connections from the transport.
         /// </summary>
-        /// <param name="maxConnections">The maximum number of connections the server will support.</param>
+        /// <param name="transport">The server transport from which connections are accepted.</param>
         /// <param name="token">The token to monitor for cancellation requests.</param>
         /// <returns>A task that completes when the server is no longer listening at the address.</returns>
-        private async Task ListenAsync(int maxConnections, CancellationToken token)
+        private async Task AcceptTransportAsync(IpcServerTransport transport, CancellationToken token)
         {
-            // This disposal shuts down the transport in case an exception is thrown.
-            using var transport = IpcServerTransport.Create(_address, maxConnections, _enableTcpIpProtocol, TransportCallback);
-            // This disposal shuts down the transport in case of cancellation; causes the transport
-            // to not recreate the server stream before the AcceptAsync call observes the cancellation.
-            using var _ = token.Register(() => transport.Dispose());
-
             while (!token.IsCancellationRequested)
             {
                 Stream stream = null;
@@ -366,7 +375,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
             return false;
         }
 
-        private bool IsStarted => null != _listenTask;
+        private bool IsStarted => null != _transport;
 
         public static int MaxAllowedConnections = IpcServerTransport.MaxAllowedConnections;
 

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/ReversedServerTests.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/ReversedServerTests.cs
@@ -10,6 +10,8 @@ using System.Collections.Generic;
 using System.Diagnostics.Tracing;
 using System.IO;
 using System.Net;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -96,6 +98,38 @@ namespace Microsoft.Diagnostics.NETCore.Client
 
             Assert.Throws<ObjectDisposedException>(
                 () => server.RemoveConnection(Guid.Empty));
+        }
+
+        [Fact]
+        public async Task ReversedServerAddressInUseTest()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return;
+            }
+
+            await using var server = CreateReversedServer(out string transportName);
+
+            Assert.False(File.Exists(transportName), "Unix Domain Socket should not exist yet.");
+
+            try
+            {
+                // Create file to simulate that the socket is already created.
+                File.Create(transportName).Dispose();
+
+                SocketException ex = Assert.Throws<SocketException>(() => server.Start());
+                Assert.Equal(98, ex.ErrorCode); // Socket Error 98: Address in use
+            }
+            finally
+            {
+                try
+                {
+                    File.Delete(transportName);
+                }
+                catch (Exception)
+                {
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
In the current code of the ReversedDiagnosticsServer, if the server fails to bind to the provided address, the Start method succeeds and the SocketException is not observed until the server is disposed. This prevents any tool that uses the reverse server to not know that the binding failed until the server is shut down. See https://github.com/dotnet/dotnet-monitor/issues/2017#issuecomment-1162370671 for an example of this problem.

This change fixes this by binding the transport in the Start method, which will allow the caller to immediately observe the binding failure if it occurs.

cc @dotnet/dotnet-monitor