### PR TITLE
Add the ALC to `DumpMT`

### DIFF
--- a/src/SOS/SOS.UnitTests/Scripts/OtherCommands.script
+++ b/src/SOS/SOS.UnitTests/Scripts/OtherCommands.script
@@ -114,9 +114,12 @@ VERIFY:\s*Class Name:\s+SymbolTestApp.Program\s+
 VERIFY:\s*File:\s+.*SymbolTestApp\.(dll|exe)\s+
 
 # Verify DumpMT
+!IFDEF:MAJOR_RUNTIME_VERSION_GE_7
+# https://github.com/dotnet/diagnostics/issues/3516
 SOSCOMMAND:DumpMT <POUT>\s*Method Table:\s+(<HEXVAL>)\s+<POUT>
 VERIFY:\s*Name:\s+SymbolTestApp.Program\s+
 VERIFY:\s*File:\s+.*SymbolTestApp\.(dll|exe)\s+
+ENDIF:MAJOR_RUNTIME_VERSION_GE_7
 
 SOSCOMMAND:FinalizeQueue
 VERIFY:\s*SyncBlocks to be cleaned up:\s+<DECVAL>\s+

--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -1327,7 +1327,7 @@ DECLARE_API(DumpMT)
     }
 
     ReleaseHolder<ISOSDacInterface8> sos8;
-    //if (SUCCEEDED(Status = g_sos->QueryInterface(__uuidof(ISOSDacInterface8), &sos8)))
+    if (SUCCEEDED(g_sos->QueryInterface(__uuidof(ISOSDacInterface8), &sos8)))
     {
         // CLRDATA_ADDRESS assemblyLoadContext = 0;
         // Status = sos8->GetAssemblyLoadContext(TO_CDADDR(dwStartAddr), &assemblyLoadContext);

--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -1329,20 +1329,20 @@ DECLARE_API(DumpMT)
     ReleaseHolder<ISOSDacInterface8> sos8;
     if (SUCCEEDED(Status = g_sos->QueryInterface(__uuidof(ISOSDacInterface8), &sos8)))
     {
-        CLRDATA_ADDRESS assemblyLoadContext = 0;
-        Status = sos8->GetAssemblyLoadContext(TO_CDADDR(dwStartAddr), &assemblyLoadContext);
-        if (SUCCEEDED(Status))
-        {
-            const char* title = "AssemblyLoadContext:";
-            if (assemblyLoadContext != 0)
-            {
-                table.WriteRow(title, ObjectPtr(assemblyLoadContext));
-            }
-            else
-            {
-                table.WriteRow(title, "Default ALC - The managed instance of this context doesn't exist yet.");
-            }
-        }
+        // CLRDATA_ADDRESS assemblyLoadContext = 0;
+        // Status = sos8->GetAssemblyLoadContext(TO_CDADDR(dwStartAddr), &assemblyLoadContext);
+        // if (SUCCEEDED(Status))
+        // {
+        //     const char* title = "AssemblyLoadContext:";
+        //     if (assemblyLoadContext != 0)
+        //     {
+        //         table.WriteRow(title, ObjectPtr(assemblyLoadContext));
+        //     }
+        //     else
+        //     {
+        //         table.WriteRow(title, "Default ALC - The managed instance of this context doesn't exist yet.");
+        //     }
+        // }
     }
 
     table.WriteRow("BaseSize:", PrefixHex(vMethTable.BaseSize));

--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -1336,7 +1336,7 @@ DECLARE_API(DumpMT)
             const char* title = "AssemblyLoadContext:";
             if (assemblyLoadContext != 0)
             {
-                table.WriteRow(title, PrefixHex(assemblyLoadContext));
+                table.WriteRow(title, ObjectPtr(assemblyLoadContext));
             }
             else
             {

--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -1327,20 +1327,21 @@ DECLARE_API(DumpMT)
     }
 
     ReleaseHolder<ISOSDacInterface8> sos8;
-    if (SUCCEEDED(g_sos->QueryInterface(__uuidof(ISOSDacInterface8), &sos8)))
+    if (SUCCEEDED(Status = g_sos->QueryInterface(__uuidof(ISOSDacInterface8), &sos8)))
     {
         CLRDATA_ADDRESS assemblyLoadContext = 0;
-        if (SUCCEEDED(sos8->GetAssemblyLoadContext(TO_CDADDR(dwStartAddr), &assemblyLoadContext)))
+        Status = sos8->GetAssemblyLoadContext(TO_CDADDR(dwStartAddr), &assemblyLoadContext);
+        if (SUCCEEDED(Status))
         {
-            // const char* title = "AssemblyLoadContext:";
-            // if (assemblyLoadContext != 0)
-            // {
-            //     table.WriteRow(title, ObjectPtr(assemblyLoadContext));
-            // }
-            // else
-            // {
-            //     table.WriteRow(title, "Default ALC - The managed instance of this context doesn't exist yet.");
-            // }
+            const char* title = "AssemblyLoadContext:";
+            if (assemblyLoadContext != 0)
+            {
+                table.WriteRow(title, ObjectPtr(assemblyLoadContext));
+            }
+            else
+            {
+                table.WriteRow(title, "Default ALC - The managed instance of this context doesn't exist yet.");
+            }
         }
     }
 

--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -1327,7 +1327,8 @@ DECLARE_API(DumpMT)
     }
 
     ReleaseHolder<ISOSDacInterface8> sos8;
