### PR TITLE
Optimize eeheap presentation for regions

### DIFF
--- a/src/SOS/SOS.UnitTests/Scripts/GCPOH.script
+++ b/src/SOS/SOS.UnitTests/Scripts/GCPOH.script
@@ -61,13 +61,10 @@ VERIFY:\s+Jit code heap:\s+
 VERIFY:\s+LoaderCodeHeap:\s+<HEXVAL>.*bytes\.\s+
 VERIFY:\s+Total LoaderHeap size:\s+Size:\s+0x<HEXVAL>\s+\(<DECVAL>|lu\)\s+bytes\.\s+
 VERIFY:\s+Number of GC Heaps:\s+<DECVAL>\s+
-VERIFY:\s+generation\s+<DECVAL>\s+starts\s+at\s+0x<HEXVAL>\s+
-VERIFY:\s+generation\s+<DECVAL>\s+starts\s+at\s+0x<HEXVAL>\s+
-VERIFY:\s+generation\s+<DECVAL>\s+starts\s+at\s+0x<HEXVAL>\s+
 VERIFY:\s+segment\s+begin\s+allocated\s+committed\s+allocated\s+size\s+committed\s+size\s+
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+<HEXVAL>\s+<HEXVAL>\s+0x<HEXVAL>\(<DECVAL>\)\s+0x<HEXVAL>\(<DECVAL>\)\s+
-VERIFY:\s+Large object heap starts at 0x<HEXVAL>\s+
-VERIFY:\s+Pinned object heap starts at 0x<HEXVAL>\s+
+VERIFY:\s+Large object heap.*
+VERIFY:\s+Pinned object heap.*
 
 # Continue to the next DebugBreak
 CONTINUE

--- a/src/SOS/SOS.UnitTests/Scripts/GCTests.script
+++ b/src/SOS/SOS.UnitTests/Scripts/GCTests.script
@@ -97,12 +97,9 @@ VERIFY:\s+Jit code heap:\s+
 VERIFY:\s+LoaderCodeHeap:\s+<HEXVAL>.*bytes\.\s+
 VERIFY:\s+Total LoaderHeap size:\s+Size:\s+0x<HEXVAL>\s+\(<DECVAL>|lu\)\s+bytes\.\s+
 VERIFY:\s+Number of GC Heaps:\s+<DECVAL>\s+
-VERIFY:\s+generation\s+<DECVAL>\s+starts\s+at\s+0x<HEXVAL>\s+
-VERIFY:\s+generation\s+<DECVAL>\s+starts\s+at\s+0x<HEXVAL>\s+
-VERIFY:\s+generation\s+<DECVAL>\s+starts\s+at\s+0x<HEXVAL>\s+
 VERIFY:\s+segment\s+begin\s+allocated\s+committed\s+allocated\s+size\s+committed\s+size\s+
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+<HEXVAL>\s+<HEXVAL>\s+0x<HEXVAL>\(<DECVAL>\)\s+0x<HEXVAL>\(<DECVAL>\)\s+
-VERIFY:\s+Large object heap starts at 0x<HEXVAL>\s+
+VERIFY:\s+Large object heap.*
 
 # Continue to the next DebugBreak
 CONTINUE

