### PR TITLE
StackFrame.cs null handling

### DIFF
--- a/src/Microsoft.Diagnostics.ExtensionCommands/ParallelStacks.Runtime/StackFrame.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/ParallelStacks.Runtime/StackFrame.cs
@@ -19,16 +19,13 @@ namespace ParallelStacks
 
         public StackFrame(ClrStackFrame frame)
         {
-            if (frame.Method is null)
-                throw new ArgumentException("frame.Method is null");
-
             ComputeNames(frame);
         }
 
         private void ComputeNames(ClrStackFrame frame)
         {
             // start by parsing (short)type name
-            var typeName = frame.Method!.Type.Name;
+            var typeName = frame.Method?.Type.Name;
             if (string.IsNullOrEmpty(typeName))
             {
                 // IL generated frames
@@ -41,7 +38,7 @@ namespace ParallelStacks
 
             // generic methods are not well formatted by ClrMD
             // foo<...>()  =>   foo[[...]]()
-            var signature = frame.Method.Signature;
+            var signature = frame.Method?.Signature;
             if (string.IsNullOrEmpty(signature))
             {
                 Text = "?";
@@ -52,7 +49,7 @@ namespace ParallelStacks
                 Signature.AddRange(BuildSignature(signature));
             }
 
-            var methodName = frame.Method.Name;
+            var methodName = frame.Method?.Name;
             if (string.IsNullOrEmpty(methodName))
             {
                 // IL generated frames


### PR DESCRIPTION
Fixes https://github.com/dotnet/performance/issues/2890 . I've opened it in dotnet/performance by mistake.
What this does:
When Type is ILGenerated it's methods do not have a name or signature. TypeName which is also null in such case was handled but MethodName and MethodSignature weren't. This improves handling of those values.