### PR TITLE
Extend dotnet-gcdump support for mobile and dotnet-dsrouter scenarios.

### DIFF
--- a/src/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj
+++ b/src/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFrameworks Condition="'$(DotNetBuildFromSource)' != 'true'">netstandard2.0;net6.0</TargetFrameworks>
@@ -31,6 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="dotnet-gcdump" />
     <InternalsVisibleTo Include="dotnet-counters" />
     <InternalsVisibleTo Include="dotnet-dsrouter" />
     <InternalsVisibleTo Include="dotnet-monitor" />

--- a/src/Tools/dotnet-gcdump/CommandLine/ConvertCommandHandler.cs
+++ b/src/Tools/dotnet-gcdump/CommandLine/ConvertCommandHandler.cs
@@ -1,0 +1,92 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.CommandLine;
+using System.IO;
+using Graphs;
+using Microsoft.Tools.Common;
+
+namespace Microsoft.Diagnostics.Tools.GCDump
+{
+    internal static class ConvertCommandHandler
+    {
+        public static int ConvertFile(FileInfo input, string output, bool verbose)
+        {
+            if (!input.Exists)
+            {
+                Console.Error.WriteLine($"File '{input.FullName}' does not exist.");
+                return -1;
+            }
+
+            output = string.IsNullOrEmpty(output)
+                    ? Path.ChangeExtension(input.FullName, "gcdump")
+                    : output;
+
+            FileInfo outputFileInfo = new(output);
+
+            if (outputFileInfo.Exists)
+            {
+                outputFileInfo.Delete();
+            }
+
+            if (string.IsNullOrEmpty(outputFileInfo.Extension) || outputFileInfo.Extension != ".gcdump")
+            {
+                outputFileInfo = new FileInfo(outputFileInfo.FullName + ".gcdump");
+            }
+
+            Console.Out.WriteLine($"Writing gcdump to '{outputFileInfo.FullName}'...");
+
+            DotNetHeapInfo heapInfo = new();
+            TextWriter log = verbose ? Console.Out : TextWriter.Null;
+
+            MemoryGraph memoryGraph = new(50_000);
+
+            if (!EventPipeDotNetHeapDumper.DumpFromEventPipeFile(input.FullName, memoryGraph, log, heapInfo))
+            {
+                return -1;
+            }
+
+            memoryGraph.AllowReading();
+            GCHeapDump.WriteMemoryGraph(memoryGraph, outputFileInfo.FullName, "dotnet-gcdump");
+
+            return 0;
+        }
+
+        public static System.CommandLine.Command ConvertCommand() =>
+            new(
+                name: "convert",
+                description: "Converts nettrace file into .gcdump file handled by analysis tools. Can only convert from the nettrace format.")
+            {
+                // Handler
+                System.CommandLine.Invocation.CommandHandler.Create<FileInfo, string, bool>(ConvertFile),
+                // Arguments and Options
+                InputPathArgument(),
+                OutputPathOption(),
+                VerboseOption()
+            };
+
+        private static Argument<FileInfo> InputPathArgument() =>
+            new Argument<FileInfo>("input")
+            {
+                Description = "Input trace file to be converted.",
+                Arity = new ArgumentArity(0, 1)
+            }.ExistingOnly();
+
+        private static Option<string> OutputPathOption() =>
+            new(
+                aliases: new[] { "-o", "--output" },
+                description: $@"The path where converted gcdump should be written. Defaults to '<input>.gcdump'")
+            {
+                Argument = new Argument<string>(name: "output", getDefaultValue: () => string.Empty)
+            };
+
+        private static Option<bool> VerboseOption() =>
+            new(
+                aliases: new[] { "-v", "--verbose" },
+                description: "Output the log while converting the gcdump.")
+            {
+                Argument = new Argument<bool>(name: "verbose", getDefaultValue: () => false)
+            };
+    }
+}

