### PR TITLE
Fix parsing of thread names

### DIFF
--- a/src/Tools/dotnet-stack/ReportCommand.cs
+++ b/src/Tools/dotnet-stack/ReportCommand.cs
@@ -123,9 +123,9 @@ namespace Microsoft.Diagnostics.Tools.Stack
                         string threadFrame = stackSource.GetFrameName(stackSource.GetFrameIndex(stackIndex), false);
 
                         // we are looking for the first index of ) because
-                        // we need to handle a thread name like this: Thread (4008) (.NET IO ThreadPool Worker)
-                        var firstIndex = threadFrame.IndexOf(")");
-                        var threadId = int.Parse(threadFrame.Substring(template.Length, firstIndex - template.Length));
+                        // we need to handle a thread name like: Thread (4008) (.NET IO ThreadPool Worker)
+                        int firstIndex = threadFrame.IndexOf(")");
+                        int threadId = int.Parse(threadFrame.Substring(template.Length, firstIndex - template.Length));
 
                         if (samplesForThread.TryGetValue(threadId, out List<StackSourceSample> samples))
                         {

--- a/src/Tools/dotnet-stack/ReportCommand.cs
+++ b/src/Tools/dotnet-stack/ReportCommand.cs
@@ -121,7 +121,11 @@ namespace Microsoft.Diagnostics.Tools.Stack
                         // Thread id is in the frame name as "Thread (<ID>)"
                         string template = "Thread (";
                         string threadFrame = stackSource.GetFrameName(stackSource.GetFrameIndex(stackIndex), false);
-                        int threadId = int.Parse(threadFrame.Substring(template.Length, threadFrame.Length - (template.Length + 1)));
+
+                        // we are looking for the first index of ) because
+                        // we need to handle a thread name like this: Thread (4008) (.NET IO ThreadPool Worker)
+                        var firstIndex = threadFrame.IndexOf(")");
+                        var threadId = int.Parse(threadFrame.Substring(template.Length, firstIndex - template.Length));
 
                         if (samplesForThread.TryGetValue(threadId, out List<StackSourceSample> samples))
                         {

--- a/src/Tools/dotnet-stack/ReportCommand.cs
+++ b/src/Tools/dotnet-stack/ReportCommand.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Diagnostics.Tools.Stack
 
                         // we are looking for the first index of ) because
                         // we need to handle a thread name like: Thread (4008) (.NET IO ThreadPool Worker)
-                        int firstIndex = threadFrame.IndexOf(")");
+                        int firstIndex = threadFrame.IndexOf(')');
                         int threadId = int.Parse(threadFrame.Substring(template.Length, firstIndex - template.Length));
 
                         if (samplesForThread.TryGetValue(threadId, out List<StackSourceSample> samples))

--- a/src/Tools/dotnet-stack/ReportCommand.cs
+++ b/src/Tools/dotnet-stack/ReportCommand.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Diagnostics.Tools.Stack
                         // we are looking for the first index of ) because
                         // we need to handle a thread name like: Thread (4008) (.NET IO ThreadPool Worker)
                         int firstIndex = threadFrame.IndexOf(')');
-                        int threadId = int.Parse(threadFrame.Substring(template.Length, firstIndex - template.Length));
+                        int threadId = int.Parse(threadFrame.AsSpan(template.Length, firstIndex - template.Length));
 
                         if (samplesForThread.TryGetValue(threadId, out List<StackSourceSample> samples))
                         {


### PR DESCRIPTION
Fix parsing thread frames with names like: `Thread (4008) (.NET IO ThreadPool Worker)`.
