### PR TITLE
feat: dumphttp command initial implementation

### DIFF
--- a/src/Microsoft.Diagnostics.ExtensionCommands/DumpHttpCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/DumpHttpCommand.cs
@@ -1,0 +1,298 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Diagnostics.DebugServices;
+using Microsoft.Diagnostics.ExtensionCommands.Output;
+using Microsoft.Diagnostics.Runtime;
+
+namespace Microsoft.Diagnostics.ExtensionCommands
+{
+    [Command(Name = CommandName, Aliases = new string[] { "DumpHttp" }, Help = "Displays information about HTTP requests")]
+    public sealed class DumpHttpCommand : ClrRuntimeCommandBase
+    {
+        /// <summary>The name of the command.</summary>
+        private const string CommandName = "dumphttp";
+
+        /// <summary>Gets whether to summarize all httpRequests found rather than showing detailed info.</summary>
+        [Option(Name = "--stats", Help = "Summarize all HTTP requests found rather than showing detailed info.")]
+        public bool Summarize { get; set; }
+
+        /// <summary>Gets whether to show only requests without response.</summary>
+        [Option(Name = "-pending", Help = "Show only requests without response")]
+        public bool Pending { get; set; }
+
+        /// <summary>Gets whether to show only requests with response.</summary>
+        [Option(Name = "-completed", Help = "Show only requests with response")]
+        public bool Completed { get; set; }
+
+        [Option(Name = "-gen")]
+        public string? Generation { get; set; }
+
+        private HeapWithFilters? FilteredHeap { get; set; }
+
+        private static readonly Column s_httpMethodColumn = new(Align.Left, 6, Formats.Text);
+        private static readonly Column s_statusCodeColumn = new(Align.Right, 10, Formats.Integer);
+
+        /// <summary>Invokes the command.</summary>
+        public override void Invoke()
+        {
+            ParseArguments();
+
+            // Enumerate the heap, gathering up all relevant HTTP request related httpRequests.
+            IEnumerable<HttpRequestInfo> httpRequests = CollectHttpRequests();
+            httpRequests = FilterDuplicates(httpRequests);
+            if (Pending || Completed)
+            {
+                httpRequests = FilterByStatus(httpRequests);
+            }
+
+            // Render the data according to the options specified.
+            if (Summarize)
+            {
+                RenderStats();
+            }
+            else
+            {
+                RenderRequests();
+            }
+
+            return;
+
+            // <summary>Group httpRequests and summarize how many of each occurred.</summary>
+            void RenderStats()
+            {
+                Dictionary<HttpRequestStatGroupKey, HttpRequestStat> statCounts = new();
+
+                foreach (HttpRequestInfo httpRequest in httpRequests)
+                {
+                    HttpRequestStatGroupKey statKey = httpRequest.GetGroupKey();
+                    if (statCounts.TryGetValue(statKey, out HttpRequestStat stat))
+                    {
+                        stat.AddRequest();
+                    }
+                    else
+                    {
+                        stat = new HttpRequestStat(httpRequest);
+                        statCounts.Add(statKey, stat);
+                    }
+                }
+
+                WriteLine("Statistics:");
+                Table output = new(Console, ColumnKind.Integer, s_httpMethodColumn, s_statusCodeColumn, ColumnKind.Text);
+                output.WriteHeader("Count", "Method", "StatusCode", "Host");
+
+                foreach (KeyValuePair<HttpRequestStatGroupKey, HttpRequestStat> entry in statCounts.OrderByDescending(s => s.Value.Count))
+                {
+                    output.WriteRow(entry.Value.Count, entry.Value.HttpMethod, entry.Value.StatusCode, entry.Value.Host);
+                }
+
+                int total = statCounts.Select(stat => stat.Value.Count).Sum();
+                WriteLine($"Total {total} requests");
+            }
+
+            // <summary>Render each http request.</summary>
+            void RenderRequests()
+            {
+                Table output = new(Console, ColumnKind.Pointer, ColumnKind.Pointer, s_httpMethodColumn, s_statusCodeColumn, ColumnKind.Text);
+                output.WriteHeader("Address", "MethodTable", "Method", "StatusCode", "Uri");
+
+                foreach (HttpRequestInfo httpRequest in httpRequests)
+                {
+                    output.WriteRow(httpRequest.Address, httpRequest.MethodTable, httpRequest.HttpMethod, httpRequest.StatusCode, httpRequest.Url);
+                }
+            }
+        }
+
+        private IEnumerable<HttpRequestInfo> CollectHttpRequests()
+        {
+            IEnumerable<ClrObject> objectsToPrint = FilteredHeap!.EnumerateFilteredObjects(Console.CancellationToken);
+
+            foreach (ClrObject clrObject in objectsToPrint)
+            {
+                if (clrObject.Type?.Name == "System.Net.Http.HttpRequestMessage")
+                {
+                    // HttpRequestMessage doesn't have reference to HttpResponseMessage
+                    // the same http request can be found by HttpResponseMessage
+                    // these duplicates handled by FilterDuplicates method
+                    yield return BuildRequest(clrObject, null);
+                }
+
+                if (clrObject.Type?.Name == "System.Net.Http.HttpResponseMessage")
+                {
+                    ClrObject request = GetRequest(clrObject);
+                    yield return BuildRequest(request, clrObject);
+                }
+
+                // TODO handle System.Net.HttpWebRequest for .NET Framework dumps
+            }
+
+            yield break;
+
+            HttpRequestInfo BuildRequest(ClrObject request, ClrObject? response)
+            {
+                string httpMethod = GetHttpMethod(request);
+                string uri = GetUri(request);
+                int? statusCode = response != null ? GetStatusCode(response.Value) : null;
+
+                return new HttpRequestInfo(
+                    request.Address,
+                    request.Type!.MethodTable,
+                    httpMethod,
+                    uri, statusCode);
+            }
+
+            string GetHttpMethod(ClrObject request)
+            {
+                return Runtime.ClrInfo.Flavor == ClrFlavor.Core
+                    ? request.ReadObjectField("_method").ReadStringField("_method")!
+                    : request.ReadObjectField("method").ReadStringField("method")!;
+            }
+
+            ClrObject GetRequest(ClrObject request)
+            {
+                return Runtime.ClrInfo.Flavor == ClrFlavor.Core
+                    ? request.ReadObjectField("_requestMessage")
+                    : request.ReadObjectField("requestMessage");
+            }
+
+            string GetUri(ClrObject request)
+            {
+                return Runtime.ClrInfo.Flavor == ClrFlavor.Core
+                    ? request.ReadObjectField("_requestUri").ReadStringField("_string")!
+                    : request.ReadObjectField("requestUri").ReadStringField("m_String")!;
+            }
+
+            int GetStatusCode(ClrObject response)
+            {
+                return Runtime.ClrInfo.Flavor == ClrFlavor.Core
+                    ? response.ReadField<int>("_statusCode")
+                    : response.ReadField<int>("statusCode");
+            }
+        }
+
+        /// <summary>
+        /// Filter duplicates from requests collection
+        /// </summary>
+        /// <remarks>
+        /// Filter out requests found by HttpRequestMessage only.
+        /// Requests found by HttpResponseMessage+HttpRequestMessage have more filled props.
+        /// </remarks>
+        private static IEnumerable<HttpRequestInfo> FilterDuplicates(IEnumerable<HttpRequestInfo> requests)
+        {
+            HashSet<ulong> processedRequests = new();
+
+            foreach (HttpRequestInfo request in requests.OrderBy(r => r.StatusCode == null))
+            {
+                if (!processedRequests.Add(request.Address))
+                {
+                    continue;
+                }
+
+                yield return request;
+            }
+        }
+
+        private IEnumerable<HttpRequestInfo> FilterByStatus(IEnumerable<HttpRequestInfo> requests)
+        {
+            foreach (HttpRequestInfo request in requests)
+            {
+                bool matchFilter = Pending && request.StatusCode == null
+                                   || Completed && request.StatusCode != null;
+
+                if (matchFilter)
+                {
+                    yield return request;
+                }
+            }
+        }
+
+        private void ParseArguments()
+        {
+            if (Pending && Completed)
+            {
+                Pending = false;
+                Completed = false;
+            }
+
+            FilteredHeap = new HeapWithFilters(Runtime.Heap);
+
+            // TODO: duplicate from dumpheap and dumpexceptions. Add [Option] attribute handler for Generation type
+            if (!string.IsNullOrWhiteSpace(Generation))
+            {
+                Generation generation = Generation!.ToLowerInvariant() switch {
+                    "gen0" => Diagnostics.Runtime.Generation.Generation0,
+                    "gen1" => Diagnostics.Runtime.Generation.Generation1,
+                    "gen2" => Diagnostics.Runtime.Generation.Generation2,
+                    "loh" or "large" => Diagnostics.Runtime.Generation.Large,
+                    "poh" or "pinned" => Diagnostics.Runtime.Generation.Pinned,
+                    "foh" or "frozen" => Diagnostics.Runtime.Generation.Frozen,
+                    _ => throw new ArgumentException(
+                        $"Unknown generation: {Generation}. Only gen0, gen1, gen2, loh (large), poh (pinned) and foh (frozen) are supported")
+                };
+
+                FilteredHeap.Generation = generation;
+            }
+        }
+
+        /// <summary>Gets detailed help for the command.</summary>
+        [HelpInvoke]
+        public static string GetDetailedHelp() =>
+            @"Examples:
+    Summarize all http requests:        dumphttp --stats
+    Show http requests in Generation1:  dumphttp -gen gen1
+    Show only completed http requests:  dumphttp -completed
+";
+
+        private sealed class HttpRequestInfo
+        {
+            public ulong Address { get; }
+            public ulong MethodTable { get; }
+            public string HttpMethod { get; }
+            public int? StatusCode{ get; }
+            public string Url { get; }
+            public string Host{ get; }
+
+            // TODO add response content-type header?
+            // TODO add response length? (can be difficult to calculate)
+
+            public HttpRequestInfo(ulong address, ulong methodTable, string httpMethod, string url, int? statusCode)
+            {
+                Address = address;
+                MethodTable = methodTable;
+                HttpMethod = httpMethod;
+                Url = url;
+                Host = new Uri(url).Host;
+                StatusCode = statusCode;
+            }
+
+            public HttpRequestStatGroupKey GetGroupKey() => new(StatusCode, HttpMethod, Host);
+        }
+
+        private sealed class HttpRequestStat
+        {
+            public int Count { get; private set; }
+            public string Host { get; }
+            public string HttpMethod { get; }
+            public int? StatusCode { get; }
+
+            public HttpRequestStat(HttpRequestInfo request)
+            {
+                Count = 1;
+                Host = new Uri(request.Url).Host;
+                HttpMethod = request.HttpMethod;
+                StatusCode = request.StatusCode;
+            }
+
+            public void AddRequest()
+            {
+                Count++;
+            }
+        }
+
+        private record struct HttpRequestStatGroupKey(int? StatusCode, string HttpMethod, string Host);
+    }
+}

