### PR TITLE
Fix log scope construction

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/LoggingSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/LoggingSourceConfiguration.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics.Tracing;
 using System.Text;
 using Microsoft.Diagnostics.NETCore.Client;
+using Microsoft.Diagnostics.Tracing.Parsers;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Diagnostics.Monitoring.EventPipe
@@ -39,7 +40,13 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
                         {
                             { "FilterSpecs", _filterSpecs }
                         }
-                )
+                ),
+                // Activity correlation
+                new EventPipeProvider(
+                    TplEventSource,
+                    EventLevel.Informational,
+                    (long)TplEtwProviderTraceEventParser.Keywords.TasksFlowActivityIds
+                ),
             };
         }
 

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/EventLogsPipeline.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/EventLogsPipeline.cs
@@ -124,8 +124,8 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
                 // This is because TplEventSource's TasksFlowActivityIds is a singleton implementation that is shared for all traces,
                 // regardless of if the other traces have TasksFlowActivityIds enabled.
                 //
-                // In this scenario there's still a chance that only a single branch has occurred and we're the first event logged with the newly branched ActivityId,
-                // in which case we can use the RelatedActivityId to still grab the whole scope.
+                // In this scenario there's still a chance that only a single branch has occurred and we're the first event logged with the newly branched ActivityId.
+                // In which case we can use the RelatedActivityId to find our way back onto the tree.
                 //
                 // If not then we will be operating on a subtree without a way of getting back to the root node and will only have a subset (if any) of the
                 // applicable scopes.

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/EventLogsPipeline.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/EventLogsPipeline.cs
@@ -14,9 +14,6 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
 {
     internal class EventLogsPipeline : EventSourcePipeline<EventLogsPipelineSettings>
     {
-        // We guard against excessive scope depth
-        private const int ActivityIdLimit = 10_000;
-
         private readonly ILoggerFactory _factory;
         private static readonly Func<object, Exception, string> _messageFormatter = MessageFormatter;
         public EventLogsPipeline(DiagnosticsClient client, EventLogsPipelineSettings settings, ILoggerFactory factory)
@@ -84,7 +81,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
                         item.Parent = parentItem;
                     }
 
-                    if (activityIdToScope.Count < ActivityIdLimit || activityIdToScope.ContainsKey(traceEvent.ActivityID))
+                    if (activityIdToScope.Count < Settings.ScopeLimit || activityIdToScope.ContainsKey(traceEvent.ActivityID))
                     {
                         activityIdToScope[traceEvent.ActivityID] = item;
                     }

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/EventLogsPipeline.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/EventLogsPipeline.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/EventLogsPipelineSettings.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/EventLogsPipelineSettings.cs
@@ -16,5 +16,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
 
         // This setting will collect logs for the application-defined categories and levels.
         public bool UseAppFilters { get; set; } = true;
+
+        public bool CollectScopes { get; set; } = true;
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/EventLogsPipelineSettings.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/EventLogsPipelineSettings.cs
@@ -18,5 +18,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
         public bool UseAppFilters { get; set; } = true;
 
         public bool CollectScopes { get; set; } = true;
+
+        public int ScopeLimit { get; set; } = 10_000;
     }
 }

--- a/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventLogsPipelineUnitTests.cs
+++ b/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventLogsPipelineUnitTests.cs
@@ -43,10 +43,10 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
         [SkippableTheory, MemberData(nameof(Configurations))]
         public async Task TestLogsAllCategoriesAllLevels(TestConfiguration config)
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                throw new SkipTestException("https://github.com/dotnet/diagnostics/issues/2541");
-            }
+            //if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            //{
+            //    throw new SkipTestException("https://github.com/dotnet/diagnostics/issues/2541");
+            //}
 
             using Stream outputStream = await GetLogsAsync(config, settings => {
                 settings.UseAppFilters = false;
@@ -95,13 +95,13 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
         /// <summary>
         /// Test that log events at the default level are collected for categories without a specified level.
         /// </summary>
-        [SkippableTheory(Skip = "Unreliable test https://github.com/dotnet/diagnostics/issues/3143"), MemberData(nameof(Configurations))]
+        [SkippableTheory, MemberData(nameof(Configurations))]
         public async Task TestLogsAllCategoriesDefaultLevelFallback(TestConfiguration config)
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                throw new SkipTestException("https://github.com/dotnet/diagnostics/issues/2541");
-            }
+            //if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            //{
+            //    throw new SkipTestException("https://github.com/dotnet/diagnostics/issues/2541");
+            //}
 
             using Stream outputStream = await GetLogsAsync(config, settings => {
                 settings.UseAppFilters = false;

--- a/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventLogsPipelineUnitTests.cs
+++ b/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventLogsPipelineUnitTests.cs
@@ -263,6 +263,18 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
             Assert.Equal(string.Empty, result.EventName);
             Validate(result.Scopes, ("BoolValue", "true"), ("StringValue", "test"), ("IntValue", "5"));
             Validate(result.Arguments, ("Arg", "6"));
+
+            message = reader.ReadLine();
+            Assert.NotNull(message);
+
+            result = JsonSerializer.Deserialize<LoggerTestResult>(message);
+            Assert.Equal("Some other message with 7", result.Message);
+            Assert.Equal(LoggerRemoteTestName, result.Category);
+            Assert.Equal("Information", result.LogLevel);
+            Assert.Equal(0, result.EventId);
+            Assert.Equal(string.Empty, result.EventName);
+            Validate(result.Scopes, ("BoolValue", "false"), ("StringValue", "string"), ("IntValue", "6"));
+            Validate(result.Arguments, ("Arg", "7"));
         }
 
         private static void ValidateLoggerRemoteCategoryWarningMessage(StreamReader reader)

--- a/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventLogsPipelineUnitTests.cs
+++ b/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventLogsPipelineUnitTests.cs
@@ -43,10 +43,10 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
         [SkippableTheory, MemberData(nameof(Configurations))]
         public async Task TestLogsAllCategoriesAllLevels(TestConfiguration config)
         {
-            //if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            //{
-            //    throw new SkipTestException("https://github.com/dotnet/diagnostics/issues/2541");
-            //}
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                throw new SkipTestException("https://github.com/dotnet/diagnostics/issues/2541");
+            }
 
             using Stream outputStream = await GetLogsAsync(config, settings => {
                 settings.UseAppFilters = false;
@@ -95,13 +95,13 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
         /// <summary>
         /// Test that log events at the default level are collected for categories without a specified level.
         /// </summary>
-        [SkippableTheory, MemberData(nameof(Configurations))]
+        [SkippableTheory(Skip = "Unreliable test https://github.com/dotnet/diagnostics/issues/3143"), MemberData(nameof(Configurations))]
         public async Task TestLogsAllCategoriesDefaultLevelFallback(TestConfiguration config)
         {
-            //if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            //{
-            //    throw new SkipTestException("https://github.com/dotnet/diagnostics/issues/2541");
-            //}
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                throw new SkipTestException("https://github.com/dotnet/diagnostics/issues/2541");
+            }
 
             using Stream outputStream = await GetLogsAsync(config, settings => {
                 settings.UseAppFilters = false;


### PR DESCRIPTION
This PR reworks how log scopes are reconstructed. The current implementation has a several issues that results in it only working in single-threaded contexts. Once multiple threads are involved, scopes will be incorrectly associated to log messages in addition to scopes being deleted early while they are still active.

I've described how the new approach works in the source code so it doesn't get lost after this PR is merged. I've also left a comment with a visual representation of edge cases with concurrent traces.

/cc @dotnet/dotnet-monitor 