--- a/src/SOS/Strike/eeheap.cpp
+++ b/src/SOS/Strike/eeheap.cpp
@@ -484,13 +484,27 @@ void GCPrintSegmentInfo(const GCHeapDetails &heap, DWORD_PTR &total_allocated_si
 {
     DWORD_PTR dwAddrSeg;
     DacpHeapSegmentData segment;
+    const size_t heap_segment_flags_readonly = 1;
+    UINT max_generation = GetMaxGeneration();
 
     if (heap.has_regions)
     {
-        for (UINT n = 0; n <= GetMaxGeneration(); n++)
+        const size_t regions_committed_adjustment = 0x20;
+
+        for (UINT n = 0; n <= max_generation + 1; n++)
         {
-            ExtOut("generation %d:\n", n);
-            dwAddrSeg = (DWORD_PTR)heap.generation_table[n].start_segment;
+            bool showing_frozen = (n == max_generation + 1);
+            if (showing_frozen)
+            {
+                ExtOut("Frozen object heap\n");
+                ExtOut("%" POINTERSIZE "s  %" POINTERSIZE "s  %" POINTERSIZE "s  %" POINTERSIZE "s  %" POINTERSIZE "s  %" POINTERSIZE "s\n", "segment", "begin", "allocated", "committed", "allocated size", "committed size");
+                dwAddrSeg = (DWORD_PTR)heap.generation_table[max_generation].start_segment;
+            }
+            else
+            {
+                ExtOut("generation %d:\n", n);
+                dwAddrSeg = (DWORD_PTR)heap.generation_table[n].start_segment;
+            }
             while (dwAddrSeg != 0)
             {
                 if (IsInterrupt())
@@ -500,71 +514,90 @@ void GCPrintSegmentInfo(const GCHeapDetails &heap, DWORD_PTR &total_allocated_si
                     ExtOut("Error requesting heap segment %p\n", SOS_PTR(dwAddrSeg));
                     return;
                 }
+                
+                CLRDATA_ADDRESS allocated = segment.highAllocMark - segment.mem;
+                CLRDATA_ADDRESS committed = segment.committed - segment.mem + regions_committed_adjustment;
+                bool frozen = segment.flags & heap_segment_flags_readonly;
+                
+                if (frozen != showing_frozen)
+                {
+                    dwAddrSeg = (DWORD_PTR)segment.next;
+                    continue;
+                }
                 ExtOut("%p  %p  %p  %p  0x%" POINTERSIZE_TYPE "x(%" POINTERSIZE_TYPE"d)  0x%" POINTERSIZE_TYPE "x(%" POINTERSIZE_TYPE "d)\n",
                     SOS_PTR(dwAddrSeg),
                     SOS_PTR(segment.mem), SOS_PTR(segment.highAllocMark), SOS_PTR(segment.committed),
-                    (ULONG_PTR)(segment.highAllocMark - segment.mem),
-                    (ULONG_PTR)(segment.highAllocMark - segment.mem),
-                    (ULONG_PTR)(segment.committed - segment.mem),
-                    (ULONG_PTR)(segment.committed - segment.mem));
-                total_allocated_size += (DWORD_PTR)(segment.highAllocMark - segment.mem);
-                total_committed_size += (DWORD_PTR)(segment.committed - segment.mem);
+                    (ULONG_PTR)allocated,
+                    (ULONG_PTR)allocated,
+                    (ULONG_PTR)committed,
+                    (ULONG_PTR)committed);
+                total_allocated_size += (DWORD_PTR)allocated;
+                total_committed_size += (DWORD_PTR)committed;
                 dwAddrSeg = (DWORD_PTR)segment.next;
             }
         }
     }
     else
     {
-        dwAddrSeg = (DWORD_PTR)heap.generation_table[GetMaxGeneration()].start_segment;
-        total_allocated_size = 0;
-        total_committed_size = 0;
-
-        while (dwAddrSeg != (DWORD_PTR)heap.generation_table[0].start_segment)
+        for (UINT n = 0; n < 2; n++)
         {
-            if (IsInterrupt())
-                return;
-            if (segment.Request(g_sos, dwAddrSeg, heap.original_heap_details) != S_OK)
+            dwAddrSeg = (DWORD_PTR)heap.generation_table[GetMaxGeneration()].start_segment;
+            bool showing_frozen = (n == 1);
+            if (showing_frozen)
             {
-                ExtOut("Error requesting heap segment %p\n", SOS_PTR(dwAddrSeg));
-                return;
+                ExtOut("Frozen object heap\n");
+                ExtOut("%" POINTERSIZE "s  %" POINTERSIZE "s  %" POINTERSIZE "s  %" POINTERSIZE "s  %" POINTERSIZE "s  %" POINTERSIZE "s\n", "segment", "begin", "allocated", "committed", "allocated size", "committed size");
             }
-            ExtOut("%p  %p  %p  %p  0x%" POINTERSIZE_TYPE "x(%" POINTERSIZE_TYPE"d)  0x%" POINTERSIZE_TYPE "x(%" POINTERSIZE_TYPE "d)\n",
-                    SOS_PTR(dwAddrSeg),
-                    SOS_PTR(segment.mem), SOS_PTR(segment.allocated), SOS_PTR(segment.committed),
-                    (ULONG_PTR)(segment.allocated - segment.mem),
-                    (ULONG_PTR)(segment.allocated - segment.mem),
-                    (ULONG_PTR)(segment.committed - segment.mem),
-                    (ULONG_PTR)(segment.committed - segment.mem));
-            total_allocated_size += (DWORD_PTR) (segment.allocated - segment.mem);
-            total_committed_size += (DWORD_PTR) (segment.committed - segment.mem);
-            dwAddrSeg = (DWORD_PTR)segment.next;
+            while (true)
+            {
+                if (IsInterrupt())
+                    return;
+
+                if (segment.Request(g_sos, dwAddrSeg, heap.original_heap_details) != S_OK)
+                {
+                    ExtOut("Error requesting heap segment %p\n", SOS_PTR(dwAddrSeg));
+                    return;
+                }
+
+                CLRDATA_ADDRESS allocated = segment.highAllocMark - segment.mem;
+                CLRDATA_ADDRESS committed = segment.committed - segment.mem;
+                bool frozen = segment.flags & heap_segment_flags_readonly;
+
+                if (frozen != showing_frozen)
+                {
+                    if (dwAddrSeg == (DWORD_PTR)heap.generation_table[0].start_segment)
+                    {
+                        break;
+                    }
+                    dwAddrSeg = (DWORD_PTR)segment.next;
+                    continue;
+                }
+
+                ExtOut("%p  %p  %p  %p  0x%" POINTERSIZE_TYPE "x(%" POINTERSIZE_TYPE"d)  0x%" POINTERSIZE_TYPE "x(%" POINTERSIZE_TYPE "d)\n",
+                        SOS_PTR(dwAddrSeg),
+                        SOS_PTR(segment.mem), SOS_PTR(segment.allocated), SOS_PTR(segment.committed),
+                        (ULONG_PTR)allocated,
+                        (ULONG_PTR)allocated,
+                        (ULONG_PTR)committed,
+                        (ULONG_PTR)committed);
+                total_allocated_size += (DWORD_PTR)allocated;
+                total_committed_size += (DWORD_PTR)committed;
+                if (dwAddrSeg == (DWORD_PTR)heap.generation_table[0].start_segment)
+                {
+                    break;
+                }
+                dwAddrSeg = (DWORD_PTR)segment.next;
+            }
         }
-
-        if (segment.Request(g_sos, dwAddrSeg, heap.original_heap_details) != S_OK)
-        {
-            ExtOut("Error requesting heap segment %p\n", SOS_PTR(dwAddrSeg));
-            return;
-        }
-
-        DWORD_PTR end = (DWORD_PTR)heap.alloc_allocated;
-        ExtOut("%p  %p  %p  %p  0x%" POINTERSIZE_TYPE "x(%" POINTERSIZE_TYPE"d)  0x%" POINTERSIZE_TYPE "x(%" POINTERSIZE_TYPE "d)\n",
-                SOS_PTR(dwAddrSeg),
-                SOS_PTR(segment.mem), SOS_PTR(end), SOS_PTR(segment.committed),
-                (ULONG_PTR)(end - (DWORD_PTR)segment.mem),
-                (ULONG_PTR)(end - (DWORD_PTR)segment.mem),
-                (ULONG_PTR)(segment.committed - (DWORD_PTR)segment.mem),
-                (ULONG_PTR)(segment.committed - (DWORD_PTR)segment.mem));
-
-        total_allocated_size += end - (DWORD_PTR)segment.mem;
-        total_committed_size += (DWORD_PTR)(segment.committed - segment.mem);
     }
 }
 
