### PR TITLE
[tools][trace] Add stopping event options to dotnet-trace

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Microsoft.Diagnostics.Monitoring.EventPipe.csproj
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Microsoft.Diagnostics.Monitoring.EventPipe.csproj
@@ -40,6 +40,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="dotnet-monitor" />
     <InternalsVisibleTo Include="dotnet-counters" />
+    <InternalsVisibleTo Include="dotnet-trace" />
     <InternalsVisibleTo Include="DotnetCounters.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.Diagnostics.Monitoring.WebApi" />

--- a/src/Tools/dotnet-trace/dotnet-trace.csproj
+++ b/src/Tools/dotnet-trace/dotnet-trace.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Microsoft.Diagnostics.NETCore.Client\Microsoft.Diagnostics.NETCore.Client.csproj" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Microsoft.Diagnostics.Monitoring.EventPipe\Microsoft.Diagnostics.Monitoring.EventPipe.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/dotnet/diagnostics/issues/3125

This PR provides users another method to stop a dotnet-trace via a stopping event similar to that of dotnet-monitor, originally implemented in https://github.com/dotnet/dotnet-monitor/pull/2557. 

Three arguments are added to the `dotnet-trace collect` command to specify a stopping event:
| Argument | Description |
|----------|----------|
|`--stopping-event-provider-name` | A string, parsed as-is, that will stop the trace upon hitting an event with the matching provider name. For a more specific stopping event, additionally provide `--stopping-event-event-name` and/or `--stopping-event-payload-filter`. |
| `--stopping-event-event-name` | A string, parsed as-is, that will stop the trace upon hitting an event with the matching event name. Requires `--stopping-event-provider-name` to be set. For a more specific stopping event, additionally provide `--stopping-event-payload-filter`. |
| `--stopping-event-payload-filter` | A string, parsed as [payload_field_name]:[payload_field_value] pairs separated by commas, that will stop the trace upon hitting an event with a matching payload. Requires `--stopping-event-provider-name` and `--stopping-event-event-name` to be set. |

Note: Though technically `--stopping-event-payload-filter` can be set without needing a `--stopping-event-event-name`, this may lead to mismatched payloads should another `TraceEvent` under the same provider not have that particular payload field name. Until there is a good reason to stop a trace given a payload filter regardless of the event name, we require `--stopping-event-event-name` to be set whenever `--stopping-event-payload-filter` is provided.

To stop a trace at a particular event, dotnet-monitor's [approach](https://github.com/dotnet/dotnet-monitor/blob/0820b6911f3ac47b6b5ec867ac906699e5c15787/src/Tools/dotnet-monitor/Trace/TraceUntilEventOperation.cs#L47) using an [EventMonitor](https://github.com/dotnet/diagnostics/blob/main/src/Microsoft.Diagnostics.Monitoring.EventPipe/EventMonitor.cs) is adopted. Upon hitting a TraceEvent with a matching ProviderName, EventName (if specified), and PayloadFilter (if specified), we trigger dotnet-trace's fallback logic to stop the EventPipeSession before the EventStream ends.

Note: As the EventStream is being parsed asynchronously, there will be some events that pass through between the time a trace event matching the specified stopping event arguments is parsed and the EventPipeSession is stopped.

In addition, this PR modifies `EventMonitor` to use the `ClrTraceEventParser` to parse `TraceEvent` objects under the `Microsoft-Windows-DotNETRuntime` provider, and the `DynamicTraceEventParser` otherwise. The `ClrTraceEventParser` is generated to understand the ETW event manifest for `Microsoft-Windows-DotNETRuntime` events. The previous implementation defaulting to `DynamicTraceEventParser` would not work on non-Windows platforms such as OSX which could not parse the payload to populate `PayloadNames` and `PayloadValue(i)` because there was no manifest available. On the other hand, Windows is able to locate manifest data for known events through the OS.

-------------------

## Testing

With an Android App
``` C#
    private static void PrintA()
    {
        Console.WriteLine("A");
        Thread.Sleep(1000);
    }
    
    ...
    
    private static void PrintK()
    {
        Console.WriteLine("K");
        Thread.Sleep(1000);
    }

    public static void Main(string[] args)
    {
        Console.WriteLine("Hello, Android!"); // logcat
        PrintA();
        PrintB();
        PrintC();
        PrintD();
        PrintE();
        PrintF();
        PrintG();
        PrintH();
        PrintI();
        PrintJ();
        PrintK();

        while (true)
        {
            Thread.Sleep(100);
        }
    }
```

Running dotnet-dsrouter to connect the diagnostic tooling with the android device
`./artifacts/bin/dotnet-dsrouter/Debug/net6.0/dotnet-dsrouter android -v debug`

Tracing with a stopping event args provided
`./artifacts/bin/dotnet-trace/Debug/net6.0/dotnet-trace collect -p 16683 --providers Microsoft-Windows-DotNETRuntime:0x1F000080018:5 --stopping-event-provider-name Microsoft-Windows-DotNETRuntime --stopping-event-event-name Method/JittingStarted --stopping-event-payload-filter MethodName:PrintA`

[dotnet-dsrouter_20231024_165648.nettrace.zip](https://github.com/dotnet/diagnostics/files/13147788/dotnet-dsrouter_20231024_165648.nettrace.zip)

There are no `Method/JittingStarted` events with MethodName `PrintC` through `PrintK` in the `.nettrace`, showing that the trace was indeed stopped after seeing the `PrintA` event. The events after `PrintA` are an artifact of the second note above. Below is the JITStats of the .nettrace opened in perfview, showing that the last method was `PrintB`.

<img width="1128" alt="JITStatsPrintA" src="https://github.com/dotnet/diagnostics/assets/16830051/1742baf4-b528-43c3-aef3-b00a576f2fb8">
