### PR TITLE
Flush target state on breakpoint hit under dbgeng

### DIFF
--- a/src/SOS/Strike/dbgengservices.cpp
+++ b/src/SOS/Strike/dbgengservices.cpp
@@ -532,10 +532,10 @@ HRESULT DbgEngServices::ChangeEngineState(
 {
     if (Flags == DEBUG_CES_EXECUTION_STATUS)
     {
-        if (((Argument & DEBUG_STATUS_MASK) == DEBUG_STATUS_BREAK) && ((Argument & DEBUG_STATUS_INSIDE_WAIT) == 0))
+        if ((Argument & DEBUG_STATUS_MASK) == DEBUG_STATUS_BREAK)
         {
             // Flush the target when the debugger target breaks
-            Extensions::GetInstance()->FlushTarget();
+            m_flushNeeded = true;
         }
     }
     return DEBUG_STATUS_NO_CHANGE;
@@ -642,6 +642,17 @@ HRESULT DbgEngServices::UnloadModule(
 //----------------------------------------------------------------------------
 // Helper Functions
 //----------------------------------------------------------------------------
+
+void 
+DbgEngServices::FlushCheck(Extensions* extensions)
+{
+    // Flush the target when the debugger target breaks
+    if (m_flushNeeded)
+    {
+        m_flushNeeded = false;
+        extensions->FlushTarget();
+    }
+}
 
 IMachine*
 DbgEngServices::GetMachine()

--- a/src/SOS/Strike/dbgengservices.h
+++ b/src/SOS/Strike/dbgengservices.h
@@ -30,6 +30,7 @@ private:
     PDEBUG_SYSTEM_OBJECTS m_system;
     PDEBUG_ADVANCED       m_advanced;
     IMachine*             m_targetMachine;
+    bool                  m_flushNeeded;
 
 public:
     DbgEngServices(IDebugClient* client);
@@ -40,6 +41,8 @@ public:
     //----------------------------------------------------------------------------
     // Helper functions
     //----------------------------------------------------------------------------
+
+    void FlushCheck(Extensions* extensions);
 
     IMachine* GetMachine();
 

--- a/src/SOS/Strike/exts.cpp
+++ b/src/SOS/Strike/exts.cpp
@@ -405,6 +405,8 @@ HRESULT GetRuntime(IRuntime** ppRuntime)
     {
         return E_FAIL;
     }
+#ifndef FEATURE_PAL
     extensions->FlushCheck();
+#endif
     return target->GetRuntime(ppRuntime);
 }

--- a/src/SOS/Strike/exts.cpp
+++ b/src/SOS/Strike/exts.cpp
@@ -391,3 +391,20 @@ IHost* SOSExtensions::GetHost()
     }
     return m_pHost;
 }
+
+/// <summary>
+/// Returns the runtime or fails if no target or current runtime
+/// </summary>
+/// <param name="ppRuntime">runtime instance</param>
+/// <returns>error code</returns>
+HRESULT GetRuntime(IRuntime** ppRuntime)
+{
+    SOSExtensions* extensions = (SOSExtensions*)Extensions::GetInstance();
+    ITarget* target = extensions->GetTarget();
+    if (target == nullptr)
+    {
+        return E_FAIL;
+    }
+    extensions->FlushCheck();
+    return target->GetRuntime(ppRuntime);
+}

--- a/src/SOS/Strike/exts.h
+++ b/src/SOS/Strike/exts.h
@@ -179,8 +179,15 @@ public:
         }
     }
 
+    void FlushCheck()
+    {
+        ((DbgEngServices*)m_pDebuggerServices)->FlushCheck(this);
+    }
+
     IHost* GetHost();
 };
+
+extern HRESULT GetRuntime(IRuntime** ppRuntime);
 
 #ifndef MINIDUMP
  

--- a/src/SOS/Strike/exts.h
+++ b/src/SOS/Strike/exts.h
@@ -179,10 +179,12 @@ public:
         }
     }
 
+#ifndef FEATURE_PAL
     void FlushCheck()
     {
         ((DbgEngServices*)m_pDebuggerServices)->FlushCheck(this);
     }
+#endif
 
     IHost* GetHost();
 };

--- a/src/SOS/Strike/exts.h
+++ b/src/SOS/Strike/exts.h
@@ -182,7 +182,10 @@ public:
 #ifndef FEATURE_PAL
     void FlushCheck()
     {
-        ((DbgEngServices*)m_pDebuggerServices)->FlushCheck(this);
+        if (m_pDebuggerServices != nullptr)
+        {
+            ((DbgEngServices*)m_pDebuggerServices)->FlushCheck(this);
+        }
     }
 #endif
 

--- a/src/SOS/extensions/extensions.cpp
+++ b/src/SOS/extensions/extensions.cpp
@@ -216,21 +216,6 @@ void Extensions::ReleaseTarget()
 }
 
 /// <summary>
-/// Returns the runtime or fails if no target or current runtime
-/// </summary>
-/// <param name="ppRuntime">runtime instance</param>
-/// <returns>error code</returns>
-HRESULT GetRuntime(IRuntime** ppRuntime)
-{
-    ITarget* target = GetTarget();
-    if (target == nullptr)
-    {
-        return E_FAIL;
-    }
-    return target->GetRuntime(ppRuntime);
-}
-
-/// <summary>
 /// Helper function to get the absolute path from a relative one
 /// </summary>
 /// <param name="path">relative path</param>

--- a/src/SOS/extensions/extensions.h
+++ b/src/SOS/extensions/extensions.h
@@ -150,8 +150,6 @@ inline ISymbolService* GetSymbolService()
     return Extensions::GetInstance()->GetSymbolService();
 }
 
-extern HRESULT GetRuntime(IRuntime** ppRuntime);
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This fixes breakpoint commands like `bm foo_function "k;!clrstack;g"`

/cc: @cshung