### PR TITLE
[Dotnet Monitor] Add Metadata Support For `CounterPayload`

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/CounterPayload.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/CounterPayload.cs
@@ -3,14 +3,19 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
+using System.Collections.ObjectModel;
 
 namespace Microsoft.Diagnostics.Monitoring.EventPipe
 {
     internal class CounterPayload : ICounterPayload
     {
+#if NETSTANDARD
+        private static readonly IReadOnlyDictionary<string, string> Empty = new ReadOnlyDictionary<string, string>(new Dictionary<string, string>(0));
+#else
+        private static readonly IReadOnlyDictionary<string, string> Empty = System.Collections.Immutable.ImmutableDictionary<string, string>.Empty;
+#endif
+
         public CounterPayload(DateTime timestamp,
             string provider,
             string name,
@@ -29,7 +34,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
             CounterType = counterType;
             Provider = provider;
             Interval = interval;
-            Metadata = metadata;
+            Metadata = metadata ?? Empty;
         }
 
         public string Namespace { get; }
@@ -50,6 +55,6 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
 
         public string Provider { get; }
 
-        public Dictionary<string, string> Metadata { get; } = new Dictionary<string, string>(0);
+        public IReadOnlyDictionary<string, string> Metadata { get; } = new Dictionary<string, string>(0);
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/CounterPayload.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/CounterPayload.cs
@@ -55,6 +55,6 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
 
         public string Provider { get; }
 
-        public IReadOnlyDictionary<string, string> Metadata { get; } = new Dictionary<string, string>(0);
+        public IReadOnlyDictionary<string, string> Metadata { get; }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/CounterPayload.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/CounterPayload.cs
@@ -18,7 +18,8 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
             string unit,
             double value,
             CounterType counterType,
-            float interval)
+            float interval,
+            Dictionary<string, string> metadata)
         {
             Timestamp = timestamp;
             Name = name;
@@ -28,6 +29,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
             CounterType = counterType;
             Provider = provider;
             Interval = interval;
+            Metadata = metadata;
         }
 
         public string Namespace { get; }
@@ -47,5 +49,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
         public CounterType CounterType { get; }
 
         public string Provider { get; }
+
+        public Dictionary<string, string> Metadata { get; } = new Dictionary<string, string>(0);
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/ICounterPayload.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/ICounterPayload.cs
@@ -34,5 +34,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
         DateTime Timestamp { get; }
 
         float Interval { get; }
+
+        public Dictionary<string, string> Metadata { get; }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/ICounterPayload.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/ICounterPayload.cs
@@ -35,6 +35,6 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
 
         float Interval { get; }
 
-        public Dictionary<string, string> Metadata { get; }
+        IReadOnlyDictionary<string, string> Metadata { get; }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/TraceEventExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/TraceEventExtensions.cs
@@ -72,7 +72,11 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
             return false;
         }
 
