### PR TITLE
[Dotnet Monitor] Revert To Logging a single payload (not a list)

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/MetricSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/MetricSourceConfiguration.cs
@@ -44,6 +44,34 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
                {
                     { "EventCounterIntervalSec", MetricIntervalSeconds }
                })).ToList();
+
+            const long TimeSeriesValues = 0x2;
+            StringBuilder metrics = new StringBuilder();
+            foreach (string provider in customProviderNames)
+            {
+                if (metrics.Length != 0)
+                {
+                    metrics.Append(",");
+                }
+
+                metrics.Append(provider);
+            }
+
+            var metricsEventSourceSessionId = Guid.NewGuid().ToString();
+
+            EventPipeProvider metricsEventSourceProvider =
+                new EventPipeProvider("System.Diagnostics.Metrics", EventLevel.Informational, TimeSeriesValues,
+                    new Dictionary<string, string>()
+                    {
+                        { "SessionId", metricsEventSourceSessionId },
+                        { "Metrics", metrics.ToString() },
+                        { "RefreshInterval", MetricIntervalSeconds.ToString() },
+                        { "MaxTimeSeries", "1000" },
+                        { "MaxHistograms", "10" }
+                    }
+                );
+
+            _eventPipeProviders = _eventPipeProviders.Append(metricsEventSourceProvider).ToArray();
         }
 
         public MetricSourceConfiguration(float metricIntervalSeconds, IEnumerable<string> customProviderNames, int maxHistograms, int maxTimeSeries) : this(metricIntervalSeconds, customProviderNames)

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/MetricSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/MetricSourceConfiguration.cs
@@ -44,34 +44,6 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
                {
                     { "EventCounterIntervalSec", MetricIntervalSeconds }
                })).ToList();
-
-            const long TimeSeriesValues = 0x2;
-            StringBuilder metrics = new StringBuilder();
-            foreach (string provider in customProviderNames)
-            {
-                if (metrics.Length != 0)
-                {
-                    metrics.Append(",");
-                }
-
-                metrics.Append(provider);
-            }
-
-            var metricsEventSourceSessionId = Guid.NewGuid().ToString();
-
-            EventPipeProvider metricsEventSourceProvider =
-                new EventPipeProvider("System.Diagnostics.Metrics", EventLevel.Informational, TimeSeriesValues,
-                    new Dictionary<string, string>()
-                    {
-                        { "SessionId", metricsEventSourceSessionId },
-                        { "Metrics", metrics.ToString() },
-                        { "RefreshInterval", MetricIntervalSeconds.ToString() },
-                        { "MaxTimeSeries", "1000" },
-                        { "MaxHistograms", "10" }
-                    }
-                );
-
-            _eventPipeProviders = _eventPipeProviders.Append(metricsEventSourceProvider).ToArray();
         }
 
         public MetricSourceConfiguration(float metricIntervalSeconds, IEnumerable<string> customProviderNames, int maxHistograms, int maxTimeSeries) : this(metricIntervalSeconds, customProviderNames)

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/CounterPayload.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/CounterPayload.cs
@@ -71,7 +71,6 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
         public IReadOnlyDictionary<string, string> Metadata { get; }
 
         public EventType EventType { get; set; }
-
     }
 
     public class GaugePayload : CounterPayload

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/EventCounterPipeline.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/EventCounterPipeline.cs
@@ -56,7 +56,12 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
                 {
                     if (traceEvent.TryGetCounterPayload(_filter, _sessionId, out List<ICounterPayload> counterPayload))
                     {
-                        ExecuteCounterLoggerAction((metricLogger) => metricLogger.Log(counterPayload));
+                        ExecuteCounterLoggerAction((metricLogger) => {
+                            foreach (var payload in counterPayload)
+                            {
+                                metricLogger.Log(payload);
+                            }
+                        });
                     }
                 }
                 catch (Exception)

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/ICountersLogger.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/ICountersLogger.cs
@@ -2,19 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace Microsoft.Diagnostics.Monitoring.EventPipe
 {
     internal interface ICountersLogger
     {
         //TODO Consider making these async.
 
-        void Log(List<ICounterPayload> counter);
+        void Log(ICounterPayload counter);
         void PipelineStarted();
         void PipelineStopped();
     }

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/TraceEventExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/TraceEventExtensions.cs
@@ -219,7 +219,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
                 metadataDict.Add("quantile", key.ToString());
                 payload.Add(new PercentilePayload(meterName, instrumentName, null, unit, metadataDict, val, obj.TimeStamp));
             }
