### PR TITLE
Fix dotnet-dsrouter Android port reverse local/remote ports.

### DIFF
--- a/src/Tools/dotnet-dsrouter/DiagnosticsServerRouterCommands.cs
+++ b/src/Tools/dotnet-dsrouter/DiagnosticsServerRouterCommands.cs
@@ -336,7 +336,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
 
         public async Task<int> RunIpcServerIOSSimulatorRouter(CancellationToken token, int runtimeTimeout, string verbose, bool info)
         {
-            if (info)
+            if (info || ParseLogLevel(verbose) <= LogLevel.Information)
             {
                 logRouterUsageInfo("ios simulator", "127.0.0.1:9000", true);
             }
@@ -346,7 +346,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
 
         public async Task<int> RunIpcServerIOSRouter(CancellationToken token, int runtimeTimeout, string verbose, bool info)
         {
-            if (info)
+            if (info || ParseLogLevel(verbose) <= LogLevel.Information)
             {
                 logRouterUsageInfo("ios device", "127.0.0.1:9000", true);
             }
@@ -356,7 +356,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
 
         public async Task<int> RunIpcServerAndroidEmulatorRouter(CancellationToken token, int runtimeTimeout, string verbose, bool info)
         {
-            if (info)
+            if (info || ParseLogLevel(verbose) <= LogLevel.Information)
             {
                 logRouterUsageInfo("android emulator", "10.0.2.2:9000", false);
             }
@@ -366,12 +366,12 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
 
         public async Task<int> RunIpcServerAndroidRouter(CancellationToken token, int runtimeTimeout, string verbose, bool info)
         {
-            if (info)
+            if (info || ParseLogLevel(verbose) <= LogLevel.Information)
             {
                 logRouterUsageInfo("android device", "127.0.0.1:9000", false);
             }
 
-            return await RunIpcServerTcpServerRouter(token, "", "127.0.0.1:9000", runtimeTimeout, verbose, "Android").ConfigureAwait(false);
+            return await RunIpcServerTcpServerRouter(token, "", "127.0.0.1:9001", runtimeTimeout, verbose, "Android").ConfigureAwait(false);
         }
 
         private static string GetDefaultIpcServerPath(ILogger logger)


### PR DESCRIPTION
The use of automatic port forwarding on Android device used the same port as local and remote, that should be possible, but turns out there is some issue with `adb` around that configuration when running against a physical Android device (works when using port forwarding/reverse against Android emulator).

This PR change the port defaults and align to Xamarin Android documentation as well as using different ports for local and remove when using -`tcps` or -`tcpc` arguments together with `--forward-port android`.

When running using the "Android" connect profile, `dotnet-dsrouter android` we will default to 9001 as local/host and 9000 as remote/device port.

When running with -`tcps` or -`tcpc` we will use passed port as local/host port and then set the remote/device port to local/host port - 1 in call to `adb reverse|forward`.

Fixes https://github.com/dotnet/diagnostics/issues/4337