-void GCPrintLargeHeapSegmentInfo(const GCHeapDetails &heap, DWORD_PTR &total_allocated_size, DWORD_PTR &total_committed_size)
+void GCPrintUohHeapSegmentInfo(const GCHeapDetails &heap, UINT generation, DWORD_PTR &total_allocated_size, DWORD_PTR &total_committed_size)
 {
     DWORD_PTR dwAddrSeg;
     DacpHeapSegmentData segment;
-    dwAddrSeg = (DWORD_PTR)heap.generation_table[GetMaxGeneration()+1].start_segment;
+    dwAddrSeg = (DWORD_PTR)heap.generation_table[generation].start_segment;
+    const size_t regions_committed_adjustment = 0x20;
 
     // total_size = 0;
     while (dwAddrSeg != NULL)
@@ -576,67 +609,60 @@ void GCPrintLargeHeapSegmentInfo(const GCHeapDetails &heap, DWORD_PTR &total_all
             ExtOut("Error requesting heap segment %p\n", SOS_PTR(dwAddrSeg));
             return;
         }
-        ExtOut("%p  %p  %p  %p  0x%" POINTERSIZE_TYPE "x(%" POINTERSIZE_TYPE"d)  0x%" POINTERSIZE_TYPE "x(%" POINTERSIZE_TYPE "d)\n",
-                SOS_PTR(dwAddrSeg),
-                SOS_PTR(segment.mem),
-                SOS_PTR(segment.allocated),
-                SOS_PTR(segment.committed),
-                (ULONG_PTR)(segment.allocated - segment.mem),
-                (ULONG_PTR)(segment.allocated - segment.mem),
-                (ULONG_PTR)(segment.committed - segment.mem),
-                (ULONG_PTR)(segment.committed - segment.mem));
-        total_allocated_size += (DWORD_PTR) (segment.allocated - segment.mem);
-        total_committed_size += (DWORD_PTR) (segment.committed - segment.mem);
-        dwAddrSeg = (DWORD_PTR)segment.next;
-    }
-}
-
-void GCPrintPinnedHeapSegmentInfo(const GCHeapDetails &heap, DWORD_PTR &total_allocated_size, DWORD_PTR& total_committed_size)
-{
-    DWORD_PTR dwAddrSeg;
-    DacpHeapSegmentData segment;
-    dwAddrSeg = (DWORD_PTR)heap.generation_table[GetMaxGeneration() + 2].start_segment;
-
-    while (dwAddrSeg != NULL)
-    {
-        if (IsInterrupt())
-            return;
-        if (segment.Request(g_sos, dwAddrSeg, heap.original_heap_details) != S_OK)
+        CLRDATA_ADDRESS allocated = segment.allocated - segment.mem;
+        CLRDATA_ADDRESS committed = segment.committed - segment.mem;
+        if (heap.has_regions)
         {
-            ExtOut("Error requesting heap segment %p\n", SOS_PTR(dwAddrSeg));
-            return;
+            committed += regions_committed_adjustment;
         }
         ExtOut("%p  %p  %p  %p  0x%" POINTERSIZE_TYPE "x(%" POINTERSIZE_TYPE"d)  0x%" POINTERSIZE_TYPE "x(%" POINTERSIZE_TYPE "d)\n",
                 SOS_PTR(dwAddrSeg),
                 SOS_PTR(segment.mem),
                 SOS_PTR(segment.allocated),
                 SOS_PTR(segment.committed),
-                (ULONG_PTR)(segment.allocated - segment.mem),
-                (ULONG_PTR)(segment.allocated - segment.mem),
-                (ULONG_PTR)(segment.committed - segment.mem),
-                (ULONG_PTR)(segment.committed - segment.mem));
-        total_allocated_size += (DWORD_PTR) (segment.allocated - segment.mem);
-        total_committed_size += (DWORD_PTR) (segment.committed - segment.mem);
+                (ULONG_PTR)allocated,
+                (ULONG_PTR)allocated,
+                (ULONG_PTR)committed,
+                (ULONG_PTR)committed);
+        total_allocated_size += (DWORD_PTR)allocated;
+        total_committed_size += (DWORD_PTR)committed;
         dwAddrSeg = (DWORD_PTR)segment.next;
     }
 }
 
 void GCHeapInfo(const GCHeapDetails &heap, DWORD_PTR &total_allocated_size, DWORD_PTR &total_committed_size)
 {
-    GCPrintGenerationInfo(heap);
+    if (!heap.has_regions)
+    {
+        GCPrintGenerationInfo(heap);
+    }
+    ExtOut("Small object heap\n");
     ExtOut("%" POINTERSIZE "s  %" POINTERSIZE "s  %" POINTERSIZE "s  %" POINTERSIZE "s  %" POINTERSIZE "s  %" POINTERSIZE "s\n", "segment", "begin", "allocated", "committed", "allocated size", "committed size");
     GCPrintSegmentInfo(heap, total_allocated_size, total_committed_size);
 
-    ExtOut("Large object heap starts at 0x%p\n",
-                  SOS_PTR(heap.generation_table[GetMaxGeneration() + 1].allocation_start));
+    if (heap.has_regions)
+    {
+        ExtOut("Large object heap\n");
+    }
+    else
+    {
+        ExtOut("Large object heap starts at 0x%p\n", SOS_PTR(heap.generation_table[GetMaxGeneration() + 1].allocation_start));
+    }
     ExtOut("%" POINTERSIZE "s  %" POINTERSIZE "s  %" POINTERSIZE "s  %" POINTERSIZE "s  %" POINTERSIZE "s  %" POINTERSIZE "s\n", "segment", "begin", "allocated", "committed", "allocated size", "committed size");
-    GCPrintLargeHeapSegmentInfo(heap, total_allocated_size, total_committed_size);
+    GCPrintUohHeapSegmentInfo(heap, GetMaxGeneration() + 1, total_allocated_size, total_committed_size);
 
     if (heap.has_poh)
     {
-        ExtOut("Pinned object heap starts at 0x%p\n",
-                      SOS_PTR(heap.generation_table[GetMaxGeneration() + 2].allocation_start));
-        GCPrintPinnedHeapSegmentInfo(heap, total_allocated_size, total_committed_size);
+        if (heap.has_regions)
+        {
+            ExtOut("Pinned object heap\n");
+        }
+        else
+        {
+            ExtOut("Pinned object heap starts at 0x%p\n", SOS_PTR(heap.generation_table[GetMaxGeneration() + 2].allocation_start));
+        }
+        ExtOut("%" POINTERSIZE "s  %" POINTERSIZE "s  %" POINTERSIZE "s  %" POINTERSIZE "s  %" POINTERSIZE "s  %" POINTERSIZE "s\n", "segment", "begin", "allocated", "committed", "allocated size", "committed size");
+        GCPrintUohHeapSegmentInfo(heap, GetMaxGeneration() + 2, total_allocated_size, total_committed_size);
     }
 }
 


