### PR TITLE
Fix memory leaks detected by static analyzer

### DIFF
--- a/src/SOS/extensions/hostcoreclr.cpp
+++ b/src/SOS/extensions/hostcoreclr.cpp
@@ -393,6 +393,7 @@ static HRESULT ProbeInstallationMarkerFile(const char* const markerName, std::st
     if (getline(&line, &lineLen, locationFile) == -1)
     {
         TraceError("Unable to read .NET installation marker at %s\n", markerName);
+        free(line);
         return E_FAIL;
     }
 

--- a/src/shared/pal/src/thread/process.cpp
+++ b/src/shared/pal/src/thread/process.cpp
@@ -1836,6 +1836,7 @@ GetProcessIdDisambiguationKey(DWORD processId, UINT64 *disambiguationKey)
     {
         TRACE("GetProcessIdDisambiguationKey: getline() FAILED");
         SetLastError(ERROR_INVALID_HANDLE);
+        free(line);
         return FALSE;
     }
 
@@ -3270,6 +3271,7 @@ buildArgv(
         (strcat_s(lpAsciiCmdLine, iLength, " ") != SAFECRT_SUCCESS))
     {
         ERROR("strcpy_s/strcat_s failed!\n");
+        free(lpAsciiCmdLine);
         return NULL;
     }
 


### PR DESCRIPTION
The buffer used for getline() function should be freed by user even if getline() failed.