### PR TITLE
Fix/clean up command service 'command not found' paths.

### DIFF
--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/CommandService.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/CommandService.cs
@@ -41,11 +41,11 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
         /// </summary>
         /// <param name="commandLine">command line text</param>
         /// <param name="services">services for the command</param>
-        /// <returns>true - found command, false - command not found</returns>
         /// <exception cref="ArgumentException">empty command line</exception>
-        /// <exception cref="DiagnosticsException">other errors</exception>
+        /// <exception cref="CommandNotFoundException">command not found</exception>
         /// <exception cref="CommandParsingException ">parsing error</exception>
-        public bool Execute(string commandLine, IServiceProvider services)
+        /// <exception cref="DiagnosticsException">other errors</exception>
+        public void Execute(string commandLine, IServiceProvider services)
         {
             string[] commandLineArray = CommandLineStringSplitter.Instance.Split(commandLine).ToArray();
             if (commandLineArray.Length <= 0)
@@ -53,7 +53,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
                 throw new ArgumentException("Empty command line", nameof(commandLine));
             }
             string commandName = commandLineArray[0].Trim();
-            return Execute(commandName, commandLineArray, services);
+            Execute(commandName, commandLineArray, services);
         }
 
         /// <summary>
@@ -62,11 +62,11 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
         /// <param name="commandName">command name</param>
         /// <param name="commandArguments">command arguments/options</param>
         /// <param name="services">services for the command</param>
-        /// <returns>true - found command, false - command not found</returns>
         /// <exception cref="ArgumentException">empty command name or arguments</exception>
-        /// <exception cref="DiagnosticsException">other errors</exception>
+        /// <exception cref="CommandNotFoundException">command not found</exception>
         /// <exception cref="CommandParsingException ">parsing error</exception>
-        public bool Execute(string commandName, string commandArguments, IServiceProvider services)
+        /// <exception cref="DiagnosticsException">other errors</exception>
+        public void Execute(string commandName, string commandArguments, IServiceProvider services)
         {
             commandName = commandName.Trim();
             string[] commandLineArray = CommandLineStringSplitter.Instance.Split(commandName + " " + (commandArguments ?? "")).ToArray();
@@ -74,7 +74,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
             {
                 throw new ArgumentException("Empty command name or arguments", nameof(commandArguments));
             }
-            return Execute(commandName, commandLineArray, services);
+            Execute(commandName, commandLineArray, services);
         }
 
         /// <summary>
@@ -83,11 +83,11 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
         /// <param name="commandName">command name</param>
         /// <param name="commandLineArray">command line</param>
         /// <param name="services">services for the command</param>
-        /// <returns>true - found command, false - command not found</returns>
         /// <exception cref="ArgumentException">empty command name</exception>
-        /// <exception cref="DiagnosticsException">other errors</exception>
+        /// <exception cref="CommandNotFoundException">command not found</exception>
         /// <exception cref="CommandParsingException ">parsing error</exception>
-        private bool Execute(string commandName, string[] commandLineArray, IServiceProvider services)
+        /// <exception cref="DiagnosticsException">other errors</exception>
+        private void Execute(string commandName, string[] commandLineArray, IServiceProvider services)
         {
             if (string.IsNullOrEmpty(commandName))
             {
@@ -104,7 +104,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
                         {
                             if (group.Execute(commandLineArray, services))
                             {
-                                return true;
+                                return;
                             }
                         }
                         if (handler.FilterInvokeMessage != null)
@@ -120,9 +120,12 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
             }
             if (messages.Count > 0)
             {
-                throw new CommandNotFoundException(string.Concat(messages.Select(s => s + Environment.NewLine)));
+                throw new CommandNotFoundException(messages);
             }
-            return false;
+            else
+            {
+                throw new CommandNotFoundException(commandName);
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.Diagnostics.DebugServices/DiagnosticsException.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/DiagnosticsException.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Diagnostics.DebugServices
         }
 
         public CommandNotFoundException(IEnumerable<string> messages)
-            : base(string.Concat(messages.Select(s => s + Environment.NewLine)))
+            : base(string.Join(Environment.NewLine, messages))
         {
         }
     }

