### PR TITLE
[FabricBot] Remove usage of 'noActivitySince' operand condition

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -122,17 +122,6 @@
               "operator": "not",
               "operands": [
                 {
-                  "name": "noActivitySince",
-                  "parameters": {
-                    "days": 30
-                  }
-                }
-              ]
-            },
-            {
-              "operator": "not",
-              "operands": [
-                {
                   "name": "isCloseAndComment",
                   "parameters": {}
                 }


### PR DESCRIPTION
With the pending migration away from FabricBot to the Policy Service bot, the `noActivitySince` event condition will no longer be supported. This PR removes the only occurrence of that condition in this repository's configuration, as the condition was redundant with other automation anyway.

The condition was used in an idle issue management task such that:

* A comment was made on a closed issue by the issue's author and the issue has the label of `Needs: Author Feedback`
* Filtered to the condition of "NOT noActivitySince 30 days ago", thus there _has_ been other activity within 30 days (this event does not count as activity)
* Reopen the issue, remove the `Needs: Author Feedback` and `Status: No Recent Activity` labels, and add the `Needs: Attention 👋` label

This condition of ensuring there _has_ been activity within 30 days is redundant with the other automation that locks issues with 30 days of inactivity after closure. Therefore, rather than replicating this condition/behavior a different way, we can rely on the issue being unlocked as sufficient.

_Note: The `noActivitySince` search condition will still be supported within scheduled searches as used in this configuration; it's only unsupported in event triggers going forward._

/cc @wtgodbe 