### PR TITLE
Check for cancellation when reading memory

### DIFF
--- a/src/SOS/SOS.Extensions/MemoryServiceFromDebuggerServices.cs
+++ b/src/SOS/SOS.Extensions/MemoryServiceFromDebuggerServices.cs
@@ -59,6 +59,8 @@ namespace SOS.Extensions
             HResult hr = _debuggerServices.ReadVirtual(address, buffer, out bytesRead);
             if (hr != HResult.S_OK)
             {
+                CheckCancellation(hr);
+
                 bytesRead = 0;
             }
             return bytesRead > 0;
@@ -76,11 +78,24 @@ namespace SOS.Extensions
             HResult hr = _debuggerServices.WriteVirtual(address, buffer, out bytesWritten);
             if (hr != HResult.S_OK)
             {
+                CheckCancellation(hr);
+
                 bytesWritten = 0;
             }
             return bytesWritten > 0;
         }
 
         #endregion
+
+        private static void CheckCancellation(HResult hr)
+        {
+            unchecked
+            {
+                if (hr == (int)0xd000013a)
+                {
+                    throw new OperationCanceledException();
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
DbgEng returns a specific error code when the user hits Control-C.  We can work around any command or code which forgets to check for cancellation by throwing this manually when we detect the cancellation error code.

This should also improve ClrMD's handling of Control-C.  A read that _should_ complete (but failed due to cancellation) may cause ClrMD to cache the fact that the read failed.  By throwing an exception we will bypass any place where we would have interpreted that failed read as something other than cancellation.