### PR TITLE
Merge main to release/stable

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,2 @@
+<!-- This file is to prevent implicit imports from breaking out of the repo root. -->
+<Project />

--- a/eng/AuxMsbuildFiles/Directory.Build.props
+++ b/eng/AuxMsbuildFiles/Directory.Build.props
@@ -1,0 +1,15 @@
+<Project>
+    <!-- Importing arcade depends on the existence of a global.json. Fix
+        this to a set of well known imports when moving to Helix. -->
+    <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+    <PropertyGroup>
+        <BaseOutputPath>bin\</BaseOutputPath>
+        <BaseIntermediateOutputPath>obj\</BaseIntermediateOutputPath>
+        <OutputPath Condition="'$(PlatformName)' == 'AnyCPU'">$(BaseOutputPath)$(Configuration)\</OutputPath>
+        <OutputPath Condition="'$(PlatformName)' != 'AnyCPU'">$(BaseOutputPath)$(PlatformName)\$(Configuration)\</OutputPath>
+        <IntermediateOutputPath Condition="'$(PlatformName)' == 'AnyCPU'">$(BaseIntermediateOutputPath)$(Configuration)\</IntermediateOutputPath>
+        <IntermediateOutputPath Condition="'$(PlatformName)' != 'AnyCPU'">$(BaseIntermediateOutputPath)$(PlatformName)\$(Configuration)\</IntermediateOutputPath>
+    </PropertyGroup>
+</Project>

--- a/eng/AuxMsbuildFiles/Directory.Build.targets
+++ b/eng/AuxMsbuildFiles/Directory.Build.targets
@@ -1,0 +1,5 @@
+<Project>
+    <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" />
+    <Import Project="SdkPackOverrides.targets"/>
+</Project>

--- a/eng/AuxMsbuildFiles/SdkPackOverrides.targets
+++ b/eng/AuxMsbuildFiles/SdkPackOverrides.targets
@@ -1,0 +1,26 @@
+<Project InitialTargets="OverrideTestingVersions">
+  <Target Name="OverrideTestingVersions">
+    <ItemGroup>
+      <KnownFrameworkReference>
+        <TargetingPackVersion Condition="'%(TargetFramework)' == 'net6.0'">$(MicrosoftNETCoreApp60Version)</TargetingPackVersion>
+        <LatestRuntimeFrameworkVersion Condition="'%(TargetFramework)' == 'net6.0'">$(MicrosoftNETCoreApp60Version)</LatestRuntimeFrameworkVersion>
+      </KnownFrameworkReference>
+      <KnownAppHostPack>
+        <AppHostPackVersion Condition="'%(TargetFramework)' == 'net6.0'">$(MicrosoftNETCoreApp60Version)</AppHostPackVersion>
+      </KnownAppHostPack>
+      <KnownCrossgen2Pack>
+        <Crossgen2PackVersion Condition="'%(TargetFramework)' == 'net6.0'">$(MicrosoftNETCoreApp60Version)</Crossgen2PackVersion>
+      </KnownCrossgen2Pack>
+      <KnownRuntimePack>
+        <LatestRuntimeFrameworkVersion Condition="'%(TargetFramework)' == 'net6.0'">$(MicrosoftNETCoreApp60Version)</LatestRuntimeFrameworkVersion>
+      </KnownRuntimePack>
+
+      <KnownFrameworkReference>
+        <LatestRuntimeFrameworkVersion Condition="'%(TargetFramework)' == 'netcoreapp3.1'">$(MicrosoftNETCoreApp31Version)</LatestRuntimeFrameworkVersion>
+      </KnownFrameworkReference>
+      <KnownAppHostPack>
+        <AppHostPackVersion Condition="'%(TargetFramework)' == 'netcoreapp3.1'">$(MicrosoftNETCoreApp31Version)</AppHostPackVersion>
+      </KnownAppHostPack>
+    </ItemGroup>
+  </Target>
+</Project>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -12,41 +12,41 @@
       <Uri>https://github.com/microsoft/clrmd</Uri>
       <Sha>a64d9ac11086f28fbd4b2b2337c19be7826fbfa9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="8.0.0-alpha.1.22472.2">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="8.0.0-alpha.1.22480.1">
       <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
-      <Sha>1f91bc10ab56e67fe2f79dd03bd0e44136fc8b3f</Sha>
+      <Sha>86f1b8bab00224aad270d0524cf76d5a8779a299</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.22466.3">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.22480.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>bf47db2617320c82f94713d7b538f7bc0fa9d662</Sha>
+      <Sha>60e9ab3c31d68167f8dac5b8e2c536deb12ef737</Sha>
       <SourceBuild RepoName="arcade" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="7.0.0-beta.22316.2" Pinned="true">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>ccfe6da198c5f05534863bbb1bff66e830e0c6ab</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="7.0.100-rc.2.22454.1">
