### PR TITLE
added an option to collect rundown events

### DIFF
--- a/src/Tools/dotnet-trace/CommandLine/Commands/ListProfilesCommandHandler.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/ListProfilesCommandHandler.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                         keywords: (long)ClrTraceEventParser.Keywords.GC
                     )
                 },
-                "Tracks GC collections only at very low overhead."),
+                "Tracks GC collections only at very low overhead.") { Rundown = false },
             new Profile(
                 "database",
                 new EventPipeProvider[] {

--- a/src/Tools/dotnet-trace/Profile.cs
+++ b/src/Tools/dotnet-trace/Profile.cs
@@ -22,6 +22,8 @@ namespace Microsoft.Diagnostics.Tools.Trace
 
         public string Description { get; }
 
+        public bool Rundown { get; set;  }
+
         public static void MergeProfileAndProviders(Profile selectedProfile, List<EventPipeProvider> providerCollection, Dictionary<string, string> enabledBy)
         {
             List<EventPipeProvider> profileProviders = new();


### PR DESCRIPTION
and have gc-collect not collect them.

dotnet trace right now always collects rundown events but they are not needed in some scenarios, eg, the gc-collect profile. it's much preferred to not include these unnecessary events which could take up way more space than the GC events. 
