### PR TITLE
Installer update and fixed lldb's ReadVirtual to support partial reads

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -28,9 +28,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>ccfe6da198c5f05534863bbb1bff66e830e0c6ab</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="7.0.100-rc.1.22407.1">
+    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="7.0.100-rc.1.22414.7">
       <Uri>https://github.com/dotnet/installer</Uri>
-      <Sha>8f639696e6d57fb09e03e89c6397d913de1231ed</Sha>
+      <Sha>1dc3340838d6a59dd1c83e7064358e3a42fb150c</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="7.0.0-rc.2.22424.4">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -28,9 +28,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>ccfe6da198c5f05534863bbb1bff66e830e0c6ab</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="7.0.100-rc.1.22414.7">
+    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="7.0.100-rc.2.22419.24">
       <Uri>https://github.com/dotnet/installer</Uri>
-      <Sha>1dc3340838d6a59dd1c83e7064358e3a42fb150c</Sha>
+      <Sha>84d26a070704dc4eb7870f15d44880228bb82cb8</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="7.0.0-rc.2.22424.4">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -24,7 +24,7 @@
     <MicrosoftAspNetCoreAppRefInternalVersion>7.0.0-rc.2.22424.4</MicrosoftAspNetCoreAppRefInternalVersion>
     <MicrosoftAspNetCoreAppRefVersion>7.0.0-rc.2.22424.4</MicrosoftAspNetCoreAppRefVersion>
     <!-- dotnet/installer: Testing version of the SDK. Needed for the signed & entitled host. -->
-    <MicrosoftDotnetSdkInternalVersion>7.0.100-rc.1.22414.7</MicrosoftDotnetSdkInternalVersion>
+    <MicrosoftDotnetSdkInternalVersion>7.0.100-rc.2.22419.24</MicrosoftDotnetSdkInternalVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Runtime versions to test -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -34,7 +34,7 @@
     <MicrosoftAspNetCoreApp60Version>$(MicrosoftNETCoreApp60Version)</MicrosoftAspNetCoreApp60Version>
     <!-- The SDK runtime version used to build single-file apps (currently hardcoded) -->
     <SingleFileRuntime60Version>6.0.8</SingleFileRuntime60Version>
-    <SingleFileRuntimeLatestVersion>7.0.0-rc.1.22403.8</SingleFileRuntimeLatestVersion>
+    <SingleFileRuntimeLatestVersion>7.0.0-rc.1.22411.12</SingleFileRuntimeLatestVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Opt-in/out repo features -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -24,7 +24,7 @@
     <MicrosoftAspNetCoreAppRefInternalVersion>7.0.0-rc.2.22424.4</MicrosoftAspNetCoreAppRefInternalVersion>
     <MicrosoftAspNetCoreAppRefVersion>7.0.0-rc.2.22424.4</MicrosoftAspNetCoreAppRefVersion>
     <!-- dotnet/installer: Testing version of the SDK. Needed for the signed & entitled host. -->
-    <MicrosoftDotnetSdkInternalVersion>7.0.100-rc.1.22407.1</MicrosoftDotnetSdkInternalVersion>
+    <MicrosoftDotnetSdkInternalVersion>7.0.100-rc.1.22414.7</MicrosoftDotnetSdkInternalVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Runtime versions to test -->