-        public static Dictionary<string, string> GetMetadata(string metadataPayload)
+        //The metadata payload is formatted as a string of comma separated key:value pairs.
+        //This limitation means that metadata values cannot include commas; otherwise, the
+        //metadata will be parsed incorrectly. If a value contains a comma, then all metadata
+        //is treated as invalid and excluded from the payload.
+        internal static Dictionary<string, string> GetMetadata(string metadataPayload)
         {
             var metadataDict = new Dictionary<string, string>();
 

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/TraceEventExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/TraceEventExtensions.cs
@@ -23,41 +23,25 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
                 string series = payloadFields["Series"].ToString();
                 string counterName = payloadFields["Name"].ToString();
 
-                string metadata = payloadFields["Metadata"].ToString();
-
-                // Just playing around...
-                // Read up until colon, then look for comma. If another colon shows up, fail
-                // Num_colons == num_commas - 1
-                // Also need to validate which characters are included, but that can maybe be done later...?
-                // Technically, label keys can't have colons/commas, but values can be any unicode character...
-                // without making changes in the Runtime repo, not sure we can work around this.
                 var metadataDict = new Dictionary<string, string>();
 
-                while (metadata.Length > 0)
+                string[] kvPairs = payloadFields["Metadata"].ToString().Split(",");
+
+                foreach (string kvPair in kvPairs)
                 {
-                    int colonIndex = metadata.IndexOf(':');
-                    string metadataKey = metadata.Substring(0, colonIndex);
-                    metadata = metadata.Substring(colonIndex + 1);
-                    int commaIndex = metadata.IndexOf(',');
-                    string metadataValue = string.Empty;
-                    if (commaIndex == -1)
+                    int colonIndex = kvPair.IndexOf(':');
+                    if (colonIndex == -1)
                     {
-                        if (metadata.Contains(':'))
-                        {
-                            metadataDict = new Dictionary<string, string>();
-                            break;
-                            // Fail
-                        }
-                        metadataValue = metadata;
-                        metadata = string.Empty;
+                        // Remove all entries from metadataDict if has bad formatting
+                        metadataDict.Clear();
+                        break;
                     }
                     else
                     {
-                        metadataValue = metadata.Substring(0, commaIndex);
-                        metadata = metadata.Substring(commaIndex + 1);
+                        string metadataKey = kvPair.Substring(0, colonIndex);
+                        string metadataValue = kvPair.Substring(colonIndex + 1);
+                        metadataDict[metadataKey] = metadataValue;
                     }
-
-                    metadataDict[metadataKey] = metadataValue;
                 }
 
                 //CONSIDER

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/TraceEventExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/TraceEventExtensions.cs
@@ -23,6 +23,43 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
                 string series = payloadFields["Series"].ToString();
                 string counterName = payloadFields["Name"].ToString();
 
+                string metadata = payloadFields["Metadata"].ToString();
+
+                // Just playing around...
+                // Read up until colon, then look for comma. If another colon shows up, fail
+                // Num_colons == num_commas - 1
+                // Also need to validate which characters are included, but that can maybe be done later...?
+                // Technically, label keys can't have colons/commas, but values can be any unicode character...
+                // without making changes in the Runtime repo, not sure we can work around this.
+                var metadataDict = new Dictionary<string, string>();
+
+                while (metadata.Length > 0)
+                {
+                    int colonIndex = metadata.IndexOf(':');
+                    string metadataKey = metadata.Substring(0, colonIndex);
+                    metadata = metadata.Substring(colonIndex + 1);
+                    int commaIndex = metadata.IndexOf(',');
+                    string metadataValue = string.Empty;
+                    if (commaIndex == -1)
+                    {
+                        if (metadata.Contains(':'))
+                        {
+                            metadataDict = new Dictionary<string, string>();
+                            break;
+                            // Fail
+                        }
+                        metadataValue = metadata;
+                        metadata = string.Empty;
+                    }
+                    else
+                    {
+                        metadataValue = metadata.Substring(0, commaIndex);
+                        metadata = metadata.Substring(commaIndex + 1);
+                    }
+
+                    metadataDict[metadataKey] = metadataValue;
+                }
+
                 //CONSIDER
                 //Concurrent counter sessions do not each get a separate interval. Instead the payload
                 //for _all_ the counters changes the Series to be the lowest specified interval, on a per provider basis.
@@ -62,7 +99,8 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
                     displayUnits,
                     value,
                     counterType,
-                    intervalSec);
+                    intervalSec,
+                    metadataDict);
                 return true;
             }
 

--- a/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventCounterTriggerTests.cs
+++ b/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventCounterTriggerTests.cs
@@ -484,7 +484,8 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
                     EventCounterConstants.CpuUsageUnits,
                     value,
                     CounterType.Metric,
-                    actualInterval);
+                    actualInterval,
+                    null);
             }
         }
     }

--- a/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventCounterTriggerTests.cs
+++ b/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventCounterTriggerTests.cs
@@ -488,5 +488,36 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
                     null);
             }
         }
+
+        /// <summary>
+        /// Validates that metadata from TraceEvent payloads is parsed correctly.
+        /// </summary>
+        [Fact]
+        public void ValidateMetadataParsing_Success()
+        {
+            const string key1 = "K1";
+            const string value1 = "V1";
+            const string key2 = "K2";
+            const string value2 = "V:2";
+            Dictionary<string, string> metadataDict = TraceEventExtensions.GetMetadata($"{key1}:{value1},{key2}:{value2}");
+
+            Assert.Equal(2, metadataDict.Count);
+            Assert.Equal(value1, metadataDict[key1]);
+            Assert.Equal(value2, metadataDict[key2]);
+        }
+
+        /// <summary>
+        /// Validates that metadata with an invalid format from TraceEvent payloads is handled correctly.
+        /// </summary>
+        [Theory]
+        [InlineData("K1:V,1")]
+        [InlineData("K,1:V")]
+        [InlineData("K1")]
+        public void ValidateMetadataParsing_Failure(string invalidMetadata)
+        {
+            Dictionary<string, string> metadataDict = TraceEventExtensions.GetMetadata(invalidMetadata);
+
+            Assert.Empty(metadataDict);
+        }
     }
 }


### PR DESCRIPTION
These changes are the first part of addressing https://github.com/dotnet/dotnet-monitor/issues/430; the second part will be integrated directly into the `dotnet-monitor` repo.