### PR TITLE
[Dotnet Monitor] Standardize DiagnosticFilterString, No Longer Assume TraceEvent Arg Ordering

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/AspNetTriggerSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/AspNetTriggerSourceConfiguration.cs
@@ -23,28 +23,57 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
             _heartbeatIntervalSeconds = heartbeatIntervalSeconds;
         }
 
-        /// <summary>
-        /// Filter string for trigger data. Note that even though some triggers use start OR stop,
-        /// collecting just one causes unusual behavior in data collection.
-        /// </summary>
-        /// <remarks>
-        /// IMPORTANT! We rely on these transformations to make sure we can access relevant data
-        /// by index. The order must match the data extracted in the triggers.
-        /// </remarks>
-        private const string DiagnosticFilterString =
-                "Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.HttpRequestIn.Start@Activity1Start:-" +
-                    "ActivityId=*Activity.Id" +
-                    ";Request.Path" +
-                    ";ActivityStartTime=*Activity.StartTimeUtc.Ticks" +
-                    "\r\n" +
-                "Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.HttpRequestIn.Stop@Activity1Stop:-" +
-                    "ActivityId=*Activity.Id" +
-                    ";Request.Path" +
-                    ";Response.StatusCode" +
-                    ";ActivityDuration=*Activity.Duration.Ticks" +
-                    "\r\n";
+    /// <summary>
+    /// Filter string for trigger data. Note that even though some triggers use start OR stop,
+    /// collecting just one causes unusual behavior in data collection. This value is identical to
+    /// the DiagnosticFilterString in HttpRequestSourceConfiguration.
+    /// </summary>
+    /// <remarks>
+    /// IMPORTANT! We rely on these transformations to make sure we can access relevant data
+    /// by index. The order must match the data extracted in the triggers.
+    /// </remarks>
+    private const string DiagnosticFilterString =
+            "Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.HttpRequestIn.Start@Activity1Start:-" +
+                "Request.Scheme" +
+                ";Request.Host" +
+                ";Request.PathBase" +
+                ";Request.QueryString" +
+                ";Request.Path" +
+                ";Request.Method" +
+                ";ActivityStartTime=*Activity.StartTimeUtc.Ticks" +
+                ";ActivityParentId=*Activity.ParentId" +
+                ";ActivityId=*Activity.Id" +
+                ";ActivitySpanId=*Activity.SpanId" +
+                ";ActivityTraceId=*Activity.TraceId" +
+                ";ActivityParentSpanId=*Activity.ParentSpanId" +
+                ";ActivityIdFormat=*Activity.IdFormat" +
+            "\r\n" +
+            "Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.HttpRequestIn.Stop@Activity1Stop:-" +
+                "Response.StatusCode" +
+                ";ActivityDuration=*Activity.Duration.Ticks" +
+                ";ActivityId=*Activity.Id" +
+            "\r\n" +
+            "HttpHandlerDiagnosticListener/System.Net.Http.HttpRequestOut@Event:-" +
+            "\r\n" +
+            "HttpHandlerDiagnosticListener/System.Net.Http.HttpRequestOut.Start@Activity2Start:-" +
+                "Request.RequestUri" +
+                ";Request.Method" +
+                ";Request.RequestUri.Host" +
+                ";Request.RequestUri.Port" +
+                ";ActivityStartTime=*Activity.StartTimeUtc.Ticks" +
+                ";ActivityId=*Activity.Id" +
+                ";ActivitySpanId=*Activity.SpanId" +
+                ";ActivityTraceId=*Activity.TraceId" +
+                ";ActivityParentSpanId=*Activity.ParentSpanId" +
+                ";ActivityIdFormat=*Activity.IdFormat" +
+                ";ActivityId=*Activity.Id" +
+                "\r\n" +
+            "HttpHandlerDiagnosticListener/System.Net.Http.HttpRequestOut.Stop@Activity2Stop:-" +
+                ";ActivityDuration=*Activity.Duration.Ticks" +
+                ";ActivityId=*Activity.Id" +
+            "\r\n";
 
