### PR TITLE
Add new provider for gc-collect profile

### DIFF
--- a/src/Tools/dotnet-trace/CommandLine/Commands/ListProfilesCommandHandler.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/ListProfilesCommandHandler.cs
@@ -66,7 +66,12 @@ namespace Microsoft.Diagnostics.Tools.Trace
                     new EventPipeProvider(
                         name: "Microsoft-Windows-DotNETRuntime",
                         eventLevel: EventLevel.Informational,
-                        keywords:   (long)ClrTraceEventParser.Keywords.GC
+                        keywords: (long)ClrTraceEventParser.Keywords.GC
+                    ),
+                    new EventPipeProvider(
+                        name: "Microsoft-Windows-DotNETRuntimePrivate",
+                        eventLevel: EventLevel.Informational,
+                        keywords: (long)ClrTraceEventParser.Keywords.GC
                     )
                 },
                 "Tracks GC collections only at very low overhead."),


### PR DESCRIPTION
Adds the profile mentioned in https://github.com/dotnet/diagnostics/issues/3521 in order to include private gc events in the gc-collect profile. Can see this working by using the following sample application:

```
using System.Collections;

class ConsoleTest{
    public static void Main(){
        List<int> nums = new List<int> {};

        Console.WriteLine("Currently Running");
     
        while(true){
            List<object> objects = new List<object>();
            for (int i = 0; i < 100000; ++i)
            {
                objects.Add(new object());
            }
            objects.Clear();
        }
    }
}
```
and dotnet-trace to collect a trace:
```
dotnet-trace collect --profile gc-collect -n sampleapp
```
This results in the following events being generated, making note of the private gc events: 
![private gc events](https://user-images.githubusercontent.com/111319334/211637439-982ac35c-d393-4778-9fbc-33e210b31627.png)
