### PR TITLE
Fix Build

### DIFF
--- a/src/tests/CommonTestRunner/CommonTestRunner.csproj
+++ b/src/tests/CommonTestRunner/CommonTestRunner.csproj
@@ -41,10 +41,6 @@
     <Message Importance="High" Text="Created config file $(CommonTestRunnerConfigFileName)" />
     <ItemGroup>
       <FileWrites Include="$(CommonTestRunnerConfigFileName)" />
-      <Content Include="$(CommonTestRunnerConfigFileName)">
-        <Link>Debugger.Tests.Common.txt</Link>
-        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      </Content>
     </ItemGroup>
   </Target>
 

--- a/src/tests/CommonTestRunner/CommonTestRunner.csproj
+++ b/src/tests/CommonTestRunner/CommonTestRunner.csproj
@@ -20,7 +20,6 @@
     </Content>
     <Content Include="$(CommonTestRunnerConfigFileName)">
       <Link>Debugger.Tests.Common.txt</Link>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
 

--- a/src/tests/CommonTestRunner/CommonTestRunner.csproj
+++ b/src/tests/CommonTestRunner/CommonTestRunner.csproj
@@ -18,9 +18,6 @@
       <Link>Debugger.Tests.Config.txt</Link>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
-    <Content Include="$(CommonTestRunnerConfigFileName)">
-      <Link>Debugger.Tests.Common.txt</Link>
-    </Content>
   </ItemGroup>
 
   <ItemGroup>
@@ -44,6 +41,10 @@
     <Message Importance="High" Text="Created config file $(CommonTestRunnerConfigFileName)" />
     <ItemGroup>
       <FileWrites Include="$(CommonTestRunnerConfigFileName)" />
+      <Content Include="$(CommonTestRunnerConfigFileName)">
+        <Link>Debugger.Tests.Common.txt</Link>
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </Content>
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
`Debugger.Tests.Common.txt` file may not exists when building on x64 ubuntu with .NET 6.

```
  CommonTestRunner -> /home/leee/dotnet/diagnostics/artifacts/bin/CommonTestRunner/Debug/netcoreapp3.1/CommonTestRunner.dll
/home/leee/dotnet/diagnostics/.dotnet/sdk/7.0.100-rc.1.22431.12/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Publish.targets(277,5): error MSB3030: Could not copy the file "/home/leee/dotnet/diagnosti
cs/artifacts/bin/CommonTestRunner/Debug/netcoreapp3.1/Debugger.Tests.Common.txt" because it was not found. [/home/leee/dotnet/diagnostics/src/tests/CommonTestRunner/CommonTestRunner.csproj]
```

```
± ~/dotnet/diagnostics (fix_build {1} ✓) $ dotnet --info
.NET SDK (reflecting any global.json):
 Version:   6.0.109
 Commit:    58a93139d8

Runtime Environment:
 OS Name:     ubuntu
 OS Version:  22.04
 OS Platform: Linux
 RID:         ubuntu.22.04-x64
 Base Path:   /usr/lib/dotnet/dotnet6-6.0.109/sdk/6.0.109/

global.json file:
  Not found

Host:
  Version:      6.0.9
  Architecture: x64
  Commit:       163a63591c

.NET SDKs installed:
  6.0.109 [/usr/lib/dotnet/dotnet6-6.0.109/sdk]

.NET runtimes installed:
  Microsoft.AspNetCore.App 6.0.9 [/usr/lib/dotnet/dotnet6-6.0.109/shared/Microsoft.AspNetCore.App]
  Microsoft.NETCore.App 6.0.9 [/usr/lib/dotnet/dotnet6-6.0.109/shared/Microsoft.NETCore.App]

Download .NET:
  https://aka.ms/dotnet-download

Learn about .NET Runtimes and SDKs:
  https://aka.ms/dotnet/runtimes-sdk-info
```

With this fix, `Debugger.Tests.Common.txt` is copied later.
```
  CommonTestRunner -> /home/leee/dotnet/diagnostics/artifacts/bin/CommonTestRunner/Debug/netcoreapp3.1/CommonTestRunner.dll
  Microsoft.Diagnostics.Monitoring.UnitTests -> /home/leee/dotnet/diagnostics/artifacts/bin/Microsoft.Diagnostics.Monitoring.UnitTests/Debug/netcoreapp3.1/Microsoft.Diagnostics.Monitoring.UnitTests.dll
  Created config file /home/leee/dotnet/diagnostics/artifacts/bin/CommonTestRunner/Debug/netcoreapp3.1/Debugger.Tests.Common.txt
```