--- a/src/Microsoft.Diagnostics.ExtensionCommands/DumpHttpCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/DumpHttpCommand.cs
@@ -22,11 +22,11 @@ namespace Microsoft.Diagnostics.ExtensionCommands
         public bool Summarize { get; set; }
 
         /// <summary>Gets whether to show only requests without response.</summary>
-        [Option(Name = "-pending", Help = "Show only requests without response")]
+        [Option(Name = "--pending", Help = "Show only requests without response")]
         public bool Pending { get; set; }
 
         /// <summary>Gets whether to show only requests with response.</summary>
-        [Option(Name = "-completed", Help = "Show only requests with response")]
+        [Option(Name = "--completed", Help = "Show only requests with response")]
         public bool Completed { get; set; }
 
         private HeapWithFilters? FilteredHeap { get; set; }
@@ -222,8 +222,8 @@ namespace Microsoft.Diagnostics.ExtensionCommands
         [HelpInvoke]
         public static string GetDetailedHelp() =>
             @"Examples:
-    Summarize all http requests:        dumphttp --stats
-    Show only completed http requests:  dumphttp -completed
+    Summarize all http requests:            dumphttp --stats
+    Show only completed http requests:      dumphttp --completed
 ";
 
         private sealed class HttpRequestInfo

--- a/src/Microsoft.Diagnostics.ExtensionCommands/DumpHttpCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/DumpHttpCommand.cs
@@ -29,9 +29,6 @@ namespace Microsoft.Diagnostics.ExtensionCommands
         [Option(Name = "-completed", Help = "Show only requests with response")]
         public bool Completed { get; set; }
 
