### PR TITLE
Fix/disable nullable warnings treated as errors with newer SDKs installed

### DIFF
--- a/src/SOS/SOS.UnitTests/SOS.cs
+++ b/src/SOS/SOS.UnitTests/SOS.cs
@@ -14,6 +14,11 @@ using Xunit;
 using Xunit.Abstractions;
 using Xunit.Extensions;
 
+// Newer SDKs flag MemberData(nameof(Configurations)) with this error
+// Avoid unnecessary zero-length array allocations.  Use Array.Empty<object>() instead.
+#pragma warning disable CA1825 
+
+[Collection("Windows Dump Generation")]
 public class SOS
 {
     public SOS(ITestOutputHelper output)

--- a/src/tests/DbgShim.UnitTests/DbgShimTests.cs
+++ b/src/tests/DbgShim.UnitTests/DbgShimTests.cs
@@ -20,6 +20,10 @@ using Xunit;
 using Xunit.Abstractions;
 using Xunit.Extensions;
 
+// Newer SDKs flag MemberData(nameof(Configurations)) with this error
+// Avoid unnecessary zero-length array allocations.  Use Array.Empty<object>() instead.
+#pragma warning disable CA1825 
+
 namespace Microsoft.Diagnostics
 {
     public class DbgShimTests : IDisposable

--- a/src/tests/Microsoft.Diagnostics.DebugServices.UnitTests/DebugServicesTests.cs
+++ b/src/tests/Microsoft.Diagnostics.DebugServices.UnitTests/DebugServicesTests.cs
@@ -11,6 +11,10 @@ using Xunit;
 using Xunit.Abstractions;
 using Xunit.Extensions;
 
+// Newer SDKs flag MemberData(nameof(Configurations)) with this error
+// Avoid unnecessary zero-length array allocations.  Use Array.Empty<object>() instead.
+#pragma warning disable CA1825 
+
 namespace Microsoft.Diagnostics.DebugServices.UnitTests
 {
     public class DebugServicesTests : IDisposable

--- a/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventCounterPipelineUnitTests.cs
+++ b/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventCounterPipelineUnitTests.cs
@@ -13,6 +13,10 @@ using Xunit.Abstractions;
 using Xunit.Extensions;
 using TestRunner = Microsoft.Diagnostics.CommonTestRunner.TestRunner;
 
+// Newer SDKs flag MemberData(nameof(Configurations)) with this error
+// Avoid unnecessary zero-length array allocations.  Use Array.Empty<object>() instead.
+#pragma warning disable CA1825 
+
 namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
 {
     public class EventCounterPipelineUnitTests

--- a/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventCounterTriggerTests.cs
+++ b/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventCounterTriggerTests.cs
@@ -10,13 +10,16 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Globalization;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 using Xunit.Extensions;
 using TestRunner = Microsoft.Diagnostics.CommonTestRunner.TestRunner;
+
+// Newer SDKs flag MemberData(nameof(Configurations)) with this error
+// Avoid unnecessary zero-length array allocations.  Use Array.Empty<object>() instead.
+#pragma warning disable CA1825 
 
 namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
 {

--- a/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventLogsPipelineUnitTests.cs
+++ b/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventLogsPipelineUnitTests.cs
@@ -18,6 +18,10 @@ using Xunit.Abstractions;
 using Xunit.Extensions;
 using TestRunner = Microsoft.Diagnostics.CommonTestRunner.TestRunner;
 
+// Newer SDKs flag MemberData(nameof(Configurations)) with this error
+// Avoid unnecessary zero-length array allocations.  Use Array.Empty<object>() instead.
+#pragma warning disable CA1825 
+
 namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
 {
     public class EventLogsPipelineUnitTests

--- a/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventTracePipelineUnitTests.cs
+++ b/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventTracePipelineUnitTests.cs
@@ -17,6 +17,10 @@ using Xunit.Abstractions;
 using Xunit.Extensions;
 using TestRunner = Microsoft.Diagnostics.CommonTestRunner.TestRunner;
 
+// Newer SDKs flag MemberData(nameof(Configurations)) with this error
+// Avoid unnecessary zero-length array allocations.  Use Array.Empty<object>() instead.
+#pragma warning disable CA1825 
+
 namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
 {
     public class EventTracePipelineUnitTests

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/EventPipeSessionTests.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/EventPipeSessionTests.cs
@@ -14,6 +14,10 @@ using Xunit.Abstractions;
 using Xunit.Extensions;
 using TestRunner = Microsoft.Diagnostics.CommonTestRunner.TestRunner;
 
+// Newer SDKs flag MemberData(nameof(Configurations)) with this error
+// Avoid unnecessary zero-length array allocations.  Use Array.Empty<object>() instead.
+#pragma warning disable CA1825 
+
 namespace Microsoft.Diagnostics.NETCore.Client
 {
     public class EventPipeSessionTests

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/GetProcessEnvironmentTests.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/GetProcessEnvironmentTests.cs
@@ -10,6 +10,10 @@ using Xunit.Abstractions;
 using Xunit.Extensions;
 using TestRunner = Microsoft.Diagnostics.CommonTestRunner.TestRunner;
 
+// Newer SDKs flag MemberData(nameof(Configurations)) with this error
+// Avoid unnecessary zero-length array allocations.  Use Array.Empty<object>() instead.
+#pragma warning disable CA1825 
+
 namespace Microsoft.Diagnostics.NETCore.Client
 {
     public class ProcessEnvironmentTests

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/GetProcessInfoTests.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/GetProcessInfoTests.cs
@@ -13,6 +13,10 @@ using Xunit.Abstractions;
 using Xunit.Extensions;
 using TestRunner = Microsoft.Diagnostics.CommonTestRunner.TestRunner;
 
+// Newer SDKs flag MemberData(nameof(Configurations)) with this error
+// Avoid unnecessary zero-length array allocations.  Use Array.Empty<object>() instead.
+#pragma warning disable CA1825 
+
 namespace Microsoft.Diagnostics.NETCore.Client
 {
     public class GetProcessInfoTests

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/GetPublishedProcessesTests.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/GetPublishedProcessesTests.cs
@@ -5,13 +5,16 @@
 using Microsoft.Diagnostics.TestHelpers;
 using System;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 using Xunit.Extensions;
 using TestRunner = Microsoft.Diagnostics.CommonTestRunner.TestRunner;
+
+// Newer SDKs flag MemberData(nameof(Configurations)) with this error
+// Avoid unnecessary zero-length array allocations.  Use Array.Empty<object>() instead.
+#pragma warning disable CA1825 
 
 namespace Microsoft.Diagnostics.NETCore.Client
 {

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/ReversedServerTests.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/ReversedServerTests.cs
@@ -19,6 +19,10 @@ using Xunit.Abstractions;
 using Xunit.Extensions;
 using TestRunner = Microsoft.Diagnostics.CommonTestRunner.TestRunner;
 
+// Newer SDKs flag MemberData(nameof(Configurations)) with this error
+// Avoid unnecessary zero-length array allocations.  Use Array.Empty<object>() instead.
+#pragma warning disable CA1825 
+
 namespace Microsoft.Diagnostics.NETCore.Client
 {
     public class ReversedServerTests

--- a/src/tests/dotnet-counters/JSONExporterTests.cs
+++ b/src/tests/dotnet-counters/JSONExporterTests.cs
@@ -4,11 +4,12 @@
 
 using System;
 using System.IO;
-using System.Collections.Generic;
 using Xunit;
 using Microsoft.Diagnostics.Tools.Counters.Exporters;
 using Newtonsoft.Json;
 using Microsoft.Diagnostics.Tools.Counters;
+
+#pragma warning disable CA1507 // Use nameof to express symbol names
 
 namespace DotnetCounters.UnitTests
 {

--- a/src/tests/dotnet-trace/ChildProcessTests.cs
+++ b/src/tests/dotnet-trace/ChildProcessTests.cs
@@ -12,9 +12,12 @@ using Xunit.Abstractions;
 using Xunit.Extensions;
 using TestRunner = Microsoft.Diagnostics.CommonTestRunner.TestRunner;
 
+// Newer SDKs flag MemberData(nameof(Configurations)) with this error
+// Avoid unnecessary zero-length array allocations.  Use Array.Empty<object>() instead.
+#pragma warning disable CA1825 
+
 namespace Microsoft.Diagnostics.Tools.Trace
 {
-
     public class ChildProcessTests
     {
         public static IEnumerable<object[]> Configurations => TestRunner.Configurations;


### PR DESCRIPTION
Fixes the build errors when newer SDKs are installed or building under VS.