### PR TITLE
Add PGO to DacpTieredVersionData

### DIFF
--- a/src/SOS/Strike/util.cpp
+++ b/src/SOS/Strike/util.cpp
@@ -2801,6 +2801,12 @@ void DumpTieredNativeCodeAddressInfo(struct DacpTieredVersionData * pTieredVersi
             case DacpTieredVersionData::OptimizationTier_ReadyToRun:
                 descriptor = "ReadyToRun";
                 break;
+            case DacpTieredVersionData::OptimizationTier_QuickJittedInstrumented:
+                descriptor = "QuickJitted + Instrumented";
+                break;
+            case DacpTieredVersionData::OptimizationTier_OptimizedTier1Instrumented:
+                descriptor = "OptimizedTier1 + Instrumented";
+                break;
             }
             DMLOut("     CodeAddr:           %s  (%s)\n", DMLIP(pTieredVersionData[i].NativeCodeAddr), descriptor);
             ExtOut("     NativeCodeVersion:  %p\n", SOS_PTR(pTieredVersionData[i].NativeCodeVersionNodePtr));

--- a/src/shared/inc/dacprivate.h
+++ b/src/shared/inc/dacprivate.h
@@ -610,6 +610,8 @@ struct MSLAYOUT DacpTieredVersionData
         OptimizationTier_OptimizedTier1,
         OptimizationTier_ReadyToRun,
         OptimizationTier_OptimizedTier1OSR,
+        OptimizationTier_QuickJittedInstrumented,
+        OptimizationTier_OptimizedTier1Instrumented
     };
 
     CLRDATA_ADDRESS NativeCodeAddr;


### PR DESCRIPTION
PGO introduces two new native code version types. The runtime already has this change, but SOS does not.