### PR DESCRIPTION
In order to maintain the old format for backward compatibility, the presentation of `!eeheap` command contained questionable data that does not make sense for regions. 

In this change, I optimized the presentation of `!eeheap` for regions so that:

- It eliminated the `Generation starts at 0x...` lines, they don't apply for regions.
- It replaced the `Large (or pinned) object heaps starts at 0x...` with just `Large object heap`, the starting address also doesn't make sense for regions.
- It added a line `Small object heap` before the small object heap segments.
- It added the column headers for the pinned object heap.
- It includes the `Frozen object heap` section, it is optional (but very likely to be present in some heap for .NET 8+). If we don't have a frozen object heap it will not be there. This behavior is consistent with pinned object heap.

For segments, the presentation stays mostly the same, except I kept the small object heap line, it seems sensible that way. 

The PR works, but it is incomplete. Except for the `region_free_list` which may introduce a new block, this is how the format will look like. 

Regions/workstation:
```
Number of GC Heaps: 1
Small object heap
         segment             begin         allocated         committed    allocated size    committed size
generation 0:
000002EEC83401D0  000002ED8A800020  000002ED8AB78680  000002ED8AC00000  0x378660(3638880)  0x400000(4194304)
generation 1:
000002EEC8340128  000002ED8A400020  000002ED8A43EEA8  000002ED8A441000  0x3ee88(257672)  0x41000(266240)
generation 2:
000002EEC8340080  000002ED8A000020  000002ED8A000020  000002ED8A001000  0x0(0)  0x1000(4096)
Frozen object heap
         segment             begin         allocated         committed    allocated size    committed size
000002ED87C2A8F0  000002F00A970008  000002F00A9720E8  000002F00A980000  0x20e0(8416)  0x10018(65560)
Large object heap
         segment             begin         allocated         committed    allocated size    committed size
000002EEC8340278  000002ED8AC00020  000002ED8AC00020  000002ED8AC01000  0x0(0)  0x1000(4096)
Pinned object heap
         segment             begin         allocated         committed    allocated size    committed size
000002EEC833FB40  000002ED88000020  000002ED88004010  000002ED88011000  0x3ff0(16368)  0x11000(69632)
Total Allocated Size:              Size: 0x3bd5b8 (3921336) bytes.
Total Committed Size:              Size: 0x464018 (4603928) bytes.
------------------------------
GC Allocated Heap Size:    Size: 0x3bd5b8 (3921336) bytes.
GC Committed Heap Size:    Size: 0x464018 (4603928) bytes.
```

