### PR TITLE
Remove SOS's CRT invalid parameter handler

### DIFF
--- a/src/SOS/SOS.UnitTests/Debuggees/DesktopClrHost/CMakeLists.txt
+++ b/src/SOS/SOS.UnitTests/Debuggees/DesktopClrHost/CMakeLists.txt
@@ -6,7 +6,6 @@ include_directories(inc)
 include_directories("$ENV{VSInstallDir}/DIA SDK/include")
 
 add_definitions(-DUSE_STL)
-add_definitions(-MT) 
 
 set(DESKTOPCLRHOST_SOURCES
     DesktopClrHost.cpp

--- a/src/SOS/Strike/CMakeLists.txt
+++ b/src/SOS/Strike/CMakeLists.txt
@@ -32,9 +32,9 @@ if(CLR_CMAKE_HOST_ARCH_AMD64)
   add_definitions(-D_TARGET_WIN64_=1)
   add_definitions(-DDBG_TARGET_64BIT)
   add_definitions(-DDBG_TARGET_WIN64=1)
-  if(WIN32)
+  if (CLR_CMAKE_HOST_WIN32)
     add_definitions(-DSOS_TARGET_ARM64=1)
-  endif(WIN32)
+  endif(CLR_CMAKE_HOST_WIN32)
   remove_definitions(-D_TARGET_ARM64_=1)
   add_definitions(-D_TARGET_AMD64_)
   add_definitions(-DDBG_TARGET_AMD64)
@@ -44,9 +44,9 @@ elseif(CLR_CMAKE_HOST_ARCH_I386)
   add_definitions(-D_TARGET_X86_=1)
   add_definitions(-DTARGET_X86)
   add_definitions(-DDBG_TARGET_32BIT)
-  if(WIN32)
+  if (CLR_CMAKE_HOST_WIN32)
     add_definitions(-DSOS_TARGET_ARM=1)
-  endif(WIN32)
+  endif(CLR_CMAKE_HOST_WIN32)
 elseif(CLR_CMAKE_HOST_ARCH_ARM)
   message(STATUS "CLR_CMAKE_HOST_ARCH_ARM")
   add_definitions(-DSOS_TARGET_ARM=1)
@@ -73,11 +73,8 @@ include_directories(${ROOT_DIR}/src/SOS/extensions)
 include_directories(${CLR_SHARED_DIR}/gcdump)
 include_directories(platform)
 
-if(WIN32)
+if (CLR_CMAKE_HOST_WIN32)
   add_definitions(-DUSE_STL)
-
-  #use static crt
-  add_definitions(-MT) 
 
   set(SOS_SOURCES
     disasm.cpp
@@ -138,7 +135,7 @@ if(WIN32)
         mscoree.lib)
   endif(NOT CLR_CMAKE_HOST_ARCH_ARM64 AND NOT CLR_CMAKE_HOST_ARCH_ARM)
 
-else(WIN32)
+else(CLR_CMAKE_HOST_WIN32)
   add_definitions(-DFEATURE_ENABLE_HARDWARE_EXCEPTIONS)
   add_definitions(-DPAL_STDCPP_COMPAT=1)
   add_compile_options(-Wno-null-arithmetic)
@@ -187,28 +184,28 @@ else(WIN32)
     coreclrpal
   )
 
-endif(WIN32)
+endif(CLR_CMAKE_HOST_WIN32)
 
 if(CLR_CMAKE_HOST_ARCH_AMD64)
   set(SOS_SOURCES_ARCH
     disasmX86.cpp
   )
-  if(WIN32)
+  if (CLR_CMAKE_HOST_WIN32)
     list(APPEND 
       SOS_SOURCES_ARCH  
       disasmARM64.cpp
     )
-  endif(WIN32)
+  endif(CLR_CMAKE_HOST_WIN32)
 elseif(CLR_CMAKE_HOST_ARCH_I386)
   set(SOS_SOURCES_ARCH 
     disasmX86.cpp
   )
-  if(WIN32)
+  if (CLR_CMAKE_HOST_WIN32)
     list(APPEND
       SOS_SOURCES_ARCH
       disasmARM.cpp
     )
-  endif(WIN32)
+  endif(CLR_CMAKE_HOST_WIN32)
 elseif(CLR_CMAKE_HOST_ARCH_ARM)
   set(SOS_SOURCES_ARCH
     disasmARM.cpp
@@ -246,6 +243,6 @@ target_link_libraries(sos ${SOS_LIBRARY})
 # add the install targets
 install_clr(TARGETS sos DESTINATIONS .)
 
-if(NOT WIN32)
+if(NOT CLR_CMAKE_HOST_WIN32)
   install(FILES sosdocsunix.txt DESTINATION .)
-endif(NOT WIN32)
+endif(NOT CLR_CMAKE_HOST_WIN32)

--- a/src/SOS/Strike/exts.cpp
+++ b/src/SOS/Strike/exts.cpp
@@ -264,20 +264,6 @@ DACMessage(HRESULT Status)
 BOOL IsMiniDumpFileNODAC();
 extern HMODULE g_hInstance;
 
-// This function throws an exception that can be caught by the debugger,
-// instead of allowing the default CRT behavior of invoking Watson to failfast.
-void __cdecl _SOS_invalid_parameter(
-   const WCHAR * expression,
-   const WCHAR * function, 
-   const WCHAR * file, 
-   unsigned int line,
-   uintptr_t pReserved
-)
-{
-    ExtErr("\nSOS failure!\n");
-    throw "SOS failure";
-}
-
 bool g_Initialized = false;
 const char* g_sosPrefix = "";
 
@@ -344,12 +330,6 @@ DebugExtensionInitialize(PULONG Version, PULONG Flags)
             "----------------------------------------------------------------------------\n");
     }
     ExtRelease();
-    
-#ifndef _ARM_
-    // Make sure we do not tear down the debugger when a security function fails
-    // Since we link statically against CRT this will only affect the SOS module.
-    _set_invalid_parameter_handler(_SOS_invalid_parameter);
-#endif
     
     return S_OK;
 }

--- a/src/SOS/extensions/CMakeLists.txt
+++ b/src/SOS/extensions/CMakeLists.txt
@@ -2,10 +2,6 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 include(configure.cmake)
 
-if(WIN32)
-    add_definitions(-MT)
-endif(WIN32)
-
 add_definitions(-DPAL_STDCPP_COMPAT)
 
 include_directories(${ROOT_DIR}/src/SOS/inc)

--- a/src/SOS/runcommand/CMakeLists.txt
+++ b/src/SOS/runcommand/CMakeLists.txt
@@ -7,9 +7,6 @@ include_directories("$ENV{VSInstallDir}/DIA SDK/include")
 
 add_definitions(-DUSE_STL)
 
-#use static crt
-add_definitions(-MT) 
-
 set(RUNCOMMAND_SOURCES
     runcommand.cpp
 )


### PR DESCRIPTION
SOS does get built dynamically linking to the C++ CRT in release so the invalid parameter handler that gets installed affects all the code in the process.

Fixes issue: https://github.com/dotnet/diagnostics/issues/4070