-        [Option(Name = "-gen")]
-        public string? Generation { get; set; }
-
         private HeapWithFilters? FilteredHeap { get; set; }
 
         private static readonly Column s_httpMethodColumn = new(Align.Left, 6, Formats.Text);
@@ -219,23 +216,6 @@ namespace Microsoft.Diagnostics.ExtensionCommands
             }
 
             FilteredHeap = new HeapWithFilters(Runtime.Heap);
-
-            // TODO: duplicate from dumpheap and dumpexceptions. Add [Option] attribute handler for Generation type
-            if (!string.IsNullOrWhiteSpace(Generation))
-            {
-                Generation generation = Generation!.ToLowerInvariant() switch {
-                    "gen0" => Diagnostics.Runtime.Generation.Generation0,
-                    "gen1" => Diagnostics.Runtime.Generation.Generation1,
-                    "gen2" => Diagnostics.Runtime.Generation.Generation2,
-                    "loh" or "large" => Diagnostics.Runtime.Generation.Large,
-                    "poh" or "pinned" => Diagnostics.Runtime.Generation.Pinned,
-                    "foh" or "frozen" => Diagnostics.Runtime.Generation.Frozen,
-                    _ => throw new ArgumentException(
-                        $"Unknown generation: {Generation}. Only gen0, gen1, gen2, loh (large), poh (pinned) and foh (frozen) are supported")
-                };
-
-                FilteredHeap.Generation = generation;
-            }
         }
 
         /// <summary>Gets detailed help for the command.</summary>
