### PR TITLE
Fix #3699

### DIFF
--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -318,6 +319,15 @@ namespace Microsoft.Diagnostics.NETCore.Client
 
                     string group = match.Groups[1].Value;
                     if (!int.TryParse(group, NumberStyles.Integer, CultureInfo.InvariantCulture, out int processId))
+                    {
+                        continue;
+                    }
+
+                    try
+                    {
+                        Process.GetProcessById(processId);
+                    }
+                    catch (ArgumentException)
                     {
                         continue;
                     }


### PR DESCRIPTION
I was able to repo on Linux and verified this fix works. I think when the app is killed, the domain sockets are not getting cleaned up from the temp path. When enumerating the domain sockets from the temp directory it picks up dead processes. This should work around the issue by validating the process is still alive.
#3699