### PR TITLE
Update the default version of dotnet-counters to be 6.0

### DIFF
--- a/src/Tools/dotnet-counters/KnownData.cs
+++ b/src/Tools/dotnet-counters/KnownData.cs
@@ -12,10 +12,17 @@ namespace Microsoft.Diagnostics.Tools.Counters
 {
     internal static class KnownData
     {
-        private const string maxVersion = "6.0";
+        private const string maxVersion = "8.0";
+        
+        internal static readonly string[] s_AllVersions = new[] { net30, net31, net50, net60, net70, net80 };
+        private static readonly string[] s_StartingNet5 = new[] { net50, net60, net70, net80 };
+        private static readonly string[] s_StartingNet6 = new[] { net60, net70, net80 };
+        private static readonly string[] s_StartingNet7 = new[] { net70, net80 };
+        
         private static readonly IReadOnlyDictionary<string, CounterProvider> _knownProviders =
             CreateKnownProviders(maxVersion).ToDictionary(p => p.Name, StringComparer.OrdinalIgnoreCase);
 
+        private const string net80 = "8.0";
         private const string net70 = "7.0";
         private const string net60 = "6.0";
         private const string net50 = "5.0";
@@ -30,30 +37,30 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 "0xffffffff", // Keywords
                 "5", // Level 
                 new[] { // Counters
-                    new CounterProfile{ Name="cpu-usage", Description="The percent of process' CPU usage relative to all of the system CPU resources [0-100]", SupportedVersions=new[] { net30, net31, net50, net60 } },
-                    new CounterProfile{ Name="working-set", Description="Amount of working set used by the process (MB)", SupportedVersions=new[] { net30, net31, net50, net60 } },
-                    new CounterProfile{ Name="gc-heap-size", Description="Total heap size reported by the GC (MB)", SupportedVersions=new[] { net30, net31, net50, net60 } },
-                    new CounterProfile{ Name="gen-0-gc-count", Description="Number of Gen 0 GCs between update intervals", SupportedVersions=new[] { net30, net31, net50, net60 } },
-                    new CounterProfile{ Name="gen-1-gc-count", Description="Number of Gen 1 GCs between update intervals", SupportedVersions=new[] { net30, net31, net50, net60 } },
-                    new CounterProfile{ Name="gen-2-gc-count", Description="Number of Gen 2 GCs between update intervals", SupportedVersions=new[] { net30, net31, net50, net60 } },
-                    new CounterProfile{ Name="time-in-gc", Description="% time in GC since the last GC", SupportedVersions=new[] { net30, net31, net50, net60 } },
-                    new CounterProfile{ Name="gen-0-size", Description="Gen 0 Heap Size", SupportedVersions=new[] { net30, net31, net50, net60 } },
-                    new CounterProfile{ Name="gen-1-size", Description="Gen 1 Heap Size", SupportedVersions=new[] { net30, net31, net50, net60 } },
-                    new CounterProfile{ Name="gen-2-size", Description="Gen 2 Heap Size", SupportedVersions=new[] { net30, net31, net50, net60 } },
-                    new CounterProfile{ Name="loh-size", Description="LOH Size", SupportedVersions=new[] { net30, net31, net50, net60 } },
-                    new CounterProfile{ Name="poh-size", Description="POH (Pinned Object Heap) Size", SupportedVersions=new[] { net50, net60 } },
-                    new CounterProfile{ Name="alloc-rate", Description="Number of bytes allocated in the managed heap between update intervals", SupportedVersions=new[] { net30, net31, net50, net60 } },
-                    new CounterProfile{ Name="gc-fragmentation", Description="GC Heap Fragmentation", SupportedVersions=new[] { net50, net60 } },
-                    new CounterProfile{ Name="assembly-count", Description="Number of Assemblies Loaded", SupportedVersions=new[] { net30, net31, net50, net60 } },
-                    new CounterProfile{ Name="exception-count", Description="Number of Exceptions / sec", SupportedVersions=new[] { net30, net31, net50, net60 } },
-                    new CounterProfile{ Name="threadpool-thread-count", Description="Number of ThreadPool Threads", SupportedVersions=new[] { net30, net31, net50, net60 } },
-                    new CounterProfile{ Name="monitor-lock-contention-count", Description="Number of times there were contention when trying to take the monitor lock between update intervals", SupportedVersions=new[] { net30, net31, net50, net60 } },
-                    new CounterProfile{ Name="threadpool-queue-length", Description="ThreadPool Work Items Queue Length", SupportedVersions=new[] { net30, net31, net50, net60 } },
-                    new CounterProfile{ Name="threadpool-completed-items-count", Description="ThreadPool Completed Work Items Count", SupportedVersions=new[] { net30, net31, net50, net60 } },
-                    new CounterProfile{ Name="active-timer-count", Description="Number of timers that are currently active", SupportedVersions=new[] { net30, net31, net50, net60 } },
-                    new CounterProfile{ Name="il-bytes-jitted", Description="Total IL bytes jitted", SupportedVersions=new[] { net50, net60 } },
-                    new CounterProfile{ Name="methods-jitted-count", Description="Number of methods jitted", SupportedVersions=new[] { net50, net60 } },
-                    new CounterProfile{ Name="gc-committed", Description="Size of committed memory by the GC (MB)", SupportedVersions=new[] { net60, net60 } }
+                    new CounterProfile{ Name="cpu-usage", Description="The percent of process' CPU usage relative to all of the system CPU resources [0-100]", SupportedVersions=s_AllVersions },
+                    new CounterProfile{ Name="working-set", Description="Amount of working set used by the process (MB)", SupportedVersions=s_AllVersions },
+                    new CounterProfile{ Name="gc-heap-size", Description="Total heap size reported by the GC (MB)", SupportedVersions=s_AllVersions },
+                    new CounterProfile{ Name="gen-0-gc-count", Description="Number of Gen 0 GCs between update intervals", SupportedVersions=s_AllVersions },
+                    new CounterProfile{ Name="gen-1-gc-count", Description="Number of Gen 1 GCs between update intervals", SupportedVersions=s_AllVersions },
+                    new CounterProfile{ Name="gen-2-gc-count", Description="Number of Gen 2 GCs between update intervals", SupportedVersions=s_AllVersions },
+                    new CounterProfile{ Name="time-in-gc", Description="% time in GC since the last GC", SupportedVersions=s_AllVersions },
+                    new CounterProfile{ Name="gen-0-size", Description="Gen 0 Heap Size", SupportedVersions=s_AllVersions },
+                    new CounterProfile{ Name="gen-1-size", Description="Gen 1 Heap Size", SupportedVersions=s_AllVersions },
+                    new CounterProfile{ Name="gen-2-size", Description="Gen 2 Heap Size", SupportedVersions=s_AllVersions },
+                    new CounterProfile{ Name="loh-size", Description="LOH Size", SupportedVersions=s_AllVersions },
+                    new CounterProfile{ Name="poh-size", Description="POH (Pinned Object Heap) Size", SupportedVersions=s_StartingNet5 },
+                    new CounterProfile{ Name="alloc-rate", Description="Number of bytes allocated in the managed heap between update intervals", SupportedVersions=s_AllVersions },
+                    new CounterProfile{ Name="gc-fragmentation", Description="GC Heap Fragmentation", SupportedVersions=s_StartingNet5 },
+                    new CounterProfile{ Name="assembly-count", Description="Number of Assemblies Loaded", SupportedVersions=s_AllVersions },
+                    new CounterProfile{ Name="exception-count", Description="Number of Exceptions / sec", SupportedVersions=s_AllVersions },
+                    new CounterProfile{ Name="threadpool-thread-count", Description="Number of ThreadPool Threads", SupportedVersions=s_AllVersions },
+                    new CounterProfile{ Name="monitor-lock-contention-count", Description="Number of times there were contention when trying to take the monitor lock between update intervals", SupportedVersions=s_AllVersions },
+                    new CounterProfile{ Name="threadpool-queue-length", Description="ThreadPool Work Items Queue Length", SupportedVersions=s_AllVersions },
+                    new CounterProfile{ Name="threadpool-completed-items-count", Description="ThreadPool Completed Work Items Count", SupportedVersions=s_AllVersions },
+                    new CounterProfile{ Name="active-timer-count", Description="Number of timers that are currently active", SupportedVersions=s_AllVersions },
+                    new CounterProfile{ Name="il-bytes-jitted", Description="Total IL bytes jitted", SupportedVersions=s_StartingNet5 },
+                    new CounterProfile{ Name="methods-jitted-count", Description="Number of methods jitted", SupportedVersions=s_StartingNet5 },
+                    new CounterProfile{ Name="gc-committed", Description="Size of committed memory by the GC (MB)", SupportedVersions=s_StartingNet6 }
                 },
                 runtimeVersion // RuntimeVersion
             );
@@ -63,10 +70,10 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 "0x0", // Keywords
                 "4", // Level 
                 new[] { // Counters
-                    new CounterProfile{ Name="requests-per-second", Description="Number of requests between update intervals", SupportedVersions=new[] { net30, net31, net50, net60 } },
-                    new CounterProfile{ Name="total-requests", Description="Total number of requests", SupportedVersions=new[] { net30, net31, net50, net60 } },
-                    new CounterProfile{ Name="current-requests", Description="Current number of requests", SupportedVersions=new[] { net30, net31, net50, net60 } },
-                    new CounterProfile{ Name="failed-requests", Description="Failed number of requests", SupportedVersions=new[] { net30, net31, net50, net60 } },
+                    new CounterProfile{ Name="requests-per-second", Description="Number of requests between update intervals", SupportedVersions=s_AllVersions },
+                    new CounterProfile{ Name="total-requests", Description="Total number of requests", SupportedVersions=s_AllVersions },
+                    new CounterProfile{ Name="current-requests", Description="Current number of requests", SupportedVersions=s_AllVersions },
+                    new CounterProfile{ Name="failed-requests", Description="Failed number of requests", SupportedVersions=s_AllVersions },
                 },
                 runtimeVersion
             );
