### PR TITLE
Check CursorTop before changing CursorLeft to prevent ArgumentOutOfRangeException

### DIFF
--- a/src/Microsoft.Diagnostics.Repl/ConsoleService.cs
+++ b/src/Microsoft.Diagnostics.Repl/ConsoleService.cs
@@ -246,6 +246,7 @@ namespace Microsoft.Diagnostics.Repl
         private void CommandFinished()
         {
             if (--m_commandExecuting == 0) {
+                m_activeLine = new StringBuilder();
                 RefreshLine();
             }
         }
@@ -268,7 +269,12 @@ namespace Microsoft.Diagnostics.Repl
             Console.Write(m_clearLine);
 
             if (!m_outputRedirected) {
-                Console.CursorLeft = 0;
+                try {
+                    Console.CursorLeft = 0;
+                }
+                catch (ArgumentOutOfRangeException)
+                {
+                }
             }
         }
 
@@ -314,7 +320,12 @@ namespace Microsoft.Diagnostics.Repl
             Console.Write("{0}{1}", prompt, text);
 
             if (!m_outputRedirected) {
-                Console.CursorLeft = prompt.Length + (m_cursorPosition - m_scrollPosition);
+                try {
+                    Console.CursorLeft = prompt.Length + (m_cursorPosition - m_scrollPosition);
+                }
+                catch (ArgumentOutOfRangeException)
+                {
+                }
             }
         }
 

--- a/src/Microsoft.Diagnostics.Repl/ConsoleService.cs
+++ b/src/Microsoft.Diagnostics.Repl/ConsoleService.cs
@@ -246,7 +246,6 @@ namespace Microsoft.Diagnostics.Repl
         private void CommandFinished()
         {
             if (--m_commandExecuting == 0) {
-                m_activeLine = new StringBuilder();
                 RefreshLine();
             }
         }
@@ -268,13 +267,8 @@ namespace Microsoft.Diagnostics.Repl
 
             Console.Write(m_clearLine);
 
-            if (!m_outputRedirected) {
-                try {
-                    Console.CursorLeft = 0;
-                }
-                catch (ArgumentOutOfRangeException)
-                {
-                }
+            if (!m_outputRedirected && Console.CursorTop >= 0 ) {
+                Console.CursorLeft = 0;
             }
         }
 
@@ -319,13 +313,8 @@ namespace Microsoft.Diagnostics.Repl
 
             Console.Write("{0}{1}", prompt, text);
 
-            if (!m_outputRedirected) {
-                try {
-                    Console.CursorLeft = prompt.Length + (m_cursorPosition - m_scrollPosition);
-                }
-                catch (ArgumentOutOfRangeException)
-                {
-                }
+            if (!m_outputRedirected && Console.CursorTop >= 0) {
+                Console.CursorLeft = prompt.Length + (m_cursorPosition - m_scrollPosition);
             }
         }
 


### PR DESCRIPTION
dotnet-dump analyze causes an Exception when a console returns `CursorTop` as -1.

```
[root@localhost tmp]# dotnet dump analyze core_19700108_100550 
Loading core dump: core_19700108_100550 ...
Ready to process analysis commands. Type 'help' to list available commands or 'help [command]' to get detailed help on a command.
Type 'quit' or 'exit' to exit the session.
Unhandled exception: System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
 ---> System.ArgumentOutOfRangeException: The value must be greater than or equal to zero and less than the console's buffer size in that dimension. (Parameter 'top')
Actual value was -1.
   at System.Console.SetCursorPosition(Int32 left, Int32 top)
   at System.Console.set_CursorLeft(Int32 value)
   at Microsoft.Diagnostics.Repl.ConsoleProvider.ClearLine()
   at Microsoft.Diagnostics.Repl.ConsoleProvider.RefreshLine()
   at Microsoft.Diagnostics.Repl.ConsoleProvider.AppendNewText(String text)
   at Microsoft.Diagnostics.Repl.ConsoleProvider.ProcessKeyInfo(ConsoleKeyInfo keyInfo, Action`2 dispatchCommand)
   at Microsoft.Diagnostics.Repl.ConsoleProvider.Start(Action`2 dispatchCommand)
   at Microsoft.Diagnostics.Tools.Dump.Analyzer.Analyze(FileInfo dump_path, String[] command)
```

Related to https://github.com/dotnet/diagnostics/pull/3354
> Fix issue https://github.com/dotnet/diagnostics/issues/3187. dotnet-dump analyze causes an Exception when console width is 0.