### PR TITLE
Allow larger single file apps debugging in DbgShim

### DIFF
--- a/src/dbgshim/dbgshim.cpp
+++ b/src/dbgshim/dbgshim.cpp
@@ -1117,12 +1117,6 @@ GetTargetCLRMetrics(
         return HRESULT_FROM_WIN32(GetLastError());
     }
 
-    // A maximum size of 100 MB should be more than enough for coreclr.dll.
-    if ((cbFileHigh != 0) || (cbFileLow > 0x6400000) || (cbFileLow == 0))
-    {
-        return E_FAIL;
-    }
-
     HandleHolder hCoreClrMap = WszCreateFileMapping(hCoreClrFile, NULL, PAGE_READONLY, cbFileHigh, cbFileLow, NULL);
     if (hCoreClrMap == NULL)
     {


### PR DESCRIPTION
Remove check in dbgshim.cpp to ensure the file is less than 100 MB. This allows single file apps with larger sizes to be debugged under a managed debugger.