### PR TITLE
Update SOS to show the relevant information for the !ThreadPool command when using the Windows thread pool

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -4,14 +4,13 @@
       <Uri>https://github.com/dotnet/symstore</Uri>
       <Sha>8cc6f03fdbd9c79f0bf9ffbe0a788dca1a81348a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Diagnostics.Runtime" Version="3.0.447801">
+    <Dependency Name="Microsoft.Diagnostics.Runtime" Version="3.0.447901">
       <Uri>https://github.com/microsoft/clrmd</Uri>
-      <Sha>10e87fb192d41e22d5fd0fd54f02ed011726e991</Sha>
+      <Sha>547545a301475a7cfd23ce8c2f6e24eddf55d83e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Diagnostics.Runtime.Utilities" Version="3.0.447801">
+    <Dependency Name="Microsoft.Diagnostics.Runtime.Utilities" Version="3.0.447901">
       <Uri>https://github.com/microsoft/clrmd</Uri>
-      <Sha>10e87fb192d41e22d5fd0fd54f02ed011726e991</Sha>
-    </Dependency>
+      <Sha>547545a301475a7cfd23ce8c2f6e24eddf55d83e</Sha>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.23463.1">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -11,6 +11,7 @@
     <Dependency Name="Microsoft.Diagnostics.Runtime.Utilities" Version="3.0.447901">
       <Uri>https://github.com/microsoft/clrmd</Uri>
       <Sha>547545a301475a7cfd23ce8c2f6e24eddf55d83e</Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.23463.1">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -4,9 +4,9 @@
       <Uri>https://github.com/dotnet/symstore</Uri>
       <Sha>8cc6f03fdbd9c79f0bf9ffbe0a788dca1a81348a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Diagnostics.Runtime" Version="3.0.447801">
+    <Dependency Name="Microsoft.Diagnostics.Runtime" Version="3.0.447901">
       <Uri>https://github.com/microsoft/clrmd</Uri>
-      <Sha>10e87fb192d41e22d5fd0fd54f02ed011726e991</Sha>
+      <Sha>547545a301475a7cfd23ce8c2f6e24eddf55d83e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Diagnostics.Runtime.Utilities" Version="3.0.447801">
       <Uri>https://github.com/microsoft/clrmd</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -4,9 +4,9 @@
       <Uri>https://github.com/dotnet/symstore</Uri>
       <Sha>8cc6f03fdbd9c79f0bf9ffbe0a788dca1a81348a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Diagnostics.Runtime" Version="3.0.447901">
+    <Dependency Name="Microsoft.Diagnostics.Runtime" Version="3.0.447801">
       <Uri>https://github.com/microsoft/clrmd</Uri>
-      <Sha>547545a301475a7cfd23ce8c2f6e24eddf55d83e</Sha>
+      <Sha>10e87fb192d41e22d5fd0fd54f02ed011726e991</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Diagnostics.Runtime.Utilities" Version="3.0.447801">
       <Uri>https://github.com/microsoft/clrmd</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -45,7 +45,7 @@
     <SystemReflectionMetadataVersion>5.0.0</SystemReflectionMetadataVersion>
     <!-- Other libs -->
     <MicrosoftBclAsyncInterfacesVersion>6.0.0</MicrosoftBclAsyncInterfacesVersion>
-    <MicrosoftDiagnosticsRuntimeVersion>3.0.447801</MicrosoftDiagnosticsRuntimeVersion>
+    <MicrosoftDiagnosticsRuntimeVersion>3.0.447901</MicrosoftDiagnosticsRuntimeVersion>
     <MicrosoftDiaSymReaderNativeVersion>16.11.27-beta1.23180.1</MicrosoftDiaSymReaderNativeVersion>
     <MicrosoftDiagnosticsTracingTraceEventVersion>3.0.7</MicrosoftDiagnosticsTracingTraceEventVersion>
     <MicrosoftExtensionsLoggingVersion>6.0.0</MicrosoftExtensionsLoggingVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -45,7 +45,7 @@
     <SystemReflectionMetadataVersion>5.0.0</SystemReflectionMetadataVersion>
     <!-- Other libs -->
     <MicrosoftBclAsyncInterfacesVersion>6.0.0</MicrosoftBclAsyncInterfacesVersion>
-    <MicrosoftDiagnosticsRuntimeVersion>3.0.447901</MicrosoftDiagnosticsRuntimeVersion>
+    <MicrosoftDiagnosticsRuntimeVersion>3.0.447801</MicrosoftDiagnosticsRuntimeVersion>
     <MicrosoftDiaSymReaderNativeVersion>16.11.27-beta1.23180.1</MicrosoftDiaSymReaderNativeVersion>
     <MicrosoftDiagnosticsTracingTraceEventVersion>3.0.7</MicrosoftDiagnosticsTracingTraceEventVersion>
     <MicrosoftExtensionsLoggingVersion>6.0.0</MicrosoftExtensionsLoggingVersion>

