### PR TITLE
Enable UpDownCounter For Dotnet-Counters and Dotnet-Monitor

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/CounterPayload.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/CounterPayload.cs
@@ -86,6 +86,17 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
         }
     }
 
+    internal class UpDownCounterPayload : CounterPayload
+    {
+        public UpDownCounterPayload(string providerName, string name, string displayName, string displayUnits, string metadata, double value, DateTime timestamp) :
+            base(providerName, name, metadata, value, timestamp, "Metric", EventType.UpDownCounter)
+        {
+            // In case these properties are not provided, set them to appropriate values.
+            string counterName = string.IsNullOrEmpty(displayName) ? name : displayName;
+            DisplayName = !string.IsNullOrEmpty(displayUnits) ? $"{counterName} ({displayUnits})" : counterName;
+        }
+    }
+
     internal class CounterEndedPayload : CounterPayload
     {
         public CounterEndedPayload(string providerName, string name, DateTime timestamp)
@@ -144,6 +155,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
         Rate,
         Gauge,
         Histogram,
+        UpDownCounter,
         Error,
         CounterEnded
     }

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/TraceEventExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/TraceEventExtensions.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
                 }
                 else if (traceEvent.EventName == "UpDownCounterRateValuePublished")
                 {
-                    HandleUpDownCounterRate(traceEvent, filter, sessionId, out payload);
+                    HandleUpDownCounterValue(traceEvent, filter, sessionId, out payload);
                 }
                 else if (traceEvent.EventName == "TimeSeriesLimitReached")
                 {
@@ -193,7 +193,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
             }
         }
 
-        private static void HandleUpDownCounterRate(TraceEvent traceEvent, CounterFilter filter, string sessionId, out ICounterPayload payload)
+        private static void HandleUpDownCounterValue(TraceEvent traceEvent, CounterFilter filter, string sessionId, out ICounterPayload payload)
         {
             payload = null;
 
@@ -209,7 +209,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
             string instrumentName = (string)traceEvent.PayloadValue(3);
             string unit = (string)traceEvent.PayloadValue(4);
             string tags = (string)traceEvent.PayloadValue(5);
-            _ = (string)traceEvent.PayloadValue(6); // Not currently using rate for Counters.
+            _ = (string)traceEvent.PayloadValue(6); // Not currently using rate for UpDownCounters.
             string valueText = (string)traceEvent.PayloadValue(7);
 
             if (!filter.IsIncluded(meterName, instrumentName))
@@ -221,7 +221,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
             {
                 // UpDownCounter reports the value, not the rate - this is different than how Counter behaves.
                 //payload = new RatePayload(meterName, instrumentName, null, unit, tags, rate, filter.DefaultIntervalSeconds, traceEvent.TimeStamp);
-                payload = new GaugePayload(meterName, instrumentName, null, unit, tags, value, traceEvent.TimeStamp);
+                payload = new UpDownCounterPayload(meterName, instrumentName, null, unit, tags, value, traceEvent.TimeStamp);
 
             }
             else

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/TraceEventExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/TraceEventExtensions.cs
@@ -220,14 +220,13 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
             if (double.TryParse(valueText, NumberStyles.Number | NumberStyles.Float, CultureInfo.InvariantCulture, out double value))
             {
                 // UpDownCounter reports the value, not the rate - this is different than how Counter behaves.
-                //payload = new RatePayload(meterName, instrumentName, null, unit, tags, rate, filter.DefaultIntervalSeconds, traceEvent.TimeStamp);
                 payload = new UpDownCounterPayload(meterName, instrumentName, null, unit, tags, value, traceEvent.TimeStamp);
 
             }
             else
             {
                 // for observable instruments we assume the lack of data is meaningful and remove it from the UI
-                // this happens when the ObservableCounter callback function throws an exception.
+                // this happens when the ObservableUpDownCounter callback function throws an exception.
                 payload = new CounterEndedPayload(meterName, instrumentName, traceEvent.TimeStamp);
             }
         }

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/TraceEventExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/TraceEventExtensions.cs
@@ -174,7 +174,6 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
             string unit = (string)traceEvent.PayloadValue(4);
             string tags = (string)traceEvent.PayloadValue(5);
             string rateText = (string)traceEvent.PayloadValue(6);
