### PR TITLE
Fix gcroot test failures

### DIFF
--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/DataReader.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/DataReader.cs
@@ -55,10 +55,10 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
             try
             {
                 byte[] registerContext = ThreadService.GetThreadFromId(threadId).GetThreadContext();
-                context = new Span<byte>(registerContext);
+                registerContext.AsSpan().Slice(0, context.Length).CopyTo(context);
                 return true;
             }
-            catch (DiagnosticsException ex)
+            catch (Exception ex) when (ex is DiagnosticsException or ArgumentException)
             {
                 Trace.TraceError($"GetThreadContext: {threadId} exception {ex.Message}");
             }


### PR DESCRIPTION
The SOS DataReader impl given to clrmd didn't copy the thread context correctly.

A future PR will improve the IThread.GetThreadContext() interface method to reduce these kind of bugs.