### PR TITLE
Improve dotnet-dsrouter log levels and info.

### DIFF
--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsServerRouter/DiagnosticsServerRouterFactory.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsServerRouter/DiagnosticsServerRouterFactory.cs
@@ -406,6 +406,8 @@ namespace Microsoft.Diagnostics.NETCore.Client
 
         protected int TcpClientRetryTimeoutMs { get; set; } = 500;
 
+        protected ILogger Logger => _logger;
+
         public delegate TcpClientRouterFactory CreateInstanceDelegate(string tcpClient, int runtimeTimeoutMs, ILogger logger);
 
         public static TcpClientRouterFactory CreateDefaultInstance(string tcpClient, int runtimeTimeoutMs, ILogger logger)

--- a/src/Tools/dotnet-dsrouter/DiagnosticsServerRouterCommands.cs
+++ b/src/Tools/dotnet-dsrouter/DiagnosticsServerRouterCommands.cs
@@ -72,26 +72,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
                 LogLevel = logLevel;
             }
 
-            protected SpecificRunnerBase(string logLevel) : this(ParseLogLevel(logLevel))
-            {
-            }
-
             public abstract void ConfigureLauncher(CancellationToken cancellationToken);
-
-            protected static LogLevel ParseLogLevel(string verbose)
-            {
-                LogLevel logLevel = LogLevel.Information;
-                if (string.Equals(verbose, "debug", StringComparison.OrdinalIgnoreCase))
-                {
-                    logLevel = LogLevel.Debug;
-                }
-                else if (string.Equals(verbose, "trace", StringComparison.OrdinalIgnoreCase))
-                {
-                    logLevel = LogLevel.Trace;
-                }
-
-                return logLevel;
-            }
 
             // The basic run loop: configure logging and the launcher, then create the router and run it until it exits or the user interrupts
             public async Task<int> CommonRunLoop(Func<ILogger, DiagnosticsServerRouterRunner.ICallbacks, CancellationTokenSource, Task<int>> createRouterTask, CancellationToken token)
@@ -103,9 +84,11 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
 
                 ConfigureLauncher(token);
 
-                ILogger logger = loggerFactory.CreateLogger("dotnet-dsrouter");
+                int pid = Process.GetCurrentProcess().Id;
 
-                logger.LogInformation($"Starting dotnet-dsrouter using pid={Process.GetCurrentProcess().Id}");
+                ILogger logger = loggerFactory.CreateLogger($"dotnet-dsrouter-{pid}");
+
+                logger.LogInformation($"Starting dotnet-dsrouter using pid={pid}");
 
                 Task<int> routerTask = createRouterTask(logger, Launcher, linkedCancelToken);
 
