### PR TITLE
[Tizen] Handle exception in System.Console.SetCursorPosition in some environments

### DIFF
--- a/src/Tools/Common/Commands/Utils.cs
+++ b/src/Tools/Common/Commands/Utils.cs
@@ -159,7 +159,16 @@ namespace Microsoft.Internal.Common.Utils
             }
         }
 
-        private void SystemConsoleLineRewriter() => Console.SetCursorPosition(0, LineToClear);
+        private static bool isSetCursorPositionSupported = true;
+        private void SystemConsoleLineRewriter() {
+            try {
+                if (isSetCursorPositionSupported)
+                    Console.SetCursorPosition(0, LineToClear);
+            } catch {
+                Console.WriteLine("Console.SetCursorPosition() is not supported in this env.");
+                isSetCursorPositionSupported = false;
+            }
+        }
     }
 
     internal class ReturnCode


### PR DESCRIPTION
For some environments that do not support some terminal interactions next exception happens:
```
System.ArgumentOutOfRangeException: The value must be greater than or equal to zero and less than the console's buffer size in that dimension. (Parameter 'top') 
Actual value was -1.
at System.Console.SetCursorPosition(Int32 left, Int32 top) 
at Microsoft.Internal.Common.Utils.LineRewriter.SystemConsoleLineRewriter()
at Microsoft.Internal.Common.Utils.LineRewriter.RewriteConsoleLine()
at Microsoft.Diagnostics.Tools.Trace.CollectCommandHandler.<>c__DisplayClass6_2.b__4()
at Microsoft.Diagnostics.Tools.Trace.CollectCommandHandler.Collect(CancellationToken ct, IConsole console, Int32 processId, FileInfo output, UInt32 buffersize, String providers, String profile, TraceFileFormat format, TimeSpan duration, String clrevents, String clreventlevel, String name, String diagnosticPort, Boolean showchildio, Boolean resumeRuntime
```

Is there a better fix for this?

cc @HJLeee @alpencolt 