### PR TITLE
Add generation option to dumpheap command

### DIFF
--- a/src/Microsoft.Diagnostics.ExtensionCommands/DumpHeapCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/DumpHeapCommand.cs
@@ -232,15 +232,15 @@ namespace Microsoft.Diagnostics.ExtensionCommands
 
             if (!string.IsNullOrWhiteSpace(Generation))
             {
-                Generation generation = Generation switch
+                Generation generation = Generation.ToLowerInvariant() switch
                 {
                     "gen0" => Diagnostics.Runtime.Generation.Generation0,
                     "gen1" => Diagnostics.Runtime.Generation.Generation1,
                     "gen2" => Diagnostics.Runtime.Generation.Generation2,
-                    "loh" => Diagnostics.Runtime.Generation.Large,
-                    "poh" => Diagnostics.Runtime.Generation.Pinned,
-                    "foh" => Diagnostics.Runtime.Generation.Frozen,
-                    _ => throw new ArgumentException($"Unknown generation: {Generation}. Only gen0, gen1, gen2, loh, poh and foh are supported")
+                    "loh" or "large" => Diagnostics.Runtime.Generation.Large,
+                    "poh" or "pinned" => Diagnostics.Runtime.Generation.Pinned,
+                    "foh" or "frozen" => Diagnostics.Runtime.Generation.Frozen,
+                    _ => throw new ArgumentException($"Unknown generation: {Generation}. Only gen0, gen1, gen2, loh (large), poh (pinned) and foh (frozen) are supported")
                 };
 
                 FilteredHeap.Generation = generation;

--- a/src/Microsoft.Diagnostics.ExtensionCommands/DumpHeapCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/DumpHeapCommand.cs
@@ -62,6 +62,9 @@ namespace Microsoft.Diagnostics.ExtensionCommands
         [Option(Name = "-thinlock")]
         public bool ThinLock { get; set; }
 
+        [Option(Name = "-gen")]
+        public string Generation { get; set; }
+
         [Argument(Help = "Optional memory ranges in the form of: [Start [End]]")]
         public string[] MemoryRange { get; set; }
 
@@ -225,6 +228,22 @@ namespace Microsoft.Diagnostics.ExtensionCommands
             if (Strings)
             {
                 MethodTable = Runtime.Heap.StringType.MethodTable;
+            }
+
+            if (!string.IsNullOrWhiteSpace(Generation))
+            {
+                Generation generation = Generation switch
+                {
+                    "gen0" => Diagnostics.Runtime.Generation.Generation0,
+                    "gen1" => Diagnostics.Runtime.Generation.Generation1,
+                    "gen2" => Diagnostics.Runtime.Generation.Generation2,
+                    "loh" => Diagnostics.Runtime.Generation.Large,
+                    "poh" => Diagnostics.Runtime.Generation.Pinned,
+                    "foh" => Diagnostics.Runtime.Generation.Frozen,
+                    _ => throw new ArgumentException($"Unknown generation: {Generation}. Only gen0, gen1, gen2, loh, poh and foh are supported")
+                };
+
+                FilteredHeap.Generation = generation;
             }
 
             FilteredHeap.SortSegments = (seg) => seg.OrderBy(seg => seg.Start);

--- a/src/Microsoft.Diagnostics.ExtensionCommands/HeapWithFilters.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/HeapWithFilters.cs
@@ -64,6 +64,11 @@ namespace Microsoft.Diagnostics.ExtensionCommands
         public ulong MaximumObjectSize { get; set; }
 
         /// <summary>
+        /// Only enumerate object from this generation
+        /// </summary>
+        public Generation? Generation { get; set; }
+
+        /// <summary>
         /// The order in which to enumerate segments.  This also applies to object enumeration.
         /// </summary>
         public Func<IEnumerable<ClrSegment>, IOrderedEnumerable<ClrSegment>> SortSegments { get; set; }
@@ -226,6 +231,11 @@ namespace Microsoft.Diagnostics.ExtensionCommands
                 else
                 {
                     objs = segment.EnumerateObjects(carefully: true);
+                }
+
+                if (Generation is Generation generation)
+                {
+                    objs = objs.Where(obj => segment.GetGeneration(obj.Address) == generation);
                 }
 
                 foreach (ClrObject obj in objs)

--- a/src/Microsoft.Diagnostics.ExtensionCommands/HeapWithFilters.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/HeapWithFilters.cs
@@ -235,7 +235,7 @@ namespace Microsoft.Diagnostics.ExtensionCommands
 
                 if (Generation is Generation generation)
                 {
-                    objs = objs.Where(obj => segment.GetGeneration(obj.Address) == generation);
+                    objs = objs.Where(obj => segment.GetGeneration(obj) == generation);
                 }
 
                 foreach (ClrObject obj in objs)

--- a/src/SOS/SOS.UnitTests/Scripts/GCPOH.script
+++ b/src/SOS/SOS.UnitTests/Scripts/GCPOH.script
@@ -52,6 +52,11 @@ VERIFY:\s*Statistics:\s+
 VERIFY:\s+MT\s+Count\s+TotalSize\s+Class\s+Name\s+
 VERIFY:\s+<HEXVAL>\s+<DECVAL>\s+<DECVAL>\s+System.Byte\[\]\s+
 
+SOSCOMMAND:DumpHeap -stat -gen poh
+VERIFY:\s*Statistics:\s+
+VERIFY:\s+MT\s+Count\s+TotalSize\s+Class\s+Name\s+
+VERIFY:\s+<HEXVAL>\s+<DECVAL>\s+<DECVAL>\s+System.Byte\[\]\s+
+
 SOSCOMMAND:EEHeap
 VERIFY:\s*Loader Heap:\s+
 VERIFY:\s+System Domain:\s+<HEXVAL>\s+

--- a/src/SOS/SOS.UnitTests/Scripts/GCTests.script
+++ b/src/SOS/SOS.UnitTests/Scripts/GCTests.script
@@ -82,6 +82,14 @@ VERIFY:\s*Statistics:\s+
 VERIFY:\s+MT\s+Count\s+TotalSize\s+Class\s+Name\s+
 VERIFY:\s+<HEXVAL>\s+<DECVAL>\s+<DECVAL>\s+GCWhere\s+
 
+SOSCOMMAND:DumpHeap -stat -gen gen0
+VERIFY:\s*Statistics:\s+
+VERIFY:\s+MT\s+Count\s+TotalSize\s+Class\s+Name\s+
+VERIFY:\s+<HEXVAL>\s+<DECVAL>\s+<DECVAL>\s+GCWhere\s+
+
+SOSCOMMAND:DumpHeap -stat -gen xxx
+VERIFY:\s*System\.ArgumentException: Unknown generation: xxx\. Only gen0, gen1, gen2, loh \(large\), poh \(pinned\) and foh \(frozen\) are supported\s+
+
 IFDEF:WINDOWS
 SOSCOMMAND:DumpHeap -strings
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+<DECVAL>\s+

--- a/src/SOS/SOS.UnitTests/Scripts/GCTests.script
+++ b/src/SOS/SOS.UnitTests/Scripts/GCTests.script
@@ -87,8 +87,10 @@ VERIFY:\s*Statistics:\s+
 VERIFY:\s+MT\s+Count\s+TotalSize\s+Class\s+Name\s+
 VERIFY:\s+<HEXVAL>\s+<DECVAL>\s+<DECVAL>\s+GCWhere\s+
 
+IFDEF:WINDOWS
 SOSCOMMAND:DumpHeap -stat -gen xxx
 VERIFY:\s*System\.ArgumentException: Unknown generation: xxx\. Only gen0, gen1, gen2, loh \(large\), poh \(pinned\) and foh \(frozen\) are supported\s+
+ENDIF:WINDOWS
 
 IFDEF:WINDOWS
 SOSCOMMAND:DumpHeap -strings


### PR DESCRIPTION
This is a very small change to address https://github.com/dotnet/diagnostics/issues/3963#issuecomment-1585505859

Few questions:
1) Should I add tests for this?
2) I've asked about GCGeneration custom type that is a clone of Generation "official" type in that issue. It is a part of dumpgen command which itself, after this change, kinda loses it's meaning. I think the way forward is just to either remove dumpgen command or leave it as a proxy for dumpheap.