Regions/server
```
Number of GC Heaps: 2
------------------------------
Heap 0 (0000014DCBC4D250)
Small object heap
         segment             begin         allocated         committed    allocated size    committed size
generation 0:
0000014F0E1A08C0  0000014DD2400020  0000014DD27FFF50  0000014DD2800000  0x3fff30(4194096)  0x400000(4194304)
generation 1:
0000014F0E1A0800  0000014DD2000020  0000014DD2000020  0000014DD2001000  0x0(0)  0x1000(4096)
generation 2:
0000014F0E1A0740  0000014DD1C00020  0000014DD1C00020  0000014DD1C01000  0x0(0)  0x1000(4096)
Frozen object heap
         segment             begin         allocated         committed    allocated size    committed size
0000014F10BFA6B0  0000014F10C80008  0000014F10C81CC8  0000014F10C90000  0x1cc0(7360)  0x10018(65560)
Large object heap
         segment             begin         allocated         committed    allocated size    committed size
0000014F0E1A0BC0  0000014DD3400020  0000014DD3400020  0000014DD3401000  0x0(0)  0x1000(4096)
Pinned object heap
         segment             begin         allocated         committed    allocated size    committed size
0000014F0E19FB40  0000014DCDC00020  0000014DCDC02018  0000014DCDC11000  0x1ff8(8184)  0x11000(69632)
Allocated Heap Size:       Size: 0x403be8 (4209640) bytes.
Committed Heap Size:       Size: 0x424018 (4341784) bytes.
------------------------------
Heap 1 (0000014DCBC53BD0)
Small object heap
         segment             begin         allocated         committed    allocated size    committed size
generation 0:
0000014F0E1A0B00  0000014DD3000020  0000014DD33BEFE8  0000014DD33C1000  0x3befc8(3928008)  0x3c1000(3936256)
generation 1:
0000014F0E1A0A40  0000014DD2C00020  0000014DD2C00020  0000014DD2C01000  0x0(0)  0x1000(4096)
generation 2:
0000014F0E1A0980  0000014DD2800020  0000014DD2800020  0000014DD2801000  0x0(0)  0x1000(4096)
Large object heap
         segment             begin         allocated         committed    allocated size    committed size
0000014F0E1A11C0  0000014DD5400020  0000014DD5400020  0000014DD5401000  0x0(0)  0x1000(4096)
Pinned object heap
         segment             begin         allocated         committed    allocated size    committed size
0000014F0E1A0140  0000014DCFC00020  0000014DCFC02018  0000014DCFC11000  0x1ff8(8184)  0x11000(69632)
Allocated Heap Size:       Size: 0x3c0fc0 (3936192) bytes.
Committed Heap Size:       Size: 0x3d5000 (4018176) bytes.
------------------------------
GC Allocated Heap Size:    Size: 0x7c4ba8 (8145832) bytes.
GC Committed Heap Size:    Size: 0x7f9018 (8359960) bytes.
```