--- a/src/SOS/SOS.UnitTests/SOS.cs
+++ b/src/SOS/SOS.UnitTests/SOS.cs
@@ -366,6 +366,8 @@ public class SOS
     [SkippableTheory, MemberData(nameof(Configurations))]
     public async Task LLDBPluginTests(TestConfiguration config)
     {
+        SkipIfArm(config);
+
         if (OS.Kind == OSKind.Windows || config.IsDesktop || config.RuntimeFrameworkVersionMajor == 1 || OS.IsAlpine)
         {
             throw new SkipTestException("lldb plugin tests not supported on Windows, Alpine Linux or .NET Core 1.1");

--- a/src/SOS/SOS.UnitTests/Scripts/StackAndOtherTests.script
+++ b/src/SOS/SOS.UnitTests/Scripts/StackAndOtherTests.script
@@ -198,6 +198,7 @@ ENDIF:NETCORE_OR_DOTNETDUMP
 
 # Issue: https://github.com/dotnet/diagnostics/issues/2947
 !IFDEF:DOTNETDUMP
+!IFDEF:ARM64
 !IFDEF:ARM
 
 # Verify DumpStack works
@@ -218,6 +219,7 @@ VERIFY:.*Child(-SP|EBP|FP)\s+RetAddr\s+Caller, Callee\s+
 VERIFY:(.*\s+<HEXVAL>\s+<HEXVAL>\s+\(MethodDesc\s+<HEXVAL>\s+(\+\s*0x<HEXVAL>\s+)?SymbolTestApp\.Program\.Foo4\(System\.String\)\),\s+calling.*\s+)|(.*\s+<HEXVAL>\s+<HEXVAL>\s+\(MethodDesc\s+<HEXVAL>\s+(\+\s*0x<HEXVAL>\s+)?SymbolTestApp\.Program\.Foo2\(Int32, System\.String\)\),\s+calling.*\s+)
 
 ENDIF:ARM
+ENDIF:ARM64
 ENDIF:DOTNETDUMP
 
 # Verify that IP2MD works (uses IP from ClrStack)

--- a/src/SOS/SOS.UnitTests/Scripts/StackTests.script
+++ b/src/SOS/SOS.UnitTests/Scripts/StackTests.script
@@ -152,6 +152,7 @@ VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+System\.String.*
 
 # Issue: https://github.com/dotnet/diagnostics/issues/2947
 !IFDEF:DOTNETDUMP
+!IFDEF:ARM64
 !IFDEF:ARM
 
 # 9) Verify DumpStack works
@@ -172,4 +173,5 @@ VERIFY:.*Child(-SP|EBP|FP)\s+RetAddr\s+Caller, Callee\s+
 VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+\(MethodDesc\s+<HEXVAL>\s+\+\s*0x<HEXVAL>\s+NestedExceptionTest\.Program\.Main\(System\.String\[\]\)\),\s+calling.*
 
 ENDIF:ARM
+ENDIF:ARM64
 ENDIF:DOTNETDUMP

--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -3956,6 +3956,12 @@ DECLARE_API(DumpRuntimeTypes)
            "Address", "Domain", "MT");
     ExtOut("------------------------------------------------------------------------------\n");
 
+    if (!g_snapshot.Build())
+    {
+        ExtOut("Unable to build snapshot of the garbage collector state\n");
+        return E_FAIL;
+    }
+
     PrintRuntimeTypeArgs pargs;
     ZeroMemory(&pargs, sizeof(PrintRuntimeTypeArgs));
 

--- a/src/SOS/lldbplugin/services.cpp
+++ b/src/SOS/lldbplugin/services.cpp
@@ -757,15 +757,28 @@ exit:
 // IDebugDataSpaces
 //----------------------------------------------------------------------------
 
+#define PAGE_SIZE 0x1000
+#define PAGE_MASK (~(PAGE_SIZE-1)) 
+
 HRESULT 
 LLDBServices::ReadVirtual(
     ULONG64 offset,
     PVOID buffer,
     ULONG bufferSize,
-    PULONG bytesRead)
+    PULONG pbytesRead)
 {
     lldb::SBError error;
-    size_t read = 0;
+    size_t bytesRead = 0;
+    ULONG64 page;
+
+    if (bufferSize == 0)
+    {
+        if (pbytesRead)
+        {
+            *pbytesRead = 0;
+        }
+        return S_OK;
+    }
 
     // lldb doesn't expect sign-extended address
     offset = CONVERT_FROM_SIGN_EXTENDED(offset);
@@ -776,9 +789,41 @@ LLDBServices::ReadVirtual(
         goto exit;
     }
 
-    read = process.ReadMemory(offset, buffer, bufferSize, error);
+    // Try the full read and return if successful
+    bytesRead = process.ReadMemory(offset, buffer, bufferSize, error);
+    if (error.Success())
+    {
+        goto exit;
+    }
 
-    if (!error.Success())
+    // As it turns out the lldb ReadMemory API doesn't do partial reads and the SOS
+    // caching depends on that behavior. Round up to the next page boundry and attempt
+    // to read up to the page boundries.
+    page = (offset + PAGE_SIZE - 1) & PAGE_MASK;
+
+    while (bufferSize > 0)
+    {
+        size_t size = page - offset;
+        if (size > bufferSize)
+        {
+            size = bufferSize;
+        }
+        size_t read = process.ReadMemory(offset, buffer, size, error);
+
+        bytesRead += read;
+        offset += read;
+        buffer = (BYTE*)buffer + read;
+        bufferSize -= read;
+        page += PAGE_SIZE;
+
+        if (!error.Success())
+        {
+            break;
+        }
+    }
+
+    // If the read isn't complete, try reading directly from native modules in the address range.
+    if (bufferSize > 0)
     {
         lldb::SBTarget target = process.GetTarget();
         if (!target.IsValid())
@@ -787,8 +832,7 @@ LLDBServices::ReadVirtual(
         }
 
         int numModules = target.GetNumModules();
-        bool found = false;
-        for (int i = 0; !found && i < numModules; i++)
+        for (int i = 0; i < numModules; i++)
         {
             lldb::SBModule module = target.GetModuleAtIndex(i);
             int numSections = module.GetNumSections();
@@ -803,9 +847,8 @@ LLDBServices::ReadVirtual(
                     lldb::SBData sectionData = section.GetSectionData(offset - loadAddr, bufferSize);
                     if (sectionData.IsValid())
                     {
-                        read = sectionData.ReadRawData(error, 0, buffer, bufferSize);
-                        found = true;
-                        break;
+                        bytesRead += sectionData.ReadRawData(error, 0, buffer, bufferSize);
+                        goto exit;
                     }
                 }
             }
@@ -813,11 +856,11 @@ LLDBServices::ReadVirtual(
     }
 
 exit:
-    if (bytesRead)
+    if (pbytesRead)
     {
-        *bytesRead = read;
+        *pbytesRead = bytesRead;
     }
-    return error.Success() || (read != 0) ? S_OK : E_FAIL;
+    return bytesRead > 0 ? S_OK : E_FAIL;
 }
 
 HRESULT 

--- a/src/SOS/lldbplugin/services.cpp
+++ b/src/SOS/lldbplugin/services.cpp
@@ -757,8 +757,10 @@ exit:
 // IDebugDataSpaces
 //----------------------------------------------------------------------------
 
+#ifndef PAGE_SIZE 
 #define PAGE_SIZE 0x1000
-#define PAGE_MASK (~(PAGE_SIZE-1)) 
+#endif
+#define PAGE_MASK (~(PAGE_SIZE-1))
 
 HRESULT 
 LLDBServices::ReadVirtual(

--- a/src/SOS/lldbplugin/services.cpp
+++ b/src/SOS/lldbplugin/services.cpp
@@ -20,19 +20,11 @@
 #define InvalidChecksum     0xFFFFFFFF;
 
 #ifndef PAGE_SIZE 
-#if (defined(__arm__) || defined(__aarch64__) || defined(__loongarch64))
-#define PAGE_SIZE g_pageSize
-#else
 #define PAGE_SIZE 0x1000
-#endif
 #endif
 
 #undef PAGE_MASK 
 #define PAGE_MASK (~(PAGE_SIZE-1))
-
-#if defined(__arm__) || defined(__aarch64__) || defined(__loongarch64)
-long g_pageSize = 0;
-#endif
 
 char *g_coreclrDirectory = nullptr;
 char *g_pluginModuleDirectory = nullptr;
@@ -47,11 +39,6 @@ LLDBServices::LLDBServices(lldb::SBDebugger debugger) :
     m_processId(0),
     m_threadInfoInitialized(false)
 {
-    // Initialize PAGE_SIZE
-#if defined(__arm__) || defined(__aarch64__) || defined(__loongarch64)
-    g_pageSize = sysconf(_SC_PAGESIZE);
-#endif
-
     ClearCache();
 
     lldb::SBProcess process = GetCurrentProcess();


### PR DESCRIPTION
Fixed lldb's ReadVirtual to support partial reads

Fixed the DumpRuntimeTypes command to build the GC heap info. It was looking up segments uninitialized.

Update dependencies from https://github.com/dotnet/installer build 20220819.24

Microsoft.Dotnet.Sdk.Internal
 From Version 7.0.100-rc.1.22407.1 -> To Version 7.0.100-rc.2.22419.24