--- a/src/Microsoft.Diagnostics.DebugServices/DiagnosticsException.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/DiagnosticsException.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.Diagnostics.DebugServices
 {
@@ -31,15 +33,13 @@ namespace Microsoft.Diagnostics.DebugServices
     /// </summary>
     public class CommandNotFoundException : DiagnosticsException
     {
-        public const string NotFoundMessage = $"Unrecognized SOS command";
-
-        public CommandNotFoundException(string message)
-            : base(message)
+        public CommandNotFoundException(string command)
+            : base($"Unrecognized SOS command '{command}'")
         {
         }
 
-        public CommandNotFoundException(string message, Exception innerException)
-            : base(message, innerException)
+        public CommandNotFoundException(IEnumerable<string> messages)
+            : base(string.Concat(messages.Select(s => s + Environment.NewLine)))
         {
         }
     }

--- a/src/Microsoft.Diagnostics.ExtensionCommands/ClrMDHelper.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/ClrMDHelper.cs
@@ -26,8 +26,9 @@ namespace Microsoft.Diagnostics.ExtensionCommands
                     return new ClrMDHelper(clrRuntime);
                 }
             }
-            catch (NotSupportedException)
+            catch (NotSupportedException ex)
             {
+                Trace.TraceError(ex.ToString());
             }
             return null;
         }

--- a/src/Microsoft.Diagnostics.ExtensionCommands/ClrMDHelper.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/ClrMDHelper.cs
@@ -19,7 +19,17 @@ namespace Microsoft.Diagnostics.ExtensionCommands
         [ServiceExport(Scope = ServiceScope.Runtime)]
         public static ClrMDHelper TryCreate([ServiceImport(Optional = true)] ClrRuntime clrRuntime)
         {
-            return clrRuntime != null ? new ClrMDHelper(clrRuntime) : null;
+            try
+            {
+                if (clrRuntime != null)
+                {
+                    return new ClrMDHelper(clrRuntime);
+                }
+            }
+            catch (NotSupportedException)
+            {
+            }
+            return null;
         }
 
         private ClrMDHelper(ClrRuntime clr)

