### PR TITLE
dotnet-dump returns failure after exhausting retries on ERROR_PARTIAL_COPY

### DIFF
--- a/src/Tools/dotnet-dump/Dumper.Windows.cs
+++ b/src/Tools/dotnet-dump/Dumper.Windows.cs
@@ -5,7 +5,6 @@ using System;
 using System.ComponentModel;
 using System.IO;
 using System.Runtime.InteropServices;
-
 using Microsoft.Win32.SafeHandles;
 
 namespace Microsoft.Diagnostics.Tools.Dump

--- a/src/Tools/dotnet-dump/Dumper.Windows.cs
+++ b/src/Tools/dotnet-dump/Dumper.Windows.cs
@@ -5,6 +5,7 @@ using System;
 using System.ComponentModel;
 using System.IO;
 using System.Runtime.InteropServices;
+
 using Microsoft.Win32.SafeHandles;
 
 namespace Microsoft.Diagnostics.Tools.Dump
@@ -67,8 +68,9 @@ namespace Microsoft.Diagnostics.Tools.Dump
                             break;
                     }
 
+                    int loopEnd = 10;
                     // Retry the write dump on ERROR_PARTIAL_COPY
-                    for (int i = 0; i < 5; i++)
+                    for (int i = 0; i <= loopEnd; i++)
                     {
                         // Dump the process!
                         if (NativeMethods.MiniDumpWriteDump(processHandle.DangerousGetHandle(), (uint)processId, stream.SafeFileHandle, dumpType, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero))
@@ -78,9 +80,13 @@ namespace Microsoft.Diagnostics.Tools.Dump
                         else
                         {
                             int err = Marshal.GetHRForLastWin32Error();
-                            if (err != NativeMethods.HR_ERROR_PARTIAL_COPY)
+                            if (err != NativeMethods.HR_ERROR_PARTIAL_COPY || i == loopEnd)
                             {
                                 Marshal.ThrowExceptionForHR(err);
+                            }
+                            else
+                            {
+                                Console.WriteLine($"retrying due to PARTIAL_COPY #{i}");
                             }
                         }
                     }


### PR DESCRIPTION
dotnet-dump will now retry 11 times then throw after the last attempt if `ERROR_PARTIAL_COPY` is returned by the `NativeMethods.MiniDumpWriteDump` API call.
Fixes issue #3829.