+    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="7.0.100-rtm.22480.6">
       <Uri>https://github.com/dotnet/installer</Uri>
-      <Sha>330dee39e5e4dcf765f4c41c76b94c8e4497e91c</Sha>
+      <Sha>61f59eff2c102046b8b2f6df9c0605ef3b7f6d63</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="7.0.0-rtm.22472.9">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="7.0.0-rtm.22504.29">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>5195e688c25ad9b4e9e7891dcebd31fc26df8d45</Sha>
+      <Sha>2651d9202b0bf5fdd081930cd7a4438ced351410</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="7.0.0-rtm.22472.9">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="7.0.0-rtm.22504.29">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>5195e688c25ad9b4e9e7891dcebd31fc26df8d45</Sha>
+      <Sha>2651d9202b0bf5fdd081930cd7a4438ced351410</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="7.0.0-rtm.22471.13">
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="7.0.0-rtm.22504.4">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>34c548842218c1ef421bb75681f772ed5ced4d95</Sha>
+      <Sha>6bcb45f2d8913e67a3b1e7dc814d76b5ab8be4e9</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.7.0" Version="7.0.0-rtm.22471.13">
+    <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.7.0" Version="7.0.0-rtm.22504.4">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>34c548842218c1ef421bb75681f772ed5ced4d95</Sha>
+      <Sha>6bcb45f2d8913e67a3b1e7dc814d76b5ab8be4e9</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -18,13 +18,13 @@
     <!-- Latest symstore version updated by darc -->
     <MicrosoftSymbolStoreVersion>1.0.345501</MicrosoftSymbolStoreVersion>
     <!-- Latest shared runtime version updated by darc -->
-    <VSRedistCommonNetCoreSharedFrameworkx6470Version>7.0.0-rtm.22471.13</VSRedistCommonNetCoreSharedFrameworkx6470Version>
-    <MicrosoftNETCoreAppRuntimewinx64Version>7.0.0-rtm.22471.13</MicrosoftNETCoreAppRuntimewinx64Version>
+    <VSRedistCommonNetCoreSharedFrameworkx6470Version>7.0.0-rtm.22504.4</VSRedistCommonNetCoreSharedFrameworkx6470Version>
+    <MicrosoftNETCoreAppRuntimewinx64Version>7.0.0-rtm.22504.4</MicrosoftNETCoreAppRuntimewinx64Version>
     <!-- Latest shared aspnetcore version updated by darc -->
-    <MicrosoftAspNetCoreAppRefInternalVersion>7.0.0-rtm.22472.9</MicrosoftAspNetCoreAppRefInternalVersion>
-    <MicrosoftAspNetCoreAppRefVersion>7.0.0-rtm.22472.9</MicrosoftAspNetCoreAppRefVersion>
+    <MicrosoftAspNetCoreAppRefInternalVersion>7.0.0-rtm.22504.29</MicrosoftAspNetCoreAppRefInternalVersion>
+    <MicrosoftAspNetCoreAppRefVersion>7.0.0-rtm.22504.29</MicrosoftAspNetCoreAppRefVersion>
     <!-- dotnet/installer: Testing version of the SDK. Needed for the signed & entitled host. -->
-    <MicrosoftDotnetSdkInternalVersion>7.0.100-rc.2.22454.1</MicrosoftDotnetSdkInternalVersion>
+    <MicrosoftDotnetSdkInternalVersion>7.0.100-rtm.22480.6</MicrosoftDotnetSdkInternalVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Runtime versions to test -->
@@ -34,14 +34,12 @@
     <MicrosoftAspNetCoreApp60Version>$(MicrosoftNETCoreApp60Version)</MicrosoftAspNetCoreApp60Version>
     <!-- The SDK runtime version used to build single-file apps (currently hardcoded) -->
     <SingleFileRuntime60Version>6.0.8</SingleFileRuntime60Version>
-    <SingleFileRuntimeLatestVersion>7.0.0-rc.1.22422.12</SingleFileRuntimeLatestVersion>
+    <SingleFileRuntimeLatestVersion>7.0.0-rtm.22478.9</SingleFileRuntimeLatestVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Opt-in/out repo features -->
     <UsingToolXliff>false</UsingToolXliff>
     <UsingToolNetFrameworkReferenceAssemblies>true</UsingToolNetFrameworkReferenceAssemblies>
