### PR TITLE
Handle exception in System.Console.SetCursorPosition in some environments

### DIFF
--- a/src/Tools/Common/Commands/Utils.cs
+++ b/src/Tools/Common/Commands/Utils.cs
@@ -160,6 +160,29 @@ namespace Microsoft.Internal.Common.Utils
         }
 
         private void SystemConsoleLineRewriter() => Console.SetCursorPosition(0, LineToClear);
+
+        private static bool? _isSetCursorPositionSupported;
+        public bool IsRewriteConsoleLineSupported
+        {
+            get {
+                bool isSupported = _isSetCursorPositionSupported ?? EnsureInitialized();
+                return isSupported;
+
+                bool EnsureInitialized()
+                {
+                    try {
+                        var left = Console.CursorLeft;
+                        var top = Console.CursorTop;
+                        Console.SetCursorPosition(0, LineToClear);
+                        Console.SetCursorPosition(left, top);
+                        _isSetCursorPositionSupported = true;
+                    } catch {
+                        _isSetCursorPositionSupported = false;
+                    }
+                    return (bool)_isSetCursorPositionSupported;
+                }
+            }
+        }
     }
 
     internal class ReturnCode

--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
@@ -284,16 +284,23 @@ namespace Microsoft.Diagnostics.Tools.Trace
                             {
                                 rewriter = new LineRewriter { LineToClear = Console.CursorTop - 1 };
                                 Console.CursorVisible = false;
+                                if (!rewriter.IsRewriteConsoleLineSupported)
+                                {
+                                    ConsoleWriteLine("Recording trace in progress. Press <Enter> or <Ctrl+C> to exit...");
+                                }
                             }
 
                             Action printStatus = () =>
                             {
                                 if (printStatusOverTime)
                                 {
-                                    rewriter?.RewriteConsoleLine();
-                                    fileInfo.Refresh();
-                                    ConsoleWriteLine($"[{stopwatch.Elapsed.ToString(@"dd\:hh\:mm\:ss")}]\tRecording trace {GetSize(fileInfo.Length)}");
-                                    ConsoleWriteLine("Press <Enter> or <Ctrl+C> to exit...");
+                                    if (rewriter.IsRewriteConsoleLineSupported)
+                                    {
+                                        rewriter?.RewriteConsoleLine();
+                                        fileInfo.Refresh();
+                                        ConsoleWriteLine($"[{stopwatch.Elapsed.ToString(@"dd\:hh\:mm\:ss")}]\tRecording trace {GetSize(fileInfo.Length)}");
+                                        ConsoleWriteLine("Press <Enter> or <Ctrl+C> to exit...");
+                                    }
                                 }
 
                                 if (rundownRequested)


### PR DESCRIPTION
Apply feedback. 
https://github.com/dotnet/diagnostics/pull/3635#issuecomment-1420001603

Now it looks like the below when `System.Console.SetCursorPosition(Int32 left, Int32 top)` throws exception.
```
[?1h=No profile or providers specified, defaulting to trace profile 'cpu-sampling'

Provider Name                           Keywords            Level               Enabled By
Microsoft-DotNETCore-SampleProfiler     0x0000F00000000000  Informational(4)    --profile
Microsoft-Windows-DotNETRuntime         0x00000014C14FCCBD  Informational(4)    --profile

Process        : /usr/bin/dotnet-launcher
Output File    : /tmp/dotnet-launcher_20230222_063808.nettrace



[6n[?25l[6n[6nRecording trace in progress. Press <Enter> or <Ctrl+C> to exit...
```

cc/ @gbalykov @noahfalk 