### PR TITLE
Missing memory improvements

### DIFF
--- a/src/Microsoft.Diagnostics.ExtensionCommands/MAddressCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/MAddressCommand.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Diagnostics.ExtensionCommands
 
                 output.WriteRowWithSpacing('-', "Memory Kind", "StartAddr", "EndAddr-1", "Size", "Type", "State", "Protect", "Image");
                 foreach (DescribedRegion mem in ranges)
-                    output.WriteRow(mem.Name, mem.Start, mem.End, mem.Length.ConvertToHumanReadable(), mem.Type, mem.State, mem.Protection, mem.Image);
+                    output.WriteRow(mem.Name, mem.Start, mem.End, mem.Size.ConvertToHumanReadable(), mem.Type, mem.State, mem.Protection, mem.Image);
 
                 output.WriteSpacer('-');
             }

--- a/src/Microsoft.Diagnostics.ExtensionCommands/NativeAddressHelper.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/NativeAddressHelper.cs
@@ -30,6 +30,9 @@ namespace Microsoft.Diagnostics.ExtensionCommands
         [ServiceImport]
         public IMemoryRegionService MemoryRegionService { get; set; }
 
+        [ServiceImport]
+        public IConsoleService Console { get; set; }
+
         /// <summary>
         /// Enumerates the entire address space, optionally tagging special CLR heaps, and optionally "collapsing"
         /// MEM_RESERVE regions with a heuristic to blame them on the MEM_COMMIT region that came before it.
