### PR TITLE
[Dotnet Monitor] Small Fix For SDM Triggers

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/SystemDiagnosticsMetricsTrigger/SystemDiagnosticsMetricsTriggerImpl.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Triggers/SystemDiagnosticsMetricsTrigger/SystemDiagnosticsMetricsTriggerImpl.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.Triggers.SystemDiagnosticsM
         {
             EventType eventType = payload.EventType;
 
-            if (eventType.IsError() || eventType == EventType.CounterEnded)
+            if (!eventType.IsValuePublishedEvent())
             {
                 // not currently logging the error messages
 


### PR DESCRIPTION
Small bug fix on the dotnet-monitor side from the unification work - we previously didn't create a payload for `BeginInstrumentReporting`, and thus only checked that a payload wasn't an error or the end of a counter. The code now leverages the newly-added `IsValuePublishedEvent` from the unification to only apply to the correct payloads.