### PR TITLE
Handle log messages with duplicate placeholders and null args

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/EventLogsPipeline.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/EventLogsPipeline.cs
@@ -137,7 +137,10 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
                         object[] args = new object[formatter.ValueNames.Count];
                         for (int i = 0; i < args.Length; i++)
                         {
-                            args[i] = message.GetProperty(formatter.ValueNames[i]).GetString();
+                            if (message.TryGetProperty(formatter.ValueNames[i], out JsonElement value))
+                            {
+                                args[i] = value.GetString();
+                            }
                         }
 
                         //We want to propagate the timestamp to the underlying logger, but that's not part of the ILogger interface.

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/EventLogsPipeline.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/EventLogsPipeline.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
                         using JsonElement.ObjectEnumerator argsEnumerator = message.EnumerateObject();
                         if (argsEnumerator.MoveNext())
                         {
-                            JsonProperty currentElement = argsEnumerator.Current;
+                            JsonProperty currentProperty = argsEnumerator.Current;
                             parsedState = true;
 
                             // NOTE: In general there'll be N+1 properties in the arguments payload, where the last entry is the original format string.
@@ -152,18 +152,18 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
                             // It's possible that a log message with placeholders will supply a null array for the arguments.
                             // In which case there will only be the original format string in the arguments payload
                             // and we can skip filling the args array as all values should be null.
-                            if (!string.Equals(OriginalFormatProperty, currentElement.Name, StringComparison.Ordinal))
+                            if (!string.Equals(OriginalFormatProperty, currentProperty.Name, StringComparison.Ordinal))
                             {
                                 for (int i = 0; i < formatter.ValueNames.Count; i++)
                                 {
-                                    args[i] = currentElement.Value.GetString();
+                                    args[i] = currentProperty.Value.GetString();
 
                                     if (!argsEnumerator.MoveNext())
                                     {
                                         parsedState = false;
                                         break;
                                     }
-                                    currentElement = argsEnumerator.Current;
+                                    currentProperty = argsEnumerator.Current;
                                 }
                             }
 

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/EventLogsPipeline.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/EventLogsPipeline.cs
@@ -160,6 +160,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
 
                                     if (!argsEnumerator.MoveNext())
                                     {
+                                        // Unexpected, fallback to logging the original message without the extra formatting.
                                         parsedState = false;
                                         break;
                                     }

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/EventLogsPipeline.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/EventLogsPipeline.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
                         using JsonElement.ObjectEnumerator argsEnumerator = message.EnumerateObject();
                         if (argsEnumerator.MoveNext())
                         {
-                            JsonProperty currentElement = enuargsEnumeratormerator.Current;
+                            JsonProperty currentElement = argsEnumerator.Current;
                             parsedState = true;
 
                             // NOTE: In general there'll be N+1 properties in the arguments payload, where the last entry is the original format string.


### PR DESCRIPTION
This PR addresses two issues with the event source log processing:
1. A log template string can consist of multiple placeholders with the same name. Placeholders are ordinal-based and not name-aligned.
   - The current code assumes placeholder names are unique and so fills each placeholder with the same value. (e.g. a message of `"{A}, {A}, {A}", [5, 10, 15]` would be incorrectly processed as `A: 5, A: 5, A: 5`).
3. A log message with placeholders can have an entirely null state (e.g. `_logger.LogInformational("Test {A}", args: null)`). In this scenario, the event source args payload will only contain the original format string, not the null args. 
   - The current code assumes all placeholders will exist in the event source args payload, which results in an exception being thrown and the log message being dropped.

cc @dotnet/dotnet-monitor 