### PR TITLE
Fix debugging on UWP/.NET Core 1.0

### DIFF
--- a/src/dbgshim/dbgshim.cpp
+++ b/src/dbgshim/dbgshim.cpp
@@ -1173,9 +1173,12 @@ GetTargetCLRMetrics(
                 pClrInfo->DacSizeOfImage = pDebugResource->dwDacSizeOfImage;
                 return true;
             });
-            if (!pedecoder.EnumerateWin32Resources(W("CLRDEBUGINFO"), MAKEINTRESOURCEW(10), callback, pClrInfoOut))
+            if (!pedecoder.EnumerateWin32Resources(CLRDEBUGINFO_RESOURCE_NAME, MAKEINTRESOURCEW(10), callback, pClrInfoOut) || !pClrInfoOut->IsValid())
             {
-                return E_FAIL;
+                if (!pedecoder.EnumerateWin32Resources(W("CLRDEBUGINFO"), MAKEINTRESOURCEW(10), callback, pClrInfoOut) || !pClrInfoOut->IsValid())
+                {
+                    return E_FAIL;
+                }
             }
         }
         else

--- a/src/dbgshim/debugshim.cpp
+++ b/src/dbgshim/debugshim.cpp
@@ -604,43 +604,8 @@ HRESULT CLRDebuggingImpl::GetCLRInfo(ICorDebugDataTarget * pDataTarget,
         BOOL useCrossPlatformNaming = FALSE;
         if (SUCCEEDED(hr))
         {
-            // the initial state is that we haven't found a proper resource
-            HRESULT hrGetResource = E_FAIL;
-
             // First check for the resource which has type = RC_DATA = 10, name = "CLRDEBUGINFO<host_os><host_arch>", language = 0
-    #if defined (HOST_WINDOWS) && defined(HOST_X86)
-            const WCHAR * resourceName = W("CLRDEBUGINFOWINDOWSX86");
-    #endif
-
-    #if !defined (HOST_WINDOWS) && defined(HOST_X86)
-            const WCHAR * resourceName = W("CLRDEBUGINFOCORESYSX86");
-    #endif
-
-    #if defined (HOST_WINDOWS) && defined(HOST_AMD64)
-            const WCHAR * resourceName = W("CLRDEBUGINFOWINDOWSAMD64");
-    #endif
-
-    #if !defined (HOST_WINDOWS) && defined(HOST_AMD64)
-            const WCHAR * resourceName = W("CLRDEBUGINFOCORESYSAMD64");
-    #endif
-
-    #if defined (HOST_WINDOWS) && defined(HOST_ARM64)
-            const WCHAR * resourceName = W("CLRDEBUGINFOWINDOWSARM64");
-    #endif
-
-    #if !defined (HOST_WINDOWS) && defined(HOST_ARM64)
-            const WCHAR * resourceName = W("CLRDEBUGINFOCORESYSARM64");
-    #endif
-
-    #if defined (HOST_WINDOWS) && defined(HOST_ARM)
-            const WCHAR * resourceName = W("CLRDEBUGINFOWINDOWSARM");
-    #endif
-
-    #if !defined (HOST_WINDOWS) && defined(HOST_ARM)
-            const WCHAR * resourceName = W("CLRDEBUGINFOCORESYSARM");
-    #endif
-
-            hrGetResource = GetResourceRvaFromResourceSectionRvaByName(pDataTarget, moduleBaseAddress, resourceSectionRVA, 10, resourceName, 0, &debugResourceRVA, &debugResourceSize);
+            HRESULT hrGetResource = GetResourceRvaFromResourceSectionRvaByName(pDataTarget, moduleBaseAddress, resourceSectionRVA, 10, CLRDEBUGINFO_RESOURCE_NAME, 0, &debugResourceRVA, &debugResourceSize);
             useCrossPlatformNaming = SUCCEEDED(hrGetResource);
 
     #if defined(HOST_WINDOWS) && (defined(HOST_X86) || defined(HOST_AMD64) || defined(HOST_ARM) || defined(HOST_ARM64))

--- a/src/dbgshim/debugshim.h
+++ b/src/dbgshim/debugshim.h
@@ -17,6 +17,31 @@
 #include <metahost.h>
 #include "runtimeinfo.h"
 
+#if defined (HOST_WINDOWS) && defined(HOST_X86)
+#define CLRDEBUGINFO_RESOURCE_NAME W("CLRDEBUGINFOWINDOWSX86")
+#endif
+#if !defined (HOST_WINDOWS) && defined(HOST_X86)
+#define CLRDEBUGINFO_RESOURCE_NAME W("CLRDEBUGINFOCORESYSX86")
+#endif
+#if defined (HOST_WINDOWS) && defined(HOST_AMD64)
+#define CLRDEBUGINFO_RESOURCE_NAME W("CLRDEBUGINFOWINDOWSAMD64")
+#endif
+#if !defined (HOST_WINDOWS) && defined(HOST_AMD64)
+#define CLRDEBUGINFO_RESOURCE_NAME W("CLRDEBUGINFOCORESYSAMD64")
+#endif
+#if defined (HOST_WINDOWS) && defined(HOST_ARM64)
+#define CLRDEBUGINFO_RESOURCE_NAME W("CLRDEBUGINFOWINDOWSARM64")
+#endif
+#if !defined (HOST_WINDOWS) && defined(HOST_ARM64)
+#define CLRDEBUGINFO_RESOURCE_NAME W("CLRDEBUGINFOCORESYSARM64")
+#endif
+#if defined (HOST_WINDOWS) && defined(HOST_ARM)
+#define CLRDEBUGINFO_RESOURCE_NAME W("CLRDEBUGINFOWINDOWSARM")
+#endif
+#if !defined (HOST_WINDOWS) && defined(HOST_ARM)
+#define CLRDEBUGINFO_RESOURCE_NAME W("CLRDEBUGINFOCORESYSARM")
+#endif
+
 #define CORECLR_DAC_MODULE_NAME_W W("mscordaccore")
 #define CLR_DAC_MODULE_NAME_W W("mscordacwks")
 #define MAIN_DBI_MODULE_NAME_W W("mscordbi")


### PR DESCRIPTION
Need to check for the architecture named CLRDEBUGINFO (i.e. "CLRDEBUGINFOCORESYSAMD64", etc.) resource in
coreclr.dll for the live debugging APIs.