@@ -76,15 +83,15 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 "0x0", // Keywords
                 "4", // Level
                 new[] {
-                    new CounterProfile{ Name="connections-per-second", Description="Number of connections between update intervals", SupportedVersions=new[] { net50, net60 } },
-                    new CounterProfile{ Name="total-connections", Description="Total Connections", SupportedVersions=new[] { net50, net60 } },
-                    new CounterProfile{ Name="tls-handshakes-per-second", Description="Number of TLS Handshakes made between update intervals", SupportedVersions=new[] { net50, net60 } },
-                    new CounterProfile{ Name="total-tls-handshakes", Description="Total number of TLS handshakes made", SupportedVersions=new[] { net50, net60 } },
-                    new CounterProfile{ Name="current-tls-handshakes", Description="Number of currently active TLS handshakes", SupportedVersions=new[] { net50, net60 } },
-                    new CounterProfile{ Name="failed-tls-handshakes", Description="Total number of failed TLS handshakes", SupportedVersions=new[] { net50, net60 } },
-                    new CounterProfile{ Name="current-connections", Description="Number of current connections", SupportedVersions=new[] { net50, net60 } },
-                    new CounterProfile{ Name="connection-queue-length", Description="Length of Kestrel Connection Queue", SupportedVersions=new[] { net50, net60 } },
-                    new CounterProfile{ Name="request-queue-length", Description="Length total HTTP request queue", SupportedVersions=new[] { net50, net60 } },
+                    new CounterProfile{ Name="connections-per-second", Description="Number of connections between update intervals", SupportedVersions=s_StartingNet5 },
+                    new CounterProfile{ Name="total-connections", Description="Total Connections", SupportedVersions=s_StartingNet5 },
+                    new CounterProfile{ Name="tls-handshakes-per-second", Description="Number of TLS Handshakes made between update intervals", SupportedVersions=s_StartingNet5 },
+                    new CounterProfile{ Name="total-tls-handshakes", Description="Total number of TLS handshakes made", SupportedVersions=s_StartingNet5 },
+                    new CounterProfile{ Name="current-tls-handshakes", Description="Number of currently active TLS handshakes", SupportedVersions=s_StartingNet5 },
+                    new CounterProfile{ Name="failed-tls-handshakes", Description="Total number of failed TLS handshakes", SupportedVersions=s_StartingNet5 },
+                    new CounterProfile{ Name="current-connections", Description="Number of current connections", SupportedVersions=s_StartingNet5 },
+                    new CounterProfile{ Name="connection-queue-length", Description="Length of Kestrel Connection Queue", SupportedVersions=s_StartingNet5 },
+                    new CounterProfile{ Name="request-queue-length", Description="Length total HTTP request queue", SupportedVersions=s_StartingNet5 },
                 },
                 runtimeVersion
             );
