### PR TITLE
Fix issue with nint/nuint formatting

### DIFF
--- a/src/Microsoft.Diagnostics.ExtensionCommands/Output/Formats.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/Output/Formats.cs
@@ -58,6 +58,17 @@ namespace Microsoft.Diagnostics.ExtensionCommands.Output
                     case null:
                         break;
 
+                    case nuint:
+                        result.AppendFormat(_format, (ulong)value);
+                        break;
+
+                    case nint:
+                        unchecked
+                        {
+                            result.AppendFormat(_format, (ulong)value);
+                        }
+                        break;
+
                     default:
                         result.AppendFormat(_format, value);
                         break;

--- a/src/Microsoft.Diagnostics.ExtensionCommands/Output/Formats.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/Output/Formats.cs
@@ -58,14 +58,14 @@ namespace Microsoft.Diagnostics.ExtensionCommands.Output
                     case null:
                         break;
 
-                    case nuint:
-                        result.AppendFormat(_format, (ulong)value);
+                    case nuint nui:
+                        result.AppendFormat(_format, (ulong)nui);
                         break;
 
-                    case nint:
+                    case nint ni:
                         unchecked
                         {
-                            result.AppendFormat(_format, (ulong)value);
+                            result.AppendFormat(_format, (ulong)ni);
                         }
                         break;
 


### PR DESCRIPTION
Using `object value = (nint)1;  StringBuilder.Format("{0:x}", value);` fails to format the given value as hex, since `nint` and `nuint` do not have a `ToString(string format)` method.  This manifested as assert failures on x86 where we expected an 8 digit hex value, but got a longer integer (non-hex).  Both x86 and x64 were affected, but only x86 asserted.