### PR TITLE
Rename COMPlus_ to DOTNET_

### DIFF
--- a/documentation/FAQ.md
+++ b/documentation/FAQ.md
@@ -31,7 +31,7 @@ Frequently Asked Questions
 
     If that doesn't work, try using the `setclrpath <directory>` command with a directory that contains the matching version of the DAC module. This is useful for private runtimes or debug builds that haven't been published to our symbol servers.
 
-    If this is a dump, the problem could also be that the dump is missing some memory required by SOS. Try generating a "full" dump (the default with `dotnet-dump collect` without a `--type` option) or add setting the crash dump generation (createdump) environment variable `COMPlus_DbgMiniDumpType=4`. For more details on crash dump generation see [here](https://docs.microsoft.com/en-us/dotnet/core/diagnostics/dumps#collecting-dumps-on-crash).
+    If this is a dump, the problem could also be that the dump is missing some memory required by SOS. Try generating a "full" dump (the default with `dotnet-dump collect` without a `--type` option) or add setting the crash dump generation (createdump) environment variable `DOTNET_DbgMiniDumpType=4`. For more details on crash dump generation see [here](https://docs.microsoft.com/en-us/dotnet/core/diagnostics/dumps#collecting-dumps-on-crash).
 
 * If you receive this error message executing a SOS command:
     ```

--- a/documentation/FAQ.md
+++ b/documentation/FAQ.md
@@ -31,7 +31,7 @@ Frequently Asked Questions
 
     If that doesn't work, try using the `setclrpath <directory>` command with a directory that contains the matching version of the DAC module. This is useful for private runtimes or debug builds that haven't been published to our symbol servers.
 
-    If this is a dump, the problem could also be that the dump is missing some memory required by SOS. Try generating a "full" dump (the default with `dotnet-dump collect` without a `--type` option) or add setting the crash dump generation (createdump) environment variable `DOTNET_DbgMiniDumpType=4`. For more details on crash dump generation see [here](https://docs.microsoft.com/en-us/dotnet/core/diagnostics/dumps#collecting-dumps-on-crash).
+    If this is a dump, the problem could also be that the dump is missing some memory required by SOS. Try generating a "full" dump (the default with `dotnet-dump collect` without a `--type` option) or add setting the crash dump generation (createdump) environment variable `DOTNET_DbgMiniDumpType=4` (.NET 6 and below require `COMPlus_` prefix instead of `DOTNET_`). For more details on crash dump generation see [here](https://docs.microsoft.com/en-us/dotnet/core/diagnostics/dumps#collecting-dumps-on-crash).
 
 * If you receive this error message executing a SOS command:
     ```

--- a/documentation/tutorial/app_running_slow_highcpu.md
+++ b/documentation/tutorial/app_running_slow_highcpu.md
@@ -64,7 +64,7 @@ Reproduce the problem and when done, hit CTRL-C to exit the perfcollect tool. Yo
 If you  are more familiar with existing performance tools on Linux, .net core is also instrumented to allow you to make use of those tools. Here, we will illustrate how you can use the 'perf' tool to generate traces that can be used on Linux to diagnose performance problems. Exit the previous instance of the webapi and set the following in the terminal:
 
 > ```bash
-> export COMPlus_PerfMapEnabled=1
+> export DOTNET_PerfMapEnabled=1
 > ```
 
 Next, re-launch the webapi. This step is required to get more legible frames in the traces. 

--- a/src/Microsoft.Diagnostics.TestHelpers/ProcessRunner.cs
+++ b/src/Microsoft.Diagnostics.TestHelpers/ProcessRunner.cs
@@ -124,6 +124,7 @@ namespace Microsoft.Diagnostics.TestHelpers
             return this;
         }
 
+        // Remove COMPlus_ fallback once minimum supported runtime is .NET 8
         public ProcessRunner WithRuntimeConfiguration(string key, string value) =>
             WithEnvironmentVariable($"DOTNET_{key}", value)
             .WithEnvironmentVariable($"COMPlus_{key}", value);

--- a/src/Microsoft.Diagnostics.TestHelpers/ProcessRunner.cs
+++ b/src/Microsoft.Diagnostics.TestHelpers/ProcessRunner.cs
@@ -124,6 +124,10 @@ namespace Microsoft.Diagnostics.TestHelpers
             return this;
         }
 