@@ -94,17 +101,17 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 "0x0", // Keywords
                 "1", // Level
                 new[] {
-                    new CounterProfile{ Name="requests-started", Description="Total Requests Started", SupportedVersions=new[] { net50, net60 } },
-                    new CounterProfile{ Name="requests-started-rate", Description="Number of Requests Started between update intervals", SupportedVersions=new[] { net50, net60 } },
-                    new CounterProfile{ Name="requests-aborted", Description="Total Requests Aborted", SupportedVersions=new[] { net50, net60 } },
-                    new CounterProfile{ Name="requests-aborted-rate", Description="Number of Requests Aborted between update intervals", SupportedVersions=new[] { net50, net60 } },
-                    new CounterProfile{ Name="current-requests", Description="Current Requests", SupportedVersions=new[] { net50, net60 } },
-                    new CounterProfile{ Name="http11-connections-current-total", Description="Current number of HTTP 1.1 connections", SupportedVersions=new[] { net50, net60 } },
-                    new CounterProfile{ Name="http20-connections-current-total", Description="Current number of HTTP 2.0 connections", SupportedVersions=new[] { net50, net60 } },
-                    new CounterProfile{ Name="http30-connections-current-total", Description="Current number of HTTP 3.0 connections", SupportedVersions=new[] { net70 } },
-                    new CounterProfile{ Name="http11-requests-queue-duration", Description="Average duration of the time HTTP 1.1 requests spent in the request queue", SupportedVersions=new[] { net50, net60 } },
-                    new CounterProfile{ Name="http20-requests-queue-duration", Description="Average duration of the time HTTP 2.0 requests spent in the request queue", SupportedVersions=new[] { net50, net60 } },
-                    new CounterProfile{ Name="http30-requests-queue-duration", Description="Average duration of the time HTTP 3.0 requests spent in the request queue", SupportedVersions=new[] { net70 } },
+                    new CounterProfile{ Name="requests-started", Description="Total Requests Started", SupportedVersions=s_StartingNet5 },
+                    new CounterProfile{ Name="requests-started-rate", Description="Number of Requests Started between update intervals", SupportedVersions=s_StartingNet5 },
+                    new CounterProfile{ Name="requests-aborted", Description="Total Requests Aborted", SupportedVersions=s_StartingNet5 },
+                    new CounterProfile{ Name="requests-aborted-rate", Description="Number of Requests Aborted between update intervals", SupportedVersions=s_StartingNet5 },
+                    new CounterProfile{ Name="current-requests", Description="Current Requests", SupportedVersions=s_StartingNet5 },
+                    new CounterProfile{ Name="http11-connections-current-total", Description="Current number of HTTP 1.1 connections", SupportedVersions=s_StartingNet5 },
+                    new CounterProfile{ Name="http20-connections-current-total", Description="Current number of HTTP 2.0 connections", SupportedVersions=s_StartingNet5 },
+                    new CounterProfile{ Name="http30-connections-current-total", Description="Current number of HTTP 3.0 connections", SupportedVersions=s_StartingNet7 },
+                    new CounterProfile{ Name="http11-requests-queue-duration", Description="Average duration of the time HTTP 1.1 requests spent in the request queue", SupportedVersions=s_StartingNet5 },
+                    new CounterProfile{ Name="http20-requests-queue-duration", Description="Average duration of the time HTTP 2.0 requests spent in the request queue", SupportedVersions=s_StartingNet5 },
+                    new CounterProfile{ Name="http30-requests-queue-duration", Description="Average duration of the time HTTP 3.0 requests spent in the request queue", SupportedVersions=s_StartingNet7 },
                 },
                 runtimeVersion
             );
