### PR TITLE
Counter instruments display absolute values now in dotnet-counters

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/MetricsPipeline.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/MetricsPipeline.cs
@@ -57,7 +57,8 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
                 SessionId = _sessionId,
                 ClientId = _clientId,
                 MaxHistograms = Settings.MaxHistograms,
-                MaxTimeseries = Settings.MaxTimeSeries
+                MaxTimeseries = Settings.MaxTimeSeries,
+                UseCounterRateAndValuePayload = Settings.UseCounterRateAndValuePayloads
             };
 
             return config;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/MetricsPipelineSettings.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/MetricsPipelineSettings.cs
@@ -18,6 +18,11 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
         public int MaxTimeSeries { get; set; }
 
         public bool UseSharedSession { get; set; }
+
+        // Starting in .NET 8 MetricsEventSource reports both absolute value and rate for Counter instruments
+        // If this is false the pipeline will produce RatePayload objects
+        // If this is true and the new absolute value field is available the pipeline will produce CounterRateAndValuePayload instead
+        public bool UseCounterRateAndValuePayloads { get; set; }
     }
 
     [Flags]

--- a/src/Tools/dotnet-counters/CounterMonitor.cs
+++ b/src/Tools/dotnet-counters/CounterMonitor.cs
@@ -166,7 +166,8 @@ namespace Microsoft.Diagnostics.Tools.Counters
             bool resumeRuntime,
             int maxHistograms,
             int maxTimeSeries,
-            TimeSpan duration)
+            TimeSpan duration,
+            bool showDeltas)
         {
             try
             {
@@ -197,7 +198,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
                         // the launch command may misinterpret app arguments as the old space separated
                         // provider list so we need to ignore it in that case
                         _counterList = ConfigureCounters(counters, _processId != 0 ? counter_list : null);
-                        _renderer = new ConsoleWriter(new DefaultConsole(useAnsi));
+                        _renderer = new ConsoleWriter(new DefaultConsole(useAnsi), showDeltaColumn:showDeltas);
                         _diagnosticsClient = holder.Client;
                         _settings = new MetricsPipelineSettings();
                         _settings.Duration = duration == TimeSpan.Zero ? Timeout.InfiniteTimeSpan : duration;
@@ -206,6 +207,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
                         _settings.CounterIntervalSeconds = refreshInterval;
                         _settings.ResumeRuntime = resumeRuntime;
                         _settings.CounterGroups = GetEventPipeProviders();
+                        _settings.UseCounterRateAndValuePayloads = true;
 
                         bool useSharedSession = false;
                         if (_diagnosticsClient.GetProcessInfo().TryGetProcessClrVersion(out Version version))

--- a/src/Tools/dotnet-counters/Program.cs
+++ b/src/Tools/dotnet-counters/Program.cs
@@ -49,7 +49,8 @@ namespace Microsoft.Diagnostics.Tools.Counters
             bool resumeRuntime,
             int maxHistograms,
             int maxTimeSeries,
-            TimeSpan duration);
+            TimeSpan duration,
+            bool showDeltas);
 
         private static Command MonitorCommand() =>
             new(
@@ -68,7 +69,8 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 ResumeRuntimeOption(),
                 MaxHistogramOption(),
                 MaxTimeSeriesOption(),
-                DurationOption()
+                DurationOption(),
+                ShowDeltasOption()
             };
 
         private static Command CollectCommand() =>
@@ -206,6 +208,13 @@ namespace Microsoft.Diagnostics.Tools.Counters
             {
                 Argument = new Argument<TimeSpan>(name: "duration-timespan", getDefaultValue: () => default)
             };
+
+        private static Option ShowDeltasOption() =>
+            new(
+                alias: "--showDeltas",
+                description: @"Shows an extra column in the metrics table that displays the delta between the previous metric value and the most recent value." +
+               " This is useful to monitor the rate of change for a metric.")
+            { };
 
         private static readonly string[] s_SupportedRuntimeVersions = KnownData.s_AllVersions;
 

--- a/src/tests/dotnet-counters/ConsoleExporterTests.cs
+++ b/src/tests/dotnet-counters/ConsoleExporterTests.cs
@@ -36,6 +36,7 @@ namespace DotnetCounters.UnitTests
             console.AssertLinesEqual("Press p to pause, r to resume, q to quit.",
                                      "    Status: Running",
                                      "",
+                                     "Name                                           Current Value",
                                      "[System.Runtime]",
                                      "    % Time in GC since last GC (%)                    12");
         }
