### PR TITLE
Prepare the FabricBot config for migration to Policy Service

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -98,6 +98,10 @@
           "operator": "and",
           "operands": [
             {
+              "name": "isIssue",
+              "parameters": {}
+            },
+            {
               "operator": "not",
               "operands": [
                 {
@@ -195,6 +199,10 @@
               "parameters": {
                 "label": "Needs: Author Feedback"
               }
+            },
+            {
+              "name": "isIssue",
+              "parameters": {}
             },
             {
               "name": "isOpen",
@@ -789,6 +797,10 @@
               ]
             },
             {
+              "name": "isIssue",
+              "parameters": {}
+            },
+            {
               "name": "hasLabel",
               "parameters": {
                 "label": "Status: No Recent Activity"
@@ -822,6 +834,10 @@
           "operator": "and",
           "operands": [
             {
+              "name": "isIssue",
+              "parameters": {}
+            },
+            {
               "name": "hasLabel",
               "parameters": {
                 "label": "Status: No Recent Activity"
@@ -852,6 +868,10 @@
         "conditions": {
           "operator": "and",
           "operands": [
+            {
+              "name": "isIssue",
+              "parameters": {}
+            },
             {
               "name": "labelAdded",
               "parameters": {

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -74,8 +74,7 @@
         "eventType": "pull_request",
         "eventNames": [
           "pull_request",
-          "issues",
-          "project_card"
+          "issues"
         ],
         "taskName": "Auto approve dependencies",
         "actions": [
@@ -818,8 +817,7 @@
         ],
         "eventType": "issue",
         "eventNames": [
-          "issues",
-          "project_card"
+          "issues"
         ]
       }
     },
@@ -882,8 +880,7 @@
         },
         "eventType": "issue",
         "eventNames": [
-          "issues",
-          "project_card"
+          "issues"
         ],
         "taskName": "Add comment when 'Needs Author Feedback' is applied to issue",
         "actions": [


### PR DESCRIPTION
This updates the FabricBot configuration to address issues we've seen migrating other repositories to the Policy Service automation. There are no behavioral changes.