@@ -147,13 +130,13 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
 
         private sealed class IpcClientTcpServerRunner : SpecificRunnerBase
         {
-            public IpcClientTcpServerRunner(string verbose) : base(verbose) { }
+            public IpcClientTcpServerRunner(LogLevel logLevel) : base(logLevel) { }
 
             public override void ConfigureLauncher(CancellationToken cancellationToken)
             {
                 Launcher.SuspendProcess = true;
                 Launcher.ConnectMode = true;
-                Launcher.Verbose = LogLevel != LogLevel.Information;
+                Launcher.Verbose = LogLevel < LogLevel.Information;
                 Launcher.CommandToken = cancellationToken;
             }
 
@@ -169,9 +152,11 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
 
         public async Task<int> RunIpcClientTcpServerRouter(CancellationToken token, string ipcClient, string tcpServer, int runtimeTimeout, string verbose, string forwardPort)
         {
-            checkLoopbackOnly(tcpServer);
+            LogLevel logLevel = ParseLogLevel(verbose);
 
-            IpcClientTcpServerRunner runner = new(verbose);
+            checkLoopbackOnly(tcpServer, logLevel);
+
+            IpcClientTcpServerRunner runner = new(logLevel);
 
             return await runner.CommonRunLoop((logger, launcherCallbacks, linkedCancelToken) => {
                 NetServerRouterFactory.CreateInstanceDelegate tcpServerRouterFactory = ChooseTcpServerRouterFactory(forwardPort, logger);
@@ -183,22 +168,24 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
 
         private sealed class IpcServerTcpServerRunner : SpecificRunnerBase
         {
-            public IpcServerTcpServerRunner(string verbose) : base(verbose) { }
+            public IpcServerTcpServerRunner(LogLevel logLevel) : base(logLevel) { }
 
             public override void ConfigureLauncher(CancellationToken cancellationToken)
             {
                 Launcher.SuspendProcess = false;
                 Launcher.ConnectMode = true;
-                Launcher.Verbose = LogLevel != LogLevel.Information;
+                Launcher.Verbose = LogLevel < LogLevel.Information;
                 Launcher.CommandToken = cancellationToken;
             }
         }
 
         public async Task<int> RunIpcServerTcpServerRouter(CancellationToken token, string ipcServer, string tcpServer, int runtimeTimeout, string verbose, string forwardPort)
         {
-            checkLoopbackOnly(tcpServer);
+            LogLevel logLevel = ParseLogLevel(verbose);
 
-            IpcServerTcpServerRunner runner = new(verbose);
+            checkLoopbackOnly(tcpServer, logLevel);
+
+            IpcServerTcpServerRunner runner = new(logLevel);
 
             return await runner.CommonRunLoop((logger, launcherCallbacks, linkedCancelToken) => {
                 NetServerRouterFactory.CreateInstanceDelegate tcpServerRouterFactory = ChooseTcpServerRouterFactory(forwardPort, logger);
@@ -215,20 +202,20 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
 
         private sealed class IpcServerTcpClientRunner : SpecificRunnerBase
         {
-            public IpcServerTcpClientRunner(string verbose) : base(verbose) { }
+            public IpcServerTcpClientRunner(LogLevel logLevel) : base(logLevel) { }
 
             public override void ConfigureLauncher(CancellationToken cancellationToken)
             {
                 Launcher.SuspendProcess = false;
                 Launcher.ConnectMode = false;
-                Launcher.Verbose = LogLevel != LogLevel.Information;
+                Launcher.Verbose = LogLevel < LogLevel.Information;
                 Launcher.CommandToken = cancellationToken;
             }
         }
 
         public async Task<int> RunIpcServerTcpClientRouter(CancellationToken token, string ipcServer, string tcpClient, int runtimeTimeout, string verbose, string forwardPort)
         {
-            IpcServerTcpClientRunner runner = new(verbose);
+            IpcServerTcpClientRunner runner = new(ParseLogLevel(verbose));
             return await runner.CommonRunLoop((logger, launcherCallbacks, linkedCancelToken) => {
                 TcpClientRouterFactory.CreateInstanceDelegate tcpClientRouterFactory = ChooseTcpClientRouterFactory(forwardPort, logger);
 
@@ -244,20 +231,20 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
 
         private sealed class IpcClientTcpClientRunner : SpecificRunnerBase
         {
-            public IpcClientTcpClientRunner(string verbose) : base(verbose) { }
+            public IpcClientTcpClientRunner(LogLevel logLevel) : base(logLevel) { }
 
             public override void ConfigureLauncher(CancellationToken cancellationToken)
             {
                 Launcher.SuspendProcess = true;
                 Launcher.ConnectMode = false;
-                Launcher.Verbose = LogLevel != LogLevel.Information;
+                Launcher.Verbose = LogLevel < LogLevel.Information;
                 Launcher.CommandToken = cancellationToken;
             }
         }
 
         public async Task<int> RunIpcClientTcpClientRouter(CancellationToken token, string ipcClient, string tcpClient, int runtimeTimeout, string verbose, string forwardPort)
         {
-            IpcClientTcpClientRunner runner = new(verbose);
+            IpcClientTcpClientRunner runner = new(ParseLogLevel(verbose));
             return await runner.CommonRunLoop((logger, launcherCallbacks, linkedCancelToken) => {
                 TcpClientRouterFactory.CreateInstanceDelegate tcpClientRouterFactory = ChooseTcpClientRouterFactory(forwardPort, logger);
 
@@ -268,20 +255,20 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
 
         private sealed class IpcServerWebSocketServerRunner : SpecificRunnerBase
         {
-            public IpcServerWebSocketServerRunner(string verbose) : base(verbose) { }
+            public IpcServerWebSocketServerRunner(LogLevel logLevel) : base(logLevel) { }
 
             public override void ConfigureLauncher(CancellationToken cancellationToken)
             {
                 Launcher.SuspendProcess = false;
                 Launcher.ConnectMode = true;
-                Launcher.Verbose = LogLevel != LogLevel.Information;
+                Launcher.Verbose = LogLevel < LogLevel.Information;
                 Launcher.CommandToken = cancellationToken;
             }
         }
 
         public async Task<int> RunIpcServerWebSocketServerRouter(CancellationToken token, string ipcServer, string webSocket, int runtimeTimeout, string verbose)
         {
-            IpcServerWebSocketServerRunner runner = new(verbose);
+            IpcServerWebSocketServerRunner runner = new(ParseLogLevel(verbose));
 
             WebSocketServer.WebSocketServerImpl server = new(runner.LogLevel);
 
@@ -311,20 +298,20 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
 
         private sealed class IpcClientWebSocketServerRunner : SpecificRunnerBase
         {
-            public IpcClientWebSocketServerRunner(string verbose) : base(verbose) { }
+            public IpcClientWebSocketServerRunner(LogLevel logLevel) : base(logLevel) { }
 
             public override void ConfigureLauncher(CancellationToken cancellationToken)
             {
                 Launcher.SuspendProcess = true;
                 Launcher.ConnectMode = true;
-                Launcher.Verbose = LogLevel != LogLevel.Information;
+                Launcher.Verbose = LogLevel < LogLevel.Information;
                 Launcher.CommandToken = cancellationToken;
             }
         }
 
         public async Task<int> RunIpcClientWebSocketServerRouter(CancellationToken token, string ipcClient, string webSocket, int runtimeTimeout, string verbose)
         {
-            IpcClientWebSocketServerRunner runner = new(verbose);
+            IpcClientWebSocketServerRunner runner = new(ParseLogLevel(verbose));
 
             WebSocketServer.WebSocketServerImpl server = new(runner.LogLevel);
 
@@ -347,27 +334,43 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
             }
         }
 
-        public async Task<int> RunIpcServerIOSSimulatorRouter(CancellationToken token, int runtimeTimeout, string verbose)
+        public async Task<int> RunIpcServerIOSSimulatorRouter(CancellationToken token, int runtimeTimeout, string verbose, bool info)
         {
-            logDiagnosticPortsConfiguration("ios simulator", "127.0.0.1:9000", false, verbose);
-            return await RunIpcServerTcpServerRouter(token, "", "127.0.0.1:9000", runtimeTimeout, verbose, "").ConfigureAwait(false);
+            if (info)
+            {
+                logRouterUsageInfo("ios simulator", "127.0.0.1:9000", false);
+            }
+
+            return await RunIpcServerTcpClientRouter(token, "", "127.0.0.1:9000", runtimeTimeout, verbose, "").ConfigureAwait(false);
         }
 
-        public async Task<int> RunIpcServerIOSRouter(CancellationToken token, int runtimeTimeout, string verbose)
+        public async Task<int> RunIpcServerIOSRouter(CancellationToken token, int runtimeTimeout, string verbose, bool info)
         {
-            logDiagnosticPortsConfiguration("ios device", "127.0.0.1:9000", true, verbose);
+            if (info)
+            {
+                logRouterUsageInfo("ios device", "127.0.0.1:9000", true);
+            }
+
             return await RunIpcServerTcpClientRouter(token, "", "127.0.0.1:9000", runtimeTimeout, verbose, "iOS").ConfigureAwait(false);
         }
 
-        public async Task<int> RunIpcServerAndroidEmulatorRouter(CancellationToken token, int runtimeTimeout, string verbose)
+        public async Task<int> RunIpcServerAndroidEmulatorRouter(CancellationToken token, int runtimeTimeout, string verbose, bool info)
         {
-            logDiagnosticPortsConfiguration("android emulator", "10.0.2.2:9000", false, verbose);
+            if (info)
+            {
+                logRouterUsageInfo("android emulator", "10.0.2.2:9000", false);
+            }
+
             return await RunIpcServerTcpServerRouter(token, "", "127.0.0.1:9000", runtimeTimeout, verbose, "").ConfigureAwait(false);
         }
 
-        public async Task<int> RunIpcServerAndroidRouter(CancellationToken token, int runtimeTimeout, string verbose)
+        public async Task<int> RunIpcServerAndroidRouter(CancellationToken token, int runtimeTimeout, string verbose, bool info)
         {
-            logDiagnosticPortsConfiguration("android emulator", "127.0.0.1:9000", false, verbose);
+            if (info)
+            {
+                logRouterUsageInfo("android device", "127.0.0.1:9000", false);
+            }
+
             return await RunIpcServerTcpServerRouter(token, "", "127.0.0.1:9000", runtimeTimeout, verbose, "Android").ConfigureAwait(false);
         }
 
@@ -436,26 +439,67 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
             return tcpServerRouterFactory;
         }
 
-        private static void logDiagnosticPortsConfiguration(string deviceName, string deviceTcpIpAddress, bool deviceListenMode, string verbose)
+        private static LogLevel ParseLogLevel(string verbose)
+        {
+            LogLevel logLevel = LogLevel.Information;
+            if (string.Equals(verbose, "none", StringComparison.OrdinalIgnoreCase))
+            {
+                logLevel = LogLevel.None;
+            }
+            else if (string.Equals(verbose, "critical", StringComparison.OrdinalIgnoreCase))
+            {
+                logLevel = LogLevel.Critical;
+            }
+            else if (string.Equals(verbose, "error", StringComparison.OrdinalIgnoreCase))
+            {
+                logLevel = LogLevel.Error;
+            }
+            else if (string.Equals(verbose, "warning", StringComparison.OrdinalIgnoreCase))
+            {
+                logLevel = LogLevel.Warning;
+            }
+            else if (string.Equals(verbose, "info", StringComparison.OrdinalIgnoreCase))
+            {
+                logLevel = LogLevel.Information;
+            }
+            else if (string.Equals(verbose, "debug", StringComparison.OrdinalIgnoreCase))
+            {
+                logLevel = LogLevel.Debug;
+            }
+            else if (string.Equals(verbose, "trace", StringComparison.OrdinalIgnoreCase))
+            {
+                logLevel = LogLevel.Trace;
+            }
+
+            return logLevel;
+        }
+
+        private static void logRouterUsageInfo(string deviceName, string deviceTcpIpAddress, bool deviceListenMode)
         {
             StringBuilder message = new();
 
-            if (!string.IsNullOrEmpty(verbose))
-            {
-                deviceName = !string.IsNullOrEmpty(deviceName) ? $" on {deviceName} " : " ";
-                message.AppendLine($"Start an application{deviceName}with one of the following environment variables set:");
-            }
+            string listenMode = deviceListenMode ? "listen" : "connect";
+            int pid = Process.GetCurrentProcess().Id;
 
-            string listenMode = deviceListenMode ? ",listen" : ",connect";
-            message.AppendLine($"DOTNET_DiagnosticPorts={deviceTcpIpAddress},nosuspend{listenMode}");
-            message.AppendLine($"DOTNET_DiagnosticPorts={deviceTcpIpAddress},suspend{listenMode}");
+            message.AppendLine($"How to connect current dotnet-dsrouter pid={pid} with {deviceName} and diagnostics tooling.");
+            message.AppendLine($"Start an application on {deviceName} with ONE of the following environment variables set:");
+            message.AppendLine("[Default Tracing]");
+            message.AppendLine($"DOTNET_DiagnosticPorts={deviceTcpIpAddress},nosuspend,{listenMode}");
+            message.AppendLine("[Startup Tracing]");
+            message.AppendLine($"DOTNET_DiagnosticPorts={deviceTcpIpAddress},suspend,{listenMode}");
+            message.AppendLine($"Run diagnotic tool connecting application on {deviceName} through dotnet-dsrouter pid={pid}:");
+            message.AppendLine($"dotnet-trace collect -p {pid}");
+            message.AppendLine($"See https://learn.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-dsrouter for additional details and examples.");
 
+            ConsoleColor currentColor = Console.ForegroundColor;
+            Console.ForegroundColor = ConsoleColor.Green;
             Console.WriteLine(message.ToString());
+            Console.ForegroundColor = currentColor;
         }
 
-        private static void checkLoopbackOnly(string tcpServer)
+        private static void checkLoopbackOnly(string tcpServer, LogLevel logLevel)
         {
-            if (!string.IsNullOrEmpty(tcpServer) && !DiagnosticsServerRouterRunner.isLoopbackOnly(tcpServer))
+            if (logLevel != LogLevel.None && !string.IsNullOrEmpty(tcpServer) && !DiagnosticsServerRouterRunner.isLoopbackOnly(tcpServer))
             {
                 StringBuilder message = new();
 

--- a/src/Tools/dotnet-dsrouter/DiagnosticsServerRouterCommands.cs
+++ b/src/Tools/dotnet-dsrouter/DiagnosticsServerRouterCommands.cs
@@ -441,7 +441,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
 
         private static LogLevel ParseLogLevel(string verbose)
         {
-            LogLevel logLevel = LogLevel.Information;
+            LogLevel logLevel;
             if (string.Equals(verbose, "none", StringComparison.OrdinalIgnoreCase))
             {
                 logLevel = LogLevel.None;
@@ -469,6 +469,10 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
             else if (string.Equals(verbose, "trace", StringComparison.OrdinalIgnoreCase))
             {
                 logLevel = LogLevel.Trace;
+            }
+            else
+            {
+                throw new ArgumentException($"Unknown verbose log level, {verbose}");
             }
 
             return logLevel;

--- a/src/Tools/dotnet-dsrouter/DiagnosticsServerRouterCommands.cs
+++ b/src/Tools/dotnet-dsrouter/DiagnosticsServerRouterCommands.cs
@@ -338,7 +338,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
         {
             if (info)
             {
-                logRouterUsageInfo("ios simulator", "127.0.0.1:9000", false);
+                logRouterUsageInfo("ios simulator", "127.0.0.1:9000", true);
             }
 
             return await RunIpcServerTcpClientRouter(token, "", "127.0.0.1:9000", runtimeTimeout, verbose, "").ConfigureAwait(false);

--- a/src/Tools/dotnet-dsrouter/Program.cs
+++ b/src/Tools/dotnet-dsrouter/Program.cs
@@ -226,7 +226,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
         private static Option VerboseOption() =>
             new(
                 aliases: new[] { "--verbose", "-v" },
-                description: "Enable verbose logging (none|info|debug|trace)")
+                description: "Enable verbose logging (none|critical|error|warning|info|debug|trace)")
             {
                 Argument = new Argument<string>(name: "verbose", getDefaultValue: () => "info")
             };


### PR DESCRIPTION
* Add support for -v none, suppressing all logging making dotnet-dsrouter quiet.
* Add support for --info option for new iOS/Android preconfig commands, outputs details on how to configure app and diagnostic tools to connect to current running dsrouter instance.
*  Improve error handling when failing to find or execute adb binary.
*  Specify and validate supported verbose logging levels.