### PR TITLE
Handle log messages with null state

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/EventLogsPipeline.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/EventLogsPipeline.cs
@@ -137,7 +137,10 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
                         object[] args = new object[formatter.ValueNames.Count];
                         for (int i = 0; i < args.Length; i++)
                         {
-                            args[i] = message.GetProperty(formatter.ValueNames[i]).GetString();
+                            if (message.TryGetProperty(formatter.ValueNames[i], out JsonElement value))
+                            {
+                                args[i] = value.GetString();
+                            }
                         }
 
                         //We want to propagate the timestamp to the underlying logger, but that's not part of the ILogger interface.


### PR DESCRIPTION
This PR addresses an issue were certain log messages could be dropped:
- A log message with placeholders can have an entirely null state (e.g. `_logger.LogInformational("Test {A}", args: null)`). In this scenario, the event source args payload will only contain the original format string, not the null args. 
   - The current code assumes all placeholders will exist in the event source args payload, which results in an exception being thrown and the log message being dropped.
   
The changes in this PR are only used by dotnet-monitor so there should be no/minimal impact to the rest of the repo.

(This is subset of https://github.com/dotnet/diagnostics/pull/4284)

cc @dotnet/dotnet-monitor @noahfalk 