### PR TITLE
Updated version of TraceEvent to 3.0.7 in order to add escaped characters to Chromium files

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -45,7 +45,7 @@
     <MicrosoftBclAsyncInterfacesVersion>1.1.0</MicrosoftBclAsyncInterfacesVersion>
     <MicrosoftDiagnosticsRuntimeVersion>2.3.405501</MicrosoftDiagnosticsRuntimeVersion>
     <MicrosoftDiaSymReaderNativePackageVersion>16.9.0-beta1.21055.5</MicrosoftDiaSymReaderNativePackageVersion>
-    <MicrosoftDiagnosticsTracingTraceEventVersion>2.0.76</MicrosoftDiagnosticsTracingTraceEventVersion>
+    <MicrosoftDiagnosticsTracingTraceEventVersion>3.0.7</MicrosoftDiagnosticsTracingTraceEventVersion>
     <!-- Use pinned version to avoid picking up latest (which doesn't support netcoreapp3.1) during source-build -->
     <MicrosoftExtensionsLoggingPinnedVersion>2.1.1</MicrosoftExtensionsLoggingPinnedVersion>
     <!-- dotnet-dsrouter needs a net6.0 version of logging -->


### PR DESCRIPTION
 Escaping characters in the Chromium file was added in this [pr](https://github.com/microsoft/perfview/commit/3f06e493e1935c1846ccef6170469ca0c6cd5c00#diff-ce00bfa58a5fff2e9a08746a4e41803d6e66488f6e5483cad8adb4ea114ada1fR74). Version 3.7 contains this solution to resolve https://github.com/dotnet/diagnostics/issues/3607, just needed to bump the version of TraceEvent to have it properly convert nettrace files to Chromium.