### PR TITLE
Improve !maddress

### DIFF
--- a/src/Microsoft.Diagnostics.ExtensionCommands/FindPointersInCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/FindPointersInCommand.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Diagnostics.ExtensionCommands
 
         private void PrintPointers(bool pinnedOnly, params string[] memTypes)
         {
-            DescribedRegion[] allRegions = AddressHelper.EnumerateAddressSpace(tagClrMemoryRanges: true, includeReserveMemory: false, tagReserveMemoryHeuristically: false).ToArray();
+            DescribedRegion[] allRegions = AddressHelper.EnumerateAddressSpace(tagClrMemoryRanges: true, includeReserveMemory: false, tagReserveMemoryHeuristically: false, includeHandleTableIfSlow: false).ToArray();
 
             WriteLine("Scanning for pinned objects...");
             MemoryWalkContext ctx = CreateMemoryWalkContext();

--- a/src/Microsoft.Diagnostics.ExtensionCommands/GCToNativeCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/GCToNativeCommand.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Diagnostics.ExtensionCommands
                 return;
             }
 
-            IEnumerable<DescribedRegion> rangeEnum = AddressHelper.EnumerateAddressSpace(tagClrMemoryRanges: true, includeReserveMemory: false, tagReserveMemoryHeuristically: false);
+            IEnumerable<DescribedRegion> rangeEnum = AddressHelper.EnumerateAddressSpace(tagClrMemoryRanges: true, includeReserveMemory: false, tagReserveMemoryHeuristically: false, includeHandleTableIfSlow: false);
             rangeEnum = rangeEnum.Where(r => memoryTypes.Any(memType => r.Name.Equals(memType, StringComparison.OrdinalIgnoreCase)));
             rangeEnum = rangeEnum.OrderBy(r => r.Start);
 


### PR DESCRIPTION
- Using single '-' instead of '--' for Options to match the rest of SOS
- Change the default behavior of maddress to print the entire list of memory, this matches !address
- Only display the HandleTable if we can efficiently do so (or if the user requests that we show HandleTable data anyway)
- Use the RootCacheService to only walk the handle table once per runtime