-        }
+        }*/
 
         private static void HandleHistogramLimitReached(TraceEvent obj, string sessionId, out ICounterPayload payload)
         {

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/TraceEventExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/TraceEventExtensions.cs
@@ -74,6 +74,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
 
             if (sessionId != null && "System.Diagnostics.Metrics".Equals(traceEvent.ProviderName))
             {
+                
                 ICounterPayload individualPayload = null;
 
                 if (traceEvent.EventName == "BeginInstrumentReporting")

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/TraceEventExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/TraceEventExtensions.cs
@@ -74,7 +74,6 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
 
             if (sessionId != null && "System.Diagnostics.Metrics".Equals(traceEvent.ProviderName))
             {
-                
                 ICounterPayload individualPayload = null;
 
                 if (traceEvent.EventName == "BeginInstrumentReporting")
@@ -126,9 +125,13 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
             return false;
         }
 
-        public static bool TryGetCounterPayload(this TraceEvent traceEvent, CounterFilter filter, out List<ICounterPayload> payload)
+        public static bool TryGetIndividualCounterPayload(this TraceEvent traceEvent, CounterFilter filter, out ICounterPayload payload)
         {
-            return TryGetCounterPayload(traceEvent, filter, null, out payload);
+            bool gotCounterPayload = TryGetCounterPayload(traceEvent, filter, null, out List<ICounterPayload> payloadsList);
+
+            payload = payloadsList.FirstOrDefault();
+
+            return gotCounterPayload;
         }
 
         private static void HandleGauge(TraceEvent obj, CounterFilter filter, string sessionId, out ICounterPayload payload)

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/TraceEventExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/TraceEventExtensions.cs
@@ -306,7 +306,6 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
             payload = new ErrorPayload(string.Empty, string.Empty, string.Empty, string.Empty, new(), 0, obj.TimeStamp, errorMessage);
         }
 
-
         //The metadata payload is formatted as a string of comma separated key:value pairs.
         //This limitation means that metadata values cannot include commas; otherwise, the
         //metadata will be parsed incorrectly. If a value contains a comma, then all metadata

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/TraceEventExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/TraceEventExtensions.cs
@@ -74,7 +74,6 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
 
             if (sessionId != null && "System.Diagnostics.Metrics".Equals(traceEvent.ProviderName))
             {
-                
                 ICounterPayload individualPayload = null;
 
                 if (traceEvent.EventName == "BeginInstrumentReporting")
@@ -219,7 +218,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
                 metadataDict.Add("quantile", key.ToString());
                 payload.Add(new PercentilePayload(meterName, instrumentName, null, unit, metadataDict, val, obj.TimeStamp));
             }
-        }*/
+        }
 
         private static void HandleHistogramLimitReached(TraceEvent obj, string sessionId, out ICounterPayload payload)
         {

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/EventCounter/EventCounterTrigger.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/EventCounter/EventCounterTrigger.cs
@@ -59,9 +59,9 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.Triggers.EventCounter
         public bool HasSatisfiedCondition(TraceEvent traceEvent)
         {
             // Filter to the counter of interest before forwarding to the implementation
-            if (traceEvent.TryGetCounterPayload(_filter, out List<ICounterPayload> payload))
+            if (traceEvent.TryGetIndividualCounterPayload(_filter, out ICounterPayload payload))
             {
-                return _impl.HasSatisfiedCondition(payload[0]); // Need to check if this is safe - in theory just want the first (and only) result
+                return _impl.HasSatisfiedCondition(payload);
             }
             return false;
         }


### PR DESCRIPTION
Note that this feature is in-progress and this PR is going into a feature branch.

@wiktork 