### PR TITLE
Enable `UpDownCounter` For Dotnet-Counters and Dotnet-Monitor

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/CounterPayload.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/CounterPayload.cs
@@ -108,6 +108,19 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
         }
     }
 
+    internal class UpDownCounterRatePayload : CounterPayload
+    {
+        public UpDownCounterRatePayload(string providerName, string name, string displayName, string displayUnits, string metadata, double value, double intervalSecs, DateTime timestamp) :
+            base(providerName, name, metadata, value, timestamp, "Rate", EventType.UpDownCounter)
+        {
+            // In case these properties are not provided, set them to appropriate values.
+            string counterName = string.IsNullOrEmpty(displayName) ? name : displayName;
+            string unitsName = string.IsNullOrEmpty(displayUnits) ? "Count" : displayUnits;
+            string intervalName = intervalSecs.ToString() + " sec";
+            DisplayName = $"{counterName} ({unitsName} / {intervalName})";
+        }
+    }
+
     internal class PercentilePayload : CounterPayload
     {
         public PercentilePayload(string providerName, string name, string displayName, string displayUnits, string metadata, IEnumerable<Quantile> quantiles, DateTime timestamp) :
@@ -144,6 +157,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
         Rate,
         Gauge,
         Histogram,
+        UpDownCounter,
         Error,
         CounterEnded
     }

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/CounterPayload.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/CounterPayload.cs
@@ -108,19 +108,6 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
         }
     }
 
-    internal class UpDownCounterRatePayload : CounterPayload
-    {
-        public UpDownCounterRatePayload(string providerName, string name, string displayName, string displayUnits, string metadata, double value, double intervalSecs, DateTime timestamp) :
-            base(providerName, name, metadata, value, timestamp, "Rate", EventType.UpDownCounter)
-        {
-            // In case these properties are not provided, set them to appropriate values.
-            string counterName = string.IsNullOrEmpty(displayName) ? name : displayName;
-            string unitsName = string.IsNullOrEmpty(displayUnits) ? "Count" : displayUnits;
-            string intervalName = intervalSecs.ToString() + " sec";
-            DisplayName = $"{counterName} ({unitsName} / {intervalName})";
-        }
-    }
-
     internal class PercentilePayload : CounterPayload
     {
         public PercentilePayload(string providerName, string name, string displayName, string displayUnits, string metadata, IEnumerable<Quantile> quantiles, DateTime timestamp) :
@@ -157,7 +144,6 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
         Rate,
         Gauge,
         Histogram,
-        UpDownCounter,
         Error,
         CounterEnded
     }

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/TraceEventExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/TraceEventExtensions.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
                 }
                 else if (traceEvent.EventName == "UpDownCounterRateValuePublished")
                 {
-                    HandleUpDownCounterRate(traceEvent, filter, sessionId, out payload);
+                    HandleCounterRate(traceEvent, filter, sessionId, out payload);
                 }
                 else if (traceEvent.EventName == "TimeSeriesLimitReached")
                 {
@@ -183,41 +183,6 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
             if (double.TryParse(rateText, NumberStyles.Number | NumberStyles.Float, CultureInfo.InvariantCulture, out double rate))
             {
                 payload = new RatePayload(meterName, instrumentName, null, unit, tags, rate, filter.DefaultIntervalSeconds, traceEvent.TimeStamp);
-            }
-            else
-            {
-                // for observable instruments we assume the lack of data is meaningful and remove it from the UI
-                // this happens when the ObservableCounter callback function throws an exception.
-                payload = new CounterEndedPayload(meterName, instrumentName, traceEvent.TimeStamp);
-            }
-        }
-
-        private static void HandleUpDownCounterRate(TraceEvent traceEvent, CounterFilter filter, string sessionId, out ICounterPayload payload)
-        {
-            payload = null;
-
-            string payloadSessionId = (string)traceEvent.PayloadValue(0);
-
-            if (payloadSessionId != sessionId)
-            {
-                return;
-            }
-
-            string meterName = (string)traceEvent.PayloadValue(1);
-            //string meterVersion = (string)obj.PayloadValue(2);
-            string instrumentName = (string)traceEvent.PayloadValue(3);
-            string unit = (string)traceEvent.PayloadValue(4);
-            string tags = (string)traceEvent.PayloadValue(5);
-            string rateText = (string)traceEvent.PayloadValue(6);
-
-            if (!filter.IsIncluded(meterName, instrumentName))
-            {
-                return;
-            }
-
-            if (double.TryParse(rateText, NumberStyles.Number | NumberStyles.Float, CultureInfo.InvariantCulture, out double rate))
-            {
-                payload = new UpDownCounterRatePayload(meterName, instrumentName, null, unit, tags, rate, filter.DefaultIntervalSeconds, traceEvent.TimeStamp);
             }
             else
             {

--- a/src/Tools/dotnet-counters/CounterMonitor.cs
+++ b/src/Tools/dotnet-counters/CounterMonitor.cs
@@ -72,10 +72,6 @@ namespace Microsoft.Diagnostics.Tools.Counters
 
                 if (obj.ProviderName == "System.Diagnostics.Metrics")
                 {
-                    if (obj.EventName == "UpDownCounterRateValuePublished")
-                    {
-                        HandleCounterRate(obj);
-                    }
                     if (obj.EventName == "BeginInstrumentReporting")
                     {
                         HandleBeginInstrumentReporting(obj);
@@ -89,6 +85,10 @@ namespace Microsoft.Diagnostics.Tools.Counters
                         HandleGauge(obj);
                     }
                     else if (obj.EventName == "CounterRateValuePublished")
+                    {
+                        HandleCounterRate(obj);
+                    }
+                    else if (obj.EventName == "UpDownCounterRateValuePublished")
                     {
                         HandleCounterRate(obj);
                     }

--- a/src/Tools/dotnet-counters/CounterMonitor.cs
+++ b/src/Tools/dotnet-counters/CounterMonitor.cs
@@ -72,6 +72,10 @@ namespace Microsoft.Diagnostics.Tools.Counters
 
                 if (obj.ProviderName == "System.Diagnostics.Metrics")
                 {
+                    if (obj.EventName == "UpDownCounterRateValuePublished")
+                    {
+                        HandleCounterRate(obj);
+                    }
                     if (obj.EventName == "BeginInstrumentReporting")
                     {
                         HandleBeginInstrumentReporting(obj);


### PR DESCRIPTION
`UpDownCounters` are now being published as of https://github.com/dotnet/runtime/pull/81041; this change consumes those events for `dotnet-monitor` and `dotnet-counters`.

Note that this approach treats `UpDownCounters` the same as `Counters` for simplicity - if there's a reason to separate `UpDownCounter` from `Counter`, I can separate the logic.

@wiktork 

Closes #3742