-    <!-- Build tools -->
-    <MicrosoftNetCompilersVersion>3.0.0</MicrosoftNetCompilersVersion>
     <!-- CoreFX -->
     <SystemReflectionMetadataVersion>5.0.0</SystemReflectionMetadataVersion>
     <MicrosoftWin32PrimitivesVersion>4.3.0</MicrosoftWin32PrimitivesVersion>
@@ -49,7 +47,7 @@
     <MicrosoftBclAsyncInterfacesVersion>1.1.0</MicrosoftBclAsyncInterfacesVersion>
     <MicrosoftDiagnosticsRuntimeVersion>2.2.332302</MicrosoftDiagnosticsRuntimeVersion>
     <MicrosoftDiaSymReaderNativePackageVersion>16.9.0-beta1.21055.5</MicrosoftDiaSymReaderNativePackageVersion>
-    <MicrosoftDiagnosticsTracingTraceEventVersion>3.0.3</MicrosoftDiagnosticsTracingTraceEventVersion>
+    <MicrosoftDiagnosticsTracingTraceEventVersion>2.0.76</MicrosoftDiagnosticsTracingTraceEventVersion>
     <!-- Use pinned version to avoid picking up latest (which doesn't support netcoreapp3.1) during source-build -->
     <MicrosoftExtensionsLoggingPinnedVersion>2.1.1</MicrosoftExtensionsLoggingPinnedVersion>
     <!-- Need version that understands UseAppFilters sentinel. -->

--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -26,6 +26,7 @@ Param(
   [string] $runtimeSourceFeed = '',
   [string] $runtimeSourceFeedKey = '',
   [switch] $excludePrereleaseVS,
+  [switch] $nativeToolsOnMachine,
   [switch] $help,
   [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
 )
@@ -67,6 +68,7 @@ function Print-Usage() {
   Write-Host "  -warnAsError <value>    Sets warnaserror msbuild parameter ('true' or 'false')"
   Write-Host "  -msbuildEngine <value>  Msbuild engine to use to run build ('dotnet', 'vs', or unspecified)."
   Write-Host "  -excludePrereleaseVS    Set to exclude build engines in prerelease versions of Visual Studio"
+  Write-Host "  -nativeToolsOnMachine   Sets the native tools on machine environment variable (indicating that the script should use native tools on machine)"
   Write-Host ""
 
   Write-Host "Command line arguments not listed above are passed thru to msbuild."
@@ -146,6 +148,9 @@ try {
     $nodeReuse = $false
   }
 
+  if ($nativeToolsOnMachine) {
+    $env:NativeToolsOnMachine = $true
+  }
   if ($restore) {
     InitializeNativeTools
   }

--- a/eng/common/init-tools-native.ps1
+++ b/eng/common/init-tools-native.ps1
@@ -113,6 +113,7 @@ try {
             $ToolPath = Convert-Path -Path $BinPath
             Write-Host "Adding $ToolName to the path ($ToolPath)..."
             Write-Host "##vso[task.prependpath]$ToolPath"
+            $env:PATH = "$ToolPath;$env:PATH"
             $InstalledTools += @{ $ToolName = $ToolDirectory.FullName }
           }
         }

--- a/eng/common/templates/job/execute-sdl.yml
+++ b/eng/common/templates/job/execute-sdl.yml
@@ -34,7 +34,7 @@ jobs:
 - job: Run_SDL
   dependsOn: ${{ parameters.dependsOn }}
   displayName: Run SDL tool
-  condition: eq( ${{ parameters.enable }}, 'true')
+  condition: and(succeededOrFailed(), eq( ${{ parameters.enable }}, 'true'))
   variables:
     - group: DotNet-VSTS-Bot
     - name: AzDOProjectName

--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -25,6 +25,7 @@ parameters:
   enablePublishTestResults: false
   enablePublishUsingPipelines: false
   disableComponentGovernance: false
+  componentGovernanceIgnoreDirectories: ''
   mergeTestResults: false
   testRunTitle: ''
   testResultsFormat: ''
@@ -146,6 +147,8 @@ jobs:
   - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(parameters.disableComponentGovernance, 'true')) }}:
       - task: ComponentGovernanceComponentDetection@0
         continueOnError: true
+        inputs:
+          ignoreDirectories: ${{ parameters.componentGovernanceIgnoreDirectories }}
 
   - ${{ if eq(parameters.enableMicrobuild, 'true') }}:
     - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