-        public override IList<EventPipeProvider> GetProviders()
+    public override IList<EventPipeProvider> GetProviders()
         {
             if (_heartbeatIntervalSeconds.HasValue)
             {

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/AspNetTriggerSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/AspNetTriggerSourceConfiguration.cs
@@ -23,57 +23,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
             _heartbeatIntervalSeconds = heartbeatIntervalSeconds;
         }
 
-    /// <summary>
-    /// Filter string for trigger data. Note that even though some triggers use start OR stop,
-    /// collecting just one causes unusual behavior in data collection. This value is identical to
-    /// the DiagnosticFilterString in HttpRequestSourceConfiguration.
-    /// </summary>
-    /// <remarks>
-    /// IMPORTANT! We rely on these transformations to make sure we can access relevant data
-    /// by index. The order must match the data extracted in the triggers.
-    /// </remarks>
-    private const string DiagnosticFilterString =
-            "Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.HttpRequestIn.Start@Activity1Start:-" +
-                "Request.Scheme" +
-                ";Request.Host" +
-                ";Request.PathBase" +
-                ";Request.QueryString" +
-                ";Request.Path" +
-                ";Request.Method" +
-                ";ActivityStartTime=*Activity.StartTimeUtc.Ticks" +
-                ";ActivityParentId=*Activity.ParentId" +
-                ";ActivityId=*Activity.Id" +
-                ";ActivitySpanId=*Activity.SpanId" +
-                ";ActivityTraceId=*Activity.TraceId" +
-                ";ActivityParentSpanId=*Activity.ParentSpanId" +
-                ";ActivityIdFormat=*Activity.IdFormat" +
-            "\r\n" +
-            "Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.HttpRequestIn.Stop@Activity1Stop:-" +
-                "Response.StatusCode" +
-                ";ActivityDuration=*Activity.Duration.Ticks" +
-                ";ActivityId=*Activity.Id" +
-            "\r\n" +
-            "HttpHandlerDiagnosticListener/System.Net.Http.HttpRequestOut@Event:-" +
-            "\r\n" +
-            "HttpHandlerDiagnosticListener/System.Net.Http.HttpRequestOut.Start@Activity2Start:-" +
-                "Request.RequestUri" +
-                ";Request.Method" +
-                ";Request.RequestUri.Host" +
-                ";Request.RequestUri.Port" +
-                ";ActivityStartTime=*Activity.StartTimeUtc.Ticks" +
-                ";ActivityId=*Activity.Id" +
-                ";ActivitySpanId=*Activity.SpanId" +
-                ";ActivityTraceId=*Activity.TraceId" +
-                ";ActivityParentSpanId=*Activity.ParentSpanId" +
-                ";ActivityIdFormat=*Activity.IdFormat" +
-                ";ActivityId=*Activity.Id" +
-                "\r\n" +
-            "HttpHandlerDiagnosticListener/System.Net.Http.HttpRequestOut.Stop@Activity2Stop:-" +
-                ";ActivityDuration=*Activity.Duration.Ticks" +
-                ";ActivityId=*Activity.Id" +
-            "\r\n";
-
-    public override IList<EventPipeProvider> GetProviders()
+        public override IList<EventPipeProvider> GetProviders()
         {
             if (_heartbeatIntervalSeconds.HasValue)
             {
@@ -91,7 +41,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
                         eventLevel: EventLevel.Verbose,
                         arguments: new Dictionary<string,string>
                         {
-                            { "FilterAndPayloadSpecs", DiagnosticFilterString }
+                            { "FilterAndPayloadSpecs", HttpRequestSourceConfiguration.DiagnosticFilterString }
                         })
                 };
             }

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/HttpRequestSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/HttpRequestSourceConfiguration.cs
@@ -16,6 +16,9 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
             RequestRundown = true;
         }
 
+        // This string is shared between HttpRequestSourceConfiguration and AspNetTriggerSourceConfiguration
+        // due to an issue that causes the FilterAndPayloadSpecs to be overwritten but never reverted.
+        // This caused http traces to interfere with AspNet* triggers due to having different arguments.
         public const string DiagnosticFilterString =
                 "Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.HttpRequestIn.Start@Activity1Start:-" +
                     "Request.Scheme" +

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/HttpRequestSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/HttpRequestSourceConfiguration.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
                     ";Request.Path" +
                     ";Response.StatusCode" +
                     ";ActivityDuration=*Activity.Duration.Ticks" +
-                    "\r\n" +
+                "\r\n" +
                 "HttpHandlerDiagnosticListener/System.Net.Http.HttpRequestOut@Event:-" +
                 "\r\n" +
                 "HttpHandlerDiagnosticListener/System.Net.Http.HttpRequestOut.Start@Activity2Start:-" +

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/HttpRequestSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/HttpRequestSourceConfiguration.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
             RequestRundown = true;
         }
 
-        private const string DiagnosticFilterString =
+        public const string DiagnosticFilterString =
                 "Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.HttpRequestIn.Start@Activity1Start:-" +
                     "Request.Scheme" +
                     ";Request.Host" +
@@ -33,10 +33,11 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
                     ";ActivityIdFormat=*Activity.IdFormat" +
                 "\r\n" +
                 "Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.HttpRequestIn.Stop@Activity1Stop:-" +
-                    "Response.StatusCode" +
+                    "ActivityId=*Activity.Id" +
+                    ";Request.Path" +
+                    ";Response.StatusCode" +
                     ";ActivityDuration=*Activity.Duration.Ticks" +
-                    ";ActivityId=*Activity.Id" +
-                "\r\n" +
+                    "\r\n" +
                 "HttpHandlerDiagnosticListener/System.Net.Http.HttpRequestOut@Event:-" +
                 "\r\n" +
                 "HttpHandlerDiagnosticListener/System.Net.Http.HttpRequestOut.Start@Activity2Start:-" +

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/AspNet/AspNetTrigger.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/AspNet/AspNetTrigger.cs
@@ -6,6 +6,7 @@ using Microsoft.Diagnostics.Tracing;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
 using System.Linq;
 
 namespace Microsoft.Diagnostics.Monitoring.EventPipe.Triggers.AspNet
