### PR TITLE
Added missing 'Triage' dump type option

### DIFF
--- a/src/Tools/dotnet-dump/Dumper.cs
+++ b/src/Tools/dotnet-dump/Dumper.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Diagnostics.Tools.Dump
 
             Mini,       // A small dump containing module lists, thread lists, exception information and all stacks.
 
-            Triage      // A small dump containing module lists, thread lists, exception information, all stacks and PMI removed.
+            Triage      // A small dump containing module lists, thread lists, exception information, all stacks and PII removed.
         }
 
         public Dumper()
@@ -82,7 +82,7 @@ namespace Microsoft.Diagnostics.Tools.Dump
                         dumpTypeMessage = "dump";
                         break;
                     case DumpTypeOption.Triage:
-                        dumpTypeMessage = "triage";
+                        dumpTypeMessage = "triage dump";
                         break;
                 }
                 console.Out.WriteLine($"Writing {dumpTypeMessage} to {output}");

--- a/src/Tools/dotnet-dump/Dumper.cs
+++ b/src/Tools/dotnet-dump/Dumper.cs
@@ -81,6 +81,9 @@ namespace Microsoft.Diagnostics.Tools.Dump
                     case DumpTypeOption.Mini:
                         dumpTypeMessage = "dump";
                         break;
+                    case DumpTypeOption.Triage:
+                        dumpTypeMessage = "triage";
+                        break;
                 }
                 console.Out.WriteLine($"Writing {dumpTypeMessage} to {output}");
 

--- a/src/Tools/dotnet-dump/Program.cs
+++ b/src/Tools/dotnet-dump/Program.cs
@@ -81,7 +81,7 @@ on Linux where YYYYMMDD is Year/Month/Day and HHMMSS is Hour/Minute/Second. Othe
         private static Option TypeOption() =>
             new Option(
                 alias: "--type",
-                description: @"The dump type determines the kinds of information that are collected from the process. There are several types: Full - The largest dump containing all memory including the module images. Heap - A large and relatively comprehensive dump containing module lists, thread lists, all stacks, exception information, handle information, and all memory except for mapped images. Mini - A small dump containing module lists, thread lists, exception information and all stacks.")
+                description: @"The dump type determines the kinds of information that are collected from the process. There are several types: Full - The largest dump containing all memory including the module images. Heap - A large and relatively comprehensive dump containing module lists, thread lists, all stacks, exception information, handle information, and all memory except for mapped images. Mini - A small dump containing module lists, thread lists, exception information and all stacks. Triage - A small dump containing module lists, thread lists, exception information, all stacks and PMI removed.")
             {
                 Argument = new Argument<Dumper.DumpTypeOption>(name: "dump_type", getDefaultValue: () => Dumper.DumpTypeOption.Full)
             };

--- a/src/Tools/dotnet-dump/Program.cs
+++ b/src/Tools/dotnet-dump/Program.cs
@@ -81,7 +81,7 @@ on Linux where YYYYMMDD is Year/Month/Day and HHMMSS is Hour/Minute/Second. Othe
         private static Option TypeOption() =>
             new Option(
                 alias: "--type",
-                description: @"The dump type determines the kinds of information that are collected from the process. There are several types: Full - The largest dump containing all memory including the module images. Heap - A large and relatively comprehensive dump containing module lists, thread lists, all stacks, exception information, handle information, and all memory except for mapped images. Mini - A small dump containing module lists, thread lists, exception information and all stacks. Triage - A small dump containing module lists, thread lists, exception information, all stacks and PMI removed.")
+                description: @"The dump type determines the kinds of information that are collected from the process. There are several types: Full - The largest dump containing all memory including the module images. Heap - A large and relatively comprehensive dump containing module lists, thread lists, all stacks, exception information, handle information, and all memory except for mapped images. Mini - A small dump containing module lists, thread lists, exception information and all stacks. Triage - A small dump containing module lists, thread lists, exception information, all stacks and PII removed.")
             {
                 Argument = new Argument<Dumper.DumpTypeOption>(name: "dump_type", getDefaultValue: () => Dumper.DumpTypeOption.Full)
             };


### PR DESCRIPTION
https://github.com/dotnet/diagnostics/blob/bfed18c6bf6867fd70300ab7366e9fc6c18bbdbe/src/Tools/dotnet-dump/Dumper.cs#L85
```console
root:~> dotnet dump collect --type Triage -p 2750

Writing  to /root/core_19700109_050032
----------
root:~> dotnet dump collect --type Mini -p 2750

Writing dump to /root/core_19700109_061913
----------
root:~> dotnet dump collect --type Heap -p 2750

Writing dump with heap to /root/core_19700109_061949
```