@@ -223,4 +226,5 @@ jobs:
       parameters:
         PackageVersion: ${{ parameters.packageVersion}}
         BuildDropPath: ${{ parameters.buildDropPath }}
+        IgnoreDirectories: ${{ parameters.componentGovernanceIgnoreDirectories }}
 

--- a/eng/common/templates/jobs/source-build.yml
+++ b/eng/common/templates/jobs/source-build.yml
@@ -14,7 +14,7 @@ parameters:
   # This is the default platform provided by Arcade, intended for use by a managed-only repo.
   defaultManagedPlatform:
     name: 'Managed'
-    container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-3e800f1-20190501005343'
+    container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8-latest'
 
   # Defines the platforms on which to run build jobs. One job is created for each platform, and the
   # object in this array is sent to the job template as 'platform'. If no platforms are specified,

--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -98,7 +98,7 @@ stages:
     jobs:
     - job:
       displayName: NuGet Validation
-      condition: eq( ${{ parameters.enableNugetValidation }}, 'true')
+      condition: and(succeededOrFailed(), eq( ${{ parameters.enableNugetValidation }}, 'true'))
       pool:
         # We don't use the collection uri here because it might vary (.visualstudio.com vs. dev.azure.com)
         ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:

--- a/eng/common/templates/steps/generate-sbom.yml
+++ b/eng/common/templates/steps/generate-sbom.yml
@@ -2,12 +2,14 @@
 # PackageName - The name of the package this SBOM represents.
 # PackageVersion - The version of the package this SBOM represents. 
 # ManifestDirPath - The path of the directory where the generated manifest files will be placed
+# IgnoreDirectories - Directories to ignore for SBOM generation. This will be passed through to the CG component detector.
 
 parameters:
   PackageVersion: 7.0.0
   BuildDropPath: '$(Build.SourcesDirectory)/artifacts'
   PackageName: '.NET'
   ManifestDirPath: $(Build.ArtifactStagingDirectory)/sbom
+  IgnoreDirectories: ''
   sbomContinueOnError: true
 
 steps:
@@ -34,6 +36,8 @@ steps:
       BuildDropPath: ${{ parameters.buildDropPath }}
       PackageVersion: ${{ parameters.packageVersion }}
       ManifestDirPath: ${{ parameters.manifestDirPath }}
+      ${{ if ne(parameters.IgnoreDirectories, '') }}:
+        AdditionalComponentDetectorArgs: '--IgnoreDirectories ${{ parameters.IgnoreDirectories }}'
 
 - task: PublishPipelineArtifact@1
   displayName: Publish SBOM manifest

--- a/eng/common/templates/steps/source-build.yml
+++ b/eng/common/templates/steps/source-build.yml
@@ -68,6 +68,11 @@ steps:
       publishArgs='--publish'
     fi
 
+    assetManifestFileName=SourceBuild_RidSpecific.xml
+    if [ '${{ parameters.platform.name }}' != '' ]; then
+      assetManifestFileName=SourceBuild_${{ parameters.platform.name }}.xml
+    fi
+
     ${{ coalesce(parameters.platform.buildScript, './build.sh') }} --ci \
       --configuration $buildConfig \
       --restore --build --pack $publishArgs -bl \
@@ -76,7 +81,8 @@ steps:
       $internalRestoreArgs \
       $targetRidArgs \
       /p:SourceBuildNonPortable=${{ parameters.platform.nonPortable }} \
-      /p:ArcadeBuildFromSource=true
+      /p:ArcadeBuildFromSource=true \
+      /p:AssetManifestFileName=$assetManifestFileName
   displayName: Build
 
 # Upload build logs for diagnosis.

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "7.0.100-preview.7.22377.5",
+    "dotnet": "7.0.100-rc.1.22431.12",
     "runtimes": {
       "dotnet/x64": [
         "$(MicrosoftNETCoreApp31Version)",
@@ -20,6 +20,6 @@
   },
   "msbuild-sdks": {
     "Microsoft.Build.NoTargets": "3.5.0",
-    "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.22466.3"
+    "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.22480.2"
   }
 }

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
-    <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
+  <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 
-    <!-- Work around https://github.com/dotnet/sourcelink/issues/572
+  <!-- Work around https://github.com/dotnet/sourcelink/issues/572
   Remove once we build using an SDK that contains https://github.com/dotnet/sdk/pull/10613 -->
   <PropertyGroup>
       <TargetFrameworkMonikerAssemblyAttributesPath>$([System.IO.Path]::Combine('$(IntermediateOutputPath)','$(TargetFrameworkMoniker).AssemblyAttributes$(DefaultLanguageSourceExtension)'))</TargetFrameworkMonikerAssemblyAttributesPath>

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Microsoft.Diagnostics.Monitoring.EventPipe.csproj
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Microsoft.Diagnostics.Monitoring.EventPipe.csproj
@@ -14,8 +14,6 @@
     <IsShipping>false</IsShipping>
     <IsShippingAssembly>true</IsShippingAssembly>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!-- Version information -->
