### PR TITLE
Add missing '$__CMakeArgs' option in build.sh

### DIFF
--- a/eng/build.sh
+++ b/eng/build.sh
@@ -131,7 +131,7 @@ mkdir -p "$__IntermediatesDir"
 mkdir -p "$__LogsDir"
 mkdir -p "$__CMakeBinDir"
 
-__ExtraCmakeArgs="$__ExtraCmakeArgs -DCLR_MANAGED_BINARY_DIR=$__RootBinDir/bin -DCLR_BUILD_TYPE=$__BuildType"
+__ExtraCmakeArgs="$__CMakeArgs $__ExtraCmakeArgs -DCLR_MANAGED_BINARY_DIR=$__RootBinDir/bin -DCLR_BUILD_TYPE=$__BuildType"
 
 # Specify path to be set for CMAKE_INSTALL_PREFIX.
 # This is where all built native libraries will copied to.


### PR DESCRIPTION
```build-commons.sh``` puts ```-DCLR_CMAKE_KEEP_NATIVE_SYMBOL=true``` to ```__CMakeArgs``` for ```keepnativesymbols``` option. Yet it is forgotten as ```build.sh``` doesn't use it.
https://github.com/dotnet/diagnostics/blob/000766177bb4dfc353029c23844f8e7931174c8d/eng/native/build-commons.sh#L339-L341