+        public ProcessRunner WithRuntimeConfiguration(string key, string value) =>
+            WithEnvironmentVariable($"DOTNET_{key}", value)
+            .WithEnvironmentVariable($"COMPlus_{key}", value);
+
         public ProcessRunner WithEnvironmentVariable(string key, string value)
         {
             lock (_lock)

--- a/src/SOS/SOS.UnitTests/SOS.cs
+++ b/src/SOS/SOS.UnitTests/SOS.cs
@@ -445,10 +445,10 @@ public class SOS
                 WithExpectedExitCode(0).
                 WithWorkingDirectory(scriptDir).
                 // Turn on stress logging so the dumplog and histinit commands pass
-                WithEnvironmentVariable("COMPlus_LogFacility", "0xffffffbf").
-                WithEnvironmentVariable("COMPlus_LogLevel", "6").
-                WithEnvironmentVariable("COMPlus_StressLog", "1").
-                WithEnvironmentVariable("COMPlus_StressLogSize", "65536");
+                WithEnvironmentVariable("DOTNET_LogFacility", "0xffffffbf").
+                WithEnvironmentVariable("DOTNET_LogLevel", "6").
+                WithEnvironmentVariable("DOTNET_StressLog", "1").
+                WithEnvironmentVariable("DOTNET_StressLogSize", "65536");
 
             // Start the process runner
             processRunner.Start();

--- a/src/SOS/SOS.UnitTests/SOSRunner.cs
+++ b/src/SOS/SOS.UnitTests/SOSRunner.cs
@@ -318,7 +318,7 @@ public class SOSRunner : IDisposable
                 ProcessRunner processRunner = new ProcessRunner(exePath, ReplaceVariables(variables, arguments.ToString())).
                     WithEnvironmentVariable("DOTNET_MULTILEVEL_LOOKUP", "0").
                     WithEnvironmentVariable("DOTNET_ROOT", config.DotNetRoot).
-                    WithEnvironmentVariable("DOTNET_DbgEnableElfDumpOnMacOS", "1").
+                    WithRuntimeConfiguration("DbgEnableElfDumpOnMacOS", "1").
                     WithLog(new TestRunner.TestLogger(outputHelper.IndentedOutput)).
                     WithTimeout(TimeSpan.FromMinutes(10));
 
@@ -326,16 +326,16 @@ public class SOSRunner : IDisposable
                 {
                     // Run the debuggee with the createdump environment variables set to generate a coredump on unhandled exception
                     processRunner.
-                        WithEnvironmentVariable("DOTNET_DbgEnableMiniDump", "1").
-                        WithEnvironmentVariable("DOTNET_DbgMiniDumpName", dumpName);
+                        WithRuntimeConfiguration("DbgEnableMiniDump", "1").
+                        WithRuntimeConfiguration("DbgMiniDumpName", dumpName);
 
                     if (information.DumpDiagnostics)
                     {
-                        processRunner.WithEnvironmentVariable("DOTNET_CreateDumpDiagnostics", "1");
+                        processRunner.WithRuntimeConfiguration("CreateDumpDiagnostics", "1");
                     }
                     if (information.TestCrashReport)
                     {
-                        processRunner.WithEnvironmentVariable("DOTNET_EnableCrashReport", "1");
+                        processRunner.WithRuntimeConfiguration("EnableCrashReport", "1");
                     }
                     // Windows createdump's triage MiniDumpWriteDump flags for .NET 5.0 are broken
                     // Disable testing triage dumps on 6.0 until the DAC signing issue is resolved - issue https://github.com/dotnet/diagnostics/issues/2542
@@ -348,13 +348,13 @@ public class SOSRunner : IDisposable
                     switch (dumpType)
                     {
                         case DumpType.Heap:
-                            processRunner.WithEnvironmentVariable("DOTNET_DbgMiniDumpType", "2");
+                            processRunner.WithRuntimeConfiguration("DbgMiniDumpType", "2");
                             break;
                         case DumpType.Triage:
-                            processRunner.WithEnvironmentVariable("DOTNET_DbgMiniDumpType", "3");
+                            processRunner.WithRuntimeConfiguration("DbgMiniDumpType", "3");
                             break;
                         case DumpType.Full:
-                            processRunner.WithEnvironmentVariable("DOTNET_DbgMiniDumpType", "4");
+                            processRunner.WithRuntimeConfiguration("DbgMiniDumpType", "4");
                             break;
                     }
                 }
@@ -684,7 +684,7 @@ public class SOSRunner : IDisposable
 
             // Disable W^E so that the bpmd command and the tests pass
             // Issue: https://github.com/dotnet/diagnostics/issues/3126
-            processRunner.WithEnvironmentVariable("DOTNET_EnableWriteXorExecute", "0");
+            processRunner.WithRuntimeConfiguration("EnableWriteXorExecute", "0");
 
             DumpType? dumpType = null;
             if (action == DebuggerAction.LoadDump || action == DebuggerAction.LoadDumpWithDotNetDump)

--- a/src/SOS/SOS.UnitTests/SOSRunner.cs
+++ b/src/SOS/SOS.UnitTests/SOSRunner.cs
@@ -318,7 +318,7 @@ public class SOSRunner : IDisposable
                 ProcessRunner processRunner = new ProcessRunner(exePath, ReplaceVariables(variables, arguments.ToString())).
                     WithEnvironmentVariable("DOTNET_MULTILEVEL_LOOKUP", "0").
                     WithEnvironmentVariable("DOTNET_ROOT", config.DotNetRoot).
-                    WithEnvironmentVariable("COMPlus_DbgEnableElfDumpOnMacOS", "1").
+                    WithEnvironmentVariable("DOTNET_DbgEnableElfDumpOnMacOS", "1").
                     WithLog(new TestRunner.TestLogger(outputHelper.IndentedOutput)).
                     WithTimeout(TimeSpan.FromMinutes(10));
 
@@ -326,16 +326,16 @@ public class SOSRunner : IDisposable
                 {
                     // Run the debuggee with the createdump environment variables set to generate a coredump on unhandled exception
                     processRunner.
-                        WithEnvironmentVariable("COMPlus_DbgEnableMiniDump", "1").
-                        WithEnvironmentVariable("COMPlus_DbgMiniDumpName", dumpName);
+                        WithEnvironmentVariable("DOTNET_DbgEnableMiniDump", "1").
+                        WithEnvironmentVariable("DOTNET_DbgMiniDumpName", dumpName);
 
                     if (information.DumpDiagnostics)
                     {
-                        processRunner.WithEnvironmentVariable("COMPlus_CreateDumpDiagnostics", "1");
+                        processRunner.WithEnvironmentVariable("DOTNET_CreateDumpDiagnostics", "1");
                     }
                     if (information.TestCrashReport)
                     {
-                        processRunner.WithEnvironmentVariable("COMPlus_EnableCrashReport", "1");
+                        processRunner.WithEnvironmentVariable("DOTNET_EnableCrashReport", "1");
                     }
                     // Windows createdump's triage MiniDumpWriteDump flags for .NET 5.0 are broken
                     // Disable testing triage dumps on 6.0 until the DAC signing issue is resolved - issue https://github.com/dotnet/diagnostics/issues/2542
@@ -348,13 +348,13 @@ public class SOSRunner : IDisposable
                     switch (dumpType)
                     {
                         case DumpType.Heap:
-                            processRunner.WithEnvironmentVariable("COMPlus_DbgMiniDumpType", "2");
+                            processRunner.WithEnvironmentVariable("DOTNET_DbgMiniDumpType", "2");
                             break;
                         case DumpType.Triage:
-                            processRunner.WithEnvironmentVariable("COMPlus_DbgMiniDumpType", "3");
+                            processRunner.WithEnvironmentVariable("DOTNET_DbgMiniDumpType", "3");
                             break;
                         case DumpType.Full:
-                            processRunner.WithEnvironmentVariable("COMPlus_DbgMiniDumpType", "4");
+                            processRunner.WithEnvironmentVariable("DOTNET_DbgMiniDumpType", "4");
                             break;
                     }
                 }
@@ -684,7 +684,7 @@ public class SOSRunner : IDisposable
 
             // Disable W^E so that the bpmd command and the tests pass
             // Issue: https://github.com/dotnet/diagnostics/issues/3126
-            processRunner.WithEnvironmentVariable("COMPlus_EnableWriteXorExecute", "0");
+            processRunner.WithEnvironmentVariable("DOTNET_EnableWriteXorExecute", "0");
 
             DumpType? dumpType = null;
             if (action == DebuggerAction.LoadDump || action == DebuggerAction.LoadDumpWithDotNetDump)

--- a/src/SOS/Strike/sosdocs.txt
+++ b/src/SOS/Strike/sosdocs.txt
@@ -2171,16 +2171,16 @@ default one.
 To turn on the stress log, set the following environment variables before
 starting the .NET Core app:
 
-set COMPlus_StressLog = 1
-set COMPlus_LogFacility = 0xffffffbf (this is a bit mask, almost all logging is on.
-                                      This is also the default value if the key 
-                                      isn't specified)
-set COMPlus_StressLogSize = 65536 (this is the default value if the key isn't
-                                   specified)
-set COMPlus_LogLevel = 6          (this is the default value if the key isn't
-                                   specified.  The higher the number the more
-                                   detailed logs are generated.  The maximum 
-                                   value is decimal 10)
+set DOTNET_StressLog = 1
+set DOTNET_LogFacility = 0xffffffbf (This is a bit mask, almost all logging is on.
+                                     This is also the default value if the key
+                                     isn't specified)
+set DOTNET_StressLogSize = 65536 (This is the default value if the key isn't
+                                  specified)
+set DOTNET_LogLevel = 6 (This is the default value if the key isn't
+                         specified. The higher the number the more
+                         detailed logs are generated. The maximum
+                         value is decimal 10)
 
 StressLogSize is the size in bytes of the in-memory log allocated for each 
 thread in the process. In the case above, each thread gets a 64K log. You 

--- a/src/SOS/Strike/sosdocsunix.txt
+++ b/src/SOS/Strike/sosdocsunix.txt
@@ -1934,16 +1934,16 @@ default one.
 To turn on the stress log, set the following environment variables before
 starting the .NET Core app:
 
-export COMPlus_StressLog = 1
-export COMPlus_LogFacility = 0xffffffbf (this is a bit mask, almost all logging is on.
-                                         This is also the default value if the key 
-                                         isn't specified)
-export COMPlus_StressLogSize = 65536 (this is the default value if the key isn't
-                                      specified)
-export COMPlus_LogLevel = 6          (this is the default value if the key isn't
-                                      specified.  The higher the number the more
-                                      detailed logs are generated.  The maximum 
-                                      value is decimal 10)
+export DOTNET_StressLog = 1
+export DOTNET_LogFacility = 0xffffffbf (This is a bit mask, almost all logging is on.
+                                        This is also the default value if the key
+                                        isn't specified)
+export DOTNET_StressLogSize = 65536 (This is the default value if the key isn't
+                                     specified)
+export DOTNET_LogLevel = 6 (This is the default value if the key isn't
+                            specified. The higher the number the more
+                            detailed logs are generated. The maximum
+                            value is decimal 10)
 
 StressLogSize is the size in bytes of the in-memory log allocated for each 
 thread in the process. In the case above, each thread gets a 64K log. You 

--- a/src/SOS/lldbplugin.tests/testsos.sh
+++ b/src/SOS/lldbplugin.tests/testsos.sh
@@ -13,10 +13,10 @@ fi
 host="$project_root/.dotnet/dotnet --fx-version $host_version"
 
 # Turn on stress logging so the dumplog and histinit commands pass
-export COMPlus_LogFacility=0xffffffbf
-export COMPlus_LogLevel=6
-export COMPlus_StressLog=1
-export COMPlus_StressLogSize=65536
+export DOTNET_LogFacility=0xffffffbf
+export DOTNET_LogLevel=6
+export DOTNET_StressLog=1
+export DOTNET_StressLogSize=65536
 
 if [[ ! -x "$LLDB_PATH" ]]; then
     echo "LLDB_PATH doesn't exist or not executable"
@@ -29,4 +29,3 @@ mkdir -p $log_dir
 cd $project_root/src/SOS/lldbplugin.tests/
 rm -f StressLog.txt
 python $project_root/src/SOS/lldbplugin.tests/test_libsosplugin.py --lldb $LLDB_PATH --host "$host" --plugin $plugin --logfiledir $log_dir --assembly $test_program
-

--- a/src/Tools/dotnet-dsrouter/DiagnosticsServerRouterCommands.cs
+++ b/src/Tools/dotnet-dsrouter/DiagnosticsServerRouterCommands.cs
@@ -337,7 +337,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
                 var path = Path.Combine(PidIpcEndpoint.IpcRootPath, $"dotnet-diagnostic-{processId}");
                 if (File.Exists(path))
                 {
-                    logger?.LogWarning($"Default IPC server path, {path}, already in use. To disable default diagnostics for dotnet-dsrouter, set COMPlus_EnableDiagnostics=0 and re-run.");
+                    logger?.LogWarning($"Default IPC server path, {path}, already in use. To disable default diagnostics for dotnet-dsrouter, set DOTNET_EnableDiagnostics=0 and re-run.");
 
                     path = Path.Combine(PidIpcEndpoint.IpcRootPath, $"dotnet-dsrouter-{processId}");
                     logger?.LogWarning($"Fallback using none default IPC server path, {path}.");
@@ -358,7 +358,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
                 var path = Path.Combine(PidIpcEndpoint.IpcRootPath, $"dotnet-diagnostic-{processId}-{(long)diff.TotalSeconds}-socket");
                 if (Directory.GetFiles(PidIpcEndpoint.IpcRootPath, $"dotnet-diagnostic-{processId}-*-socket").Length != 0)
                 {
-                    logger?.LogWarning($"Default IPC server path, {Path.Combine(PidIpcEndpoint.IpcRootPath, $"dotnet-diagnostic-{processId}-*-socket")}, already in use. To disable default diagnostics for dotnet-dsrouter, set COMPlus_EnableDiagnostics=0 and re-run.");
+                    logger?.LogWarning($"Default IPC server path, {Path.Combine(PidIpcEndpoint.IpcRootPath, $"dotnet-diagnostic-{processId}-*-socket")}, already in use. To disable default diagnostics for dotnet-dsrouter, set DOTNET_EnableDiagnostics=0 and re-run.");
 
                     path = Path.Combine(PidIpcEndpoint.IpcRootPath, $"dotnet-dsrouter-{processId}-{(long)diff.TotalSeconds}-socket");
                     logger?.LogWarning($"Fallback using none default IPC server path, {path}.");

--- a/src/shared/inc/switches.h
+++ b/src/shared/inc/switches.h
@@ -51,8 +51,8 @@
 #define JIT_IS_ALIGNED
 #endif
 
-// ALLOW_SXS_JIT enables AltJit support for JIT-ing, via COMPlus_AltJit / COMPlus_AltJitName.
-// ALLOW_SXS_JIT_NGEN enables AltJit support for NGEN, via COMPlus_AltJitNgen / COMPlus_AltJitName.
+// ALLOW_SXS_JIT enables AltJit support for JIT-ing, via DOTNET_AltJit / DOTNET_AltJitName.
+// ALLOW_SXS_JIT_NGEN enables AltJit support for NGEN, via DOTNET_AltJitNgen / DOTNET_AltJitName.
 // Note that if ALLOW_SXS_JIT_NGEN is defined, then ALLOW_SXS_JIT must be defined.
 #define ALLOW_SXS_JIT
 #define ALLOW_SXS_JIT_NGEN
@@ -111,7 +111,7 @@
 #define FEATURE_JIT_TIMER
 
 // This feature in RyuJIT supersedes the FEATURE_JIT_TIMER. In addition to supporting the time log file, this
-// feature also supports using COMPlus_JitTimeLogCsv=a.csv, which will dump method-level and phase-level timing
+// feature also supports using DOTNET_JitTimeLogCsv=a.csv, which will dump method-level and phase-level timing
 // statistics. Also see comments on FEATURE_JIT_TIMER.
 #define FEATURE_JIT_METHOD_PERF
 
@@ -123,7 +123,7 @@
 #endif
 
 // Enables a mode in which GC is completely conservative in stacks and registers: all stack slots and registers
-// are treated as potential pinned interior pointers. When enabled, the runtime flag COMPLUS_GCCONSERVATIVE
+// are treated as potential pinned interior pointers. When enabled, the runtime flag DOTNET_GCCONSERVATIVE
 // determines dynamically whether GC is conservative. Note that appdomain unload, LCG and unloadable assemblies
 // do not work reliably with conservative GC.
 #define FEATURE_CONSERVATIVE_GC 1

--- a/src/shared/pal/src/include/pal/dbgmsg.h
+++ b/src/shared/pal/src/include/pal/dbgmsg.h
@@ -500,7 +500,7 @@ Function :
     PAL_DisplayDialog
 
     Display a simple modal dialog with an alert icon and a single OK button. Caller supplies the title of the
-    dialog and the main text. The dialog is displayed only if the COMPlus_EnableAssertDialog environment
+    dialog and the main text. The dialog is displayed only if the DOTNET_EnableAssertDialog environment
     variable is set to the value "1".
 
 --*/

--- a/src/shared/pal/src/map/virtual.cpp
+++ b/src/shared/pal/src/map/virtual.cpp
@@ -2154,7 +2154,7 @@ void ExecutableMemoryAllocator::TryReserveInitialMemory()
         //     table. This satisfies the vast majority of practical cases where the total amount of loaded native image memory
         //     does not exceed approximately 2 GB.
         //   - The code heap allocator for the JIT can allocate from this address space. Beyond this reservation, one can use
-        //     the COMPlus_CodeHeapReserveForJumpStubs environment variable to reserve space for jump stubs.
+        //     the DOTNET_CodeHeapReserveForJumpStubs environment variable to reserve space for jump stubs.
         sizeOfAllocation = MaxExecutableMemorySize;
         m_startAddress = ReserveVirtualMemory(pthrCurrent, nullptr, sizeOfAllocation, MEM_RESERVE_EXECUTABLE);
         if (m_startAddress == nullptr)

--- a/src/tests/EventPipeStress/Orchestrator/Program.cs
+++ b/src/tests/EventPipeStress/Orchestrator/Program.cs
@@ -252,10 +252,10 @@ namespace Orchestrator
                 eventWritingProc.StartInfo.Arguments = $"--threads {(threads == -1 ? cores.ToString() : threads.ToString())} --event-count {eventCount} --event-size {eventSize} --event-rate {eventRate} --burst-pattern {burstPattern} --duration {(int)durationTimeSpan.TotalSeconds}";
                 eventWritingProc.StartInfo.UseShellExecute = false;
                 eventWritingProc.StartInfo.RedirectStandardInput = true;
-                eventWritingProc.StartInfo.Environment["COMPlus_StressLog"] = "1";
-                eventWritingProc.StartInfo.Environment["COMPlus_LogFacility"] = "2000";
-                eventWritingProc.StartInfo.Environment["COMPlus_LogLevel"] = "8";
-                eventWritingProc.StartInfo.Environment["COMPlus_StressLogSize"] = "0x1000000";
+                eventWritingProc.StartInfo.Environment["DOTNET_StressLog"] = "1";
+                eventWritingProc.StartInfo.Environment["DOTNET_LogFacility"] = "2000";
+                eventWritingProc.StartInfo.Environment["DOTNET_LogLevel"] = "8";
+                eventWritingProc.StartInfo.Environment["DOTNET_StressLogSize"] = "0x1000000";
                 eventWritingProc.Start();
 
                 Console.WriteLine($"Executing: {eventWritingProc.StartInfo.FileName} {eventWritingProc.StartInfo.Arguments}");


### PR DESCRIPTION
The configuration system in coreclr and mono started supporting `DOTNET_` prefix in net6.0. Using `DOTNET_` is preferred because [it has precedence](https://github.com/dotnet/runtime/blob/2876baf289e8e06fc1ec00cc2d22ea7f61b2634d/src/coreclr/inc/clrconfignocache.h#L75) over `COMPlus_`.