### PR TITLE
Update Alpine versions

### DIFF
--- a/diagnostics.yml
+++ b/diagnostics.yml
@@ -227,7 +227,7 @@ extends:
       - template: /eng/pipelines/build.yml
         parameters:
           jobTemplate: ${{ variables.jobTemplate }}
-          name: Alpine3_13
+          name: Alpine3_19
           osGroup: Linux
           osSuffix: -musl
           container: test_linux_musl_x64

--- a/eng/pipelines/pipeline-resources.yml
+++ b/eng/pipelines/pipeline-resources.yml
@@ -29,7 +29,7 @@ extends:
           ROOTFS_DIR: /crossrootfs/arm64
 
       linux_musl_x64:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.19-WithNode
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.13-WithNode
 
       linux_musl_arm:
         image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-arm-alpine

--- a/eng/pipelines/pipeline-resources.yml
+++ b/eng/pipelines/pipeline-resources.yml
@@ -29,7 +29,7 @@ extends:
           ROOTFS_DIR: /crossrootfs/arm64
 
       linux_musl_x64:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.13-WithNode
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.19-WithNode
 
       linux_musl_arm:
         image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-arm-alpine
@@ -45,7 +45,7 @@ extends:
         image: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream-9
 
       test_linux_musl_x64:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.13-WithNode
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.19-WithNode
         options: --cap-add=SYS_PTRACE
 
       test_debian_11_amd64:


### PR DESCRIPTION
This is a more pragmatic approach as proposed earlier. Use the old Alpine version for build and the new one for testing.

We can move to cross-build images when .NET 6 goes EOL.