### PR TITLE
Small change to dev container setup.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,9 +4,11 @@
 	"name": "C# (.NET)",
 	"build": {
 		"dockerfile": "Dockerfile",
-		"args": {
-			// Update 'VARIANT' to pick a .NET Core version: 2.1, 3.1, 5.0, 6.0
-			"VARIANT": "6.0-focal",
+		"args": { 
+			// Update 'VARIANT' to pick a .NET Core version: 2.1, 3.1, 5.0
+			"VARIANT": "6.0",
+			// Options
+			"NODE_VERSION": "lts/*"
 		}
 	},
 
@@ -23,6 +25,9 @@
 		"ms-dotnettools.csharp",
 		"ms-vscode.cpptools-extension-pack"
 	],
+
+	// Needed to debug sos extension under container.
+	"privileged": true,
 
 	// Add the locally installed dotnet to the path to ensure that it is activated
 	// This allows developers to just use 'dotnet build' on the command-line, and the local dotnet version will be used.

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -115,7 +115,7 @@ handle_arguments() {
 }
 
 source "$__RepoRootDir"/eng/native/build-commons.sh
-source "$repoRootDir/eng/native/init-os-and-arch.sh"
+source "$__RepoRootDir/eng/native/init-os-and-arch.sh"
 
 __BuildArch="$arch"
 


### PR DESCRIPTION
Updates it to work with the newer vs code releases, and in addition, adds --priviledged to allow debugging SOS under the devcontainer.

In addition, fixes typo in the last build pr.

Note: for arm64 macs, running x64 container images can be run with:

devcontainer.json:
	`"runArgs": ["--platform=linux/amd64" ]`

and `FROM --platform=linux/amd64 `
in the dockerfile