@@ -114,9 +121,9 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 "0x0",
                 "1",
                 new[] {
-                    new CounterProfile{ Name="dns-lookups-requested", Description="The number of DNS lookups requested since the process started", SupportedVersions=new[] { net50, net60 } },
-                    new CounterProfile{ Name="dns-lookups-duration", Description="Average DNS Lookup Duration", SupportedVersions=new[] { net50, net60 } },
-                    new CounterProfile{ Name="current-dns-lookups", Description="The current number of DNS lookups that have started but not yet completed", SupportedVersions=new[] { net60 } },
+                    new CounterProfile{ Name="dns-lookups-requested", Description="The number of DNS lookups requested since the process started", SupportedVersions=s_StartingNet5 },
+                    new CounterProfile{ Name="dns-lookups-duration", Description="Average DNS Lookup Duration", SupportedVersions=s_StartingNet5 },
+                    new CounterProfile{ Name="current-dns-lookups", Description="The current number of DNS lookups that have started but not yet completed", SupportedVersions=s_StartingNet6 },
                 },
                 runtimeVersion
             );
@@ -126,20 +133,20 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 "0x0",
                 "1",
                 new[] {
-                    new CounterProfile{ Name="tls-handshake-rate", Description="The number of TLS handshakes completed per update interval", SupportedVersions=new[] { net50, net60 } },
-                    new CounterProfile{ Name="total-tls-handshakes", Description="The total number of TLS handshakes completed since the process started", SupportedVersions=new[] { net50, net60 } },
-                    new CounterProfile{ Name="current-tls-handshakes", Description="The current number of TLS handshakes that have started but not yet completed", SupportedVersions=new[] { net50, net60 } },
-                    new CounterProfile{ Name="failed-tls-handshakes", Description="The total number of TLS handshakes failed since the process started", SupportedVersions=new[] { net50, net60 } },
-                    new CounterProfile{ Name="all-tls-sessions-open", Description="The number of active all TLS sessions", SupportedVersions=new[] { net50, net60 } },
-                    new CounterProfile{ Name="tls10-sessions-open", Description="The number of active TLS 1.0 sessions", SupportedVersions=new[] { net50, net60 } },
-                    new CounterProfile{ Name="tls11-sessions-open", Description="The number of active TLS 1.1 sessions", SupportedVersions=new[] { net50, net60 } },
-                    new CounterProfile{ Name="tls12-sessions-open", Description="The number of active TLS 1.2 sessions", SupportedVersions=new[] { net50, net60 } },
-                    new CounterProfile{ Name="tls13-sessions-open", Description="The number of active TLS 1.3 sessions", SupportedVersions=new[] { net50, net60 } },
-                    new CounterProfile{ Name="all-tls-handshake-duration", Description="The average duration of all TLS handshakes", SupportedVersions=new[] { net50, net60 } },
-                    new CounterProfile{ Name="tls10-handshake-duration", Description="The average duration of TLS 1.0 handshakes", SupportedVersions=new[] { net50, net60 } },
-                    new CounterProfile{ Name="tls11-handshake-duration", Description="The average duration of TLS 1.1 handshakes", SupportedVersions=new[] { net50, net60 } },
-                    new CounterProfile{ Name="tls12-handshake-duration", Description="The average duration of TLS 1.2 handshakes", SupportedVersions=new[] { net50, net60 } },
-                    new CounterProfile{ Name="tls13-handshake-duration", Description="The average duration of TLS 1.3 handshakes", SupportedVersions=new[] { net50, net60 } },
+                    new CounterProfile{ Name="tls-handshake-rate", Description="The number of TLS handshakes completed per update interval", SupportedVersions=s_StartingNet5 },
+                    new CounterProfile{ Name="total-tls-handshakes", Description="The total number of TLS handshakes completed since the process started", SupportedVersions=s_StartingNet5 },
+                    new CounterProfile{ Name="current-tls-handshakes", Description="The current number of TLS handshakes that have started but not yet completed", SupportedVersions=s_StartingNet5 },
+                    new CounterProfile{ Name="failed-tls-handshakes", Description="The total number of TLS handshakes failed since the process started", SupportedVersions=s_StartingNet5 },
+                    new CounterProfile{ Name="all-tls-sessions-open", Description="The number of active all TLS sessions", SupportedVersions=s_StartingNet5 },
+                    new CounterProfile{ Name="tls10-sessions-open", Description="The number of active TLS 1.0 sessions", SupportedVersions=s_StartingNet5 },
+                    new CounterProfile{ Name="tls11-sessions-open", Description="The number of active TLS 1.1 sessions", SupportedVersions=s_StartingNet5 },
+                    new CounterProfile{ Name="tls12-sessions-open", Description="The number of active TLS 1.2 sessions", SupportedVersions=s_StartingNet5 },
+                    new CounterProfile{ Name="tls13-sessions-open", Description="The number of active TLS 1.3 sessions", SupportedVersions=s_StartingNet5 },
+                    new CounterProfile{ Name="all-tls-handshake-duration", Description="The average duration of all TLS handshakes", SupportedVersions=s_StartingNet5 },
+                    new CounterProfile{ Name="tls10-handshake-duration", Description="The average duration of TLS 1.0 handshakes", SupportedVersions=s_StartingNet5 },
+                    new CounterProfile{ Name="tls11-handshake-duration", Description="The average duration of TLS 1.1 handshakes", SupportedVersions=s_StartingNet5 },
+                    new CounterProfile{ Name="tls12-handshake-duration", Description="The average duration of TLS 1.2 handshakes", SupportedVersions=s_StartingNet5 },
+                    new CounterProfile{ Name="tls13-handshake-duration", Description="The average duration of TLS 1.3 handshakes", SupportedVersions=s_StartingNet5 },
                 },
                 runtimeVersion
             );