Segment/workstation
```
Number of GC Heaps: 1
generation 0 starts at 0x00000292557EFF08
generation 1 starts at 0x00000292557B1018
generation 2 starts at 0x00000292557B1000
ephemeral segment allocation context: none
Small object heap
         segment             begin         allocated         committed    allocated size    committed size
00000292557B0000  00000292557B1000  00000292557F0320  0000029255BF2000  0x37b320(3650336)  0x441000(4460544)
Frozen object heap
         segment             begin         allocated         committed    allocated size    committed size
00000292537D1000  0000029398800008  00000293988020E8  0000029398810000  0x20e0(8416)  0xfff8(65528)
Large object heap starts at 0x00000292957B1000
         segment             begin         allocated         committed    allocated size    committed size
00000292957B0000  00000292957B1000  00000292957B1018  00000292957B2000  0x18(24)  0x1000(4096)
Pinned object heap starts at 0x00000293157B1000
         segment             begin         allocated         committed    allocated size    committed size
00000293157B0000  00000293157B1000  00000293157B5008  00000293157C2000  0x4008(16392)  0x11000(69632)
Total Allocated Size:              Size: 0x381420 (3675168) bytes.
Total Committed Size:              Size: 0x462ff8 (4599800) bytes.
------------------------------
GC Allocated Heap Size:    Size: 0x381420 (3675168) bytes.
GC Committed Heap Size:    Size: 0x462ff8 (4599800) bytes.
```