--- a/src/Microsoft.Diagnostics.ExtensionCommands/ThreadPoolCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/ThreadPoolCommand.cs
@@ -34,14 +34,23 @@ namespace Microsoft.Diagnostics.ExtensionCommands
             else
             {
                 Table output = new(Console, Text.WithWidth(17), Text);
-                output.WriteRow("CPU utilization:", $"{threadPool.CpuUtilization}%");
-                output.WriteRow("Workers Total:", threadPool.ActiveWorkerThreads + threadPool.IdleWorkerThreads + threadPool.RetiredWorkerThreads);
-                output.WriteRow("Workers Running:", threadPool.ActiveWorkerThreads);
-                output.WriteRow("Workers Idle:", threadPool.IdleWorkerThreads);
-                output.WriteRow("Worker Min Limit:", threadPool.MinThreads);
-                output.WriteRow("Worker Max Limit:", threadPool.MaxThreads);
-                Console.WriteLine();
+                string threadpoolType = threadPool.UsingWindowsThreadPool ? "Windows" : "Portable";
+                Console.WriteLine($"Using the {threadpoolType} thread pool.");
 
+                if (threadPool.UsingWindowsThreadPool)
+                {
+                    output.WriteRow("Number of thread pool threads:", threadPool.ThreadCount);
+                }
+                else
+                {
+                    output.WriteRow("CPU utilization:", $"{threadPool.CpuUtilization}%");
+                    output.WriteRow("Workers Total:", threadPool.ActiveWorkerThreads + threadPool.IdleWorkerThreads + threadPool.RetiredWorkerThreads);
+                    output.WriteRow("Workers Running:", threadPool.ActiveWorkerThreads);
+                    output.WriteRow("Workers Idle:", threadPool.IdleWorkerThreads);
+                    output.WriteRow("Worker Min Limit:", threadPool.MinThreads);
+                    output.WriteRow("Worker Max Limit:", threadPool.MaxThreads);
+                }
+                Console.WriteLine();
                 ClrType threadPoolType = Runtime.BaseClassLibrary.GetTypeByName("System.Threading.ThreadPool");
                 ClrStaticField usePortableIOField = threadPoolType?.GetStaticFieldByName("UsePortableThreadPoolForIO");
 

--- a/src/Microsoft.Diagnostics.ExtensionCommands/ThreadPoolCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/ThreadPoolCommand.cs
@@ -36,10 +36,11 @@ namespace Microsoft.Diagnostics.ExtensionCommands
                 Table output = new(Console, Text.WithWidth(17), Text);
                 string threadpoolType = threadPool.UsingWindowsThreadPool ? "Windows" : "Portable";
                 Console.WriteLine($"Using the {threadpoolType} thread pool.");
+                Console.WriteLine();
 
                 if (threadPool.UsingWindowsThreadPool)
                 {
-                    output.WriteRow("Number of thread pool threads:", threadPool.ThreadCount);
+                    output.WriteRow("Thread count:", threadPool.ThreadCount);
                 }
                 else
                 {
@@ -99,6 +100,7 @@ namespace Microsoft.Diagnostics.ExtensionCommands
                     if (threadPool.UsingWindowsThreadPool)
                     {
                         Console.WriteLine("Hill Climbing Log is not supported by the Windows thread pool.");
+                        Console.WriteLine();
                     }
                     else
                     {

--- a/src/Microsoft.Diagnostics.ExtensionCommands/ThreadPoolCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/ThreadPoolCommand.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Diagnostics.ExtensionCommands
                 // We will assume that if UsePortableThreadPoolForIO field is deleted from ThreadPool then we are always
                 // using C# version.
                 bool usingPortableCompletionPorts = threadPool.UsingPortableThreadPool && (usePortableIOField is null || usePortableIOField.Read<bool>(usePortableIOField.Type.Module.AppDomain));
-                if (!usingPortableCompletionPorts)
+                if (!usingPortableCompletionPorts && !threadPool.UsingWindowsThreadPool)
                 {
                     output.Columns[0] = output.Columns[0].WithWidth(19);
                     output.WriteRow("Completion Total:", threadPool.TotalCompletionPorts);

--- a/src/Microsoft.Diagnostics.ExtensionCommands/ThreadPoolCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/ThreadPoolCommand.cs
@@ -33,11 +33,11 @@ namespace Microsoft.Diagnostics.ExtensionCommands
             }
             else
             {
-                Table output = new(Console, Text.WithWidth(17), Text);
                 string threadpoolType = threadPool.UsingWindowsThreadPool ? "Windows" : "Portable";
                 Console.WriteLine($"Using the {threadpoolType} thread pool.");
                 Console.WriteLine();
 
+                Table output = new(Console, Text.WithWidth(17), Text);
                 if (threadPool.UsingWindowsThreadPool)
                 {
                     output.WriteRow("Thread count:", threadPool.ThreadCount);

--- a/src/Microsoft.Diagnostics.ExtensionCommands/ThreadPoolCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/ThreadPoolCommand.cs
@@ -80,8 +80,8 @@ namespace Microsoft.Diagnostics.ExtensionCommands
 
                 // We will assume that if UsePortableThreadPoolForIO field is deleted from ThreadPool then we are always
                 // using C# version.
-                bool usingPortableCompletionPorts = threadPool.UsingPortableThreadPool && (usePortableIOField is null || usePortableIOField.Read<bool>(usePortableIOField.Type.Module.AppDomain));
-                if (!usingPortableCompletionPorts && !threadPool.UsingWindowsThreadPool)
+                bool usingPortableCompletionPorts = threadPool.UsingPortableThreadPool && usePortableIOField is not null && usePortableIOField.Read<bool>(usePortableIOField.Type.Module.AppDomain);
+                if (!usingPortableCompletionPorts)
                 {
                     output.Columns[0] = output.Columns[0].WithWidth(19);
                     output.WriteRow("Completion Total:", threadPool.TotalCompletionPorts);


### PR DESCRIPTION
Uses the properties exposed in https://github.com/microsoft/clrmd/pull/1175 to show relevant Windows thread pool information if it's enabled