@@ -51,6 +52,7 @@ namespace DotnetCounters.UnitTests
             console.AssertLinesEqual("Press p to pause, r to resume, q to quit.",
                                      "    Status: Running",
                                      "",
+                                     "Name                                           Current Value",
                                      "[System.Runtime]",
                                      "    Allocation Rate (B / 1 sec)                    1,731");
         }
@@ -67,6 +69,7 @@ namespace DotnetCounters.UnitTests
             console.AssertLinesEqual("Press p to pause, r to resume, q to quit.",
                                      "    Status: Running",
                                      "",
+                                     "Name                                           Current Value",
                                      "[System.Runtime]",
                                      "    Allocation Rate (B / 1 sec)                    1,731",
                                      "[Provider2]",
@@ -86,6 +89,7 @@ namespace DotnetCounters.UnitTests
             console.AssertLinesEqual("Press p to pause, r to resume, q to quit.",
                                      "    Status: Running",
                                      "",
+                                     "Name                                           Current Value",
                                      "[System.Runtime]",
                                      "    % Time in GC since last GC (%)                    12",
                                      "    Allocation Rate (B / 1 sec)                    1,731");
@@ -96,6 +100,7 @@ namespace DotnetCounters.UnitTests
             console.AssertLinesEqual("Press p to pause, r to resume, q to quit.",
                                      "    Status: Running",
                                      "",
+                                     "Name                                           Current Value",
                                      "[System.Runtime]",
                                      "    % Time in GC since last GC (%)                     7",
                                      "    Allocation Rate (B / 1 sec)                  123,456");
@@ -114,6 +119,7 @@ namespace DotnetCounters.UnitTests
             console.AssertLinesEqual("Press p to pause, r to resume, q to quit.",
                                      "    Status: Running",
                                      "",
+                                     "Name                                           Current Value",
                                      "[System.Runtime]",
                                      "    % Time in GC since last GC (%)                    12",
                                      "    Allocation Rate (B / 1 sec)                    1,731");
@@ -123,6 +129,7 @@ namespace DotnetCounters.UnitTests
             console.AssertLinesEqual("Press p to pause, r to resume, q to quit.",
                                      "    Status: Paused",
                                      "",
+                                     "Name                                           Current Value",
                                      "[System.Runtime]",
                                      "    % Time in GC since last GC (%)                    12",
                                      "    Allocation Rate (B / 1 sec)                    1,731");
@@ -133,6 +140,7 @@ namespace DotnetCounters.UnitTests
             console.AssertLinesEqual("Press p to pause, r to resume, q to quit.",
                                      "    Status: Paused",
                                      "",
+                                     "Name                                           Current Value",
                                      "[System.Runtime]",
                                      "    % Time in GC since last GC (%)                    12",
                                      "    Allocation Rate (B / 1 sec)                    1,731");
@@ -142,6 +150,7 @@ namespace DotnetCounters.UnitTests
             console.AssertLinesEqual("Press p to pause, r to resume, q to quit.",
                                      "    Status: Running",
                                      "",
+                                     "Name                                           Current Value",
                                      "[System.Runtime]",
                                      "    % Time in GC since last GC (%)                    12",
                                      "    Allocation Rate (B / 1 sec)                    1,731");
@@ -153,6 +162,7 @@ namespace DotnetCounters.UnitTests
             console.AssertLinesEqual("Press p to pause, r to resume, q to quit.",
                                      "    Status: Running",
                                      "",
+                                     "Name                                           Current Value",
                                      "[System.Runtime]",
                                      "    % Time in GC since last GC (%)                     1",
                                      "    Allocation Rate (B / 1 sec)                        2");
@@ -171,6 +181,7 @@ namespace DotnetCounters.UnitTests
             console.AssertLinesEqual("Press p to pause, r to resume, q to quit.",
                                      "    Status: Running",
                                      "",
+                                     "Name                                           Current Value",
                                      "[System.Runtime]",
                                      "    % Time in GC since last GC (%)                     0.1",
                                      "    Allocation Rate (B / 1 sec)                    1,731",
@@ -189,6 +200,7 @@ namespace DotnetCounters.UnitTests
             console.AssertLinesEqual("Press p to pause, r to resume, q to quit.",
                                      "    Status: Running",
                                      "",
+                                     "Name                                 Current Value",
                                      "[System.Runtime]",
                                      "    % Time in GC since last GC (%)           0.1",
                                      "    Allocation Rate (B / 1 sec)          1,731");
@@ -205,6 +217,7 @@ namespace DotnetCounters.UnitTests
             console.AssertLinesEqual("Press p to pause, r to resume, q to quit.",
                                      "    Status: Running",
                                      "",
+                                     "Name                                 Current Value",
                                      "[System.Runtime]",
                                      "    ThisCounterHasAVeryLongNameTha           0.1");
         }
@@ -216,13 +229,14 @@ namespace DotnetCounters.UnitTests
             ConsoleWriter exporter = new ConsoleWriter(console);
             exporter.Initialize();
 
-            exporter.CounterPayloadReceived(CreateMeterCounter("Provider1", "Counter1", "{widget}", "color=red", 0.1), false);
-            exporter.CounterPayloadReceived(CreateMeterCounter("Provider1", "Counter1", "{widget}", "color=blue", 87), false);
-            exporter.CounterPayloadReceived(CreateMeterCounter("Provider1", "Counter2", "{widget}", "size=1", 14), false);
-            exporter.CounterPayloadReceived(CreateMeterCounter("Provider1", "Counter2", "{widget}", "temp=hot", 160), false);
+            exporter.CounterPayloadReceived(CreateMeterCounterPreNet8("Provider1", "Counter1", "{widget}", "color=red", 0.1), false);
+            exporter.CounterPayloadReceived(CreateMeterCounterPreNet8("Provider1", "Counter1", "{widget}", "color=blue", 87), false);
+            exporter.CounterPayloadReceived(CreateMeterCounterPreNet8("Provider1", "Counter2", "{widget}", "size=1", 14), false);
+            exporter.CounterPayloadReceived(CreateMeterCounterPreNet8("Provider1", "Counter2", "{widget}", "temp=hot", 160), false);
             console.AssertLinesEqual("Press p to pause, r to resume, q to quit.",
                                      "    Status: Running",
                                      "",
+                                     "Name                                 Current Value",
                                      "[Provider1]",
                                      "    Counter1 ({widget} / 1 sec)",
                                      "        color=blue                          87",
@@ -239,13 +253,14 @@ namespace DotnetCounters.UnitTests
             ConsoleWriter exporter = new ConsoleWriter(console);
             exporter.Initialize();
 
-            exporter.CounterPayloadReceived(CreateMeterCounter("Provider1", "Counter1", "{widget}", "color=red", 0.1), false);
-            exporter.CounterPayloadReceived(CreateMeterCounter("Provider1", "Counter1", "{widget}", "color=blue,LongNameTag=ThisDoesNotFit,AnotherOne=Hi", 87), false);
-            exporter.CounterPayloadReceived(CreateMeterCounter("Provider1", "Counter2", "{widget}", "size=1", 14), false);
-            exporter.CounterPayloadReceived(CreateMeterCounter("Provider1", "Counter2", "{widget}", "temp=hot", 160), false);
+            exporter.CounterPayloadReceived(CreateMeterCounterPreNet8("Provider1", "Counter1", "{widget}", "color=red", 0.1), false);
+            exporter.CounterPayloadReceived(CreateMeterCounterPreNet8("Provider1", "Counter1", "{widget}", "color=blue,LongNameTag=ThisDoesNotFit,AnotherOne=Hi", 87), false);
+            exporter.CounterPayloadReceived(CreateMeterCounterPreNet8("Provider1", "Counter2", "{widget}", "size=1", 14), false);
+            exporter.CounterPayloadReceived(CreateMeterCounterPreNet8("Provider1", "Counter2", "{widget}", "temp=hot", 160), false);
             console.AssertLinesEqual("Press p to pause, r to resume, q to quit.",
                                      "    Status: Running",
                                      "",
+                                     "Name                                 Current Value",
                                      "[Provider1]",
                                      "    Counter1 ({widget} / 1 sec)",
                                      "        color=blue,LongNameTag=Thi          87",
@@ -258,17 +273,18 @@ namespace DotnetCounters.UnitTests
         [Fact]
         public void CountersAreTruncatedBeyondScreenHeight()
         {
-            MockConsole console = new MockConsole(50, 6);
+            MockConsole console = new MockConsole(50, 7);
             ConsoleWriter exporter = new ConsoleWriter(console);
             exporter.Initialize();
 
-            exporter.CounterPayloadReceived(CreateMeterCounter("Provider1", "Counter1", "{widget}", "color=red", 0.1), false);
-            exporter.CounterPayloadReceived(CreateMeterCounter("Provider1", "Counter1", "{widget}", "color=blue", 87), false);
-            exporter.CounterPayloadReceived(CreateMeterCounter("Provider1", "Counter2", "{widget}", "size=1", 14), false);
-            exporter.CounterPayloadReceived(CreateMeterCounter("Provider1", "Counter2", "{widget}", "temp=hot", 160), false);
+            exporter.CounterPayloadReceived(CreateMeterCounterPreNet8("Provider1", "Counter1", "{widget}", "color=red", 0.1), false);
+            exporter.CounterPayloadReceived(CreateMeterCounterPreNet8("Provider1", "Counter1", "{widget}", "color=blue", 87), false);
+            exporter.CounterPayloadReceived(CreateMeterCounterPreNet8("Provider1", "Counter2", "{widget}", "size=1", 14), false);
+            exporter.CounterPayloadReceived(CreateMeterCounterPreNet8("Provider1", "Counter2", "{widget}", "temp=hot", 160), false);
             console.AssertLinesEqual("Press p to pause, r to resume, q to quit.",
                                      "    Status: Running",
                                      "",
+                                     "Name                                 Current Value",
                                      "[Provider1]",
                                      "    Counter1 ({widget} / 1 sec)",
                                      "        color=blue                          87");
@@ -281,16 +297,17 @@ namespace DotnetCounters.UnitTests
             ConsoleWriter exporter = new ConsoleWriter(console);
             exporter.Initialize();
 
-            exporter.CounterPayloadReceived(CreateMeterCounter("Provider1", "Counter1", "{widget}", "color=red", 0.1), false);
-            exporter.CounterPayloadReceived(CreateMeterCounter("Provider1", "Counter1", "{widget}", "color=blue", 87), false);
-            exporter.CounterPayloadReceived(CreateMeterCounter("Provider1", "Counter2", "{widget}", "size=1", 14), false);
-            exporter.CounterPayloadReceived(CreateMeterCounter("Provider1", "Counter2", "{widget}", "temp=hot", 160), false);
+            exporter.CounterPayloadReceived(CreateMeterCounterPreNet8("Provider1", "Counter1", "{widget}", "color=red", 0.1), false);
+            exporter.CounterPayloadReceived(CreateMeterCounterPreNet8("Provider1", "Counter1", "{widget}", "color=blue", 87), false);
+            exporter.CounterPayloadReceived(CreateMeterCounterPreNet8("Provider1", "Counter2", "{widget}", "size=1", 14), false);
+            exporter.CounterPayloadReceived(CreateMeterCounterPreNet8("Provider1", "Counter2", "{widget}", "temp=hot", 160), false);
             exporter.SetErrorText("Uh-oh, a bad thing happened");
 
             console.AssertLinesEqual("Press p to pause, r to resume, q to quit.",
                                      "    Status: Running",
                                      "Uh-oh, a bad thing happened",
                                      "",
+                                     "Name                                 Current Value",
                                      "[Provider1]",
                                      "    Counter1 ({widget} / 1 sec)",
                                      "        color=blue                          87",
@@ -300,6 +317,118 @@ namespace DotnetCounters.UnitTests
                                      "        temp=hot                           160");
         }
 
+        [Fact]
+        public void DeltaColumnDisplaysInitiallyEmpty()
+        {
+            MockConsole console = new MockConsole(64, 40);
+            ConsoleWriter exporter = new ConsoleWriter(console, showDeltaColumn:true);
+            exporter.Initialize();
+
+            exporter.CounterPayloadReceived(CreateIncrementingEventCounter("System.Runtime", "Allocation Rate", "B", 1731), false);
+            exporter.CounterPayloadReceived(CreateMeterCounterPreNet8("Provider1", "Counter1", "{widget}", "color=red", 0.1), false);
+            exporter.CounterPayloadReceived(CreateMeterCounterPreNet8("Provider1", "Counter1", "{widget}", "color=blue", 87), false);
+            exporter.CounterPayloadReceived(CreateMeterCounterPreNet8("Provider1", "Counter2", "{widget}", "size=1", 14), false);
+            exporter.CounterPayloadReceived(CreateMeterCounterPreNet8("Provider1", "Counter2", "{widget}", "temp=hot", 160), false);
+            
+            console.AssertLinesEqual("Press p to pause, r to resume, q to quit.",
+                                     "    Status: Running",
+                                     "",
+                                     "Name                               Current Value      Last Delta",
+                                     "[System.Runtime]",
+                                     "    Allocation Rate (B / 1 sec)        1,731",
+                                     "[Provider1]",
+                                     "    Counter1 ({widget} / 1 sec)",
+                                     "        color=blue                        87",
+                                     "        color=red                          0.1",
+                                     "    Counter2 ({widget} / 1 sec)",
+                                     "        size=1                            14",
+                                     "        temp=hot                         160");
+        }
+
+        [Fact]
+        public void DeltaColumnDisplaysNumbersAfterUpdate()
+        {
+            MockConsole console = new MockConsole(64, 40);
+            ConsoleWriter exporter = new ConsoleWriter(console, showDeltaColumn: true);
+            exporter.Initialize();
+
+            exporter.CounterPayloadReceived(CreateIncrementingEventCounter("System.Runtime", "Allocation Rate", "B", 1731), false);
+            exporter.CounterPayloadReceived(CreateMeterCounterPreNet8("Provider1", "Counter1", "{widget}", "color=red", 0.1), false);
+            exporter.CounterPayloadReceived(CreateMeterCounterPreNet8("Provider1", "Counter1", "{widget}", "color=blue", 87), false);
+            exporter.CounterPayloadReceived(CreateMeterCounterPreNet8("Provider1", "Counter2", "{widget}", "size=1", 14), false);
+            exporter.CounterPayloadReceived(CreateMeterCounterPreNet8("Provider1", "Counter2", "{widget}", "temp=hot", 160), false);
+            console.AssertLinesEqual("Press p to pause, r to resume, q to quit.",
+                                     "    Status: Running",
+                                     "",
+                                     "Name                               Current Value      Last Delta",
+                                     "[System.Runtime]",
+                                     "    Allocation Rate (B / 1 sec)        1,731",
+                                     "[Provider1]",
+                                     "    Counter1 ({widget} / 1 sec)",
+                                     "        color=blue                        87",
+                                     "        color=red                          0.1",
+                                     "    Counter2 ({widget} / 1 sec)",
+                                     "        size=1                            14",
+                                     "        temp=hot                         160");
+
+            exporter.CounterPayloadReceived(CreateIncrementingEventCounter("System.Runtime", "Allocation Rate", "B", 1732), false);
+            exporter.CounterPayloadReceived(CreateMeterCounterPreNet8("Provider1", "Counter1", "{widget}", "color=red", 0.2), false);
+            exporter.CounterPayloadReceived(CreateMeterCounterPreNet8("Provider1", "Counter1", "{widget}", "color=blue", 87), false);
+            exporter.CounterPayloadReceived(CreateMeterCounterPreNet8("Provider1", "Counter2", "{widget}", "size=1", 10), false);
+            console.AssertLinesEqual("Press p to pause, r to resume, q to quit.",
+                                     "    Status: Running",
+                                     "",
+                                     "Name                               Current Value      Last Delta",
+                                     "[System.Runtime]",
+                                     "    Allocation Rate (B / 1 sec)        1,732               1",
+                                     "[Provider1]",
+                                     "    Counter1 ({widget} / 1 sec)",
+                                     "        color=blue                        87               0",
+                                     "        color=red                          0.2             0.1",
+                                     "    Counter2 ({widget} / 1 sec)",
+                                     "        size=1                            10              -4",
+                                     "        temp=hot                         160");
+        }
+
+        // Starting in .NET 8 MetricsEventSource, Meter counter instruments report both rate of change and
+        // absolute value. Reporting rate in the UI was less useful for many counters than just seeing the raw
+        // value. Now dotnet-counters reports these counters as absolute by default and the optional delta column
+        // is available for folks who still want to visualize rate of change.
+        [Fact]
+        public void MeterCounterIsAbsoluteInNet8()
+        {
+            MockConsole console = new MockConsole(64, 40);
+            ConsoleWriter exporter = new ConsoleWriter(console, showDeltaColumn: true);
+            exporter.Initialize();
+
+            exporter.CounterPayloadReceived(CreateMeterCounterPostNet8("Provider1", "Counter1", "{widget}", "color=red", 0.1), false);
+            exporter.CounterPayloadReceived(CreateMeterCounterPostNet8("Provider1", "Counter1", "{widget}", "color=blue", 87), false);
+            exporter.CounterPayloadReceived(CreateMeterCounterPostNet8("Provider1", "Counter2", "{widget}", "", 14), false);
+
+            console.AssertLinesEqual("Press p to pause, r to resume, q to quit.",
+                                     "    Status: Running",
+                                     "",
+                                     "Name                               Current Value      Last Delta",
+                                     "[Provider1]",
+                                     "    Counter1 ({widget})",                                            // There is no longer (unit / 1 sec) here
+                                     "        color=blue                        87",
+                                     "        color=red                          0.1",
+                                     "    Counter2 ({widget})                   14");
+
+            exporter.CounterPayloadReceived(CreateMeterCounterPostNet8("Provider1", "Counter1", "{widget}", "color=red", 0.2), false);
+            exporter.CounterPayloadReceived(CreateMeterCounterPostNet8("Provider1", "Counter1", "{widget}", "color=blue", 87), false);
+            exporter.CounterPayloadReceived(CreateMeterCounterPostNet8("Provider1", "Counter2", "{widget}", "", 10), false);
+
+            console.AssertLinesEqual("Press p to pause, r to resume, q to quit.",
+                                     "    Status: Running",
+                                     "",
+                                     "Name                               Current Value      Last Delta",
+                                     "[Provider1]",
+                                     "    Counter1 ({widget})",                                            // There is no longer (unit / 1 sec) here
+                                     "        color=blue                        87               0",
+                                     "        color=red                          0.2             0.1",
+                                     "    Counter2 ({widget})                   10              -4");
+        }
 
 
         private static CounterPayload CreateEventCounter(string provider, string displayName, string unit, double value)
@@ -312,9 +441,14 @@ namespace DotnetCounters.UnitTests
             return new EventCounterPayload(DateTime.MinValue, provider, displayName, displayName, unit, value, CounterType.Rate, 0, 1, "");
         }
 
-        private static CounterPayload CreateMeterCounter(string meterName, string instrumentName, string unit, string tags, double value)
+        private static CounterPayload CreateMeterCounterPreNet8(string meterName, string instrumentName, string unit, string tags, double value)
         {
             return new RatePayload(new CounterMetadata(meterName, instrumentName, null, null, null), instrumentName, unit, tags, value, 1, DateTime.MinValue);
+        }
+
+        private static CounterPayload CreateMeterCounterPostNet8(string meterName, string instrumentName, string unit, string tags, double value)
+        {
+            return new CounterRateAndValuePayload(new CounterMetadata(meterName, instrumentName, null, null, null), instrumentName, unit, tags, rate:double.NaN, value, DateTime.MinValue);
         }
     }
 }

