### PR TITLE
Fix use of bitwise '&' with boolean operands in palrt

### DIFF
--- a/src/shared/palrt/bstr.cpp
+++ b/src/shared/palrt/bstr.cpp
@@ -47,7 +47,7 @@ inline HRESULT CbSysStringSize(ULONG cchSize, BOOL isByteLen, ULONG *result)
     else
     {
         ULONG temp = 0; // should not use in-place addition in ULongAdd
-        if (SUCCEEDED(ULongMult(cchSize, sizeof(WCHAR), &temp)) &
+        if (SUCCEEDED(ULongMult(cchSize, sizeof(WCHAR), &temp)) &&
             SUCCEEDED(ULongAdd(temp, constant, result)))
         {
             *result = *result & ~WIN32_ALLOC_ALIGN;


### PR DESCRIPTION
This fixes the below compile error with clang-14
```cpp
/home/leee/dotnet/diagnostics/src/shared/palrt/bstr.cpp:50:13: error: use of bitwise '&' with boolean operands [-Werror,-Wbitwise-instead-of-logical]
        if (SUCCEEDED(ULongMult(cchSize, sizeof(WCHAR), &temp)) &
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                                &&
```
Related patch in runtime repo: https://github.com/dotnet/runtime/pull/72313