### PR TITLE
validate that providers are > 0 to provide clear error when using Diagnostics Client

### DIFF
--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/EventPipeSessionConfiguration.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/EventPipeSessionConfiguration.cs
@@ -53,11 +53,16 @@ namespace Microsoft.Diagnostics.NETCore.Client
                 throw new ArgumentNullException(nameof(providers));
             };
 
+            _providers = new List<EventPipeProvider>(providers);
+            if (_providers.Count == 0)
+            {
+                throw new ArgumentException("At least one provider must be specified.");
+            };
+
             CircularBufferSizeInMB = circularBufferSizeMB;
             Format = format;
             RequestRundown = requestRundown;
             RequestStackwalk = requestStackwalk;
-            _providers = new List<EventPipeProvider>(providers);
         }
 
         /// <summary>


### PR DESCRIPTION
validate that providers are > 0 otherwise START Failed 0x80131384 get…s thrown and it's not clear what the issue is.

The current behavior when an empty list of providers is provided is to throw START Failed 0x80131384 (BadEncoding) and that doesn't make it very clear about what the issue is. This PR proposes validating the number of providers so developers  know that they should be providing 1 provider at least.

Before:
<img width="677" alt="image" src="https://github.com/dotnet/diagnostics/assets/30415120/0dfe0963-97ae-4f1a-8ce5-46b992b55428">

After:
<img width="679" alt="image" src="https://github.com/dotnet/diagnostics/assets/30415120/f171687b-eaa5-4bbb-945c-16a43f4b97b0">