@@ -51,6 +54,8 @@ namespace Microsoft.Diagnostics.ExtensionCommands
         /// <returns>An enumerable of memory ranges.</returns>
         internal IEnumerable<DescribedRegion> EnumerateAddressSpace(bool tagClrMemoryRanges, bool includeReserveMemory, bool tagReserveMemoryHeuristically)
         {
+            bool printedTruncatedWarning = false;
+
             var addressResult = from region in MemoryRegionService.EnumerateRegions()
                                 where region.State != MemoryRegionState.MEM_FREE
                                 select new DescribedRegion(region, ModuleService.GetModuleFromAddress(region.Start));
@@ -58,7 +63,7 @@ namespace Microsoft.Diagnostics.ExtensionCommands
             if (!includeReserveMemory)
                 addressResult = addressResult.Where(m => m.State != MemoryRegionState.MEM_RESERVE);
 
-            DescribedRegion[] ranges = addressResult.OrderBy(r => r.Start).ToArray();
+            List<DescribedRegion> rangeList = addressResult.ToList();
             if (tagClrMemoryRanges)
             {
                 foreach (IRuntime runtime in RuntimeService.EnumerateRuntimes())
@@ -68,24 +73,143 @@ namespace Microsoft.Diagnostics.ExtensionCommands
                     {
                         foreach (ClrMemoryPointer mem in ClrMemoryPointer.EnumerateClrMemoryAddresses(clrRuntime))
                         {
-                            var found = ranges.Where(m => m.Start <= mem.Address && mem.Address < m.End).ToArray();
+                            var found = rangeList.Select((DescribedRegion Region, int Index) => (Region, Index)).Where(m => m.Region.Start <= mem.Address && mem.Address < m.Region.End).ToArray();
 
-                            if (found.Length == 0)
-                                Trace.WriteLine($"Warning:  Could not find a memory range for {mem.Address:x} - {mem.Kind}.");
-                            else if (found.Length > 1)
-                                Trace.WriteLine($"Warning:  Found multiple memory ranges for entry {mem.Address:x} - {mem.Kind}.");
-
-                            foreach (var entry in found)
+                            if (found.Length == 0 && mem.Kind != ClrMemoryKind.GCHeapReserve)
                             {
-                                if (entry.ClrMemoryKind != ClrMemoryKind.None && entry.ClrMemoryKind != mem.Kind)
-                                    Trace.WriteLine($"Warning:  Overwriting range {entry.Start:x} {entry.ClrMemoryKind} -> {mem.Kind}.");
+                                Trace.WriteLine($"Warning:  Could not find a memory range for {mem.Address:x} - {mem.Kind}.");
 
-                                entry.ClrMemoryKind = mem.Kind;
+                                if (!printedTruncatedWarning)
+                                {
+                                    Console.WriteLine($"Warning:  Could not find a memory range for {mem.Address:x} - {mem.Kind}.");
+                                    Console.WriteLine($"This crash dump may not be a full dump!");
+                                    Console.WriteLine("");
+
+                                    printedTruncatedWarning = true;
+                                }
+
+                                // Add the memory range if we know its size.
+                                if (mem.Size > 0)
+                                {
+                                    IModule module = ModuleService.GetModuleFromAddress(mem.Address);
+                                    rangeList.Add(new DescribedRegion()
+                                    {
+                                        Start = mem.Address,
+                                        End = mem.Address + mem.Size,
+                                        ClrMemoryKind = mem.Kind,
+                                        State = mem.Kind == ClrMemoryKind.GCHeapReserve ? MemoryRegionState.MEM_RESERVE : MemoryRegionState.MEM_COMMIT,
+                                        Module = module,
+                                        Image = module?.FileName,
+                                        Protection = MemoryRegionProtection.PAGE_UNKNOWN,
+                                        Type = module != null ? MemoryRegionType.MEM_IMAGE : MemoryRegionType.MEM_PRIVATE,
+                                        Usage = MemoryRegionUsage.CLR,
+                                    });
+                                }
+                            }
+                            else if (found.Length > 1)
+                            {
+                                Trace.WriteLine($"Warning:  Found multiple memory ranges for entry {mem.Address:x} - {mem.Kind}.");
+                            }
+
+                            foreach ((DescribedRegion Region, int Index) in found)
+                            {
+                                if (mem.Kind == ClrMemoryKind.GCHeapReserve || mem.Kind == ClrMemoryKind.GCHeapSegment)
+                                {
+                                    // GC heap segments are special.  We only know report a small chunk of memory on the actual allocated
+                                    // region.  We want to mark the whole region as GC/GCReserve and not try to divide up chunks for these.
+                                    SetRegionKindWithWarning(mem.Kind, Region);
+                                }
+                                else if (mem.Size == 0)
+                                {
+                                    // If we don't know the length of memory, just mark the Region with this tag.
+                                    SetRegionKindWithWarning(mem.Kind, Region);
+                                }
+                                else
+                                {
+                                    // If the CLR memory information does contain a length, we'll split up the optionally split up the range into
+                                    // multiple entries if this doesn't span the entire segment.
+                                    if (Region.Start != mem.Address)
+                                    {
+                                        // If we don't otherwise know what this region is, we'll still blame it on mem.Kind.
+                                        // If one contiguous VirtualAlloc call contains a HighFrequencyHeap (for example) then
+                                        // it's more correct to say that memory is probably also HighFrequencyHeap than to
+                                        // mark it as some other unknown type.  CLR still allocated it, and it's still close
+                                        // by the other region kind.
+                                        if (Region.ClrMemoryKind == ClrMemoryKind.None)
+                                            Region.ClrMemoryKind = mem.Kind;
+
+                                        DescribedRegion middleRegion = new(Region)
+                                        {
+                                            Start = mem.Address,
+                                            End = mem.Address + mem.Size,
+                                            ClrMemoryKind = mem.Kind,
+                                            Usage = MemoryRegionUsage.CLR,
+                                        };
+
+                                        // we aren't sorted yet, so we don't need to worry about where we insert
+                                        rangeList.Add(middleRegion);
+
+                                        if (middleRegion.End < Region.End)
+                                        {
+                                            // The new region doesn't end where the previous region does, so we
+                                            // have to create a third region for the end chunk.
+                                            DescribedRegion endRegion = new(middleRegion)
+                                            {
+                                                Start = middleRegion.End,
+                                                End = Region.End,           // original region end
+                                                Usage = Region.Usage,
+                                                ClrMemoryKind = Region.ClrMemoryKind
+                                            };
+
+                                            rangeList.Add(endRegion);
+                                        }
+
+                                        // Now set the original region to dnd where the middle chunk begins.
+                                        // Region is now the starting region of this set.
+                                        Region.End = middleRegion.Start;
+                                    }
+                                    else if (Region.Size < mem.Size)
+                                    {
+                                        SetRegionKindWithWarning(mem.Kind, Region);
+
+                                        // That's odd.  The memory in the region is smaller than what the CLR thinks this region size should
+                                        // be.  We won't go too deep here, only look for regions which start immediately after this one and
+                                        // mark it too.  We could go deep here and make this function recursive, continually marking ranges
+                                        // if we keep spilling over, but we don't expect this to happen in practice.
+
+                                        bool foundNext = false;
+                                        foreach (DescribedRegion region in rangeList.Where(r => r != Region && r.Start <= Region.End && Region.End <= r.End))
+                                        {
+                                            SetRegionKindWithWarning(mem.Kind, region);
+                                            foundNext = true;
+                                        }
+
+                                        // If we found no matching regions, expand the current region to be the right length.
+                                        if (!foundNext)
+                                            Region.End = mem.Address + mem.Size;
+                                    }
+                                    else if (Region.Size > mem.Size)
+                                    {
+                                        // The CLR memory segment is at the beginning of this region.
+                                        DescribedRegion newRange = new(Region)
+                                        {
+                                            End = mem.Address + mem.Size,
+                                            ClrMemoryKind = mem.Kind
+                                        };
+
+                                        Region.Start = newRange.End;
+                                        if (Region.ClrMemoryKind == ClrMemoryKind.None)  // see note above
+                                            Region.ClrMemoryKind = mem.Kind;
+                                    }
+                                }
+
                             }
                         }
                     }
                 }
             }