@@ -149,13 +156,13 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 "0x0",
                 "1",
                 new[] {
-                    new CounterProfile{ Name="outgoing-connections-established", Description="The total number of outgoing connections established since the process started", SupportedVersions=new[] { net50, net60 } },
-                    new CounterProfile{ Name="incoming-connections-established", Description="The total number of incoming connections established since the process started", SupportedVersions=new[] { net50, net60 } },
-                    new CounterProfile{ Name="current-outgoing-connect-attempts", Description="The current number of outgoing connect attempts that have started but not yet completed", SupportedVersions=new[] { net70 } },
-                    new CounterProfile{ Name="bytes-received", Description="The total number of bytes received since the process started", SupportedVersions=new[] { net50, net60 } },
-                    new CounterProfile{ Name="bytes-sent", Description="The total number of bytes sent since the process started", SupportedVersions=new[] { net50, net60 } },
-                    new CounterProfile{ Name="datagrams-received", Description="The total number of datagrams received since the process started", SupportedVersions=new[] { net50, net60 } },
-                    new CounterProfile{ Name="datagrams-sent", Description="The total number of datagrams sent since the process started", SupportedVersions=new[] { net50, net60 } },
+                    new CounterProfile{ Name="outgoing-connections-established", Description="The total number of outgoing connections established since the process started", SupportedVersions=s_StartingNet5 },
+                    new CounterProfile{ Name="incoming-connections-established", Description="The total number of incoming connections established since the process started", SupportedVersions=s_StartingNet5 },
+                    new CounterProfile{ Name="current-outgoing-connect-attempts", Description="The current number of outgoing connect attempts that have started but not yet completed", SupportedVersions=s_StartingNet7 },
+                    new CounterProfile{ Name="bytes-received", Description="The total number of bytes received since the process started", SupportedVersions=s_StartingNet5 },
+                    new CounterProfile{ Name="bytes-sent", Description="The total number of bytes sent since the process started", SupportedVersions=s_StartingNet5 },
+                    new CounterProfile{ Name="datagrams-received", Description="The total number of datagrams received since the process started", SupportedVersions=s_StartingNet5 },
+                    new CounterProfile{ Name="datagrams-sent", Description="The total number of datagrams sent since the process started", SupportedVersions=s_StartingNet5 },
                 },
                 runtimeVersion
             );

