### PR TITLE
Handle sessionId as ulong instead of long in EventPipeSession.cs.

### DIFF
--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/EventPipeSession.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/EventPipeSession.cs
@@ -13,13 +13,13 @@ namespace Microsoft.Diagnostics.NETCore.Client
 {
     public class EventPipeSession : IDisposable
     {
-        private long _sessionId;
+        private ulong _sessionId;
         private IpcEndpoint _endpoint;
         private bool _disposedValue; // To detect redundant calls
         private bool _stopped; // To detect redundant calls
         private readonly IpcResponse _response;
 
-        private EventPipeSession(IpcEndpoint endpoint, IpcResponse response, long sessionId)
+        private EventPipeSession(IpcEndpoint endpoint, IpcResponse response, ulong sessionId)
         {
             _endpoint = endpoint;
             _response = response;
@@ -93,7 +93,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
             {
                 DiagnosticsClient.ValidateResponseMessage(response.Value.Message, operationName);
 
-                long sessionId = BinaryPrimitives.ReadInt64LittleEndian(new ReadOnlySpan<byte>(response.Value.Message.Payload, 0, 8));
+                ulong sessionId = BinaryPrimitives.ReadUInt64LittleEndian(new ReadOnlySpan<byte>(response.Value.Message.Payload, 0, 8));
 
                 EventPipeSession session = new(endpoint, response.Value, sessionId);
                 response = null;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/EventPipeSessionConfiguration.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/EventPipeSessionConfiguration.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
                 writer.Write(Providers.Count);
                 foreach (EventPipeProvider provider in Providers)
                 {
-                    writer.Write(provider.Keywords);
+                    writer.Write(unchecked((ulong)provider.Keywords));
                     writer.Write((uint)provider.EventLevel);
 
                     writer.WriteString(provider.Name);


### PR DESCRIPTION
Session id is a uint64 in runtime as well as specified as a uint64 in IPC protocol, https://github.com/dotnet/diagnostics/blob/main/documentation/design-docs/ipc-protocol.md#returns-as-an-ipc-message-payload.

EventPipeSession.cs however handled it as a long instead of an ulong, currently that doesn't affect release builds since it doesn't do much with the id except passing it back to stop the session, but in debug builds there is an assert that validates that session id > 0. On Android physical devices it is not uncommon to get code and memory allocated at high addresses, including having the high order bit set and when that happens, EventPipeSession.cs will see a negative session id and assert on debug builds.

Fix adjust session id as ulong inline with IPC protocol, it also makes sure keyword serialized when starting a session is handled according to IPC specification, but only when serialized into the payload, it will still be typed as long inside EventPipeProvider since it is a public property.