### PR TITLE
Support collecting GC collect only trace using a simplified profile

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/GcCollectConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/GcCollectConfiguration.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using Microsoft.Diagnostics.NETCore.Client;
+
+namespace Microsoft.Diagnostics.Monitoring.EventPipe
+{
+    public sealed class GcCollectConfiguration : MonitoringSourceConfiguration
+    {
+        public GcCollectConfiguration()
+        {
+            RequestRundown = false;
+        }
+
+        public override IList<EventPipeProvider> GetProviders() =>
+            new EventPipeProvider[]
+            {
+                new EventPipeProvider("Microsoft-Windows-DotNETRuntime", System.Diagnostics.Tracing.EventLevel.Informational, (long) Tracing.Parsers.ClrTraceEventParser.Keywords.GC),
+                new EventPipeProvider("Microsoft-Windows-DotNETRuntimePrivate", System.Diagnostics.Tracing.EventLevel.Informational, (long) Tracing.Parsers.ClrTraceEventParser.Keywords.GC),
+            };
+    }
+}


### PR DESCRIPTION
###### Summary
To make collecting gc-collect only traces easier with dotnet-monitor. I have made this change so that you can have a gc profile.

<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
With this new version, we can collect a gc-collect only trace using the gc profile.