### PR TITLE
BackgroundGC check

### DIFF
--- a/src/SOS/Strike/util.h
+++ b/src/SOS/Strike/util.h
@@ -442,11 +442,13 @@ public:
         highest_address = dacGCDetails.highest_address;
         card_table = dacGCDetails.card_table;
         has_regions = generation_table[0].start_segment != generation_table[1].start_segment;
+        has_background_gc = dacGCDetails.mark_array != -1;
     }
 
     DacpGcHeapDetails original_heap_details;
     bool has_poh;
     bool has_regions;
+    bool has_background_gc;
     CLRDATA_ADDRESS heapAddr; // Only filled in in server mode, otherwise NULL
     CLRDATA_ADDRESS alloc_allocated;
 


### PR DESCRIPTION
This change was used to test https://github.com/dotnet/runtime/pull/77328 so that we know the DAC changes there work.

We are not currently making any use of that flag yet, but it will be useful when we need to know if `BACKGROUND_GC` is defined, for example, for https://github.com/dotnet/diagnostics/issues/3482.