### PR TITLE
Test against new Ubuntu 22.04 image

### DIFF
--- a/diagnostics.yml
+++ b/diagnostics.yml
@@ -365,22 +365,22 @@ extends:
           #            _BuildConfig: Debug
           #            _BuildArch: x64
 
-          #- template: /eng/pipelines/build.yml
-          #  parameters:
-          #    name: Ubuntu_22_04
-          #    osGroup: Linux
-          #    container: test_ubuntu_22_04
-          #    dependsOn: Linux_x64
-          #    testOnly: true
-          #    strategy:
-          #      matrix:
-          #        Build_Release:
-          #          _BuildConfig: Release
-          #          _BuildArch: x64
-          #        ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
-          #          Build_Debug:
-          #            _BuildConfig: Debug
-          #            _BuildArch: x64
+          - template: /eng/pipelines/build.yml
+            parameters:
+              name: Ubuntu_22_04
+              osGroup: Linux
+              container: test_ubuntu_22_04
+              dependsOn: Linux_x64
+              testOnly: true
+              strategy:
+                matrix:
+                  Build_Release:
+                    _BuildConfig: Release
+                    _BuildArch: x64
+                  ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
+                    Build_Debug:
+                      _BuildConfig: Debug
+                      _BuildArch: x64
 
         # Download, sign, package and publish
         - ${{ if ne(variables['System.TeamProject'], 'public') }}:  

--- a/eng/pipelines/pipeline-resources.yml
+++ b/eng/pipelines/pipeline-resources.yml
@@ -57,5 +57,6 @@ resources:
 
       - container: test_ubuntu_22_04
         image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04
+        options: '--env PYTHONPATH=/usr/bin/python3.10'
 
 stages: ${{ parameters.stages }}


### PR DESCRIPTION
Enable testing against the Ubuntu 22.04 image that now contains the lldb python script fix in the internal build. 