### PR TITLE
Clean up IRuntime instance flushing

### DIFF
--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/Runtime.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/Runtime.cs
@@ -59,10 +59,10 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
 
         void IDisposable.Dispose()
         {
+            Flush();
             _serviceContainer.RemoveService(typeof(IRuntime));
             _serviceContainer.DisposeServices();
             _onFlushEvent.Dispose();
-            Flush();
         }
 
         private void Flush()

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/Runtime.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/Runtime.cs
@@ -58,9 +58,9 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
         {
             if (_serviceContainer.TryGetCachedService(typeof(ClrRuntime), out object service))
             {
-                ClrRuntime clrRuntime = (ClrRuntime)service;
-                clrRuntime.Dispose();
-                clrRuntime.DataTarget.Dispose();
+                // The DataTarget created in the RuntimeProvider is disposed here. The ClrRuntime
+                // instance is disposed below in DisposeServices().
+                ((ClrRuntime)service).DataTarget.Dispose();
             }
             _serviceContainer.RemoveService(typeof(IRuntime));
             _serviceContainer.DisposeServices();

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/Runtime.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/Runtime.cs
@@ -62,10 +62,14 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
             _serviceContainer.RemoveService(typeof(IRuntime));
             _serviceContainer.DisposeServices();
             _onFlushEvent.Dispose();
+            Flush();
         }
 
         private void Flush()
         {
+            _runtimeVersion = null;
+            _dacFilePath = null;
+            _dbiFilePath = null;
             if (_serviceContainer.TryGetCachedService(typeof(ClrRuntime), out object service))
             {
                 ((ClrRuntime)service).FlushCachedData();

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/RuntimeProvider.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/RuntimeProvider.cs
@@ -28,6 +28,10 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
         /// <param name="startingRuntimeId">The starting runtime id for this provider</param>
         public IEnumerable<IRuntime> EnumerateRuntimes(int startingRuntimeId)
         {
+            // The DataTarget isn't cached here because there is no way to flush it. It currently caches
+            // ClrInfos, modules and PE images. It also isn't disposed because the DataTarget instance
+            // needs to be around as long as the ClrInfos wrapped by the Runtime instances created below
+            // which the life time is determined by the RuntimeService.
             DataTarget dataTarget = new(new CustomDataTarget(_services.GetService<IDataReader>()))
             {
                 FileLocator = null

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/RuntimeProvider.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/RuntimeProvider.cs
@@ -28,10 +28,9 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
         /// <param name="startingRuntimeId">The starting runtime id for this provider</param>
         public IEnumerable<IRuntime> EnumerateRuntimes(int startingRuntimeId)
         {
-            // The DataTarget isn't cached here because there is no way to flush it. It currently caches
-            // ClrInfos, modules and PE images. It also isn't disposed because the DataTarget instance
-            // needs to be around as long as the ClrInfos wrapped by the Runtime instances created below
-            // which the life time is determined by the RuntimeService.
+            // The ClrInfo and DataTarget instances are disposed when Runtime instance is disposed. Runtime instances are
+            // not flushed when the Target/RuntimeService is flushed; they are all disposed and the list cleared. They are
+            // all re-created the next time the IRuntime or ClrRuntime instance is queried.
             DataTarget dataTarget = new(new CustomDataTarget(_services.GetService<IDataReader>()))
             {
                 FileLocator = null


### PR DESCRIPTION
Lee found in his investigations that ClrRuntime isn't being flushed in Runtime.Flush().  This may fix it.  The RuntimeService.Flush is called first (though there isn't any order guarantee) which disposes of all the Runtime instances (instead of flushing) which Runtime.Dispose removes/deregisters the OnFlushEvent handler so Runtime.Flush is never called.

If you followed that great, but it is confusing (and why there might be bugs).  The intent was to cleanup (flush), remove and dispose of Runtime instances on Flush so the RuntimeService re-creates them the next time a runtime service instance is requested. What got lost in one of my big changes was the "cleanup" flush part.  