--- a/src/Tools/dotnet-counters/Program.cs
+++ b/src/Tools/dotnet-counters/Program.cs
@@ -160,9 +160,9 @@ namespace Microsoft.Diagnostics.Tools.Counters
         private static Option RuntimeVersionOption() =>
             new Option(
                 aliases: new[] { "-r", "--runtime-version" },
-                description: "Version of runtime. Supported runtime version: 3.0, 3.1, 5.0") 
+                description: "Version of runtime. Supported runtime version: 3.0, 3.1, 5.0, 6.0, 7.0, 8.0") 
             {
-                Argument = new Argument<string>(name: "runtimeVersion", getDefaultValue: () => "3.1")
+                Argument = new Argument<string>(name: "runtimeVersion", getDefaultValue: () => "6.0")
             };
 
         private static Option DiagnosticPortOption() =>
@@ -207,14 +207,14 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 Argument = new Argument<TimeSpan>(name: "duration-timespan", getDefaultValue: () => default)
             };
 
-        private static readonly string[] s_SupportedRuntimeVersions = new[] { "3.0", "3.1", "5.0" };
+        private static readonly string[] s_SupportedRuntimeVersions = KnownData.s_AllVersions;
 
         public static int List(IConsole console, string runtimeVersion)
         {
             if (!s_SupportedRuntimeVersions.Contains(runtimeVersion))
             {
                 Console.WriteLine($"{runtimeVersion} is not a supported version string or a supported runtime version.");
-                Console.WriteLine("Supported version strings: 3.0, 3.1, 5.0");
+                Console.WriteLine("Supported version strings: 3.0, 3.1, 5.0, 6.0, 7.0, 8.0");
                 return 0;
             }
             var profiles = KnownData.GetAllProviders(runtimeVersion);


### PR DESCRIPTION
Fixes https://github.com/dotnet/diagnostics/issues/3622. Bumps the default version to be 6.0 and adds profile support for up to 8.0. 