@@ -243,7 +223,6 @@ namespace Microsoft.Diagnostics.ExtensionCommands
         public static string GetDetailedHelp() =>
             @"Examples:
     Summarize all http requests:        dumphttp --stats
-    Show http requests in Generation1:  dumphttp -gen gen1
     Show only completed http requests:  dumphttp -completed
 ";
 

--- a/src/Microsoft.Diagnostics.ExtensionCommands/DumpHttpCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/DumpHttpCommand.cs
@@ -12,12 +12,9 @@ using Microsoft.Diagnostics.Runtime;
 
 namespace Microsoft.Diagnostics.ExtensionCommands
 {
-    [Command(Name = CommandName, Aliases = new string[] { "DumpHttp" }, Help = "Displays information about HTTP requests")]
+    [Command(Name = "dumphttp", Aliases = new string[] { "DumpHttp" }, Help = "Displays information about HTTP requests.")]
     public sealed class DumpHttpCommand : ClrRuntimeCommandBase
     {
-        /// <summary>The name of the command.</summary>
-        private const string CommandName = "dumphttp";
-
         // Field names to get System.Net.Http.HttpRequestMessage.Method
         private static readonly string[] s_httpMethodFieldNames =["_method", "method"];
 

--- a/src/Microsoft.Diagnostics.ExtensionCommands/DumpRequestsCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/DumpRequestsCommand.cs
@@ -1,9 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections.Generic;
-using System.Data;
 using System.Linq;
 using Microsoft.Diagnostics.DebugServices;
 using Microsoft.Diagnostics.ExtensionCommands.Output;
@@ -12,8 +10,8 @@ using static Microsoft.Diagnostics.ExtensionCommands.Output.ColumnKind;
 
 namespace Microsoft.Diagnostics.ExtensionCommands
 {
-    [Command(Name = "dumphttprequests", Aliases = new string[] { "DumpHttpRequests" }, Help = "Shows all currently active incoming HTTP requests.")]
-    public class DumpHttpRequestsCommand : ClrRuntimeCommandBase
+    [Command(Name = "dumprequests", Aliases = new string[] { "DumpRequests" }, Help = "Displays all currently active incoming HTTP requests.")]
+    public class DumpRequestsCommand : ClrRuntimeCommandBase
     {
         public override void Invoke()
         {

--- a/src/SOS/Strike/managedcommands.cpp
+++ b/src/SOS/Strike/managedcommands.cpp
@@ -180,10 +180,10 @@ DECLARE_API(sizestats)
     return ExecuteManagedOnlyCommand("sizestats", args);
 }
 
-DECLARE_API(DumpHttpRequests)
+DECLARE_API(DumpHttp)
 {
     INIT_API_EXT();
-    return ExecuteManagedOnlyCommand("dumphttprequests", args);
+    return ExecuteManagedOnlyCommand("dumphttp", args);
 }
 
 typedef HRESULT (*PFN_COMMAND)(PDEBUG_CLIENT client, PCSTR args);

--- a/src/SOS/Strike/managedcommands.cpp
+++ b/src/SOS/Strike/managedcommands.cpp
@@ -186,6 +186,12 @@ DECLARE_API(DumpHttp)
     return ExecuteManagedOnlyCommand("dumphttp", args);
 }
 
+DECLARE_API(DumpRequests)
+{
+    INIT_API_EXT();
+    return ExecuteManagedOnlyCommand("dumprequests", args);
+}
+
 typedef HRESULT (*PFN_COMMAND)(PDEBUG_CLIENT client, PCSTR args);
 
 //

--- a/src/SOS/Strike/sos.def
+++ b/src/SOS/Strike/sos.def
@@ -29,8 +29,8 @@ EXPORTS
     DumpDomain
     dumpdomain=DumpDomain
     dumpexceptions
-    DumpHttpRequests
-    dumphttprequests=DumpHttpRequests
+    DumpHttp
+    dumphttp=DumpHttp
 #ifdef TRACE_GC
     DumpGCLog
     dumpgclog=DumpGCLog

--- a/src/SOS/Strike/sos.def
+++ b/src/SOS/Strike/sos.def
@@ -31,6 +31,8 @@ EXPORTS
     dumpexceptions
     DumpHttp
     dumphttp=DumpHttp
+    DumpRequests
+    dumprequests=DumpRequests
 #ifdef TRACE_GC
     DumpGCLog
     dumpgclog=DumpGCLog

--- a/src/SOS/lldbplugin/soscommand.cpp
+++ b/src/SOS/lldbplugin/soscommand.cpp
@@ -174,6 +174,7 @@ sosCommandInitialize(lldb::SBDebugger debugger)
     g_services->AddCommand("dumpgcdata", new sosCommand("DumpGCData"), "Displays information about the GC data.");
     g_services->AddManagedCommand("dumpheap", "Displays info about the garbage-collected heap and collection statistics about objects.");
     g_services->AddManagedCommand("dumphttp", "Displays information about HTTP requests.");
+    g_services->AddManagedCommand("dumprequests", "Displays all currently active incoming HTTP requests.");
     g_services->AddCommand("dumpil", new sosCommand("DumpIL"), "Displays the Microsoft intermediate language (MSIL) that's associated with a managed method.");
     g_services->AddCommand("dumplog", new sosCommand("DumpLog"), "Writes the contents of an in-memory stress log to the specified file.");
     g_services->AddCommand("dumpmd", new sosCommand("DumpMD"), "Displays information about a MethodDesc structure at the specified address.");

--- a/src/SOS/lldbplugin/soscommand.cpp
+++ b/src/SOS/lldbplugin/soscommand.cpp
@@ -173,7 +173,7 @@ sosCommandInitialize(lldb::SBDebugger debugger)
     g_services->AddCommand("dumpdomain", new sosCommand("DumpDomain"), "Displays information about the all assemblies within all the AppDomains or the specified one.");
     g_services->AddCommand("dumpgcdata", new sosCommand("DumpGCData"), "Displays information about the GC data.");
     g_services->AddManagedCommand("dumpheap", "Displays info about the garbage-collected heap and collection statistics about objects.");
-    g_services->AddManagedCommand("dumphttprequests", "Shows all currently active incoming HTTP requests.");
+    g_services->AddManagedCommand("dumphttp", "Displays information about HTTP requests.");
     g_services->AddCommand("dumpil", new sosCommand("DumpIL"), "Displays the Microsoft intermediate language (MSIL) that's associated with a managed method.");
     g_services->AddCommand("dumplog", new sosCommand("DumpLog"), "Writes the contents of an in-memory stress log to the specified file.");
     g_services->AddCommand("dumpmd", new sosCommand("DumpMD"), "Displays information about a MethodDesc structure at the specified address.");


### PR DESCRIPTION
Add a new command mentioned in https://github.com/dotnet/diagnostics/issues/536#issuecomment-1521192550

Options:
```
> help dumphttp
dumphttp:
  Displays information about HTTP requests

Usage:
  > dumphttp [options]

Options:
  --stats                      Summarize all HTTP requests found rather than showing detailed info.
  --pending                    Show only requests without response
  --completed                  Show only requests with response
  --uri <uri>                  Show only requests with with specified request uri
  --statuscode <statuscode>    Show only requests with with specified response status code

Examples:
    Summarize all http requests:                                dumphttp --stats
    Show only completed http requests:                          dumphttp --completed
    Show failed request with request uri contains weather:      dumphttp --statuscode 500 --uri weather
```

Output example:
```
> dumphttp
         Address      MethodTable Method StatusCode Uri
    0263714267f0     7ffb87afb750 GET           200 http://localhost:5180/weatherforecast
    0263714133c8     7ffb87afb750 GET               http://localhost:5180/weatherforecast/slow
Total 2 requests

> dumphttp --pending
         Address      MethodTable Method StatusCode Uri
    0263714133c8     7ffb87afb750 GET               http://localhost:5180/weatherforecast/slow
Total 1 requests

> dumphttp --stats
Statistics:
         Count Method StatusCode Host
             1 GET           200 localhost
             1 GET               localhost
Total 2 requests
```