### PR TITLE
Fix propogating BuildArch.

### DIFF
--- a/eng/build.sh
+++ b/eng/build.sh
@@ -115,6 +115,9 @@ handle_arguments() {
 }
 
 source "$__RepoRootDir"/eng/native/build-commons.sh
+source "$repoRootDir/eng/native/init-os-and-arch.sh"
+
+__BuildArch="$arch"
 
 __LogsDir="$__RootBinDir/log/$__BuildType"
 __ConfigTriplet="$__TargetOS.$__BuildArch.$__BuildType"


### PR DESCRIPTION
Simple PR to fix native non-x64 builds.

This will place the bin folder for arm64/arm/x86 builds in the correct path.