@@ -58,7 +59,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.Triggers.AspNet
             if (traceEvent.ProviderGuid == MicrosoftAspNetCoreHostingGuid)
             {
                 int? statusCode = null;
-                long? duration = 0;
+                long? duration = null;
                 string activityId = "";
                 string path = "";
 
@@ -95,6 +96,9 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.Triggers.AspNet
                 if (traceEvent.EventName == Activity1Stop)
                 {
                     eventType = AspnetTriggerEventType.Stop;
+
+                    Debug.Assert(statusCode != null, "Status code cannot be null.");
+                    Debug.Assert(duration != null, "Duration cannot be null.");
                 }
 
                 return HasSatisfiedCondition(timeStamp, eventType, activityId, path, statusCode, duration);

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/AspNet/AspNetTrigger.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/AspNet/AspNetTrigger.cs
@@ -16,6 +16,10 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.Triggers.AspNet
     /// </summary>
     internal abstract class AspNetTrigger<TSettings> : ITraceEventTrigger where TSettings : AspNetTriggerSettings
     {
+        private const string ActivityId = "activityid";
+        private const string Path = "path";
+        private const string StatusCode = "statuscode";
+        private const string ActivityDuration = "activityduration";
         private const string Activity1Start = "Activity1/Start";
         private const string Activity1Stop = "Activity1/Stop";
         private static readonly Guid MicrosoftAspNetCoreHostingGuid = new Guid("{adb401e1-5296-51f8-c125-5fda75826144}");
@@ -60,8 +64,8 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.Triggers.AspNet
             {
                 int? statusCode = null;
                 long? duration = null;
-                string activityId = "";
-                string path = "";
+                string activityId = string.Empty;
+                string path = string.Empty;
 
                 AspnetTriggerEventType eventType = AspnetTriggerEventType.Start;
 
@@ -74,19 +78,19 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.Triggers.AspNet
                         string key = (string)argumentsEnumerable.First().Value;
                         string value = (string)argumentsEnumerable.Last().Value;
 
-                        if (key.Equals("activityid", StringComparison.OrdinalIgnoreCase))
+                        if (key.Equals(ActivityId, StringComparison.OrdinalIgnoreCase))
                         {
                             activityId = value;
                         }
-                        else if (key.Equals("path", StringComparison.OrdinalIgnoreCase))
+                        else if (key.Equals(Path, StringComparison.OrdinalIgnoreCase))
                         {
                             path = value;
                         }
-                        else if (key.Equals("statuscode", StringComparison.OrdinalIgnoreCase))
+                        else if (key.Equals(StatusCode, StringComparison.OrdinalIgnoreCase))
                         {
                             statusCode = int.Parse(value);
                         }
-                        else if (key.Equals("activityduration", StringComparison.OrdinalIgnoreCase))
+                        else if (key.Equals(ActivityDuration, StringComparison.OrdinalIgnoreCase))
                         {
                             duration = long.Parse(value);
                         }

--- a/src/Microsoft.Diagnostics.TestHelpers/DotNetBuildDebuggeeTestStep.cs
+++ b/src/Microsoft.Diagnostics.TestHelpers/DotNetBuildDebuggeeTestStep.cs
@@ -192,6 +192,7 @@ namespace Microsoft.Diagnostics.TestHelpers
             ProcessRunner runner = new ProcessRunner(DotNetToolPath, args).
                 WithEnvironmentVariable("DOTNET_MULTILEVEL_LOOKUP", "0").
                 WithEnvironmentVariable("DOTNET_ROOT", Path.GetDirectoryName(DotNetToolPath)).
+                WithEnvironmentVariable("DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER", "true").
                 WithEnvironmentVariable("DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR", Path.GetDirectoryName(DotNetToolPath)).
                 WithEnvironmentVariable("DOTNET_INSTALL_DIR", Path.GetDirectoryName(DotNetToolPath)).
                 RemoveEnvironmentVariable("MSBuildSDKsPath").
@@ -238,6 +239,7 @@ namespace Microsoft.Diagnostics.TestHelpers
             ProcessRunner runner = new ProcessRunner(DotNetToolPath, dotnetArgs).
                 WithEnvironmentVariable("DOTNET_MULTILEVEL_LOOKUP", "0").
                 WithEnvironmentVariable("DOTNET_ROOT", Path.GetDirectoryName(DotNetToolPath)).
+                WithEnvironmentVariable("DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER", "true").
                 WithEnvironmentVariable("DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR", Path.GetDirectoryName(DotNetToolPath)).
                 WithEnvironmentVariable("DOTNET_INSTALL_DIR", Path.GetDirectoryName(DotNetToolPath)).
                 RemoveEnvironmentVariable("MSBuildSDKsPath").


### PR DESCRIPTION
This serves as a partial fix to an issue that caused AspNet* collection rules to no longer function after collecting a trace with the Http profile.

@jander-msft 