### PR TITLE
Validate format options in dotnet-trace convert 

### DIFF
--- a/src/Tools/dotnet-trace/CommandLine/Commands/ConvertCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/ConvertCommand.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.CommandLine;
+using System.CommandLine.IO;
 using System.IO;
+using System.Linq;
 using Microsoft.Tools.Common;
 
 namespace Microsoft.Diagnostics.Tools.Trace
@@ -12,21 +14,22 @@ namespace Microsoft.Diagnostics.Tools.Trace
     {
         public static int ConvertFile(IConsole console, FileInfo inputFilename, TraceFileFormat format, FileInfo output)
         {
-            if ((int)format <= 0)
+            if (!Enum.IsDefined(format))
             {
-                Console.Error.WriteLine("--format is required.");
+                string options = string.Join(", ", Enum.GetNames(typeof(TraceFileFormat)).Where(x => x != TraceFileFormat.NetTrace.ToString()));
+                console.Error.WriteLine($"Please specify a valid option for the --format. Valid options are: {options}.");
                 return ErrorCodes.ArgumentError;
             }
 
             if (format == TraceFileFormat.NetTrace)
             {
-                Console.Error.WriteLine("Cannot convert a nettrace file to nettrace format.");
+                console.Error.WriteLine("Cannot convert a nettrace file to nettrace format.");
                 return ErrorCodes.ArgumentError;
             }
 
             if (!inputFilename.Exists)
             {
-                Console.Error.WriteLine($"File '{inputFilename}' does not exist.");
+                console.Error.WriteLine($"File '{inputFilename}' does not exist.");
                 return ErrorCodes.ArgumentError;
             }
 

--- a/src/Tools/dotnet-trace/CommandLine/Options/CommonOptions.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Options/CommonOptions.cs
@@ -38,7 +38,8 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 alias: "--format",
                 description: $"Sets the output format for the trace file conversion.")
             {
-                Argument = new Argument<TraceFileFormat>(name: "trace-file-format")
+                Argument = new Argument<TraceFileFormat>(name: "trace-file-format"),
+                IsRequired = true
             };
     }
 }

--- a/src/Tools/dotnet-trace/TraceFileFormatConverter.cs
+++ b/src/Tools/dotnet-trace/TraceFileFormatConverter.cs
@@ -12,7 +12,7 @@ using Microsoft.Diagnostics.Tracing.Stacks.Formats;
 
 namespace Microsoft.Diagnostics.Tools.Trace
 {
-    internal enum TraceFileFormat { NetTrace, Speedscope, Chromium };
+    internal enum TraceFileFormat { NetTrace = 1, Speedscope, Chromium };
 
     internal static class TraceFileFormatConverter
     {


### PR DESCRIPTION
Fixes https://github.com/dotnet/docs/issues/39557

- Base enum at 1 since it's backed by an int and the default has semantic value (NetTrace).
- Make the conversion format required.
- Validate the Enum parameter and make help more explicit.