-            _ = (string)traceEvent.PayloadValue(7); // Not currently using value for Counters.
 
             if (!filter.IsIncluded(meterName, instrumentName))
             {
@@ -199,7 +198,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
 
             string payloadSessionId = (string)traceEvent.PayloadValue(0);
 
-            if (payloadSessionId != sessionId)
+            if (payloadSessionId != sessionId || traceEvent.Version < 1) // Version 1 added the value field.
             {
                 return;
             }

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/TraceEventExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/TraceEventExtensions.cs
@@ -208,7 +208,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
             string instrumentName = (string)traceEvent.PayloadValue(3);
             string unit = (string)traceEvent.PayloadValue(4);
             string tags = (string)traceEvent.PayloadValue(5);
-            _ = (string)traceEvent.PayloadValue(6); // Not currently using rate for UpDownCounters.
+            //string rateText = (string)traceEvent.PayloadValue(6); // Not currently using rate for UpDownCounters.
             string valueText = (string)traceEvent.PayloadValue(7);
 
             if (!filter.IsIncluded(meterName, instrumentName))

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/TraceEventExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/TraceEventExtensions.cs
@@ -187,7 +187,8 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
             else
             {
                 // for observable instruments we assume the lack of data is meaningful and remove it from the UI
-                // this happens when the ObservableCounter callback function throws an exception.
+                // this happens when the ObservableCounter callback function throws an exception
+                // or when the ObservableCounter doesn't include a measurement for a particular set of tag values.
                 payload = new CounterEndedPayload(meterName, instrumentName, traceEvent.TimeStamp);
             }
         }
@@ -225,7 +226,8 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
             else
             {
                 // for observable instruments we assume the lack of data is meaningful and remove it from the UI
-                // this happens when the ObservableUpDownCounter callback function throws an exception.
+                // this happens when the ObservableUpDownCounter callback function throws an exception
+                // or when the ObservableUpDownCounter doesn't include a measurement for a particular set of tag values.
                 payload = new CounterEndedPayload(meterName, instrumentName, traceEvent.TimeStamp);
             }
         }

--- a/src/Tools/dotnet-counters/CounterMonitor.cs
+++ b/src/Tools/dotnet-counters/CounterMonitor.cs
@@ -18,7 +18,6 @@ using Microsoft.Diagnostics.NETCore.Client;
 using Microsoft.Diagnostics.Tools.Counters.Exporters;
 using Microsoft.Diagnostics.Tracing;
 using Microsoft.Internal.Common.Utils;
-using static System.Net.WebRequestMethods;
 
 namespace Microsoft.Diagnostics.Tools.Counters
 {
@@ -222,6 +221,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
             // the value might be an empty string indicating no measurement was provided this collection interval
             if (double.TryParse(valueText, NumberStyles.Number | NumberStyles.Float, CultureInfo.InvariantCulture, out double value))
             {
+                // UpDownCounter reports the value, not the rate - this is different than how Counter behaves, and is thus treated as a gauge.
                 CounterPayload payload = new GaugePayload(meterName, instrumentName, null, unit, tags, value, obj.TimeStamp);
                 _renderer.CounterPayloadReceived(payload, _pauseCmdSet);
             }

--- a/src/Tools/dotnet-counters/CounterMonitor.cs
+++ b/src/Tools/dotnet-counters/CounterMonitor.cs
@@ -215,7 +215,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
             string instrumentName = (string)obj.PayloadValue(3);
             string unit = (string)obj.PayloadValue(4);
             string tags = (string)obj.PayloadValue(5);
-            _ = (string)obj.PayloadValue(6); // Not currently using rate for UpDownCounters.
+            //string rateText = (string)obj.PayloadValue(6); // Not currently using rate for UpDownCounters.
             string valueText = (string)obj.PayloadValue(7);
             if (sessionId != _metricsEventSourceSessionId)
             {

--- a/src/Tools/dotnet-counters/CounterMonitor.cs
+++ b/src/Tools/dotnet-counters/CounterMonitor.cs
@@ -204,6 +204,11 @@ namespace Microsoft.Diagnostics.Tools.Counters
 
         private void HandleUpDownCounterValue(TraceEvent obj)
         {
+            if (obj.Version < 1) // Version 1 added the value field.
+            {
+                return;
+            }
+
             string sessionId = (string)obj.PayloadValue(0);
             string meterName = (string)obj.PayloadValue(1);
             //string meterVersion = (string)obj.PayloadValue(2);


### PR DESCRIPTION
This is an updated version of #3795 - values for `UpDownCounters` are now being published as of https://github.com/dotnet/runtime/pull/84846; this change consumes those events for dotnet-monitor and dotnet-counters. Goes along with https://github.com/dotnet/dotnet-monitor/pull/4310 in the dotnet-monitor repo.

@wiktork @noahfalk 

Closes https://github.com/dotnet/diagnostics/issues/3742