-    <VersionPrefix>5.0.0</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Diagnostics.Monitoring/Microsoft.Diagnostics.Monitoring.csproj
+++ b/src/Microsoft.Diagnostics.Monitoring/Microsoft.Diagnostics.Monitoring.csproj
@@ -14,8 +14,6 @@
     <IsShipping>false</IsShipping>
     <IsShippingAssembly>true</IsShippingAssembly>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!-- Version information -->
-    <VersionPrefix>5.0.0</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Diagnostics.TestHelpers/CliDebuggeeCompiler.cs
+++ b/src/Microsoft.Diagnostics.TestHelpers/CliDebuggeeCompiler.cs
@@ -76,6 +76,7 @@ namespace Microsoft.Diagnostics.TestHelpers
             string logPath = GetLogPath(config, framework, runtimeIdentifier, debuggeeName);
             return new CsprojBuildDebuggeeTestStep(dotNetPath,
                                                initialSourceDirPath,
+                                               config.DebuggeeMsbuildAuxRoot,
                                                GetDebuggeeNativeLibDirPath(config, debuggeeName),
                                                GetBuildProperties(config, runtimeIdentifier),
                                                runtimeIdentifier,

--- a/src/Microsoft.Diagnostics.TestHelpers/CsprojBuildDebuggeeTestStep.cs
+++ b/src/Microsoft.Diagnostics.TestHelpers/CsprojBuildDebuggeeTestStep.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Diagnostics.TestHelpers
         /// </param>
         public CsprojBuildDebuggeeTestStep(string dotnetToolPath,
                                        string templateSolutionDirPath,
+                                       string debuggeeMsbuildAuxRoot,
                                        string debuggeeNativeLibDirPath,
                                        Dictionary<string,string> buildProperties,
                                        string runtimeIdentifier,
@@ -43,6 +44,7 @@ namespace Microsoft.Diagnostics.TestHelpers
                                        string logPath) :
             base(dotnetToolPath,
                  templateSolutionDirPath,
+                 debuggeeMsbuildAuxRoot,
                  debuggeeNativeLibDirPath,
                  debuggeeSolutionDirPath,
                  debuggeeProjectDirPath,

--- a/src/Microsoft.Diagnostics.TestHelpers/DotNetBuildDebuggeeTestStep.cs
+++ b/src/Microsoft.Diagnostics.TestHelpers/DotNetBuildDebuggeeTestStep.cs
@@ -72,6 +72,7 @@ namespace Microsoft.Diagnostics.TestHelpers
         /// </param>
         public DotNetBuildDebuggeeTestStep(string dotnetToolPath,
                                        string templateSolutionDirPath,
+                                       string debuggeeMsbuildAuxRoot,
                                        string debuggeeNativeLibDirPath,
                                        string debuggeeSolutionDirPath,
                                        string debuggeeProjectDirPath,
@@ -85,6 +86,7 @@ namespace Microsoft.Diagnostics.TestHelpers
         {
             DotNetToolPath = dotnetToolPath;
             DebuggeeTemplateSolutionDirPath = templateSolutionDirPath;
+            DebuggeeMsbuildAuxRoot = debuggeeMsbuildAuxRoot;
             DebuggeeNativeLibDirPath = debuggeeNativeLibDirPath;
             DebuggeeSolutionDirPath = debuggeeSolutionDirPath;
             DebuggeeProjectDirPath = debuggeeProjectDirPath;
@@ -109,6 +111,10 @@ namespace Microsoft.Diagnostics.TestHelpers
         /// </summary>
         public string DebuggeeTemplateSolutionDirPath { get; private set; }
         /// <summary>
+        /// The path containing supporting msbuild files for the build
+        /// </summary>
+        public string DebuggeeMsbuildAuxRoot { get; }
+        /// <summary>
         /// The path where the debuggee's native binary dependencies will be copied from.
         /// </summary>
         public string DebuggeeNativeLibDirPath { get; private set; }
@@ -117,6 +123,7 @@ namespace Microsoft.Diagnostics.TestHelpers
         /// the debuggee project directory.
         /// </summary>
         public string DebuggeeSolutionDirPath { get; private set; }
+
         /// <summary>
         /// The path where the primary debuggee executable project directory will be created. For single project solutions this
         /// will be identical to the debuggee solution directory.
@@ -158,6 +165,7 @@ namespace Microsoft.Diagnostics.TestHelpers
             output.WriteLine("{");
             IndentedTestOutputHelper indentedOutput = new IndentedTestOutputHelper(output);
             CopySourceDirectory(DebuggeeTemplateSolutionDirPath, DebuggeeSolutionDirPath, indentedOutput);
+            CopySourceDirectory(DebuggeeMsbuildAuxRoot, DebuggeeSolutionDirPath, indentedOutput);
             CreateNuGetConfig(indentedOutput);
             output.WriteLine("}");
             output.WriteLine("");

--- a/src/Microsoft.Diagnostics.TestHelpers/TestConfiguration.cs
+++ b/src/Microsoft.Diagnostics.TestHelpers/TestConfiguration.cs
@@ -638,6 +638,14 @@ namespace Microsoft.Diagnostics.TestHelpers
         }
 
         /// <summary>
+        /// Auxiliary properties used by CLI based test projects file will be fetched from this path and copied to DebuggeeSourceRoot
+        /// </summary>
+        public string DebuggeeMsbuildAuxRoot
+        {
+            get { return MakeCanonicalPath(GetValue("DebuggeeMsbuildAuxRoot")); }
+        }
+
+        /// <summary>
         /// Debuggee final sources/project file/binary outputs will be placed here: <DebuggeeBuildRoot>/<DebuggeeName>/
         /// </summary>
         public string DebuggeeBuildRoot

--- a/src/SOS/SOS.UnitTests/ConfigFiles/Unix/Debugger.Tests.Config.txt
+++ b/src/SOS/SOS.UnitTests/ConfigFiles/Unix/Debugger.Tests.Config.txt
@@ -30,6 +30,7 @@
   <BuildProjectFrameworkLatest Condition="StartsWith('$(RuntimeVersionLatest)', '3.1')">netcoreapp3.1</BuildProjectFrameworkLatest>
 
   <DebuggeeSourceRoot>$(RepoRootDir)/src/SOS/SOS.UnitTests/Debuggees</DebuggeeSourceRoot>
+  <DebuggeeMsbuildAuxRoot>$(RepoRootDir)/eng/AuxMsbuildFiles</DebuggeeMsbuildAuxRoot>
   <DebuggeeBuildProcess>sdk.prebuilt</DebuggeeBuildProcess>
   <DebuggeeBuildRoot>$(RootBinDir)</DebuggeeBuildRoot>
 

--- a/src/SOS/SOS.UnitTests/ConfigFiles/Windows/Debugger.Tests.Config.txt
+++ b/src/SOS/SOS.UnitTests/ConfigFiles/Windows/Debugger.Tests.Config.txt
@@ -40,6 +40,7 @@
   <DesktopFramework>net462</DesktopFramework>
 
   <DebuggeeSourceRoot>$(RepoRootDir)\src\SOS\SOS.UnitTests\Debuggees</DebuggeeSourceRoot>
+  <DebuggeeMsbuildAuxRoot>$(RepoRootDir)\eng\AuxMsbuildFiles</DebuggeeMsbuildAuxRoot>
   <DebuggeeBuildProcess>sdk.prebuilt</DebuggeeBuildProcess>
   <DebuggeeBuildRoot>$(RootBinDir)</DebuggeeBuildRoot>
 

--- a/src/SOS/SOS.UnitTests/Debuggees/Directory.Build.props
+++ b/src/SOS/SOS.UnitTests/Debuggees/Directory.Build.props
@@ -1,6 +1,7 @@
 <Project>
   <Import Project="$(MSBuildThisFileDirectory)..\..\..\Directory.Build.props"/>
-  
+  <Import Project="$(RepoRoot)/eng/AuxMsbuildFiles/SdkPackOverrides.targets"/>
+
   <PropertyGroup>
     <DebugType Condition="'$(TargetFramework)' == 'net462'">full</DebugType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/Tools/Common/CommandLineErrorException.cs
+++ b/src/Tools/Common/CommandLineErrorException.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace Microsoft.Diagnostics.Tools.Counters
+namespace Microsoft.Diagnostics.Tools
 {
     // This is an exception whose error message is intended to be displayed
     // to the user an error on the command line

--- a/src/Tools/dotnet-counters/CounterMonitor.cs
+++ b/src/Tools/dotnet-counters/CounterMonitor.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Diagnostics.NETCore.Client;
+using Microsoft.Diagnostics.Tools;
 using Microsoft.Diagnostics.Tools.Counters.Exporters;
 using Microsoft.Diagnostics.Tracing;
 using Microsoft.Internal.Common.Utils;

--- a/src/Tools/dotnet-counters/dotnet-counters.csproj
+++ b/src/Tools/dotnet-counters/dotnet-counters.csproj
@@ -18,6 +18,7 @@
     <Compile Include="..\Common\Commands\Utils.cs" Link="Utils.cs" />
     <Compile Include="..\Common\ProcessNativeMethods\ProcessNativeMethods.cs" Link="ProcessNativeMethods.cs" />
     <Compile Include="..\Common\WindowsProcessExtension\WindowsProcessExtension.cs" Link="WindowsProcessExtension.cs" />
+    <Compile Include="..\Common\CommandLineErrorException.cs" Link="CommandLineErrorException.cs" />
  </ItemGroup>
 
   <ItemGroup>

--- a/src/Tools/dotnet-dsrouter/dotnet-dsrouter.csproj
+++ b/src/Tools/dotnet-dsrouter/dotnet-dsrouter.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <Compile Include="..\Common\CommandExtensions.cs" Link="CommandExtensions.cs" />
     <Compile Include="..\Common\ReversedServerHelpers\ReversedServerHelpers.cs" Link="ReversedServerHelpers.cs" />
+    <Compile Include="..\Common\CommandLineErrorException.cs" Link="CommandLineErrorException.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/shared/dbgutil/elfreader.h
+++ b/src/shared/dbgutil/elfreader.h
@@ -67,7 +67,11 @@ private:
     bool EnumerateLinkMapEntries(ElfW(Dyn)* dynamicAddr);
 #endif
     bool EnumerateProgramHeaders(ElfW(Phdr)* phdrAddr, int phnum, uint64_t baseAddress, uint64_t* ploadbias, ElfW(Dyn)** pdynamicAddr);
+#ifdef __FreeBSD__
+    virtual void VisitModule(caddr_t baseAddress, std::string& moduleName) { };
+#else
     virtual void VisitModule(uint64_t baseAddress, std::string& moduleName) { };
+#endif
     virtual void VisitProgramHeader(uint64_t loadbias, uint64_t baseAddress, ElfW(Phdr)* phdr) { };
     virtual bool ReadMemory(void* address, void* buffer, size_t size) = 0;
     virtual void Trace(const char* format, ...) { };

--- a/src/shared/pal/src/init/pal.cpp
+++ b/src/shared/pal/src/init/pal.cpp
@@ -81,6 +81,7 @@ int CacheLineSize;
 
 #ifdef __FreeBSD__
 #include <sys/user.h>
+#include <sys/sysctl.h>
 #endif
 
 #include <algorithm>

--- a/src/tests/CommonTestRunner/ConfigFiles/Unix/Debugger.Tests.Config.txt
+++ b/src/tests/CommonTestRunner/ConfigFiles/Unix/Debugger.Tests.Config.txt
@@ -15,6 +15,7 @@
 
   <TestProduct>ProjectK</TestProduct>
   <DebuggeeSourceRoot>$(RepoRootDir)/src/tests</DebuggeeSourceRoot>
+  <DebuggeeMsbuildAuxRoot>$(RepoRootDir)/eng/AuxMsbuildFiles</DebuggeeMsbuildAuxRoot>
   <DebuggeeBuildProcess>cli</DebuggeeBuildProcess>
   <DebuggeeBuildProcess>sdk.prebuilt</DebuggeeBuildProcess>
   <DebuggeeBuildRoot>$(RootBinDir)</DebuggeeBuildRoot>

--- a/src/tests/CommonTestRunner/ConfigFiles/Windows/Debugger.Tests.Config.txt
+++ b/src/tests/CommonTestRunner/ConfigFiles/Windows/Debugger.Tests.Config.txt
@@ -16,6 +16,7 @@
 
   <TestProduct>ProjectK</TestProduct>
   <DebuggeeSourceRoot>$(RepoRootDir)\src\tests</DebuggeeSourceRoot>
+  <DebuggeeMsbuildAuxRoot>$(RepoRootDir)\eng\AuxMsbuildFiles</DebuggeeMsbuildAuxRoot>
   <DebuggeeBuildProcess>sdk.prebuilt</DebuggeeBuildProcess>
   <DebuggeeBuildRoot>$(RootBinDir)</DebuggeeBuildRoot>
   <CliPath>$(DotNetRoot)\dotnet.exe</CliPath>

--- a/src/tests/DbgShim.UnitTests/ConfigFiles/Unix/Debugger.Tests.Config.txt
+++ b/src/tests/DbgShim.UnitTests/ConfigFiles/Unix/Debugger.Tests.Config.txt
@@ -12,6 +12,7 @@
 
   <TestProduct>ProjectK</TestProduct>
   <DebuggeeSourceRoot>$(RepoRootDir)\src\tests\DbgShim.UnitTests\Debuggees</DebuggeeSourceRoot>
+  <DebuggeeMsbuildAuxRoot>$(RepoRootDir)\eng\AuxMsbuildFiles</DebuggeeMsbuildAuxRoot>
   <DebuggeeBuildProcess>cli</DebuggeeBuildProcess>
   <DebuggeeName>SimpleDebuggee</DebuggeeName>
 

--- a/src/tests/DbgShim.UnitTests/ConfigFiles/Windows/Debugger.Tests.Config.txt
+++ b/src/tests/DbgShim.UnitTests/ConfigFiles/Windows/Debugger.Tests.Config.txt
@@ -13,6 +13,7 @@
 
   <TestProduct>ProjectK</TestProduct>
   <DebuggeeSourceRoot>$(RepoRootDir)\src\tests\DbgShim.UnitTests\Debuggees</DebuggeeSourceRoot>
+  <DebuggeeMsbuildAuxRoot>$(RepoRootDir)\eng\AuxMsbuildFiles</DebuggeeMsbuildAuxRoot>
   <DebuggeeBuildProcess>cli</DebuggeeBuildProcess>
   <DebuggeeName>SimpleDebuggee</DebuggeeName>
 

--- a/src/tests/dotnet-counters/CounterMonitorTests.cs
+++ b/src/tests/dotnet-counters/CounterMonitorTests.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 
 using Xunit;
+using Microsoft.Diagnostics.Tools;
 using Microsoft.Diagnostics.Tools.Counters;
 using Microsoft.Diagnostics.Tools.Counters.Exporters;
 


### PR DESCRIPTION
- Update dependencies from https://github.com/dotnet/runtime build 20220923.9 (#3411)
- Update dependencies from https://github.com/dotnet/source-build-reference-packages build 20220923.1 (#3412)
- Update dependencies from https://github.com/dotnet/aspnetcore build 20220923.18 (#3410)
- Update dependencies from https://github.com/dotnet/aspnetcore build 20220924.10 (#3413)
- Update dependencies from https://github.com/dotnet/runtime build 20220923.12 (#3414)
- Update dependencies from https://github.com/dotnet/arcade build 20220923.1 (#3415)
- Update dependencies from https://github.com/dotnet/aspnetcore build 20220926.26 (#3417)
- Update dependencies from https://github.com/dotnet/runtime build 20220926.12 (#3418)
- Update dependencies from https://github.com/dotnet/runtime build 20220927.8 (#3420)
- Update dependencies from https://github.com/dotnet/source-build-reference-packages build 20220927.2 (#3421)
- [main] Update dependencies from dotnet/aspnetcore (#3419)
- Update dependencies from https://github.com/dotnet/runtime build 20220928.9 (#3424)
- Update dependencies from https://github.com/dotnet/aspnetcore build 20220929.15 (#3426)
- Update dependencies from https://github.com/dotnet/runtime build 20220930.10 (#3428)
- Update dependencies from https://github.com/dotnet/source-build-reference-packages build 20220930.1 (#3429)
- Update dependencies from https://github.com/dotnet/aspnetcore build 20221001.1 (#3427)
- Update dependencies from https://github.com/dotnet/aspnetcore build 20221001.6 (#3431)
- Update dependencies from https://github.com/dotnet/arcade build 20220930.2 (#3432)
- Rename Microsoft.Diagnostics.DbgShim.linux-musl-arm package (#3433)
- FreeBSD fixes (#3430)
- Update dependencies from https://github.com/dotnet/aspnetcore build 20221003.15 (#3435)
- [main] Update dependencies from dotnet/installer (#3370)
- Unpin monitoring assembly versions (#3436)
- Update dependencies from https://github.com/dotnet/aspnetcore build 20221004.29 (#3437)
- Update dependencies from https://github.com/dotnet/runtime build 20221004.4 (#3438)
- Fixes unhandled exception on trace if process cannot start (#3409)
- Test unpinning compiler + trace event revert. (#3439)
