### PR TITLE
FreeBSD fixes

### DIFF
--- a/src/shared/dbgutil/elfreader.h
+++ b/src/shared/dbgutil/elfreader.h
@@ -67,7 +67,11 @@ private:
     bool EnumerateLinkMapEntries(ElfW(Dyn)* dynamicAddr);
 #endif
     bool EnumerateProgramHeaders(ElfW(Phdr)* phdrAddr, int phnum, uint64_t baseAddress, uint64_t* ploadbias, ElfW(Dyn)** pdynamicAddr);
+#ifdef __FreeBSD__
+    virtual void VisitModule(caddr_t baseAddress, std::string& moduleName) { };
+#else
     virtual void VisitModule(uint64_t baseAddress, std::string& moduleName) { };
+#endif
     virtual void VisitProgramHeader(uint64_t loadbias, uint64_t baseAddress, ElfW(Phdr)* phdr) { };
     virtual bool ReadMemory(void* address, void* buffer, size_t size) = 0;
     virtual void Trace(const char* format, ...) { };

--- a/src/shared/pal/src/init/pal.cpp
+++ b/src/shared/pal/src/init/pal.cpp
@@ -81,6 +81,7 @@ int CacheLineSize;
 
 #ifdef __FreeBSD__
 #include <sys/user.h>
+#include <sys/sysctl.h>
 #endif
 
 #include <algorithm>


### PR DESCRIPTION
`src/shared/pal/src/init/pal.cpp` missing include was causing build failures
`src/shared/dbgutil/elfreader.h` this change was in past versions but got lost/reverted/missed when files got moved around