--- a/src/SOS/SOS.Extensions/HostServices.cs
+++ b/src/SOS/SOS.Extensions/HostServices.cs
@@ -358,13 +358,10 @@ namespace SOS.Extensions
             }
             catch (Exception ex)
             {
-                if (!displayCommandNotFound)
+                if (!displayCommandNotFound && ex is CommandNotFoundException)
                 {
-                    if (ex is CommandNotFoundException)
-                    {
-                        // Returning E_NOTIMPL means no managed command or it filtered away so execute the C++ version if one
-                        return HResult.E_NOTIMPL;
-                    }
+                    // Returning E_NOTIMPL means no managed command or it filtered away so execute the C++ version if one
+                    return HResult.E_NOTIMPL;
                 }
                 Trace.TraceError(ex.ToString());
                 IConsoleService consoleService = Services.GetService<IConsoleService>();

--- a/src/SOS/SOS.Hosting/SOSLibrary.cs
+++ b/src/SOS/SOS.Hosting/SOSLibrary.cs
@@ -192,12 +192,12 @@ namespace SOS.Hosting
             SOSCommandDelegate commandFunc = SOSHost.GetDelegateFunction<SOSCommandDelegate>(_sosLibrary, command);
             if (commandFunc == null)
             {
-                throw new CommandNotFoundException($"{CommandNotFoundException.NotFoundMessage} '{command}'");
+                throw new CommandNotFoundException(command);
             }
             int result = commandFunc(client, arguments ?? "");
             if (result == HResult.E_NOTIMPL)
             {
-                throw new CommandNotFoundException($"{CommandNotFoundException.NotFoundMessage} '{command}'");
+                throw new CommandNotFoundException(command);
             }
             if (result != HResult.S_OK)
             {

--- a/src/SOS/Strike/exts.cpp
+++ b/src/SOS/Strike/exts.cpp
@@ -231,37 +231,44 @@ void
 DACMessage(HRESULT Status)
 {
     ExtOut("Failed to load data access module, 0x%08x\n", Status);
-    if (GetHost()->GetHostType() == IHost::HostType::DbgEng)
+    if (g_pRuntime->GetRuntimeConfiguration() >= IRuntime::ConfigurationEnd)
     {
-        ExtOut("Verify that 1) you have a recent build of the debugger (10.0.18317.1001 or newer)\n");
-        ExtOut("            2) the file %s that matches your version of %s is\n", GetDacDllName(), GetRuntimeDllName());
-        ExtOut("                in the version directory or on the symbol path\n");
-        ExtOut("            3) or, if you are debugging a dump file, verify that the file\n");
-        ExtOut("                %s_<arch>_<arch>_<version>.dll is on your symbol path.\n", GetDacModuleName());
-        ExtOut("            4) you are debugging on a platform and architecture that supports this\n");
-        ExtOut("                the dump file. For example, an ARM dump file must be debugged\n");
-        ExtOut("                on an X86 or an ARM machine; an AMD64 dump file must be\n");
-        ExtOut("                debugged on an AMD64 machine.\n");
-        ExtOut("\n");
-        ExtOut("You can run the command '!setclrpath <directory>' to control the load path of %s.\n", GetDacDllName());
-        ExtOut("\n");
-        ExtOut("Or you can also run the debugger command .cordll to control the debugger's\n");
-        ExtOut("load of %s. .cordll -ve -u -l will do a verbose reload.\n", GetDacDllName());
-        ExtOut("If that succeeds, the SOS command should work on retry.\n");
-        ExtOut("\n");
-        ExtOut("If you are debugging a minidump, you need to make sure that your executable\n");
-        ExtOut("path is pointing to %s as well.\n", GetRuntimeDllName());
+        ExtOut("Unknown runtime type. Command not supported.\n");
     }
     else
     {
-        if (Status == CORDBG_E_MISSING_DEBUGGER_EXPORTS)
+        if (GetHost()->GetHostType() == IHost::HostType::DbgEng)
         {
-            ExtOut("You can run the debugger command 'setclrpath <directory>' to control the load of %s.\n", GetDacDllName());
+            ExtOut("Verify that 1) you have a recent build of the debugger (10.0.18317.1001 or newer)\n");
+            ExtOut("            2) the file %s that matches your version of %s is\n", GetDacDllName(), GetRuntimeDllName());
+            ExtOut("                in the version directory or on the symbol path\n");
+            ExtOut("            3) or, if you are debugging a dump file, verify that the file\n");
+            ExtOut("                %s_<arch>_<arch>_<version>.dll is on your symbol path.\n", GetDacModuleName());
+            ExtOut("            4) you are debugging on a platform and architecture that supports this\n");
+            ExtOut("                the dump file. For example, an ARM dump file must be debugged\n");
+            ExtOut("                on an X86 or an ARM machine; an AMD64 dump file must be\n");
+            ExtOut("                debugged on an AMD64 machine.\n");
+            ExtOut("\n");
+            ExtOut("You can run the command '!setclrpath <directory>' to control the load path of %s.\n", GetDacDllName());
+            ExtOut("\n");
+            ExtOut("Or you can also run the debugger command .cordll to control the debugger's\n");
+            ExtOut("load of %s. .cordll -ve -u -l will do a verbose reload.\n", GetDacDllName());
             ExtOut("If that succeeds, the SOS command should work on retry.\n");
+            ExtOut("\n");
+            ExtOut("If you are debugging a minidump, you need to make sure that your executable\n");
+            ExtOut("path is pointing to %s as well.\n", GetRuntimeDllName());
         }
         else
         {
-            ExtOut("Can not load or initialize %s. The target runtime may not be initialized.\n", GetDacDllName());
+            if (Status == CORDBG_E_MISSING_DEBUGGER_EXPORTS)
+            {
+                ExtOut("You can run the debugger command 'setclrpath <directory>' to control the load of %s.\n", GetDacDllName());
+                ExtOut("If that succeeds, the SOS command should work on retry.\n");
+            }
+            else
+            {
+                ExtOut("Can not load or initialize %s. The target runtime may not be initialized.\n", GetDacDllName());
+            }
         }
     }
     ExtOut("\n");

--- a/src/SOS/Strike/exts.cpp
+++ b/src/SOS/Strike/exts.cpp
@@ -209,7 +209,7 @@ ExecuteCommand(PCSTR commandName, PCSTR args)
         IHostServices* hostServices = GetHostServices();
         if (hostServices != nullptr)
         {
-            return hostServices->DispatchCommand(commandName, args);
+            return hostServices->DispatchCommand(commandName, args, /* displayCommandNotFound */ false);
         }
     }
     return E_NOTIMPL;

--- a/src/SOS/Strike/managedcommands.cpp
+++ b/src/SOS/Strike/managedcommands.cpp
@@ -7,12 +7,13 @@
 
 HRESULT ExecuteManagedOnlyCommand(PCSTR commandName, PCSTR args)
 {
-    HRESULT hr = ExecuteCommand(commandName, args);
-    if (hr == E_NOTIMPL)
+    IHostServices* hostServices = GetHostServices();
+    if (hostServices != nullptr)
     {
-        ExtErr("Unrecognized command '%s'\n", commandName);
+        return hostServices->DispatchCommand(commandName, args, /* displayCommandNotFound */ true);
     }
-    return hr;
+    ExtErr("Unrecognized command '%s' because managed hosting failed or was disabled. See !sethostruntime command for details.\n", commandName);
+    return E_NOTIMPL;
 }
 
 DECLARE_API(DumpStackObjects)

--- a/src/SOS/Strike/util.cpp
+++ b/src/SOS/Strike/util.cpp
@@ -1507,7 +1507,6 @@ HRESULT FileNameForModule(const DacpModuleData* const pModuleData, __out_ecount(
 
 void AssemblyInfo(DacpAssemblyData *pAssembly)
 {
-    ExtOut("ClassLoader:        %p\n", SOS_PTR(pAssembly->ClassLoader));
     if ((ULONG64)pAssembly->AssemblySecDesc != NULL)
         ExtOut("SecurityDescriptor: %p\n", SOS_PTR(pAssembly->AssemblySecDesc));
     ExtOut("  Module\n");

--- a/src/SOS/inc/hostservices.h
+++ b/src/SOS/inc/hostservices.h
@@ -77,10 +77,12 @@ public:
     /// </summary>
     /// <param name="commandName">command name</param>
     /// <param name="arguments">command arguments</param>
+    /// <param name="displayCommandNotFound">if true, display command not found error message; if false, return E_NOTIMPL</param>
     /// <returns>error code</returns>
     virtual HRESULT STDMETHODCALLTYPE DispatchCommand( 
         PCSTR commandName,
-        PCSTR arguments) = 0;
+        PCSTR arguments,
+        bool displayCommandNotFound) = 0;
 
     /// <summary>
     /// Uninitialize the extension infrastructure

--- a/src/SOS/lldbplugin/services.cpp
+++ b/src/SOS/lldbplugin/services.cpp
@@ -2153,6 +2153,7 @@ public:
         IHostServices* hostservices = GetHostServices();
         if (hostservices == nullptr)
         {
+            g_services->Output(DEBUG_OUTPUT_ERROR, "Unrecognized command '%s' because managed hosting failed or was disabled. See sethostruntime command for details.\n", m_commandName);
             result.SetStatus(lldb::eReturnStatusFailed);
             return false;
         }
@@ -2166,7 +2167,7 @@ public:
             }
         }
         g_services->FlushCheck();
-        HRESULT hr = hostservices->DispatchCommand(m_commandName, commandArguments.c_str());
+        HRESULT hr = hostservices->DispatchCommand(m_commandName, commandArguments.c_str(), /* displayCommandNotFound */ true);
         if (hr != S_OK)
         {
             result.SetStatus(lldb::eReturnStatusFailed);
@@ -2999,7 +3000,7 @@ LLDBServices::ExecuteCommand(
     if (hostservices != nullptr)
     {
         g_services->FlushCheck();
-        HRESULT hr = hostservices->DispatchCommand(commandName, commandArguments.c_str());
+        HRESULT hr = hostservices->DispatchCommand(commandName, commandArguments.c_str(), /* displayCommandNotFound */ false);
         if (hr != E_NOTIMPL)
         {
             result.SetStatus(hr == S_OK ? lldb::eReturnStatusSuccessFinishResult : lldb::eReturnStatusFailed);

--- a/src/Tools/dotnet-dump/Analyzer.cs
+++ b/src/Tools/dotnet-dump/Analyzer.cs
@@ -137,10 +137,7 @@ namespace Microsoft.Diagnostics.Tools.Dump
                 {
                     foreach (string commandLine in command)
                     {
-                        if (!_commandService.Execute(commandLine, contextService.Services))
-                        {
-                            throw new CommandNotFoundException($"{CommandNotFoundException.NotFoundMessage} '{commandLine}'");
-                        }
+                        _commandService.Execute(commandLine, contextService.Services);
                         if (_consoleService.Shutdown)
                         {
                             break;
@@ -157,10 +154,7 @@ namespace Microsoft.Diagnostics.Tools.Dump
 
                     _consoleService.Start((string prompt, string commandLine, CancellationToken cancellation) => {
                         _fileLoggingConsoleService.WriteLine("{0}{1}", prompt, commandLine);
-                        if (!_commandService.Execute(commandLine, contextService.Services))
-                        {
-                            throw new CommandNotFoundException($"{CommandNotFoundException.NotFoundMessage} '{commandLine}'");
-                        }
+                        _commandService.Execute(commandLine, contextService.Services);
                     });
                 }
             }

--- a/src/Tools/dotnet-dump/Commands/SOSCommand.cs
+++ b/src/Tools/dotnet-dump/Commands/SOSCommand.cs
@@ -39,15 +39,18 @@ namespace Microsoft.Diagnostics.Tools.Dump
                 command = "help";
                 arguments = null;
             }
-            if (CommandService.Execute(command, arguments, Services))
+            try
             {
-                return;
+                CommandService.Execute(command, arguments, Services);
             }
-            if (SOSHost is null)
+            catch (CommandNotFoundException)
             {
-                throw new CommandNotFoundException($"{CommandNotFoundException.NotFoundMessage} '{command}'");
+                if (SOSHost is null)
+                {
+                    throw;
+                }
+                SOSHost.ExecuteCommand(command, arguments);
             }
-            SOSHost.ExecuteCommand(command, arguments);
         }
     }
 }

--- a/src/tests/Microsoft.Diagnostics.DebugServices.UnitTests/CommandServiceTests.cs
+++ b/src/tests/Microsoft.Diagnostics.DebugServices.UnitTests/CommandServiceTests.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Diagnostics.DebugServices.UnitTests
             TestCommand2.Invoked = false;
             TestCommand3.FilterValue = false;
             TestCommand3.Invoked = false;
-            Assert.True(commandService.Execute("testcommand", testDump.Target.Services));
+            commandService.Execute("testcommand", testDump.Target.Services);
             Assert.True(TestCommand1.Invoked);
             Assert.False(TestCommand2.Invoked);
             Assert.False(TestCommand3.Invoked);
@@ -85,7 +85,7 @@ namespace Microsoft.Diagnostics.DebugServices.UnitTests
             TestCommand2.Invoked = false;
             TestCommand3.FilterValue = false;
             TestCommand3.Invoked = false;
-            Assert.True(commandService.Execute("testcommand", testDump.Target.Services));
+            commandService.Execute("testcommand", testDump.Target.Services);
             Assert.False(TestCommand1.Invoked);
             Assert.True(TestCommand2.Invoked);
             Assert.False(TestCommand3.Invoked);
@@ -98,7 +98,7 @@ namespace Microsoft.Diagnostics.DebugServices.UnitTests
             TestCommand2.Invoked = false;
             TestCommand3.FilterValue = true;
             TestCommand3.Invoked = false;
-            Assert.True(commandService.Execute("testcommand", "--foo 23", testDump.Target.Services));
+            commandService.Execute("testcommand", "--foo 23", testDump.Target.Services);
             Assert.False(TestCommand1.Invoked);
             Assert.False(TestCommand2.Invoked);
             Assert.True(TestCommand3.Invoked);
@@ -118,7 +118,7 @@ namespace Microsoft.Diagnostics.DebugServices.UnitTests
             TestCommand3.Invoked = false;
             try
             {
-                Assert.False(commandService.Execute("testcommand", testDump.Target.Services));
+                commandService.Execute("testcommand", testDump.Target.Services);
             }
             catch (DiagnosticsException ex)
             {


### PR DESCRIPTION
Add command not found error message when managed hosting fails for managed only commands.

Removed displaying ClassLoader address in !dumpassembly command.

Better SOS hosting error messages.