### PR TITLE
Modify the order of the processes

### DIFF
--- a/src/Tools/Common/Commands/ProcessStatus.cs
+++ b/src/Tools/Common/Commands/ProcessStatus.cs
@@ -126,8 +126,8 @@ namespace Microsoft.Internal.Common.Commands
                 var processes = DiagnosticsClient.GetPublishedProcesses()
                     .Select(GetProcessById)
                     .Where(process => process != null)
-                    .OrderBy(process => process.ProcessName)
-                    .ThenBy(process => process.Id);
+                    .OrderBy(process => process.Id)
+                    .ThenBy(process => process.ProcessName);
 
                 var currentPid = Process.GetCurrentProcess().Id;
                 List<Microsoft.Internal.Common.Commands.ProcessStatusCommandHandler.ProcessDetails> printInfo = new ();


### PR DESCRIPTION
Change the order based on the process ID according to the execution.
* Before:
```
root:~> dotnet stack ps
      3041 dotnet-loader /usr/bin/dotnet-loader
     15974 dotnet-loader /usr/bin/dotnet-loader
      1240 dotnet-nui-loader /usr/bin/dotnet-loader
      2750 TrayApplication.dll /usr/bin/dotnet-loader
```

* After:
```
root:~> dotnet stack ps
      1240 dotnet-nui-loader /usr/bin/dotnet-loader
      2750 TrayApplication.dll /usr/bin/dotnet-loader
      3041 HelloWorld.dll /usr/bin/dotnet-loader
     15974 dotnet-loader /usr/bin/dotnet-loader
```