### PR TITLE
Restore error message when the heap isn't walkable

### DIFF
--- a/src/Microsoft.Diagnostics.ExtensionCommands/DumpHeapCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/DumpHeapCommand.cs
@@ -62,6 +62,9 @@ namespace Microsoft.Diagnostics.ExtensionCommands
         [Option(Name = "-gen")]
         public string Generation { get; set; }
 
+        [Option(Name = "-ignoreGCState", Help = "Ignore the GC's marker that the heap is not walkable (will generate lots of false positive errors).")]
+        public bool IgnoreGCState { get; set; }
+
         [Argument(Help = "Optional memory ranges in the form of: [Start [End]]")]
         public string[] MemoryRange { get; set; }
 
@@ -165,6 +168,11 @@ namespace Microsoft.Diagnostics.ExtensionCommands
 
         private void ParseArguments()
         {
+            if (!Runtime.Heap.CanWalkHeap && !IgnoreGCState)
+            {
+                throw new DiagnosticsException("The GC heap is not in a valid state for traversal.  (Use -ignoreGCState to override.)");
+            }
+
             if (Live && Dead)
             {
                 Live = false;

--- a/src/Microsoft.Diagnostics.ExtensionCommands/VerifyHeapCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/VerifyHeapCommand.cs
@@ -25,6 +25,9 @@ namespace Microsoft.Diagnostics.ExtensionCommands
         [Option(Name = "-segment")]
         public string Segment { get; set; }
 
+        [Option(Name = "-ignoreGCState", Help = "Ignore the GC's marker that the heap is not walkable (will generate lots of false positive errors).")]
+        public bool IgnoreGCState { get; set; }
+
         [Argument(Help ="Optional memory ranges in the form of: [Start [End]]")]
         public string[] MemoryRange { get; set; }
 
@@ -44,6 +47,11 @@ namespace Microsoft.Diagnostics.ExtensionCommands
             if (MemoryRange is not null)
             {
                 filteredHeap.FilterByStringMemoryRange(MemoryRange, CommandName);
+            }
+
+            if (!Runtime.Heap.CanWalkHeap && !IgnoreGCState)
+            {
+                throw new DiagnosticsException("The GC heap is not in a valid state for traversal.  (Use -ignoreGCState to override.)");
             }
 
             VerifyHeap(filteredHeap.EnumerateFilteredObjects(Console.CancellationToken), verifySyncTable: filteredHeap.HasFilters);


### PR DESCRIPTION
 !dumpheap and !verifyheap used to warn you that the GC Heap was not walkable.  That error was lost when I converted the code from C++ to C#.

Added a way to override the error so that it doesn't become blocking when we still want to validate or dump the parts of the heap that we can.