### PR TITLE
Enhance client-client dotnet-dsrouter mode.

### DIFF
--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsServerRouter/DiagnosticsServerRouterFactory.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsServerRouter/DiagnosticsServerRouterFactory.cs
@@ -335,7 +335,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
         {
         }
 
-        async Task<Stream> ConnectTcpStreamAsyncInternal(CancellationToken token, bool retry)
+        private async Task<Stream> ConnectTcpStreamAsyncInternal(CancellationToken token, bool retry)
         {
             Stream tcpClientStream = null;
 
@@ -396,7 +396,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
             return tcpClientStream;
         }
 
-        async Task ConnectAsyncInternal(Socket clientSocket, EndPoint remoteEP, CancellationToken token)
+        private async Task ConnectAsyncInternal(Socket clientSocket, EndPoint remoteEP, CancellationToken token)
         {
             using (token.Register(() => clientSocket.Close(0)))
             {
@@ -1203,7 +1203,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
             return new Router(ipcClientStream, tcpClientStream, _logger, (ulong)initBackendToFrontendByteTransfer, (ulong)initFrontendToBackendByteTransfer);
         }
 
-        async Task<int> InitFrontendReadBackendWrite(Stream ipcClientStream, Stream tcpClientStream, CancellationToken token)
+        private async Task<int> InitFrontendReadBackendWrite(Stream ipcClientStream, Stream tcpClientStream, CancellationToken token)
         {
             using CancellationTokenSource cancelReadConnect = CancellationTokenSource.CreateLinkedTokenSource(token);
 
@@ -1249,7 +1249,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
             return bytesRead;
         }
 
-        async Task UpdateRuntimeInfo(CancellationToken token)
+        private async Task UpdateRuntimeInfo(CancellationToken token)
         {
             if (!_updateRuntimeInfo)
                 return;
@@ -1394,7 +1394,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
             }
         }
 
-        async Task BackendReadFrontendWrite(CancellationToken token)
+        private async Task BackendReadFrontendWrite(CancellationToken token)
         {
             try
             {
@@ -1435,7 +1435,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
             RouterTaskCompleted?.TrySetResult(true);
         }
 
-        async Task FrontendReadBackendWrite(CancellationToken token)
+        private async Task FrontendReadBackendWrite(CancellationToken token)
         {
             try
             {

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsServerRouter/DiagnosticsServerRouterFactory.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsServerRouter/DiagnosticsServerRouterFactory.cs
@@ -1180,7 +1180,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
                 // A new router instance can not be complete until frontend starts to
                 // write data to backend or a new router instance will connect against frontend
                 // that in turn will disconnects previous accepted but pending connections, triggering
-                // frequent connect/discconnects of connections.
+                // frequent connects/disconnects.
                 initFrontendToBackendByteTransfer = await InitFrontendReadBackendWrite(ipcClientStream, tcpClientStream, token).ConfigureAwait(false);
             }
             catch (Exception)


### PR DESCRIPTION
When running client-client mode in dotnet-dsrouter connects the backend tcp client against runtimes tcp server and then connects the front end ipc client towards reverse diagnostic server's ipc server (running in tools like dotnet-trace, dotnet-monitor). When both completes it will send advertise message to reverse diagnostic server and consider the router instance connected and ready for use. This works fine on tools that is rather short lived, like dotnet-trace, but for long running tools like dotnet-monitor this will lead to extensive connect/disconnect behaviors since reverse diagnostic server will ask for a new connection right away and dotnet-dsrouter is setup to handle parallel router instances and since runtime uses a TCP server in listen mode it will accept multiple parallel connectionsas well, meaning that reverse diagnostic server will accept the new connection and clear any pending connections using the same runtime id (can only have one outstanding pending connection), leading to a disconnect of previous established connection, causing a tear down of router instance in dotnet-dsrouter and a reconnect.

Running this mode without dotnet-dsrouter behaves differently since runtime is then setup in connect mode only having one outstanding pending connect towards reverse diagnostic server, so a new connection will only setup once the accepted connection is consumed by the tool. This PR makes sure that dotnet-dsrouter emulates this behavior in its client-client mode meaning that it won't consider the router connected and ready to be used until it as read bytes from the reverse diagnostic server indicating that the pending connection has been picked up and used by the tool. Doing it this way will prevent dotnet-dsrouter to produce parallel running router instances that would trigger frequent connect/disconnects in reverse diagnostic server.