### PR TITLE
Thays fix 4170

### DIFF
--- a/src/Tools/dotnet-counters/Exporters/ConsoleWriter.cs
+++ b/src/Tools/dotnet-counters/Exporters/ConsoleWriter.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using Microsoft.Diagnostics.Monitoring.EventPipe;
-using Microsoft.Diagnostics.Tracing.StackSources;
 
 namespace Microsoft.Diagnostics.Tools.Counters.Exporters
 {
@@ -221,7 +220,7 @@ namespace Microsoft.Diagnostics.Tools.Counters.Exporters
             for (int i = 0; i < header.Length; i++)
             {
                 string headerItem = header[i];
-                string headerWithSpaces = MakeFixedWidth(headerItem, Math.Max(maxValueColumnLen[i], columnHeaderLen[i]), splitLeft: true);
+                string headerWithSpaces = MakeFixedWidth(headerItem, Math.Max(maxValueColumnLen[i], columnHeaderLen[i]), truncateLeft: true);
                 headerWithSpaces += " ";
                 headerRow += headerWithSpaces;
             }
@@ -546,7 +545,7 @@ namespace Microsoft.Diagnostics.Tools.Counters.Exporters
             return valueText;
         }
 
-        private static string MakeFixedWidth(string text, int width, bool alignRight = false, bool splitLeft = false)
+        private static string MakeFixedWidth(string text, int width, bool alignRight = false, bool truncateLeft = false)
         {
             if (text == null)
             {
@@ -558,7 +557,7 @@ namespace Microsoft.Diagnostics.Tools.Counters.Exporters
             }
             else if (text.Length > width)
             {
-                if (splitLeft)
+                if (truncateLeft)
                 {
                     return text.Substring(text.Length-width, width);
                 }


### PR DESCRIPTION
As described on #4170 I did 3 things:
- Removed the 80 character horizontal width limit
- 2b - Formatted it as a little inline table with names in the header and values below
- 2c - Truncate partially each column if needed avoiding the rightmost columns are get hidden

I didn't add the "..." in the begin or in the end of the string because this would make the user lose more data, but not sure if it's weird without it.

Sample without this PR:
![image](https://github.com/dotnet/diagnostics/assets/4503299/4f9665a3-a3cf-4d1c-9881-90009cfb7ba1)

Sample with this PR:
![image](https://github.com/dotnet/diagnostics/assets/4503299/aa70757e-7445-477f-a45d-8c5a9fbdd756)
