### PR TITLE
Fix incorrect rendering of counters

### DIFF
--- a/src/Tools/dotnet-counters/Exporters/ConsoleWriter.cs
+++ b/src/Tools/dotnet-counters/Exporters/ConsoleWriter.cs
@@ -150,12 +150,12 @@ namespace Microsoft.Diagnostics.Tools.Counters.Exporters
             {
                 Console.WriteLine($"[{provider.Name}]"); row++;
 
-                foreach (var counter in provider.Counters.Values)
+                foreach (ObservedCounter counter in provider.Counters.Values)
                 {
                     counter.Row = -1;
                     if (counter.RenderValueInline)
                     {
-                        foreach (var tagSet in counter.TagSets.Values)
+                        foreach (ObservedTagSet tagSet in counter.TagSets.Values)
                         {
                             tagSet.Row = -1;
                         }


### PR DESCRIPTION
This PR addresses two problems in dotnet-counters.  

1. When the console offset is greater than zero we incorrectly truncate counter row assignment and description output
2. When the console height is less than the total number of counters that can be shown, we can sometimes incorrectly assign row numbers to counters that should not be drawn.  This causes the values to be overwritten for different counter names.

Fixes #3665 