--- a/src/Tools/dotnet-gcdump/CommandLine/ReportCommandHandler.cs
+++ b/src/Tools/dotnet-gcdump/CommandLine/ReportCommandHandler.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Diagnostics.Tools.GCDump
         private static Task<int> ReportFromProcess(int processId, CancellationToken ct)
         {
             if (!CollectCommandHandler
-                .TryCollectMemoryGraph(ct, processId, CollectCommandHandler.DefaultTimeout, false, out Graphs.MemoryGraph mg))
+                .TryCollectMemoryGraph(ct, processId, string.Empty, CollectCommandHandler.DefaultTimeout, false, out Graphs.MemoryGraph mg))
             {
                 Console.Error.WriteLine("An error occured while collecting gcdump.");
                 return Task.FromResult(-1);

--- a/src/Tools/dotnet-gcdump/DotNetHeapDump/EventPipeDotNetHeapDumper.cs
+++ b/src/Tools/dotnet-gcdump/DotNetHeapDump/EventPipeDotNetHeapDumper.cs
@@ -109,12 +109,12 @@ namespace Microsoft.Diagnostics.Tools.GCDump
         /// are given as input to the Func eventPipeEventSourceFactory.
         /// </summary>
         /// <param name="processID"></param>
-        /// <param name="eventPipeEventSourceFactory">A delegate for creating and stopping EventPipe sessions</param>
+        /// <param name="diagnosticPort"></param>
         /// <param name="memoryGraph"></param>
         /// <param name="log"></param>
         /// <param name="dotNetInfo"></param>
         /// <returns></returns>
-        public static bool DumpFromEventPipe(CancellationToken ct, int processID, MemoryGraph memoryGraph, TextWriter log, int timeout, DotNetHeapInfo dotNetInfo = null)
+        public static bool DumpFromEventPipe(CancellationToken ct, int processID, string diagnosticPort, MemoryGraph memoryGraph, TextWriter log, int timeout, DotNetHeapInfo dotNetInfo = null)
         {
             DateTime start = DateTime.Now;
             Func<TimeSpan> getElapsed = () => DateTime.Now - start;
@@ -130,7 +130,7 @@ namespace Microsoft.Diagnostics.Tools.GCDump
                 bool fDone = false;
                 log.WriteLine("{0,5:n1}s: Creating type table flushing task", getElapsed().TotalSeconds);
 
-                using (EventPipeSessionController typeFlushSession = new(processID, new List<EventPipeProvider> {
+                using (EventPipeSessionController typeFlushSession = new(processID, diagnosticPort, new List<EventPipeProvider> {
                     new EventPipeProvider("Microsoft-DotNETCore-SampleProfiler", EventLevel.Informational)
                 }, false))
                 {
@@ -155,7 +155,7 @@ namespace Microsoft.Diagnostics.Tools.GCDump
                 // Start the providers and trigger the GCs.
                 log.WriteLine("{0,5:n1}s: Requesting a .NET Heap Dump", getElapsed().TotalSeconds);
 
-                using EventPipeSessionController gcDumpSession = new(processID, new List<EventPipeProvider> {
+                using EventPipeSessionController gcDumpSession = new(processID, diagnosticPort, new List<EventPipeProvider> {
                     new EventPipeProvider("Microsoft-Windows-DotNETRuntime", EventLevel.Verbose, (long)(ClrTraceEventParser.Keywords.GCHeapSnapshot))
                 });
                 log.WriteLine("{0,5:n1}s: gcdump EventPipe Session started", getElapsed().TotalSeconds);
@@ -164,6 +164,11 @@ namespace Microsoft.Diagnostics.Tools.GCDump
 
                 gcDumpSession.Source.Clr.GCStart += delegate (GCStartTraceData data)
                 {
+                    if (processID == 0)
+                    {
+                        processID = data.ProcessID;
+                        log.WriteLine("Process wildcard selects process id {0}", processID);
+                    }
                     if (data.ProcessID != processID)
                     {
                         return;
@@ -312,15 +317,34 @@ namespace Microsoft.Diagnostics.Tools.GCDump
         private EventPipeSession _session;
         private EventPipeEventSource _source;
         private int _pid;
+        private IpcEndpointConfig _diagnosticPort;
 
         public IReadOnlyList<EventPipeProvider> Providers => _providers.AsReadOnly();
         public EventPipeEventSource Source => _source;
 
-        public EventPipeSessionController(int pid, List<EventPipeProvider> providers, bool requestRundown = true)
+        public EventPipeSessionController(int pid, string diagnosticPort, List<EventPipeProvider> providers, bool requestRundown = true)
         {
+            if (!string.IsNullOrEmpty(diagnosticPort))
+            {
+                _diagnosticPort = IpcEndpointConfig.Parse(diagnosticPort);
+                if (!_diagnosticPort.IsConnectConfig)
+                {
+                    throw new ArgumentException("DiagnosticPort is only supporting connect mode.");
+                }
+            }
+
             _pid = pid;
             _providers = providers;
-            _client = new DiagnosticsClient(pid);
+
+            if (_diagnosticPort != null)
+            {
+                _client = new DiagnosticsClient(_diagnosticPort);
+            }
+            else
+            {
+                _client = new DiagnosticsClient(pid);
+            }
+
             _session = _client.StartEventPipeSession(providers, requestRundown, 1024);
             _source = new EventPipeEventSource(_session.EventStream);
         }

--- a/src/Tools/dotnet-gcdump/DotNetHeapDump/EventPipeDotNetHeapDumper.cs
+++ b/src/Tools/dotnet-gcdump/DotNetHeapDump/EventPipeDotNetHeapDumper.cs
@@ -21,6 +21,89 @@ namespace Microsoft.Diagnostics.Tools.GCDump
         internal static volatile bool dumpComplete;
 
         /// <summary>
+        /// Given a nettrace file from a EventPipe session with the appropriate provider and keywords turned on,
+        /// generate a GCHeapDump using the resulting events.
+        /// </summary>
+        /// <param name="path"></param>
+        /// <param name="memoryGraph"></param>
+        /// <param name="log"></param>
+        /// <param name="dotNetInfo"></param>
+        /// <returns></returns>
+        public static bool DumpFromEventPipeFile(string path, MemoryGraph memoryGraph, TextWriter log, DotNetHeapInfo dotNetInfo = null)
+        {
+            DateTime start = DateTime.Now;
+            Func<TimeSpan> getElapsed = () => DateTime.Now - start;
+
+            DotNetHeapDumpGraphReader dumper = new(log)
+            {
+                DotNetHeapInfo = dotNetInfo
+            };
+
+            try
+            {
+                TimeSpan lastEventPipeUpdate = getElapsed();
+
+                int gcNum = -1;
+
+                EventPipeEventSource source = new(path);
+
+                source.Clr.GCStart += delegate (GCStartTraceData data)
+                {
+                    eventPipeDataPresent = true;
+
+                    if (gcNum < 0 && data.Depth == 2 && data.Type != GCType.BackgroundGC)
+                    {
+                        gcNum = data.Count;
+                        log.WriteLine("{0,5:n1}s: .NET Dump Started...", getElapsed().TotalSeconds);
+                    }
+                };
+
+                source.Clr.GCStop += delegate (GCEndTraceData data)
+                {
+                    if (data.Count == gcNum)
+                    {
+                        log.WriteLine("{0,5:n1}s: .NET GC Complete.", getElapsed().TotalSeconds);
+                        dumpComplete = true;
+                    }
+                };
+
+                source.Clr.GCBulkNode += delegate (GCBulkNodeTraceData data)
+                {
+                    eventPipeDataPresent = true;
+
+                    if ((getElapsed() - lastEventPipeUpdate).TotalMilliseconds > 500)
+                    {
+                        log.WriteLine("{0,5:n1}s: Making GC Heap Progress...", getElapsed().TotalSeconds);
+                    }
+
+                    lastEventPipeUpdate = getElapsed();
+                };
+
+                if (memoryGraph != null)
+                {
+                    dumper.SetupCallbacks(memoryGraph, source);
+                }
+
+                log.WriteLine("{0,5:n1}s: Starting to process events", getElapsed().TotalSeconds);
+                source.Process();
+                log.WriteLine("{0,5:n1}s: Finished processing events", getElapsed().TotalSeconds);
+
+                if (eventPipeDataPresent)
+                {
+                    dumper.ConvertHeapDataToGraph();
+                }
+            }
+            catch (Exception e)
+            {
+                log.WriteLine($"{getElapsed().TotalSeconds,5:n1}s: [Error] Exception processing events: {e}");
+            }
+
+            log.WriteLine("[{0,5:n1}s: Done Dumping .NET heap success={1}]", getElapsed().TotalSeconds, dumpComplete);
+
+            return dumpComplete;
+        }
+
+        /// <summary>
         /// Given a factory for creating an EventPipe session with the appropriate provider and keywords turned on,
         /// generate a GCHeapDump using the resulting events.  The correct keywords and provider name
         /// are given as input to the Func eventPipeEventSourceFactory.

--- a/src/Tools/dotnet-gcdump/Program.cs
+++ b/src/Tools/dotnet-gcdump/Program.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Diagnostics.Tools.GCDump
                 .AddCommand(CollectCommandHandler.CollectCommand())
                 .AddCommand(ProcessStatusCommandHandler.ProcessStatusCommand("Lists the dotnet processes that gcdumps can be collected from."))
                 .AddCommand(ReportCommandHandler.ReportCommand())
+                .AddCommand(ConvertCommandHandler.ConvertCommand())
                 .UseDefaults()
                 .Build();
 


### PR DESCRIPTION
.net8 adds support for dotnet-gcdump on Mono, meaning dotnet-gcdump will be used targeting mobile platforms. Currently dotnet-gcdump doesn't have support needed since it can only connect using pid or process name and has logic to make sure the process connected to has the same pid as the -p argument passed to dotnet-gcdump.

On mobile platforms, runtime is running on device and communicates using TCP/IP (over loopback interface, using Android adb port forwarding or usbmux on iOS). All logic related to communicate with devices on different platforms is handled by dotnet-dsrouter, that expose the same IPC channels as a normal runtime would do, meaning most diagnostic tools can connect to dotnet-dsrouter that will route all communication to/from device. Tools like dotnet-trace can leverage --diagnostic-port=<ipc>,connect instead of pid to connect to a named IPC channel on dotnet-dsrouter (routed to a TCP/IP port on device). It is also possible to connect directly towards dotnet-dsrouters pid since it will masquerade like a regular runtime, but it will not alter the pid passed in EventPipe messages, meaning that dotnet.gcdump's pid checks currently breaks that scenario.

This PR extends dotnet-gcdump support for mobile and dotnet-dsrouter scenarios.

* Add support for --diagnostic-port argument, but only support connect mode, since listen mode (reverse diagnostic server) is mainly for startup tracing where GC dump is not full supported.
* Add support for new command, convert, that can take a nettrace file as input and convert it into a gcdump file. Can be useful if GC dumps have been captured by tools like dotnet-trace, meaning that dotnet-gcdump will be able to convert it into a gcdump.
* Add ability to enable wildcard process id handling, opening up ability to use dotnet-gcdump over dotnet-routers default IPC channel using -p argument.