### PR TITLE
Update `ConsoleExporterTests` To Use Updated `RatePayload`

### DIFF
--- a/src/tests/dotnet-counters/ConsoleExporterTests.cs
+++ b/src/tests/dotnet-counters/ConsoleExporterTests.cs
@@ -314,7 +314,7 @@ namespace DotnetCounters.UnitTests
 
         private static CounterPayload CreateMeterCounter(string meterName, string instrumentName, string unit, string tags, double value)
         {
-            return new RatePayload(meterName, instrumentName, instrumentName, unit, tags, value, 1, DateTime.MinValue);
+            return new RatePayload(new CounterMetadata(meterName, instrumentName, null, null, null), instrumentName, unit, tags, value, 1, DateTime.MinValue);
         }
     }
 }


### PR DESCRIPTION
It looks like #4324 hadn't run a build in a while, and was checked in without validating against the new tests in https://github.com/dotnet/diagnostics/pull/4376 (causing the builds in main to fail). I don't believe there are any other issues, but this should give us a fresh build to confirm that.