### PR TITLE
Enhancements to NETCore.Client and dotnet-dump around ports and logging

### DIFF
--- a/documentation/design-docs/ipc-protocol.md
+++ b/documentation/design-docs/ipc-protocol.md
@@ -743,6 +743,58 @@ Payload
 }
 ```
 
+### `CreateCoreDump4`
+
+Command Code: `0x0104`
+
+The `CreateCoreDump4` command is used to instruct the runtime to generate a core dump of the process. It augments `CreateCoreDump3` with the ability to collect verbose logs and to redirect them to any given file.
+
+In the event of an [error](#errors), the runtime will attempt to send an error message and subsequently close the connection.
+
+#### Inputs
+
+Header: `{ Magic; Size; 0x0104; 0x0000 }`
+
+* `string dumpName`: As described in [`CreateCoreDump`](#createcoredump).
+* `uint dumpType`: As described in [`CreateCoreDump`](#createcoredump).
+* `uint flags`: Flags as defined by [`CreateCoreDump3`](#createcoredump3), with the following addition:
+  * `GenerateDumpFlagsLogToFile = 0x8`: Generate crashdump report next to the generated dump.
+* `string logPath`: The path to use for logging. In case this is null or empty, the runtime will log to a file adjacent to the dump.
+
+#### Returns (as an IPC Message Payload)
+
+Header: `{ Magic; Size; 0xFF00; 0x0000; }`
+
+`CreateCoreDump4` returns:
+
+* `int32 hresult`: The result of creating the core dump (`0` indicates success).
+* `string error`: Optionally the payload may have an error describing the collection issues.
+
+##### Details
+
+
+Input:
+
+```
+Payload
+{
+    string dumpName,
+    uint dumpType,
+    uint flags
+    string logPath
+}
+```
+
+Returns:
+
+```c
+Payload
+{
+    int32 hresult
+    string errorString
+}
+```
+
 ## Profiler Commands
 
 ### `AttachProfiler`

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/WriteDumpFlags.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/WriteDumpFlags.cs
@@ -3,11 +3,13 @@
 
 namespace Microsoft.Diagnostics.NETCore.Client
 {
-    public enum WriteDumpFlags
+    [System.Flags]
+    public enum WriteDumpFlags : uint
     {
         None = 0x00,
         LoggingEnabled = 0x01,
         VerboseLoggingEnabled = 0x02,
-        CrashReportEnabled = 0x04
+        CrashReportEnabled = 0x04,
+        LogToFile = 0x8
     }
 }

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcCommands.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcCommands.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
         GenerateCoreDump = 0x01,
         GenerateCoreDump2 = 0x02,
         GenerateCoreDump3 = 0x03,
+        GenerateCoreDump4 = 0x04,
     }
 
     internal enum ProfilerCommandId : byte

--- a/src/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj
+++ b/src/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj
@@ -29,6 +29,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="dotnet-counters" />
     <InternalsVisibleTo Include="dotnet-dsrouter" />
+    <InternalsVisibleTo Include="dotnet-dump" />
     <InternalsVisibleTo Include="dotnet-monitor" />
     <InternalsVisibleTo Include="dotnet-trace" />
     <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring" />

--- a/src/Tools/dotnet-dump/Program.cs
+++ b/src/Tools/dotnet-dump/Program.cs
@@ -13,6 +13,15 @@ using Microsoft.Tools.Common;
 
 namespace Microsoft.Diagnostics.Tools.Dump
 {
+    // Make sure the name of the fields match the option names.
+    internal record struct DumpCollectionConfig(
+            int ProcessId,
+            string ProcessName,
+            string DumpOutputPath,
+            bool EnableDiagnosticOutput,
+            bool GenerateCrashReport,
+            Dumper.DumpTypeOption DumpType);
+
     internal static class Program
     {
         public static Task<int> Main(string[] args)
@@ -31,9 +40,9 @@ namespace Microsoft.Diagnostics.Tools.Dump
             new(name: "collect", description: "Capture dumps from a process")
             {
                 // Handler
-                CommandHandler.Create<IConsole, int, string, bool, bool, Dumper.DumpTypeOption, string>(new Dumper().Collect),
+                CommandHandler.Create<DumpCollectionConfig, IConsole>(Dumper.Collect),
                 // Options
-                ProcessIdOption(), OutputOption(), DiagnosticLoggingOption(), CrashReportOption(), TypeOption(), ProcessNameOption()
+                ProcessIdOption(), ProcessNameOption(), OutputOption(), DiagnosticLoggingOption(), CrashReportOption(), TypeOption()
             };
 
         private static Option ProcessIdOption() =>
@@ -41,6 +50,7 @@ namespace Microsoft.Diagnostics.Tools.Dump
                 aliases: new[] { "-p", "--process-id" },
                 description: "The process id to collect a memory dump.")
             {
+                Name = nameof(DumpCollectionConfig.ProcessId),
                 Argument = new Argument<int>(name: "pid")
             };
 
@@ -49,15 +59,17 @@ namespace Microsoft.Diagnostics.Tools.Dump
                 aliases: new[] { "-n", "--name" },
                 description: "The name of the process to collect a memory dump.")
             {
-                Argument = new Argument<string>(name: "name")
+                Name = nameof(DumpCollectionConfig.ProcessName),
+                Argument = new Argument<string>(name: "ProcessName")
             };
 
         private static Option OutputOption() =>
             new(
                 aliases: new[] { "-o", "--output" },
-                description: @"The path where collected dumps should be written. Defaults to '.\dump_YYYYMMDD_HHMMSS.dmp' on Windows and './core_YYYYMMDD_HHMMSS' 
+                description: @"The path where collected dumps should be written. Defaults to '.\dump_YYYYMMDD_HHMMSS.dmp' on Windows and './core_YYYYMMDD_HHMMSS'
 on Linux where YYYYMMDD is Year/Month/Day and HHMMSS is Hour/Minute/Second. Otherwise, it is the full path and file name of the dump.")
             {
+                Name = nameof(DumpCollectionConfig.DumpOutputPath),
                 Argument = new Argument<string>(name: "output_dump_path")
             };
 
@@ -66,6 +78,7 @@ on Linux where YYYYMMDD is Year/Month/Day and HHMMSS is Hour/Minute/Second. Othe
                 alias: "--diag",
                 description: "Enable dump collection diagnostic logging.")
             {
+                Name = nameof(DumpCollectionConfig.EnableDiagnosticOutput),
                 Argument = new Argument<bool>(name: "diag")
             };
 
@@ -74,6 +87,7 @@ on Linux where YYYYMMDD is Year/Month/Day and HHMMSS is Hour/Minute/Second. Othe
                 alias: "--crashreport",
                 description: "Enable crash report generation.")
             {
+                Name = nameof(DumpCollectionConfig.GenerateCrashReport),
                 Argument = new Argument<bool>(name: "crashreport")
             };
 
@@ -82,6 +96,7 @@ on Linux where YYYYMMDD is Year/Month/Day and HHMMSS is Hour/Minute/Second. Othe
                 alias: "--type",
                 description: @"The dump type determines the kinds of information that are collected from the process. There are several types: Full - The largest dump containing all memory including the module images. Heap - A large and relatively comprehensive dump containing module lists, thread lists, all stacks, exception information, handle information, and all memory except for mapped images. Mini - A small dump containing module lists, thread lists, exception information and all stacks. Triage - A small dump containing module lists, thread lists, exception information, all stacks and PII removed.")
             {
+                Name = nameof(DumpCollectionConfig.DumpType),
                 Argument = new Argument<Dumper.DumpTypeOption>(name: "dump_type", getDefaultValue: () => Dumper.DumpTypeOption.Full)
             };
 

--- a/src/Tools/dotnet-dump/Program.cs
+++ b/src/Tools/dotnet-dump/Program.cs
@@ -7,6 +7,7 @@ using System.CommandLine.Builder;
 using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Internal.Common.Commands;
 using Microsoft.Tools.Common;
@@ -17,6 +18,7 @@ namespace Microsoft.Diagnostics.Tools.Dump
     internal record struct DumpCollectionConfig(
             int ProcessId,
             string ProcessName,
+            string DiagnosticPort,
             string DumpOutputPath,
             bool EnableDiagnosticOutput,
             bool GenerateCrashReport,
@@ -42,7 +44,7 @@ namespace Microsoft.Diagnostics.Tools.Dump
                 // Handler
                 CommandHandler.Create<DumpCollectionConfig, IConsole>(Dumper.Collect),
                 // Options
-                ProcessIdOption(), ProcessNameOption(), OutputOption(), DiagnosticLoggingOption(), CrashReportOption(), TypeOption()
+                ProcessIdOption(), ProcessNameOption(), DiagnosticPortOption(), OutputOption(), DiagnosticLoggingOption(), CrashReportOption(), TypeOption()
             };
 
         private static Option ProcessIdOption() =>
@@ -61,6 +63,15 @@ namespace Microsoft.Diagnostics.Tools.Dump
             {
                 Name = nameof(DumpCollectionConfig.ProcessName),
                 Argument = new Argument<string>(name: "ProcessName")
+            };
+
+        private static Option DiagnosticPortOption() =>
+            new(
+                alias: "--diagnostic-port",
+                description: @"The path to a diagnostic port to be used.")
+            {
+                Name = nameof(DumpCollectionConfig.DiagnosticPort),
+                Argument = new Argument<string>(name: "diagnosticPort")
             };
 
         private static Option OutputOption() =>

--- a/src/Tools/dotnet-dump/dotnet-dump.csproj
+++ b/src/Tools/dotnet-dump/dotnet-dump.csproj
@@ -25,9 +25,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)..\Common\CommandExtensions.cs" Link="CommandExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\Common\Commands\ProcessStatus.cs" Link="ProcessStatus.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\Common\Commands\Utils.cs" Link="Utils.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\Common\CommandLineErrorException.cs" Link="CommandLineErrorException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\Common\ProcessNativeMethods\ProcessNativeMethods.cs" Link="ProcessNativeMethods.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)..\Common\WindowsProcessExtension\WindowsProcessExtension.cs" Link="WindowsProcessExtension.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\Common\ReversedServerHelpers\ReversedServerHelpers.cs" Link="ReversedServerHelpers.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\Common\WindowsProcessExtension\WindowsProcessExtension.cs" Link="WindowsProcessExtension.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tools/dotnet-dump/dotnet-dump.csproj
+++ b/src/Tools/dotnet-dump/dotnet-dump.csproj
@@ -27,8 +27,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)..\Common\Commands\Utils.cs" Link="Utils.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\Common\ProcessNativeMethods\ProcessNativeMethods.cs" Link="ProcessNativeMethods.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\Common\WindowsProcessExtension\WindowsProcessExtension.cs" Link="WindowsProcessExtension.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\Common\ReversedServerHelpers\ReversedServerHelpers.cs" Link="ReversedServerHelpers.cs" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Microsoft.Diagnostics.Repl\Microsoft.Diagnostics.Repl.csproj" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Microsoft.Diagnostics.NETCore.Client\Microsoft.Diagnostics.NETCore.Client.csproj" />


### PR DESCRIPTION
- Add support for collecting dumps of apps using alternative ports.
- Update IPC spec for all generate dump commands.
- Add option for collecting verbose logging from dotnet-dump.
- Pipe logging capability to a file through dotnet-dump.