### PR TITLE
Check if the process ID value is less than 0 in dotnet-dump

### DIFF
--- a/src/Tools/dotnet-dump/Dumper.cs
+++ b/src/Tools/dotnet-dump/Dumper.cs
@@ -52,8 +52,14 @@ namespace Microsoft.Diagnostics.Tools.Dump
             }
 
             if (processId == 0) {
-                console.Error.WriteLine("ProcessId is required.");
-                return 1;
+                Console.Error.WriteLine("ProcessId is required.");
+                return 0;
+            }
+
+            if (processId < 0)
+            {
+                Console.Error.WriteLine($"The PID cannot be negative: {processId}");
+                return 0;
             }
 
             try

--- a/src/Tools/dotnet-dump/Dumper.cs
+++ b/src/Tools/dotnet-dump/Dumper.cs
@@ -53,13 +53,13 @@ namespace Microsoft.Diagnostics.Tools.Dump
 
             if (processId == 0) {
                 Console.Error.WriteLine("ProcessId is required.");
-                return 0;
+                return 1;
             }
 
             if (processId < 0)
             {
                 Console.Error.WriteLine($"The PID cannot be negative: {processId}");
-                return 0;
+                return 1;
             }
 
             try


### PR DESCRIPTION
```
root:~> dotnet dump collect -p -1

Writing full to /root/core_19700105_070307
Process -1 not running compatible .NET runtime.
```
```
root:~> dotnet gcdump collect -p -1
The PID cannot be negative: -1
```