-    if (SUCCEEDED(Status = g_sos->QueryInterface(__uuidof(ISOSDacInterface8), &sos8)))
+    if (IsRuntimeVersionAtLeast(7) // Prior to .NET 7, a bug existed that made ALC queries fail.
+        && SUCCEEDED(Status = g_sos->QueryInterface(__uuidof(ISOSDacInterface8), &sos8)))
     {
         CLRDATA_ADDRESS assemblyLoadContext = 0;
         Status = sos8->GetAssemblyLoadContext(TO_CDADDR(dwStartAddr), &assemblyLoadContext);

--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -1327,12 +1327,10 @@ DECLARE_API(DumpMT)
     }
 
     ReleaseHolder<ISOSDacInterface8> sos8;
-    if (IsRuntimeVersionAtLeast(7) // Prior to .NET 7, a bug existed that made ALC queries fail.
-        && SUCCEEDED(Status = g_sos->QueryInterface(__uuidof(ISOSDacInterface8), &sos8)))
+    if (SUCCEEDED(g_sos->QueryInterface(__uuidof(ISOSDacInterface8), &sos8)))
     {
         CLRDATA_ADDRESS assemblyLoadContext = 0;
-        Status = sos8->GetAssemblyLoadContext(TO_CDADDR(dwStartAddr), &assemblyLoadContext);
-        if (SUCCEEDED(Status))
+        if (SUCCEEDED(sos8->GetAssemblyLoadContext(TO_CDADDR(dwStartAddr), &assemblyLoadContext)))
         {
             const char* title = "AssemblyLoadContext:";
             if (assemblyLoadContext != 0)

--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -1327,7 +1327,7 @@ DECLARE_API(DumpMT)
     }
 
     ReleaseHolder<ISOSDacInterface8> sos8;
-    if (SUCCEEDED(Status = g_sos->QueryInterface(__uuidof(ISOSDacInterface8), &sos8)))
+    //if (SUCCEEDED(Status = g_sos->QueryInterface(__uuidof(ISOSDacInterface8), &sos8)))
     {
         // CLRDATA_ADDRESS assemblyLoadContext = 0;
         // Status = sos8->GetAssemblyLoadContext(TO_CDADDR(dwStartAddr), &assemblyLoadContext);

--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -1329,20 +1329,19 @@ DECLARE_API(DumpMT)
     ReleaseHolder<ISOSDacInterface8> sos8;
     if (SUCCEEDED(g_sos->QueryInterface(__uuidof(ISOSDacInterface8), &sos8)))
     {
-        // CLRDATA_ADDRESS assemblyLoadContext = 0;
-        // Status = sos8->GetAssemblyLoadContext(TO_CDADDR(dwStartAddr), &assemblyLoadContext);
-        // if (SUCCEEDED(Status))
-        // {
-        //     const char* title = "AssemblyLoadContext:";
-        //     if (assemblyLoadContext != 0)
-        //     {
-        //         table.WriteRow(title, ObjectPtr(assemblyLoadContext));
-        //     }
-        //     else
-        //     {
-        //         table.WriteRow(title, "Default ALC - The managed instance of this context doesn't exist yet.");
-        //     }
-        // }
+        CLRDATA_ADDRESS assemblyLoadContext = 0;
+        if (SUCCEEDED(sos8->GetAssemblyLoadContext(TO_CDADDR(dwStartAddr), &assemblyLoadContext)))
+        {
+            // const char* title = "AssemblyLoadContext:";
+            // if (assemblyLoadContext != 0)
+            // {
+            //     table.WriteRow(title, ObjectPtr(assemblyLoadContext));
+            // }
+            // else
+            // {
+            //     table.WriteRow(title, "Default ALC - The managed instance of this context doesn't exist yet.");
+            // }
+        }
     }
 
     table.WriteRow("BaseSize:", PrefixHex(vMethTable.BaseSize));

--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -1276,7 +1276,7 @@ DECLARE_API(DumpMT)
     }
 
     EnableDMLHolder dmlHolder(dml);
-    TableOutput table(2, 16, AlignLeft, false);
+    TableOutput table(2, 20, AlignLeft, false);
 
     if (nArg == 0)
     {
@@ -1323,6 +1323,25 @@ DECLARE_API(DumpMT)
         if (SUCCEEDED(MOVE(loaderAllocator, vMethTableCollectible.LoaderAllocatorObjectHandle)))
         {
             table.WriteRow("LoaderAllocator:", ObjectPtr(loaderAllocator));
+        }
+    }
+
+    ReleaseHolder<ISOSDacInterface8> sos8;
+    if (SUCCEEDED(Status = g_sos->QueryInterface(__uuidof(ISOSDacInterface8), &sos8)))
+    {
+        CLRDATA_ADDRESS assemblyLoadContext = 0;
+        Status = sos8->GetAssemblyLoadContext(TO_CDADDR(dwStartAddr), &assemblyLoadContext);
+        if (SUCCEEDED(Status))
+        {
+            const char* title = "AssemblyLoadContext:";
+            if (assemblyLoadContext != 0)
+            {
+                table.WriteRow(title, PrefixHex(assemblyLoadContext));
+            }
+            else
+            {
+                table.WriteRow(title, "Default ALC - The managed instance of this context doesn't exist yet.");
+            }
         }
     }
 
@@ -10338,7 +10357,7 @@ DECLARE_API(EEVersion)
         else
             ExtOut("Workstation mode\n");
 
-        if (!GetGcStructuresValid()) 
+        if (!GetGcStructuresValid())
         {
             ExtOut("In plan phase of garbage collection\n");
         }
@@ -15797,7 +15816,7 @@ public:
             }
         }
         if (IsInterrupt())
