### PR TITLE
Merge some main commits into release/stable

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -47,7 +47,7 @@
     <MicrosoftBclAsyncInterfacesVersion>1.1.0</MicrosoftBclAsyncInterfacesVersion>
     <MicrosoftDiagnosticsRuntimeVersion>2.2.332302</MicrosoftDiagnosticsRuntimeVersion>
     <MicrosoftDiaSymReaderNativePackageVersion>16.9.0-beta1.21055.5</MicrosoftDiaSymReaderNativePackageVersion>
-    <MicrosoftDiagnosticsTracingTraceEventVersion>2.0.76</MicrosoftDiagnosticsTracingTraceEventVersion>
+    <MicrosoftDiagnosticsTracingTraceEventVersion>2.0.64</MicrosoftDiagnosticsTracingTraceEventVersion>
     <!-- Use pinned version to avoid picking up latest (which doesn't support netcoreapp3.1) during source-build -->
     <MicrosoftExtensionsLoggingPinnedVersion>2.1.1</MicrosoftExtensionsLoggingPinnedVersion>
     <!-- Need version that understands UseAppFilters sentinel. -->

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/AspNetTriggerSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/AspNetTriggerSourceConfiguration.cs
@@ -23,27 +23,6 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
             _heartbeatIntervalSeconds = heartbeatIntervalSeconds;
         }
 
-        /// <summary>
-        /// Filter string for trigger data. Note that even though some triggers use start OR stop,
-        /// collecting just one causes unusual behavior in data collection.
-        /// </summary>
-        /// <remarks>
-        /// IMPORTANT! We rely on these transformations to make sure we can access relevant data
-        /// by index. The order must match the data extracted in the triggers.
-        /// </remarks>
-        private const string DiagnosticFilterString =
-                "Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.HttpRequestIn.Start@Activity1Start:-" +
-                    "ActivityId=*Activity.Id" +
-                    ";Request.Path" +
-                    ";ActivityStartTime=*Activity.StartTimeUtc.Ticks" +
-                    "\r\n" +
-                "Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.HttpRequestIn.Stop@Activity1Stop:-" +
-                    "ActivityId=*Activity.Id" +
-                    ";Request.Path" +
-                    ";Response.StatusCode" +
-                    ";ActivityDuration=*Activity.Duration.Ticks" +
-                    "\r\n";
-
         public override IList<EventPipeProvider> GetProviders()
         {
             if (_heartbeatIntervalSeconds.HasValue)
@@ -62,7 +41,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
                         eventLevel: EventLevel.Verbose,
                         arguments: new Dictionary<string,string>
                         {
-                            { "FilterAndPayloadSpecs", DiagnosticFilterString }
+                            { "FilterAndPayloadSpecs", HttpRequestSourceConfiguration.DiagnosticFilterString }
                         })
                 };
             }

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/HttpRequestSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/HttpRequestSourceConfiguration.cs
@@ -16,7 +16,10 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
             RequestRundown = true;
         }
 
-        private const string DiagnosticFilterString =
+        // This string is shared between HttpRequestSourceConfiguration and AspNetTriggerSourceConfiguration
+        // due to an issue that causes the FilterAndPayloadSpecs to be overwritten but never reverted.
+        // This caused http traces to interfere with AspNet* triggers due to having different arguments.
+        internal const string DiagnosticFilterString =
                 "Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.HttpRequestIn.Start@Activity1Start:-" +
                     "Request.Scheme" +
                     ";Request.Host" +
@@ -33,9 +36,10 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
                     ";ActivityIdFormat=*Activity.IdFormat" +
                 "\r\n" +
                 "Microsoft.AspNetCore/Microsoft.AspNetCore.Hosting.HttpRequestIn.Stop@Activity1Stop:-" +
-                    "Response.StatusCode" +
+                    "ActivityId=*Activity.Id" +
+                    ";Request.Path" +
+                    ";Response.StatusCode" +
                     ";ActivityDuration=*Activity.Duration.Ticks" +
-                    ";ActivityId=*Activity.Id" +
                 "\r\n" +
                 "HttpHandlerDiagnosticListener/System.Net.Http.HttpRequestOut@Event:-" +
                 "\r\n" +


### PR DESCRIPTION
Revert TraceEvent version to 2.0.64 (#3473)

[Dotnet Monitor] Standardize DiagnosticFilterString, No Longer Assume TraceEvent Arg Ordering (#3425)