### PR TITLE
Remove UsingToolNetFrameworkReferenceAssemblies

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -40,7 +40,6 @@
   <PropertyGroup>
     <!-- Opt-in/out repo features -->
     <UsingToolXliff>false</UsingToolXliff>
-    <UsingToolNetFrameworkReferenceAssemblies>true</UsingToolNetFrameworkReferenceAssemblies>
     <!-- CoreFX -->
     <SystemReflectionMetadataVersion>5.0.0</SystemReflectionMetadataVersion>
     <SystemCollectionsImmutableVersion>6.0.0</SystemCollectionsImmutableVersion>


### PR DESCRIPTION
UsingToolNetFrameworkReferenceAssemblies got removed from Arcade a while ago as the SDK supports that natively.