+
+            var ranges = rangeList.OrderBy(r => r.Start).ToArray();
 
             if (tagReserveMemoryHeuristically)
             {
@@ -102,6 +226,26 @@ namespace Microsoft.Diagnostics.ExtensionCommands
                 MarkStackSpace(ranges);
 
             return ranges;
+        }
+
+        private static void SetRegionKindWithWarning(ClrMemoryKind memKind, DescribedRegion region)
+        {
+            if (region.ClrMemoryKind != memKind)
+            {
+                // Only warn when the region kind meaningfully changes.  Many regions are reported as
+                // HighFrequencyHeap originally but are classified into more specific regions, so we
+                // don't warn for those.
+                if (region.ClrMemoryKind != ClrMemoryKind.None
+                    && region.ClrMemoryKind != ClrMemoryKind.HighFrequencyHeap)
+                {
+                    Trace.WriteLine($"Warning:  Overwriting range {region.Start:x} {region.ClrMemoryKind} -> {memKind}.");
+                }
+
+                region.ClrMemoryKind = memKind;
+            }
+
+            if (region.Usage == MemoryRegionUsage.Unknown)
+                region.Usage = MemoryRegionUsage.CLR;
         }
 
         private void MarkStackSpace(DescribedRegion[] ranges)
@@ -230,36 +374,57 @@ namespace Microsoft.Diagnostics.ExtensionCommands
 
         internal class DescribedRegion : IMemoryRegion
         {
-            private readonly IMemoryRegion _region;
-
-            public IModule Module { get; }
+            public DescribedRegion()
+            {
+            }
 
             public DescribedRegion(IMemoryRegion region, IModule module)
             {
-                _region = region;
                 Module = module;
+                Start = region.Start;
+                End = region.End;
+                Type = region.Type;
+                State = region.State;
+                Protection = region.Protection;
+                Usage = region.Usage;
+                Image = region.Image;
             }
 
-            public ulong Start => _region.Start;
+            public DescribedRegion(DescribedRegion copyFrom)
+            {
+                Module = copyFrom.Module;
+                Start = copyFrom.Start;
+                End = copyFrom.End;
+                Type = copyFrom.Type;
+                State = copyFrom.State;
+                Protection = copyFrom.Protection;
+                Usage = copyFrom.Usage;
+                Image = copyFrom.Image;
+                Description = copyFrom.Description;
+                ClrMemoryKind = copyFrom.ClrMemoryKind;
+            }
 
-            public ulong End => _region.End;
+            public IModule Module { get; internal set; }
 
-            public ulong Size => _region.Size;
+            public ulong Start { get; internal set; }
 
-            public MemoryRegionType Type => _region.Type;
+            public ulong End { get; internal set; }
 
-            public MemoryRegionState State => _region.State;
+            public MemoryRegionType Type { get; internal set; }
 
-            public MemoryRegionProtection Protection => _region.Protection;
+            public MemoryRegionState State { get; internal set; }
 
-            public MemoryRegionUsage Usage => _region.Usage;
+            public MemoryRegionProtection Protection { get; internal set; }
 
-            public string Image => _region.Image;
+            public MemoryRegionUsage Usage { get; internal set; }
+
+            public string Image { get; internal set; }
 
             public string Description { get; internal set; }
 
             public ClrMemoryKind ClrMemoryKind { get; internal set; }
-            public ulong Length => End <= Start ? 0 : End - Start;
+
+            public ulong Size => End <= Start ? 0 : End - Start;
 
             public string Name
             {
@@ -277,7 +442,7 @@ namespace Microsoft.Diagnostics.ExtensionCommands
                         return "FREE";
 
                     if (Type == MemoryRegionType.MEM_IMAGE || !string.IsNullOrWhiteSpace(Image))
-                        return "IMAGE";
+                        return "Image";
 
                     string result = Protection.ToString();
                     if (Type == MemoryRegionType.MEM_MAPPED)

--- a/src/Microsoft.Diagnostics.ExtensionCommands/NativeAddressHelper.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/NativeAddressHelper.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Diagnostics.ExtensionCommands
                             {
                                 if (mem.Kind == ClrMemoryKind.GCHeapReserve || mem.Kind == ClrMemoryKind.GCHeapSegment)
                                 {
-                                    // GC heap segments are special.  We only know report a small chunk of memory on the actual allocated
+                                    // GC heap segments are special.  We only know a small chunk of memory on the actual allocated
                                     // region.  We want to mark the whole region as GC/GCReserve and not try to divide up chunks for these.
                                     SetRegionKindWithWarning(mem.Kind, region);
                                 }
@@ -164,7 +164,7 @@ namespace Microsoft.Diagnostics.ExtensionCommands
                                             rangeList.Add(endRegion);
                                         }
 
-                                        // Now set the original region to dnd where the middle chunk begins.
+                                        // Now set the original region to end where the middle chunk begins.
                                         // Region is now the starting region of this set.
                                         region.End = middleRegion.Start;
                                     }

--- a/src/Microsoft.Diagnostics.ExtensionCommands/NativeAddressHelper.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/NativeAddressHelper.cs
@@ -431,15 +431,20 @@ namespace Microsoft.Diagnostics.ExtensionCommands
                 get
                 {
                     if (ClrMemoryKind != ClrMemoryKind.None)
+                    {
+                        if (ClrMemoryKind == ClrMemoryKind.GCHeapReserve)
+                            return $"[{ClrMemoryKind}]";
+
                         return ClrMemoryKind.ToString();
+                    }
 
                     if (!string.IsNullOrWhiteSpace(Description))
                         return Description;
 
                     if (State == MemoryRegionState.MEM_RESERVE)
-                        return "RESERVED";
+                        return "[RESERVED]";
                     else if (State == MemoryRegionState.MEM_FREE)
-                        return "FREE";
+                        return "[FREE]";
 
                     if (Type == MemoryRegionType.MEM_IMAGE || !string.IsNullOrWhiteSpace(Image))
                         return "Image";


### PR DESCRIPTION
I made a few improvements from using this on a couple of investigations.

We now print a warning when we notice that regions we know exist in memory are missing from IMemoryRegionService.  This shouldn't happen on Windows, but in ELF dumps we do not have a debug stream describing memory...we only use what was put into the coredump as the known memory regions.

We now split up VirtualAlloc regions when we go to tag CLR memory regions.  CLR might VirtualAlloc one big chunk and sub-divide it into its own regions.  Note that MAddress isn't actually trying to show VirtualAlloc/memmap addresses (just use !address for that), instead it's trying to take what !address knows and annotate more information.

Renamed "IMAGE" -> "Image" in output, because it better fits in with how we name other regions.
Added "[]" to free and reserve regions to further distinguish them in output.