Segment/server
```
Number of GC Heaps: 2
------------------------------
Heap 0 (00000256BA2E5E10)
generation 0 starts at 0x00000256BC3B01B8
generation 1 starts at 0x00000256BC3A1018
generation 2 starts at 0x00000256BC3A1000
ephemeral segment allocation context: none
Small object heap
         segment             begin         allocated         committed    allocated size    committed size
00000256BC3A0000  00000256BC3A1000  00000256BC3B01D0  00000256BC8B2000  0x1cf1d0(1896912)  0x511000(5312512)
Frozen object heap
         segment             begin         allocated         committed    allocated size    committed size
00000256BBCECF50  00000257FF390008  00000257FF3920E8  00000257FF3A0000  0x20e0(8416)  0xfff8(65528)
Large object heap starts at 0x00000256FC3A1000
         segment             begin         allocated         committed    allocated size    committed size
00000256FC3A0000  00000256FC3A1000  00000256FC3A1018  00000256FC3A2000  0x18(24)  0x1000(4096)
Pinned object heap starts at 0x000002577C3A1000
         segment             begin         allocated         committed    allocated size    committed size
000002577C3A0000  000002577C3A1000  000002577C3A3010  000002577C3B2000  0x2010(8208)  0x11000(69632)
Allocated Heap Size:       Size: 0x1d32d8 (1913560) bytes.
Committed Heap Size:       Size: 0x532ff8 (5451768) bytes.
------------------------------
Heap 1 (00000256BBC6BF90)
generation 0 starts at 0x00000256DC3B4718
generation 1 starts at 0x00000256DC3A1018
generation 2 starts at 0x00000256DC3A1000
ephemeral segment allocation context: none
Small object heap
         segment             begin         allocated         committed    allocated size    committed size
00000256DC3A0000  00000256DC3A1000  00000256DC3B4730  00000256DC8C2000  0x1c9730(1873712)  0x521000(5378048)
Large object heap starts at 0x000002573C3A1000
         segment             begin         allocated         committed    allocated size    committed size
000002573C3A0000  000002573C3A1000  000002573C3A1018  000002573C3A2000  0x18(24)  0x1000(4096)
Pinned object heap starts at 0x00000257BC3A1000
         segment             begin         allocated         committed    allocated size    committed size
00000257BC3A0000  00000257BC3A1000  00000257BC3A3010  00000257BC3B2000  0x2010(8208)  0x11000(69632)
Allocated Heap Size:       Size: 0x1cb758 (1881944) bytes.
Committed Heap Size:       Size: 0x533000 (5451776) bytes.
------------------------------
GC Allocated Heap Size:    Size: 0x39ea30 (3795504) bytes.
GC Committed Heap Size:    Size: 0xa65ff8 (10903544) bytes.
```