-        { 
+        {
             return COR_E_OPERATIONCANCELED;
         }
         return S_OK;
@@ -15808,7 +15827,7 @@ public:
     {
         ExtOut("%s", message);
         if (IsInterrupt())
-        { 
+        {
             return COR_E_OPERATIONCANCELED;
         }
         return S_OK;
@@ -15824,7 +15843,7 @@ DECLARE_API(enummem)
     if (SUCCEEDED(Status))
     {
         ToRelease<ICLRDataEnumMemoryRegionsCallback> callback = new EnumMemoryCallback(false, true);
-        ULONG32 minidumpType = 
+        ULONG32 minidumpType =
            (MiniDumpWithPrivateReadWriteMemory |
             MiniDumpWithDataSegs |
             MiniDumpWithHandleData |

--- a/src/SOS/Strike/util.cpp
+++ b/src/SOS/Strike/util.cpp
@@ -3488,7 +3488,7 @@ size_t FunctionType (size_t EIP)
 
 //
 // Return true if major runtime version (logical product version like 2.1,
-// 3.0 or 5.x). Currently only major versions of 3 or 5 are supported.
+// 3.0 or 5.x).
 //
 bool IsRuntimeVersion(DWORD major)
 {
@@ -3504,13 +3504,10 @@ bool IsRuntimeVersion(VS_FIXEDFILEINFO& fileInfo, DWORD major)
 {
     switch (major)
     {
-        case 5:
-            return HIWORD(fileInfo.dwFileVersionMS) == 5;
         case 3:
             return HIWORD(fileInfo.dwFileVersionMS) == 4 && LOWORD(fileInfo.dwFileVersionMS) == 700;
         default:
-            _ASSERTE(FALSE);
-            break;
+            return HIWORD(fileInfo.dwFileVersionMS) == major;
     }
     return false;
 }
@@ -3536,17 +3533,13 @@ bool IsRuntimeVersionAtLeast(VS_FIXEDFILEINFO& fileInfo, DWORD major)
             }
             // fall through
 
-        case 5:
-            if (HIWORD(fileInfo.dwFileVersionMS) >= 5)
+        default:
+            if (HIWORD(fileInfo.dwFileVersionMS) >= major)
             {
                 return true;
             }
             // fall through
 
-            break;
-
-        default:
-            _ASSERTE(FALSE);
             break;
     }
     return false;


### PR DESCRIPTION
Example output:

```
0:000> !DumpMT /d 00007ffaeb7b88a0
EEClass:             00007ffaeb7ad6a0
Module:              00007ffaeb7b68f0
Name:                Program
mdToken:             0000000002000004
File:                ...\Hello\bin\Debug\net6.0\Hello.dll
AssemblyLoadContext: Default ALC - The managed instance of this context doesn't exist yet.
BaseSize:            0x18
ComponentSize:       0x0
DynamicStatics:      false
ContainsPointers:    false
Slots in VTable:     7
Number of IFaces in IFaceMap: 0
0:000> !DumpMT /d 00007ffaeb7cf360
EEClass:             00007ffaeb7d6518
Module:              00007ffaeb7c8318
Name:                Program
mdToken:             0000000002000004
File:                ...\Hello\bin\Debug\net6.0\Hello.dll
AssemblyLoadContext: 0x20ecb360
BaseSize:            0x18
ComponentSize:       0x0
DynamicStatics:      false
ContainsPointers:    false
Slots in VTable:     7
Number of IFaces in IFaceMap: 0
```

/cc @janvorli @mikem8361 