### PR TITLE
Fix the runtime version for single-file apps

### DIFF
--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/Module.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/Module.cs
@@ -251,32 +251,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
             else 
             {
                 // If we can't get the version from the PE, search for version string embedded in the module data
-                string versionString = GetVersionString();
-                if (versionString != null)
-                {
-                    int spaceIndex = versionString.IndexOf(' ');
-                    if (spaceIndex < 0)
-                    {
-                        // It is probably a private build version that doesn't end with a space (no commit id after)
-                        spaceIndex = versionString.Length;
-                    }
-                    if (spaceIndex > 0)
-                    {
-                        if (versionString[spaceIndex - 1] == '.')
-                        {
-                            spaceIndex--;
-                        }
-                        string versionToParse = versionString.Substring(0, spaceIndex);
-                        try
-                        {
-                            version = Version.Parse(versionToParse);
-                        }
-                        catch (ArgumentException ex)
-                        {
-                            Trace.TraceError($"Module.GetVersion FAILURE: '{versionToParse}' '{versionString}' {ex}");
-                        }
-                    }
-                }
+                version = Utilities.ParseVersionString(GetVersionString());
             }
 
             return version;
@@ -290,6 +265,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
             }
             return null;
         }
+
         protected bool InitializeValue(Flags flag)
         {
             if ((_flags & flag) == 0)

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/Runtime.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/Runtime.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
         private readonly ClrInfo _clrInfo;
         private readonly IDisposable _onFlushEvent;
         private readonly ISymbolService _symbolService;
+        private Version _runtimeVersion;
         private string _dacFilePath;
         private string _dbiFilePath;
 
@@ -83,6 +84,24 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
         public IModule RuntimeModule { get; }
 
         public string RuntimeModuleDirectory { get; set; }
+
+
+        public Version RuntimeVersion
+        {
+            get
+            {
+                if (_runtimeVersion is null)
+                {
+                    Version version = _clrInfo.Version;
+                    if (version is null || version.Equals(Utilities.EmptyVersion))
+                    {
+                        version = Utilities.ParseVersionString(RuntimeModule.GetVersionString());
+                    }
+                    _runtimeVersion = version;
+                }
+                return _runtimeVersion;
+            }
+        }
 
         public string GetDacFilePath()
         {

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/Utilities.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/Utilities.cs
@@ -56,6 +56,40 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
         }
 
         /// <summary>
+        /// Helper function to that parses the version out of the version string that looks something 
+        /// like "8.0.23.10701 @Commit: e71a4fb10d7ea6b502dd5efe7a8fcefa2b9c1550"
+        /// </summary>
+        public static Version ParseVersionString(string versionString)
+        {
+            if (versionString != null)
+            {
+                int spaceIndex = versionString.IndexOf(' ');
+                if (spaceIndex < 0)
+                {
+                    // It is probably a private build version that doesn't end with a space (no commit id after)
+                    spaceIndex = versionString.Length;
+                }
+                if (spaceIndex > 0)
+                {
+                    if (versionString[spaceIndex - 1] == '.')
+                    {
+                        spaceIndex--;
+                    }
+                    string versionToParse = versionString.Substring(0, spaceIndex);
+                    try
+                    {
+                        return Version.Parse(versionToParse);
+                    }
+                    catch (ArgumentException ex)
+                    {
+                        Trace.TraceError($"ParseVersionString FAILURE: '{versionToParse}' '{versionString}' {ex}");
+                    }
+                }
+            }
+            return null;
+        }
+
+        /// <summary>
         /// Convert from symstore PEPdbRecord to DebugServices PdbFileInfo
         /// </summary>
         public static PdbFileInfo ToPdbFileInfo(this PEPdbRecord pdbInfo)

--- a/src/Microsoft.Diagnostics.DebugServices/IRuntime.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/IRuntime.cs
@@ -44,6 +44,12 @@ namespace Microsoft.Diagnostics.DebugServices
         RuntimeType RuntimeType { get; }
 
         /// <summary>
+        /// Returns the runtime version. This may be different from the runtime 
+        /// module's file version for single-file apps. Can be null.
+        /// </summary>
+        Version RuntimeVersion { get; }
+
+        /// <summary>
         /// Returns the runtime module
         /// </summary>
         IModule RuntimeModule { get; }


### PR DESCRIPTION
Fallback to parsing the embeded version string for single-file apps if ClrInfo.Version is null or invalid.