### PR TITLE
Unpin monitoring assembly versions

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Microsoft.Diagnostics.Monitoring.EventPipe.csproj
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Microsoft.Diagnostics.Monitoring.EventPipe.csproj
@@ -14,8 +14,6 @@
     <IsShipping>false</IsShipping>
     <IsShippingAssembly>true</IsShippingAssembly>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!-- Version information -->
-    <VersionPrefix>5.0.0</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Diagnostics.Monitoring/Microsoft.Diagnostics.Monitoring.csproj
+++ b/src/Microsoft.Diagnostics.Monitoring/Microsoft.Diagnostics.Monitoring.csproj
@@ -14,8 +14,6 @@
     <IsShipping>false</IsShipping>
     <IsShippingAssembly>true</IsShippingAssembly>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!-- Version information -->
-    <VersionPrefix>5.0.0</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
These libraries do not need to be versioned `5.0` and can version along with the other diagnostics libraries.

cc @dotnet/dotnet-monitor 