### PR TITLE
Add !dumpheap fragmentation statistics

### DIFF
--- a/src/Microsoft.Diagnostics.ExtensionCommands/DumpHeapCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/DumpHeapCommand.cs
@@ -128,6 +128,7 @@ namespace Microsoft.Diagnostics.ExtensionCommands
                 });
             }
 
+            bool printFragmentation = false;
             DumpHeapService.DisplayKind displayKind = DumpHeapService.DisplayKind.Normal;
             if (ThinLock)
             {
@@ -141,8 +142,12 @@ namespace Microsoft.Diagnostics.ExtensionCommands
             {
                 displayKind = DumpHeapService.DisplayKind.Short;
             }
+            else
+            {
+                printFragmentation = true;
+            }
 
-            DumpHeap.PrintHeap(objectsToPrint, displayKind, StatOnly);
+            DumpHeap.PrintHeap(objectsToPrint, displayKind, StatOnly, printFragmentation);
         }
 
         private void ParseArguments()

--- a/src/Microsoft.Diagnostics.ExtensionCommands/NotReachableInRangeCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/NotReachableInRangeCommand.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Diagnostics.ExtensionCommands
             ulong curr = start;
 
             IEnumerable<ClrObject> liveObjs = EnumerateLiveObjectsInRange(end, curr);
-            DumpHeap.PrintHeap(liveObjs, Short ? DumpHeapService.DisplayKind.Short : DumpHeapService.DisplayKind.Normal, statsOnly: false);
+            DumpHeap.PrintHeap(liveObjs, Short ? DumpHeapService.DisplayKind.Short : DumpHeapService.DisplayKind.Normal, statsOnly: false, printFragmentation: false);
         }
 
         private IEnumerable<ClrObject> EnumerateLiveObjectsInRange(ulong end, ulong curr)

--- a/src/Microsoft.Diagnostics.ExtensionCommands/ObjSizeCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/ObjSizeCommand.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Diagnostics.ExtensionCommands
             Console.WriteLine();
 
             DumpHeapService.DisplayKind displayKind = Strings ? DumpHeapService.DisplayKind.Strings : DumpHeapService.DisplayKind.Normal;
-            DumpHeap.PrintHeap(GetTransitiveClosure(obj), displayKind, Stat);
+            DumpHeap.PrintHeap(GetTransitiveClosure(obj), displayKind, Stat, printFragmentation: false);
         }
 
         private static IEnumerable<ClrObject> GetTransitiveClosure(ClrObject obj)

--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -3833,7 +3833,6 @@ DECLARE_API(DumpRuntimeTypes)
     return Status;
 }
 
-#define MIN_FRAGMENTATIONBLOCK_BYTES (1024*512)
 namespace sos
 {
     class FragmentationBlock


### PR DESCRIPTION
In my previous !dumpheap change I overlooked the fragmentation output.  This adds fragmentation output in the exact same was as the previous C++ code.

The new code now validates the Free region is actually followed by the next object, and that those objects do not live on the Pinned, Frozen, or Large object heaps.