--- a/src/tests/dotnet-counters/MockConsole.cs
+++ b/src/tests/dotnet-counters/MockConsole.cs
@@ -114,8 +114,15 @@ namespace DotnetCounters.UnitTests
 
         public void AssertLinesEqual(int startLine, params string[] expectedLines)
         {
-            for(int i = 0; i < expectedLines.Length; i++)
+            if (startLine + expectedLines.Length > Lines.Length)
             {
+                Assert.Fail("MockConsole output had fewer output lines than expected." + Environment.NewLine +
+                    $"Expected line count: {expectedLines.Length}" + Environment.NewLine +
+                    $"Actual line count: {Lines.Length}");
+            }
+            for (int i = 0; i < expectedLines.Length; i++)
+            {
+
                 string actualLine = GetLineText(startLine+i);
                 string expectedLine = expectedLines[i];
                 if(actualLine != expectedLine)


### PR DESCRIPTION
Fixes #3751

Previously we always showed counter instruments as a rate, but
for a variety of counters that isn't the most useful value. Now
we are showing the absolute value as long as the target process
is running .NET 8. For cases where it was useful to see rate of change
there is now a --showDeltas option which enables a 2nd column
of output for dotnet-counters monitor. The deltas show the difference
between the previous value and the current value. Making the new
column optional rather than a default setting is intended to minimize
consuming horizontal line space which is already at a premium. When
using csv or json outputs it is assumed the user's tool that processes
the data later can compute the rate if desired so there is no special
delta handling added for those.

Take a look at the updated exporter tests to see the specific changes
in dotnet-counters output format.

For other tools consuming System.Diagnostics.Monitoring.EventPipe
there is a new setting on the settings object that allows opting in to
the new behavior. I'm guessing dotnet-monitor will want to do it too
but I wanted to ensure they can opt-into the new behavior at a
time of their choosing.

@dotnet/dotnet-diag, @JamesNK, @dotnet/dotnet-monitor - please take a look. Feedback welcome on the code and/or the design of the feature overall. I considered making and discussing a separate writeup of the design first but it was easy enough to code up I just skipped ahead. I'm still happy to change the design if folks have better suggestions.

This is probably the first of several incremental improvements to dotnet-counters to improve the UX. I'm trying to do this in steps rather than all at once to make it easier to discuss and review.