### PR TITLE
Fix issue with !sos maddress

### DIFF
--- a/src/Microsoft.Diagnostics.ExtensionCommands/NativeAddressHelper.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/NativeAddressHelper.cs
@@ -262,8 +262,11 @@ namespace Microsoft.Diagnostics.ExtensionCommands
                                             region.ClrMemoryKind = mem.Kind;
                                         }
                                     }
+                                    else
+                                    {
+                                        SetRegionKindWithWarning(mem, region);
+                                    }
                                 }
-
                             }
                         }
                     }


### PR DESCRIPTION
Previous refactoring accidently eliminated the case where the CLR region perfectly overlapped the memory region.