### PR TITLE
Fix issue where DmlExec isn't implemented in Repl

### DIFF
--- a/src/Microsoft.Diagnostics.Repl/ConsoleService.cs
+++ b/src/Microsoft.Diagnostics.Repl/ConsoleService.cs
@@ -589,7 +589,7 @@ namespace Microsoft.Diagnostics.Repl
 
         bool IConsoleService.SupportsDml => false;
 
-        void IConsoleService.WriteDml(string text) => throw new NotSupportedException();
+        void IConsoleService.WriteDml(string text) => WriteOutput(OutputType.Normal, text);
 
         void IConsoleService.WriteDmlExec(string text, string _) => WriteOutput(OutputType.Normal, text);
 

--- a/src/Microsoft.Diagnostics.Repl/ConsoleService.cs
+++ b/src/Microsoft.Diagnostics.Repl/ConsoleService.cs
@@ -591,7 +591,7 @@ namespace Microsoft.Diagnostics.Repl
 
         void IConsoleService.WriteDml(string text) => throw new NotSupportedException();
 
-        void IConsoleService.WriteDmlExec(string text, string _) => throw new NotSupportedException();
+        void IConsoleService.WriteDmlExec(string text, string _) => WriteOutput(OutputType.Normal, text);
 
         CancellationToken IConsoleService.CancellationToken { get; set; }
 


### PR DESCRIPTION
WriteDmlExec is meant to work even if DML is disabled, but the Repl project throws NotSupportedException instead of passing the text argument.

Fixes #3793.