### PR TITLE
Fix build target architecture passing

### DIFF
--- a/eng/build.sh
+++ b/eng/build.sh
@@ -115,9 +115,6 @@ handle_arguments() {
 }
 
 source "$__RepoRootDir"/eng/native/build-commons.sh
-source "$__RepoRootDir/eng/native/init-os-and-arch.sh"
-
-__BuildArch="$arch"
 
 __LogsDir="$__RootBinDir/log/$__BuildType"
 __ConfigTriplet="$__TargetOS.$__BuildArch.$__BuildType"


### PR DESCRIPTION
This reverts https://github.com/dotnet/diagnostics/pull/3684 to fix official builds
