### PR TITLE
Prepare the FabricBot config for migration to Policy Service

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -3,47 +3,6 @@
   "tasks": [
     {
       "taskType": "trigger",
-      "capabilityId": "AutoMerge",
-      "subCapability": "AutoMerge",
-      "version": "1.0",
-      "config": {
-        "taskName": "Automatically merge pull requests",
-        "label": "auto-merge",
-        "silentMode": false,
-        "minMinutesOpen": "1",
-        "mergeType": "squash",
-        "deleteBranches": true,
-        "allowAutoMergeInstructionsWithoutLabel": true,
-        "enforceDMPAsStatus": true,
-        "removeLabelOnPush": true,
-        "usePrDescriptionAsCommitMessage": false,
-        "conditionalMergeTypes": [
-          {
-            "mergeType": "merge",
-            "condition": {
-              "placeholder": "branch",
-              "operator": "equals",
-              "value": "release/stable"
-            }
-          }
-        ],
-        "requireAllStatuses": true,
-        "requireSpecificCheckRuns": true,
-        "requireSpecificCheckRunsList": [
-          "diagnostics-public-ci"
-        ],
-        "minimumNumberOfStatuses": 1,
-        "minimumNumberOfCheckRuns": 1,
-        "requireAllStatuses_exemptList": [
-          "codecov",
-          "Dependabot",
-          "DotNet Maestro",
-          "DotNet Maestro - Int"
-        ]
-      }
-    },
-    {
-      "taskType": "trigger",
       "capabilityId": "IssueResponder",
       "subCapability": "PullRequestResponder",
       "version": "1.0",

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -11,6 +11,10 @@
           "operator": "and",
           "operands": [
             {
+              "name": "isPr",
+              "parameters": {}
+            },
+            {
               "name": "isAction",
               "parameters": {
                 "action": "opened"


### PR DESCRIPTION
There are 2 remaining changes that need to be made to the FabricBot configuration before this repository is ready for migration. One of them results in a loss of functionality that cannot be retained with the migration to the new Policy Service.

1. Remove the auto-merge automation
    - This automation configuration was relying on some rich features of the FabricBot's own auto-merge functionality
    - That functionality was in place before GitHub's own auto-merge functionality
    - Because GitHub has built-in auto-merge capabilities, the Policy Service does not provide its own implementation
    - Policy Service does have automation that allows for a PR to have auto-merge enabled or disabled, but it can't rely on the types of conditions used here
    - The result is there is not a way to port this configuration forward, and a different approach is needed
    - The recommendation is to investigate Arcade-based auto-merge behaviors or implementing a GitHub Action
2. Explicitly add a filter for a pull request event
    - There was a task configured for `"eventType": "pull_request"` that when ported to Policy Service, this implicit filter will be lost
    - This updates the config to explicitly add that filter so behavior stays the same after the migration

@hoyosjs @tommcdon Sorry for the loss of auto-merge functionality here; we explored ways to retain this, but we can't fill that gap for you.

/cc @wtgodbe @mkArtakMSFT @JohannesLampel 