### PR TITLE
Moderenize triggerdump in docs

### DIFF
--- a/documentation/tutorial/src/triggerdump/triggerdump.csproj
+++ b/documentation/tutorial/src/triggerdump/triggerdump.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ToolCommandName>triggerdump</ToolCommandName>
     <RootNamespace>Diagnosticv.TriggerDump</RootNamespace>
@@ -9,18 +9,11 @@
     <PackageTags>Diagnostic</PackageTags>
     <PackageReleaseNotes>$(Description)</PackageReleaseNotes>
     <TargetName>triggerdump</TargetName>
-	<OutputType>Exe</OutputType>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\src\Tools\dotnet-trace\Extensions.cs" Link="Extensions.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\..\..\src\Microsoft.Diagnostics.Tools.RuntimeClient\Microsoft.Diagnostics.Tools.RuntimeClient.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.41" />
+    <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.351802" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.0.5" />
   </ItemGroup>
 </Project>

--- a/src/Tools/dotnet-trace/Extensions.cs
+++ b/src/Tools/dotnet-trace/Extensions.cs
@@ -153,7 +153,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
 
             // Event counters
             string filterData = tokens.Length > 3 ? tokens[3] : null;
-            var argument = string.IsNullOrWhiteSpace(filterData) ? null : ParseArgumentString(filterData); 
+            var argument = string.IsNullOrWhiteSpace(filterData) ? null : ParseArgumentString(filterData);
             return new EventPipeProvider(providerName, eventLevel, keywords, argument);
         }
 
@@ -186,13 +186,13 @@ namespace Microsoft.Diagnostics.Tools.Trace
                     if (c == '=')
                     {
                         keyEnd = curIdx;
-                        valStart = curIdx+1;
+                        valStart = curIdx + 1;
                     }
                     else if (c == ';')
                     {
                         valEnd = curIdx;
                         AddKeyValueToArgumentDict(argumentDict, argument, keyStart, keyEnd, valStart, valEnd);
-                        keyStart = curIdx+1; // new key starts
+                        keyStart = curIdx + 1; // new key starts
                     }
                     else if (c == '\"')
                     {
@@ -201,7 +201,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 }
                 curIdx += 1;
             }
-            if(valStart > valEnd)
+            if (valStart > valEnd)
             {
                 valEnd = curIdx;
             }


### PR DESCRIPTION
`dotnet build documentation/tutorial/src/triggerdump/triggerdump.csproj` was broken because RuntimeClient.csproj does not exist.