### PR TITLE
Fixed dotnet-counters rendering issues

### DIFF
--- a/src/Tools/dotnet-counters/Exporters/ConsoleWriter.cs
+++ b/src/Tools/dotnet-counters/Exporters/ConsoleWriter.cs
@@ -74,6 +74,7 @@ namespace Microsoft.Diagnostics.Tools.Counters.Exporters
 
         private int _consoleWidthThreshold = 80; // Threshold of width of console at which name begins to scale down.
         private int _nameDefaultLength = 60;
+        
         public ConsoleWriter(bool useAnsi) 
         {
             this._useAnsi = useAnsi;
@@ -155,8 +156,7 @@ namespace Microsoft.Diagnostics.Tools.Counters.Exporters
                     counter.Row = row++;
                     if (counter.RenderValueInline)
                     {
-                        
-                        Console.WriteLine($"{name} {FormatValue(counter.LastValue)}");
+                        Console.WriteLine((_consoleWidth > 20) ? $"{name} {FormatValue(counter.LastValue)}" : $"{FormatValue(counter.LastValue)}");
                     }
                     else
                     {

--- a/src/Tools/dotnet-counters/Exporters/ConsoleWriter.cs
+++ b/src/Tools/dotnet-counters/Exporters/ConsoleWriter.cs
@@ -58,6 +58,8 @@ namespace Microsoft.Diagnostics.Tools.Counters.Exporters
         private readonly object _lock = new object();
         private readonly Dictionary<string, ObservedProvider> _providers = new Dictionary<string, ObservedProvider>(); // Tracks observed providers and counters.
         private const int Indent = 4; // Counter name indent size.
+        private const int CounterValueLength= 20;
+
         private int _maxNameLength = 60; // Allow room for 60 character counter names by default.
 
         private int _statusRow; // Row # of where we print the status of dotnet-counters
@@ -72,9 +74,7 @@ namespace Microsoft.Diagnostics.Tools.Counters.Exporters
         private int _consoleHeight = -1;
         private int _consoleWidth = -1;
 
-        private int _consoleWidthThreshold = 80; // Threshold of width of console at which name begins to scale down.
-        private int _nameDefaultLength = 60;
-        
+
         public ConsoleWriter(bool useAnsi) 
         {
             this._useAnsi = useAnsi;
@@ -134,11 +134,13 @@ namespace Microsoft.Diagnostics.Tools.Counters.Exporters
             
             _consoleWidth = Console.WindowWidth;
             _consoleHeight = Console.WindowHeight;
-            _maxNameLength = _consoleWidth < _consoleWidthThreshold ? _consoleWidth - 20: _nameDefaultLength;
+            _maxNameLength = _consoleWidth < 80 ? _consoleWidth - CounterValueLength: 60; // truncate the display name when the window width is less than 80
 
             int row = Console.CursorTop;
             _topRow = row;
-            Console.WriteLine("Press p to pause, r to resume, q to quit."); row++;
+
+            string instructions = "Press p to pause, r to resume, q to quit.";
+            Console.WriteLine((instructions.Length < _consoleWidth) ? instructions : instructions.Substring(0, _consoleWidth)); row++;
             Console.WriteLine($"    Status: {GetStatus()}");                _statusRow = row++;
             if (_errorText != null)
             {
@@ -156,7 +158,7 @@ namespace Microsoft.Diagnostics.Tools.Counters.Exporters
                     counter.Row = row++;
                     if (counter.RenderValueInline)
                     {
-                        Console.WriteLine((_consoleWidth > 20) ? $"{name} {FormatValue(counter.LastValue)}" : $"{FormatValue(counter.LastValue)}");
+                        Console.WriteLine((_consoleWidth > CounterValueLength) ? $"{name} {FormatValue(counter.LastValue)}" : $"{FormatValue(counter.LastValue)}");
                     }
                     else
                     {

--- a/src/Tools/dotnet-counters/Exporters/ConsoleWriter.cs
+++ b/src/Tools/dotnet-counters/Exporters/ConsoleWriter.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Diagnostics.Tools.Counters.Exporters
         private const int Indent = 4; // Counter name indent size.
         private const int CounterValueLength = 15;
 
-        private int _maxNameLength = 60; // Allow room for 60 character counter names by default.
+        private int _maxNameLength = 0;
         private int _statusRow; // Row # of where we print the status of dotnet-counters
         private int _topRow;
         private bool _paused = false;

--- a/src/Tools/dotnet-counters/Exporters/ConsoleWriter.cs
+++ b/src/Tools/dotnet-counters/Exporters/ConsoleWriter.cs
@@ -150,13 +150,22 @@ namespace Microsoft.Diagnostics.Tools.Counters.Exporters
             foreach (ObservedProvider provider in _providers.Values.OrderBy(p => p.KnownProvider == null).ThenBy(p => p.Name)) // Known providers first.
             {
                 Console.WriteLine($"[{provider.Name}]"); row++;
+                int rowCount = 0;
+                
                 foreach (ObservedCounter counter in provider.Counters.Values.OrderBy(c => c.DisplayName))
                 {
+                    if(rowCount >= _consoleHeight - 5)
+                    {
+                        break;
+                    } 
+
+
                     string name = MakeFixedWidth($"{new string(' ', Indent)}{counter.DisplayName}", Indent + _maxNameLength);
                     counter.Row = row++;
                     if (counter.RenderValueInline)
                     {
                         Console.WriteLine((_consoleWidth > CounterValueLength) ? $"{name} {FormatValue(counter.LastValue)}" : $"{FormatValue(counter.LastValue)}");
+                        rowCount += 1;
                     }
                     else
                     {
@@ -166,6 +175,7 @@ namespace Microsoft.Diagnostics.Tools.Counters.Exporters
                             string tagName = MakeFixedWidth($"{new string(' ', 2 * Indent)}{tagSet.Tags}", Indent + _maxNameLength);
                             Console.WriteLine($"{tagName} {FormatValue(tagSet.LastValue)}");
                             tagSet.Row = row++;
+                            rowCount += 1;
                         }
                     }
                 }

--- a/src/Tools/dotnet-counters/Exporters/ConsoleWriter.cs
+++ b/src/Tools/dotnet-counters/Exporters/ConsoleWriter.cs
@@ -61,7 +61,6 @@ namespace Microsoft.Diagnostics.Tools.Counters.Exporters
         private const int CounterValueLength= 20;
 
         private int _maxNameLength = 60; // Allow room for 60 character counter names by default.
-
         private int _statusRow; // Row # of where we print the status of dotnet-counters
         private int _topRow;
         private bool _paused = false;
@@ -73,7 +72,6 @@ namespace Microsoft.Diagnostics.Tools.Counters.Exporters
 
         private int _consoleHeight = -1;
         private int _consoleWidth = -1;
-
 
         public ConsoleWriter(bool useAnsi) 
         {
@@ -190,7 +188,7 @@ namespace Microsoft.Diagnostics.Tools.Counters.Exporters
         public void CounterPayloadReceived(CounterPayload payload, bool pauseCmdSet)
         {
             lock (_lock)
-            {                
+            {
                 if (!_initialized)
                 {
                     _initialized = true;

--- a/src/Tools/dotnet-counters/Exporters/ConsoleWriter.cs
+++ b/src/Tools/dotnet-counters/Exporters/ConsoleWriter.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Diagnostics.Tools.Counters.Exporters
         private readonly object _lock = new object();
         private readonly Dictionary<string, ObservedProvider> _providers = new Dictionary<string, ObservedProvider>(); // Tracks observed providers and counters.
         private const int Indent = 4; // Counter name indent size.
-        private int _maxNameLength = 40; // Allow room for 40 character counter names by default.
+        private int _maxNameLength = 60; // Allow room for 60 character counter names by default.
 
         private int _statusRow; // Row # of where we print the status of dotnet-counters
         private int _topRow;
@@ -72,6 +72,8 @@ namespace Microsoft.Diagnostics.Tools.Counters.Exporters
         private int _consoleHeight = -1;
         private int _consoleWidth = -1;
 
+        private int _consoleWidthThreshold = 80; // Threshold of width of console at which name begins to scale down.
+        private int _nameDefaultLength = 60;
         public ConsoleWriter(bool useAnsi) 
         {
             this._useAnsi = useAnsi;
@@ -131,13 +133,7 @@ namespace Microsoft.Diagnostics.Tools.Counters.Exporters
             
             _consoleWidth = Console.WindowWidth;
             _consoleHeight = Console.WindowHeight;
-            _maxNameLength = _consoleWidth < 80 ? (int)Math.Round(_consoleWidth * 0.5) : 60;
-            //_maxNameLength = (int)Math.Round(_consoleWidth * 0.8);
-
-            if(_consoleWidth < 100)
-            {
-                _maxNameLength = (int)Math.Round(_consoleWidth * 0.5);
-            }
+            _maxNameLength = _consoleWidth < _consoleWidthThreshold ? _consoleWidth - 20: _nameDefaultLength;
 
             int row = Console.CursorTop;
             _topRow = row;
@@ -159,6 +155,7 @@ namespace Microsoft.Diagnostics.Tools.Counters.Exporters
                     counter.Row = row++;
                     if (counter.RenderValueInline)
                     {
+                        
                         Console.WriteLine($"{name} {FormatValue(counter.LastValue)}");
                     }
                     else

--- a/src/Tools/dotnet-counters/Exporters/ConsoleWriter.cs
+++ b/src/Tools/dotnet-counters/Exporters/ConsoleWriter.cs
@@ -69,6 +69,9 @@ namespace Microsoft.Diagnostics.Tools.Counters.Exporters
         private int _maxRow = -1;
         private bool _useAnsi = false;
 
+        private int _consoleHeight = -1;
+        private int _consoleWidth = -1;
+
         public ConsoleWriter(bool useAnsi) 
         {
             this._useAnsi = useAnsi;
@@ -126,6 +129,16 @@ namespace Microsoft.Diagnostics.Tools.Counters.Exporters
         {
             Clear();
             
+            _consoleWidth = Console.WindowWidth;
+            _consoleHeight = Console.WindowHeight;
+            _maxNameLength = _consoleWidth < 80 ? (int)Math.Round(_consoleWidth * 0.5) : 60;
+            //_maxNameLength = (int)Math.Round(_consoleWidth * 0.8);
+
+            if(_consoleWidth < 100)
+            {
+                _maxNameLength = (int)Math.Round(_consoleWidth * 0.5);
+            }
+
             int row = Console.CursorTop;
             _topRow = row;
             Console.WriteLine("Press p to pause, r to resume, q to quit."); row++;
@@ -178,7 +191,7 @@ namespace Microsoft.Diagnostics.Tools.Counters.Exporters
         public void CounterPayloadReceived(CounterPayload payload, bool pauseCmdSet)
         {
             lock (_lock)
-            {
+            {                
                 if (!_initialized)
                 {
                     _initialized = true;
@@ -220,6 +233,11 @@ namespace Microsoft.Diagnostics.Tools.Counters.Exporters
                     _maxNameLength = Math.Max(_maxNameLength, tagSet.DisplayTags.Length);
                     tagSet.LastValue = payload.Value;
                     redraw = true;
+                }
+
+                if(Console.WindowWidth != _consoleWidth || Console.WindowHeight != _consoleHeight)
+                {
+                    redraw=true;
                 }
 
                 if (redraw)


### PR DESCRIPTION
Fixes #3036.  If the console width was lowered while dotnet-counters was being run or the console was not wide enough, the output would not render correctly.:

![dotnet-counters formatting bug](https://user-images.githubusercontent.com/111319334/188705136-9a60bf8b-a852-4ede-a267-4f154d1cdec7.png)

This was fixed by keeping track of the console size and refreshing the output with a every new payload. If the console is not wide enough, the labels are truncated to make the output fit properly.: 


![dotnet-counters formatting fix](https://user-images.githubusercontent.com/111319334/188705511-00717dac-db27-4d3d-b9c9-b43e39b195ca.png)

This was tested in powershell, Linux via WSL, and with consoles with widths as low as 20 units.