### PR TITLE
Fix recent Alpine repo build

### DIFF
--- a/src/SOS/Strike/metadata.cpp
+++ b/src/SOS/Strike/metadata.cpp
@@ -488,7 +488,7 @@ HRESULT MDInfo::GetFullNameForMD(PCCOR_SIGNATURE pbSigBlob, ULONG ulSigBlob, LON
 {
     ULONG       cbCur = 0;
     ULONG       cb;
-    ULONG       ulData = NULL;
+    ULONG       ulData = (TADDR)0;
     ULONG       ulArgs;
     HRESULT     hr = NOERROR;
 

--- a/src/SOS/Strike/sildasm.cpp
+++ b/src/SOS/Strike/sildasm.cpp
@@ -553,7 +553,7 @@ DWORD_PTR GetObj(DacpObjectData& tokenArray, UINT item)
             return objPtr;
         }
     }
-    return NULL;
+    return (TADDR)0;
 }
 
 
@@ -570,12 +570,12 @@ void DisassembleToken(DacpObjectData& tokenArray,
         {
             DWORD_PTR runtimeTypeHandle = GetObj(tokenArray, RidFromToken(token));
 
-            DWORD_PTR runtimeType = NULL;
+            DWORD_PTR runtimeType = (TADDR)0;
             MOVE(runtimeType, runtimeTypeHandle + sizeof(DWORD_PTR));
 
             int offset = GetObjFieldOffset(runtimeType, W("m_handle"));
 
-            DWORD_PTR methodTable = NULL;
+            DWORD_PTR methodTable = (TADDR)0;
             MOVE(methodTable, runtimeType + offset);
 
             if (NameForMT_s(methodTable, g_mdName,mdNameLen))
@@ -607,12 +607,12 @@ void DisassembleToken(DacpObjectData& tokenArray,
             CLRDATA_ADDRESS runtimeMethodHandle = GetObj(tokenArray, RidFromToken(token));            
             int offset = GetObjFieldOffset(runtimeMethodHandle, W("m_value"));
 
-            TADDR runtimeMethodInfo = NULL;
+            TADDR runtimeMethodInfo = (TADDR)0;
             MOVE(runtimeMethodInfo, runtimeMethodHandle+offset);
 
             offset = GetObjFieldOffset(runtimeMethodInfo, W("m_handle"));
 
-            TADDR methodDesc = NULL;
+            TADDR methodDesc = (TADDR)0;
             MOVE(methodDesc, runtimeMethodInfo+offset);
 
             NameForMD_s((DWORD_PTR)methodDesc, g_mdName, mdNameLen);

--- a/src/SOS/Strike/sos.cpp
+++ b/src/SOS/Strike/sos.cpp
@@ -99,13 +99,13 @@ namespace sos
 
     TADDR Object::GetMT() const
     {
-        if (mMT == NULL)
+        if (mMT == (TADDR)0)
         {
             TADDR temp;
             if (FAILED(MOVE(temp, mAddress)))
                 sos::Throw<DataRead>("Object %s has an invalid method table.", DMLListNearObj(mAddress));
 
-            if (temp == NULL)
+            if (temp == (TADDR)0)
                 sos::Throw<HeapCorruption>("Object %s has an invalid method table.", DMLListNearObj(mAddress));
 
             mMT = temp & ~METHODTABLE_PTR_LOW_BITMASK;
@@ -116,14 +116,14 @@ namespace sos
 
     TADDR Object::GetComponentMT() const
     {
-        if (mMT != NULL && mMT != sos::MethodTable::GetArrayMT())
-            return NULL;
+        if (mMT != (TADDR)0 && mMT != sos::MethodTable::GetArrayMT())
+            return (TADDR)0;
 
         DacpObjectData objData;
         if (FAILED(objData.Request(g_sos, TO_CDADDR(mAddress))))
             sos::Throw<DataRead>("Failed to request object data for %s.", DMLListNearObj(mAddress));
 
-        if (mMT == NULL)
+        if (mMT == (TADDR)0)
             mMT = TO_TADDR(objData.MethodTable) & ~METHODTABLE_PTR_LOW_BITMASK;
 
         return TO_TADDR(objData.ElementTypeHandle);
@@ -271,7 +271,7 @@ namespace sos
                     if (FAILED(MOVE(dwTmp, dwTmp)))
                         return false;
 
-                    if (dwTmp != NULL)
+                    if (dwTmp != (TADDR)0)
                     {
                         DacpObjectData objData;
                         if (FAILED(objData.Request(g_sos, TO_CDADDR(dwTmp))))
@@ -338,17 +338,17 @@ namespace sos
         out.ThreadId = header & SBLK_MASK_LOCK_THREADID;
         out.Recursion = (header & SBLK_MASK_LOCK_RECLEVEL) >> SBLK_RECLEVEL_SHIFT;
 
-        CLRDATA_ADDRESS threadPtr = NULL;
+        CLRDATA_ADDRESS threadPtr = (TADDR)0;
         if (g_sos->GetThreadFromThinlockID(out.ThreadId, &threadPtr) != S_OK)
         {
-            out.ThreadPtr = NULL;
+            out.ThreadPtr = (TADDR)0;
         }
         else
         {
             out.ThreadPtr = TO_TADDR(threadPtr);
         }
 
-        return out.ThreadId != 0 && out.ThreadPtr != NULL;
+        return out.ThreadId != 0 && out.ThreadPtr != (TADDR)0;
     }
 
     bool Object::GetStringData(__out_ecount(size) WCHAR *buffer, size_t size) const
@@ -369,8 +369,8 @@ namespace sos
             sos::Throw<DataRead>("Failed to read object data at %p.", mAddress);
 
         // We get the method table for free here, if we don't have it already.
-        SOS_Assert((mMT == NULL) || (mMT == TO_TADDR(stInfo.methodTable)));
-        if (mMT == NULL)
+        SOS_Assert((mMT == (TADDR)0) || (mMT == TO_TADDR(stInfo.methodTable)));
+        if (mMT == (TADDR)0)
             mMT = TO_TADDR(stInfo.methodTable);
 
         return (size_t)stInfo.m_StringLength;

--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -610,7 +610,7 @@ DECLARE_API(DumpMD)
     INIT_API_PROBE_MANAGED("dumpmd");
     MINIDUMP_NOT_SUPPORTED();
 
-    DWORD_PTR dwStartAddr = NULL;
+    DWORD_PTR dwStartAddr = (TADDR)0;
     BOOL dml = FALSE;
 
     CMDOption option[] =
@@ -725,8 +725,8 @@ DECLARE_API(DumpIL)
 {
     INIT_API_PROBE_MANAGED("dumpil");
     MINIDUMP_NOT_SUPPORTED();
-    DWORD_PTR dwStartAddr = NULL;
-    DWORD_PTR dwDynamicMethodObj = NULL;
+    DWORD_PTR dwStartAddr = (TADDR)0;
+    DWORD_PTR dwDynamicMethodObj = (TADDR)0;
     BOOL dml = FALSE;
     BOOL fILPointerDirectlySpecified = FALSE;
 
@@ -748,7 +748,7 @@ DECLARE_API(DumpIL)
     }
 
     EnableDMLHolder dmlHolder(dml);
-    if (dwStartAddr == NULL)
+    if (dwStartAddr == (TADDR)0)
     {
         ExtOut("Must pass a valid expression\n");
         return Status;
@@ -764,7 +764,7 @@ DECLARE_API(DumpIL)
         dwDynamicMethodObj = dwStartAddr;
     }
 
-    if (dwDynamicMethodObj == NULL)
+    if (dwDynamicMethodObj == (TADDR)0)
     {
         // We have been given a MethodDesc
         DacpMethodDescData MethodDescData;
@@ -777,7 +777,7 @@ DECLARE_API(DumpIL)
         if (MethodDescData.bIsDynamic && MethodDescData.managedDynamicMethodObject)
         {
             dwDynamicMethodObj = TO_TADDR(MethodDescData.managedDynamicMethodObject);
-            if (dwDynamicMethodObj == NULL)
+            if (dwDynamicMethodObj == (TADDR)0)
             {
                 ExtOut("Unable to print IL for DynamicMethodDesc %p\n", SOS_PTR(dwDynamicMethodObj));
                 return Status;
@@ -786,7 +786,7 @@ DECLARE_API(DumpIL)
         else
         {
             GetILAddressResult result = GetILAddress(MethodDescData);
-            if (std::get<0>(result) == NULL)
+            if (std::get<0>(result) == (TADDR)0)
             {
                 ExtOut("ilAddr is %p\n", SOS_PTR(std::get<0>(result)));
                 return E_FAIL;
@@ -798,7 +798,7 @@ DECLARE_API(DumpIL)
         }
     }
 
-    if (dwDynamicMethodObj != NULL)
+    if (dwDynamicMethodObj != (TADDR)0)
     {
         // We have a DynamicMethod managed object, let us visit the town and paint.
         DacpObjectData codeArray;
@@ -1068,7 +1068,7 @@ DECLARE_API(DumpClass)
     ExtOut("mdToken:         %p\n", SOS_PTR(mtdata.cl));
     ExtOut("File:            %S\n", fileName);
 
-    CLRDATA_ADDRESS ParentEEClass = NULL;
+    CLRDATA_ADDRESS ParentEEClass = (TADDR)0;
     if (mtdata.ParentMethodTable)
     {
         DacpMethodTableData mtdataparent;
@@ -1117,7 +1117,7 @@ DECLARE_API(DumpClass)
 
         if (vMethodTableFields.wNumInstanceFields + vMethodTableFields.wNumStaticFields > 0)
         {
-            DisplayFields(methodTable, &mtdata, &vMethodTableFields, NULL, TRUE, FALSE);
+            DisplayFields(methodTable, &mtdata, &vMethodTableFields, (TADDR)0, TRUE, FALSE);
         }
     }
 
@@ -1200,7 +1200,7 @@ DECLARE_API(DumpMT)
     table.WriteRow("mdToken:", Pointer(vMethTable.cl));
     table.WriteRow("File:", fileName[0] ? fileName : W("Unknown Module"));
 
-    if (vMethTableCollectible.LoaderAllocatorObjectHandle != NULL)
+    if (vMethTableCollectible.LoaderAllocatorObjectHandle != (TADDR)0)
     {
         TADDR loaderAllocator;
         if (SUCCEEDED(MOVE(loaderAllocator, vMethTableCollectible.LoaderAllocatorObjectHandle)))
@@ -1264,7 +1264,7 @@ DECLARE_API(DumpMT)
             table.WriteColumn(0, entry);
             table.WriteColumn(1, MethodDescPtr(methodDesc));
 
-            if (jitType == TYPE_UNKNOWN && methodDesc != NULL)
+            if (jitType == TYPE_UNKNOWN && methodDesc != (TADDR)0)
             {
                 // We can get a more accurate jitType from NativeCodeAddr of the methoddesc,
                 // because the methodtable entry hasn't always been patched.
@@ -1425,11 +1425,11 @@ HRESULT PrintObj(TADDR taObj, BOOL bPrintFields = TRUE)
         return Status;
     }
 
-    if (objData.RCW != NULL)
+    if (objData.RCW != (TADDR)0)
     {
         DMLOut("RCW:         %s\n", DMLRCWrapper(objData.RCW));
     }
-    if (objData.CCW != NULL)
+    if (objData.CCW != (TADDR)0)
     {
         DMLOut("CCW:         %s\n", DMLCCWrapper(objData.CCW));
     }
@@ -1489,7 +1489,7 @@ HRESULT PrintObj(TADDR taObj, BOOL bPrintFields = TRUE)
             ExtOut("Tracked Type: %s\n", isTrackedType ? "true" : "false");
             if (hasTaggedMemory)
             {
-                CLRDATA_ADDRESS taggedMemory = NULL;
+                CLRDATA_ADDRESS taggedMemory = (TADDR)0;
                 size_t taggedMemorySizeInBytes = 0;
                 (void)sos11->GetTaggedMemory(objAddr, &taggedMemory, &taggedMemorySizeInBytes);
                 DMLOut("Tagged Memory: %s (%" POINTERSIZE_TYPE "d(0x%" POINTERSIZE_TYPE "x) bytes)\n",
@@ -1742,7 +1742,7 @@ HRESULT PrintPermissionSet (TADDR p_PermSet)
     {
         TADDR tbSetPtr;
         MOVE(tbSetPtr, p_PermSet + iOffset);
-        if (tbSetPtr != NULL)
+        if (tbSetPtr != (TADDR)0)
         {
             DacpObjectData tbSetData;
             if ((Status=tbSetData.Request(g_sos, TO_CDADDR(tbSetPtr))) != S_OK)
@@ -1756,7 +1756,7 @@ HRESULT PrintPermissionSet (TADDR p_PermSet)
             {
                 DWORD_PTR PermsArrayPtr;
                 MOVE(PermsArrayPtr, tbSetPtr + iOffset);
-                if (PermsArrayPtr != NULL)
+                if (PermsArrayPtr != (TADDR)0)
                 {
                     // Print all the permissions in the array
                     DacpObjectData objData;
@@ -1776,7 +1776,7 @@ HRESULT PrintPermissionSet (TADDR p_PermSet)
             {
                 DWORD_PTR PermObjPtr;
                 MOVE(PermObjPtr, tbSetPtr + iOffset);
-                if (PermObjPtr != NULL)
+                if (PermObjPtr != (TADDR)0)
                 {
                     // Print the permission object
                     return PrintObj(PermObjPtr);
@@ -1959,7 +1959,7 @@ HRESULT PrintArray(DacpObjectData& objData, DumpArrayFlags& flags, BOOL isPermSe
         }
 
         TADDR elementAddress = TO_TADDR(objData.ArrayDataPtr + offset * objData.dwComponentSize);
-        TADDR p_Element = NULL;
+        TADDR p_Element = (TADDR)0;
         if (isElementValueType)
         {
             p_Element = elementAddress;
@@ -1998,7 +1998,7 @@ HRESULT PrintArray(DacpObjectData& objData, DumpArrayFlags& flags, BOOL isPermSe
             {
                 PrintVC(TO_TADDR(objData.ElementTypeHandle), elementAddress, !flags.bNoFieldsForElement);
             }
-            else if (p_Element != NULL)
+            else if (p_Element != (TADDR)0)
             {
                 PrintObj(p_Element, !flags.bNoFieldsForElement);
             }
@@ -2198,7 +2198,7 @@ DECLARE_API(DumpDelegate)
                                 int invocationCount;
                                 MOVE(invocationCount, delegateObj.GetAddress() + offset);
 
-                                if (invocationList == NULL)
+                                if (invocationList == (TADDR)0)
                                 {
                                     CLRDATA_ADDRESS md;
                                     DMLOut("%s ", DMLObject(target));
@@ -2224,7 +2224,7 @@ DECLARE_API(DumpDelegate)
                                         {
                                             CLRDATA_ADDRESS elementPtr;
                                             MOVE(elementPtr, TO_CDADDR(objData.ArrayDataPtr + (i * objData.dwComponentSize)));
-                                            if (elementPtr != NULL && sos::IsObject(elementPtr, false))
+                                            if (elementPtr != (TADDR)0 && sos::IsObject(elementPtr, false))
                                             {
                                                 delegatesRemaining.push_back(elementPtr);
                                             }
@@ -2252,7 +2252,7 @@ CLRDATA_ADDRESS isExceptionObj(CLRDATA_ADDRESS mtObj)
     // We want to follow back until we get the mt for System.Exception
     DacpMethodTableData dmtd;
     CLRDATA_ADDRESS walkMT = mtObj;
-    while(walkMT != NULL)
+    while(walkMT != (TADDR)0)
     {
         if (dmtd.Request(g_sos, walkMT) != S_OK)
         {
@@ -2264,7 +2264,7 @@ CLRDATA_ADDRESS isExceptionObj(CLRDATA_ADDRESS mtObj)
         }
         walkMT = dmtd.ParentMethodTable;
     }
-    return NULL;
+    return (TADDR)0;
 }
 
 CLRDATA_ADDRESS isSecurityExceptionObj(CLRDATA_ADDRESS mtObj)
@@ -2272,7 +2272,7 @@ CLRDATA_ADDRESS isSecurityExceptionObj(CLRDATA_ADDRESS mtObj)
     // We want to follow back until we get the mt for System.Exception
     DacpMethodTableData dmtd;
     CLRDATA_ADDRESS walkMT = mtObj;
-    while(walkMT != NULL)
+    while(walkMT != (TADDR)0)
     {
         if (dmtd.Request(g_sos, walkMT) != S_OK)
         {
@@ -2285,7 +2285,7 @@ CLRDATA_ADDRESS isSecurityExceptionObj(CLRDATA_ADDRESS mtObj)
         }
         walkMT = dmtd.ParentMethodTable;
     }
-    return NULL;
+    return (TADDR)0;
 }
 
 // Fill the passed in buffer with a text header for generated exception information.
@@ -2624,7 +2624,7 @@ HRESULT FormatException(CLRDATA_ADDRESS taObj, BOOL bLineNumbers = FALSE)
 
     // Make sure it is an exception object, and get the MT of Exception
     CLRDATA_ADDRESS exceptionMT = isExceptionObj(objData.MethodTable);
-    if (exceptionMT == NULL)
+    if (exceptionMT == (TADDR)0)
     {
         ExtOut("Not a valid exception object\n");
         return Status;
@@ -2822,7 +2822,7 @@ HRESULT FormatException(CLRDATA_ADDRESS taObj, BOOL bLineNumbers = FALSE)
         ExtOut("HResult: %lx\n", hResult);
     }
 
-    if (isSecurityExceptionObj(objData.MethodTable) != NULL)
+    if (isSecurityExceptionObj(objData.MethodTable) != (TADDR)0)
     {
         // We have a SecurityException Object: print out the debugString if present
         int iOffset = GetObjFieldOffset (taObj, objData.MethodTable, W("m_debugString"));
@@ -2890,7 +2890,7 @@ DECLARE_API(PrintException)
     }
 
     EnableDMLHolder dmlHolder(dml);
-    DWORD_PTR p_Object = NULL;
+    DWORD_PTR p_Object = (TADDR)0;
     if (nArg == 0)
     {
         if (bCCW)
@@ -2904,16 +2904,16 @@ DECLARE_API(PrintException)
         CLRDATA_ADDRESS threadAddr = GetCurrentManagedThread();
         DacpThreadData Thread;
 
-        if ((threadAddr == NULL) || (Thread.Request(g_sos, threadAddr) != S_OK))
+        if ((threadAddr == (TADDR)0) || (Thread.Request(g_sos, threadAddr) != S_OK))
         {
             ExtOut("The current thread is unmanaged\n");
             return Status;
         }
 
-        DWORD_PTR dwAddr = NULL;
+        DWORD_PTR dwAddr = (TADDR)0;
         if ((!SafeReadMemory(TO_TADDR(Thread.lastThrownObjectHandle),
                             &dwAddr,
-                            sizeof(dwAddr), NULL)) || (dwAddr==NULL))
+                            sizeof(dwAddr), NULL)) || (dwAddr==(TADDR)0))
         {
             ExtOut("There is no current managed exception on this thread\n");
         }
@@ -2959,7 +2959,7 @@ DECLARE_API(PrintException)
     CLRDATA_ADDRESS threadAddr = GetCurrentManagedThread();
     DacpThreadData Thread;
 
-    if ((threadAddr == NULL) || (Thread.Request(g_sos, threadAddr) != S_OK))
+    if ((threadAddr == (TADDR)0) || (Thread.Request(g_sos, threadAddr) != S_OK))
     {
         ExtOut("The current thread is unmanaged\n");
         return E_INVALIDARG;
@@ -3000,7 +3000,7 @@ DECLARE_API(PrintException)
 
             currentNested = next;
         }
-        while(currentNested != NULL);
+        while(currentNested != (TADDR)0);
     }
     return Status;
 }
@@ -3017,8 +3017,8 @@ DECLARE_API(DumpVC)
     INIT_API_PROBE_MANAGED("dumpvc");
     MINIDUMP_NOT_SUPPORTED();
 
-    DWORD_PTR p_MT = NULL;
-    DWORD_PTR p_Object = NULL;
+    DWORD_PTR p_MT = (TADDR)0;
+    DWORD_PTR p_Object = (TADDR)0;
     BOOL dml = FALSE;
 
     CMDOption option[] =
@@ -3610,7 +3610,7 @@ DECLARE_API(SyncBlk)
                 {
                     ExtOut(" orphaned ");
                 }
-                else if (syncBlockData.HoldingThread != NULL)
+                else if (syncBlockData.HoldingThread != (TADDR)0)
                 {
                     DacpThreadData Thread;
                     if ((Status = Thread.Request(g_sos, syncBlockData.HoldingThread)) != S_OK)
@@ -3871,7 +3871,7 @@ DECLARE_API(DumpModule)
     MINIDUMP_NOT_SUPPORTED();
 
 
-    DWORD_PTR p_ModuleAddr = NULL;
+    DWORD_PTR p_ModuleAddr = (TADDR)0;
     BOOL bMethodTables = FALSE;
     BOOL bProfilerModified = FALSE;
     BOOL dml = FALSE;
@@ -4111,7 +4111,7 @@ DECLARE_API(DumpDomain)
     }
     DomainInfo(&appDomain);
 
-    if (adsData.sharedDomain != NULL)
+    if (adsData.sharedDomain != (TADDR)0)
     {
         ExtOut("--------------------------------------\n");
         DMLOut("Shared Domain:      %s\n", DMLDomain(adsData.sharedDomain));
@@ -4634,11 +4634,11 @@ HRESULT SwitchToExceptionThread()
         }
 
         TADDR taLTOH;
-        if (Thread.lastThrownObjectHandle != NULL)
+        if (Thread.lastThrownObjectHandle != (TADDR)0)
         {
             if (SafeReadMemory(TO_TADDR(Thread.lastThrownObjectHandle), &taLTOH, sizeof(taLTOH), NULL))
             {
-                if (taLTOH != NULL)
+                if (taLTOH != (TADDR)0)
                 {
                     ULONG id;
                     if (g_ExtSystem->GetThreadIdBySystemId(Thread.osThreadId, &id) == S_OK)
@@ -5382,7 +5382,7 @@ private:
     HRESULT ResolvePendingNonModuleBoundBreakpoint(TADDR mod, PendingBreakpoint *pCur, SymbolReader* pSymbolReader)
     {
         // This function only works with pending breakpoints that are not module bound.
-        if (pCur->pModule == NULL)
+        if (pCur->pModule == (TADDR)0)
         {
             if (pCur->szModuleName[0] != L'\0')
             {
@@ -5884,7 +5884,7 @@ DECLARE_API(bpmd)
     int lineNumber = 0;
     size_t Offset = 0;
 
-    DWORD_PTR pMD = NULL;
+    DWORD_PTR pMD = (TADDR)0;
     BOOL fNoFutureModule = FALSE;
     BOOL fList = FALSE;
     size_t clearItem = 0;
@@ -5913,7 +5913,7 @@ DECLARE_API(bpmd)
     bool fIsFilename = false;
     int commandsParsed = 0;
 
-    if (pMD != NULL)
+    if (pMD != (TADDR)0)
     {
         if (nArg != 0)
         {
@@ -6009,7 +6009,7 @@ DECLARE_API(bpmd)
 
     BOOL bNeedNotificationExceptions = FALSE;
 
-    if (pMD == NULL)
+    if (pMD == (TADDR)0)
     {
         int numModule = 0;
         int numMethods = 0;
@@ -6139,11 +6139,11 @@ DECLARE_API(bpmd)
             // wait for the module load notification.
             if (!fIsFilename)
             {
-                g_bpoints.Add(ModuleName, FunctionName, NULL, (DWORD)Offset);
+                g_bpoints.Add(ModuleName, FunctionName, (TADDR)0, (DWORD)Offset);
             }
             else
             {
-                g_bpoints.Add(Filename, lineNumber, NULL);
+                g_bpoints.Add(Filename, lineNumber, (TADDR)0);
             }
             if (g_clrData != nullptr)
             {
@@ -6243,7 +6243,7 @@ DECLARE_API(FindAppDomain)
     INIT_API();
     MINIDUMP_NOT_SUPPORTED();
 
-    DWORD_PTR p_Object = NULL;
+    DWORD_PTR p_Object = (TADDR)0;
     BOOL dml = FALSE;
 
     CMDOption option[] =
@@ -6278,7 +6278,7 @@ DECLARE_API(FindAppDomain)
 
     CLRDATA_ADDRESS appDomain = GetAppDomain (TO_CDADDR(p_Object));
 
-    if (appDomain != NULL)
+    if (appDomain != (TADDR)0)
     {
         DMLOut("AppDomain: %s\n", DMLDomain(appDomain));
         if (appDomain == adstore.sharedDomain)
@@ -6511,7 +6511,7 @@ DECLARE_API(EHInfo)
     INIT_API_PROBE_MANAGED("ehinfo");
     MINIDUMP_NOT_SUPPORTED();
 
-    DWORD_PTR dwStartAddr = NULL;
+    DWORD_PTR dwStartAddr = (TADDR)0;
     BOOL dml = FALSE;
 
     CMDOption option[] =
@@ -6592,7 +6592,7 @@ DECLARE_API(GCInfo)
     INIT_API_PROBE_MANAGED("gcinfo");
     MINIDUMP_NOT_SUPPORTED();
 
-    TADDR taStartAddr = NULL;
+    TADDR taStartAddr = (TADDR)0;
     TADDR taGCInfoAddr;
     BOOL dml = FALSE;
 
@@ -6813,8 +6813,8 @@ HRESULT GetIntermediateLangMap(BOOL bIL, const DacpCodeHeaderData& codeHeaderDat
 
 GetILAddressResult GetILAddress(const DacpMethodDescData& MethodDescData)
 {
-    GetILAddressResult error = std::make_tuple(NULL, nullptr);
-    TADDR ilAddr = NULL;
+    GetILAddressResult error = std::make_tuple((TADDR)0, nullptr);
+    TADDR ilAddr = (TADDR)0;
     struct DacpProfilerILData ilData;
     ReleaseHolder<ISOSDacInterface7> sos7;
     if (SUCCEEDED(g_sos->QueryInterface(__uuidof(ISOSDacInterface7), &sos7)) &&
@@ -6847,7 +6847,7 @@ GetILAddressResult GetILAddress(const DacpMethodDescData& MethodDescData)
         return error;
     }
 
-    if (ilAddr == NULL)
+    if (ilAddr == (TADDR)0)
     {
         ULONG pRva;
         DWORD dwFlags;
@@ -6867,7 +6867,7 @@ GetILAddressResult GetILAddress(const DacpMethodDescData& MethodDescData)
         ilAddr = TO_TADDR(ilAddrClr);
     }
 
-    if (ilAddr == NULL)
+    if (ilAddr == (TADDR)0)
     {
         ExtOut("Unknown error in reading function IL\n");
         return error;
@@ -6888,7 +6888,7 @@ DECLARE_API(u)
     INIT_API();
     MINIDUMP_NOT_SUPPORTED();
 
-    DWORD_PTR dwStartAddr = NULL;
+    DWORD_PTR dwStartAddr = (TADDR)0;
     BOOL fWithGCInfo = FALSE;
     BOOL fWithEHInfo = FALSE;
     BOOL bSuppressLines = FALSE;
@@ -6977,7 +6977,7 @@ DECLARE_API(u)
     }
 
     GetILAddressResult result = GetILAddress(MethodDescData);
-    if (std::get<0>(result) == NULL)
+    if (std::get<0>(result) == (TADDR)0)
     {
         ExtOut("ilAddr is %p\n", SOS_PTR(std::get<0>(result)));
         return E_FAIL;
@@ -7089,7 +7089,7 @@ DECLARE_API(u)
                 }
     };
 
-    if (codeHeaderData.ColdRegionStart != NULL)
+    if (codeHeaderData.ColdRegionStart != (TADDR)0)
     {
         ExtOut("Begin %p, size %x. Cold region begin %p, size %x\n",
             SOS_PTR(codeHeaderData.MethodStart), codeHeaderData.HotRegionSize,
@@ -7122,7 +7122,7 @@ DECLARE_API(u)
         }
     }
 
-    if (codeHeaderData.ColdRegionStart == NULL)
+    if (codeHeaderData.ColdRegionStart == (TADDR)0)
     {
         g_targetMachine->Unassembly (
                 (DWORD_PTR) codeHeaderData.MethodStart,
@@ -7188,7 +7188,7 @@ inline ExtractionCodeHeaderResult extractCodeHeaderData(DWORD_PTR methodDesc, DW
     HRESULT Status =
         g_sos->GetMethodDescData(
             TO_CDADDR(methodDesc),
-            dwStartAddr == methodDesc ? NULL : dwStartAddr,
+            dwStartAddr == methodDesc ? (TADDR)0 : dwStartAddr,
             &MethodDescData,
             0, // cRevertedRejitVersions
             NULL, // rgRevertedRejitData
@@ -7433,7 +7433,7 @@ DECLARE_API(DumpLog)
     LoadRuntimeSymbols();
 
     const char* fileName = "StressLog.txt";
-    CLRDATA_ADDRESS StressLogAddress = NULL;
+    CLRDATA_ADDRESS StressLogAddress = (TADDR)0;
 
     StringHolder sFileName, sLogAddr;
     CMDOption option[] =
@@ -7460,7 +7460,7 @@ DECLARE_API(DumpLog)
         StressLogAddress = GetExpression(sLogAddr.data);
     }
 
-    if (StressLogAddress == NULL)
+    if (StressLogAddress == (TADDR)0)
     {
         if (g_bDacBroken)
         {
@@ -7485,7 +7485,7 @@ DECLARE_API(DumpLog)
         }
     }
 
-    if (StressLogAddress == NULL)
+    if (StressLogAddress == (TADDR)0)
     {
         ExtOut("Please provide the -addr argument for the address of the stress log, since no recognized runtime is loaded.\n");
         return E_FAIL;
@@ -8543,7 +8543,7 @@ DECLARE_API(FindRoots)
 
     LONG_PTR gen = -100; // initialized outside the legal range: [-1, 2]
     StringHolder sgen;
-    TADDR taObj = NULL;
+    TADDR taObj = (TADDR)0;
     BOOL dml = FALSE;
     size_t nArg;
 
@@ -8659,14 +8659,14 @@ public:
             if (adsData.Request(g_sos) != S_OK)
                 return FALSE;
 
-            LONG numSpecialDomains = (adsData.sharedDomain != NULL) ? 2 : 1;
+            LONG numSpecialDomains = (adsData.sharedDomain != (TADDR)0) ? 2 : 1;
             m_numDomains = adsData.DomainCount + numSpecialDomains;
             ArrayHolder<CLRDATA_ADDRESS> pArray = new NOTHROW CLRDATA_ADDRESS[m_numDomains];
             if (pArray == NULL)
                 return FALSE;
 
             int i = 0;
-            if (adsData.sharedDomain != NULL)
+            if (adsData.sharedDomain != (TADDR)0)
             {
                 pArray[i++] = adsData.sharedDomain;
             }
@@ -9322,7 +9322,7 @@ DECLARE_API(StopOnException)
     CLRDATA_ADDRESS threadAddr = GetCurrentManagedThread();
     DacpThreadData Thread;
 
-    if ((threadAddr == NULL) || (Thread.Request(g_sos, threadAddr) != S_OK))
+    if ((threadAddr == (TADDR)0) || (Thread.Request(g_sos, threadAddr) != S_OK))
     {
         ExtOut("The current thread is unmanaged\n");
         return Status;

--- a/src/SOS/Strike/util.cpp
+++ b/src/SOS/Strike/util.cpp
@@ -348,8 +348,8 @@ void IP2MethodDesc (DWORD_PTR IP, DWORD_PTR &methodDesc, JITTypes &jitType,
     CLRDATA_ADDRESS EIP = TO_CDADDR(IP);
     DacpCodeHeaderData codeHeaderData;
 
-    methodDesc = NULL;
-    gcinfoAddr = NULL;
+    methodDesc = (TADDR)0;
+    gcinfoAddr = (TADDR)0;
 
     if (codeHeaderData.Request(g_sos, EIP) != S_OK)
     {
@@ -1237,7 +1237,7 @@ void DisplayFields(CLRDATA_ADDRESS cdaMT, DacpMethodTableData *pMTD, DacpMethodT
 //              > 0 = offset to field from objAddr
 int GetObjFieldOffset(CLRDATA_ADDRESS cdaObj, __in_z LPCWSTR wszFieldName, BOOL bFirst)
 {
-    TADDR mt = NULL;
+    TADDR mt = (TADDR)0;
     if FAILED(GetMTOfObject(TO_TADDR(cdaObj), &mt))
         return -1;
 
@@ -1319,45 +1319,45 @@ int GetObjFieldOffset(CLRDATA_ADDRESS cdaObj, CLRDATA_ADDRESS cdaMT, __in_z LPCW
 // returns NULL
 CLRDATA_ADDRESS IsInOneDomainOnly(CLRDATA_ADDRESS AssemblyPtr)
 {
-    CLRDATA_ADDRESS appDomain = NULL;
+    CLRDATA_ADDRESS appDomain = (TADDR)0;
 
     DacpAppDomainStoreData adstore;
     if (adstore.Request(g_sos) != S_OK)
     {
         ExtOut("Unable to get appdomain store\n");
-        return NULL;
+        return (TADDR)0;
     }
 
     size_t AllocSize;
     if (!ClrSafeInt<size_t>::multiply(sizeof(CLRDATA_ADDRESS), adstore.DomainCount, AllocSize))
     {
         ReportOOM();
-        return NULL;
+        return (TADDR)0;
     }
 
     ArrayHolder<CLRDATA_ADDRESS> pArray = new CLRDATA_ADDRESS[adstore.DomainCount];
     if (pArray==NULL)
     {
         ReportOOM();
-        return NULL;
+        return (TADDR)0;
     }
 
     if (g_sos->GetAppDomainList(adstore.DomainCount, pArray, NULL)!=S_OK)
     {
         ExtOut ("Failed to get appdomain list\n");
-        return NULL;
+        return (TADDR)0;
     }
 
     for (int i = 0; i < adstore.DomainCount; i++)
     {
         if (IsInterrupt())
-            return NULL;
+            return (TADDR)0;
 
         DacpAppDomainData dadd;
         if (dadd.Request(g_sos, pArray[i]) != S_OK)
         {
             ExtOut ("Unable to get AppDomain %p\n", SOS_PTR(pArray[i]));
-            return NULL;
+            return (TADDR)0;
         }
 
         if (dadd.AssemblyCount)
@@ -1366,34 +1366,34 @@ CLRDATA_ADDRESS IsInOneDomainOnly(CLRDATA_ADDRESS AssemblyPtr)
             if (!ClrSafeInt<size_t>::multiply(sizeof(CLRDATA_ADDRESS), dadd.AssemblyCount, AssemblyAllocSize))
             {
                 ReportOOM();
-                return NULL;
+                return (TADDR)0;
             }
 
             ArrayHolder<CLRDATA_ADDRESS> pAsmArray = new CLRDATA_ADDRESS[dadd.AssemblyCount];
             if (pAsmArray==NULL)
             {
                 ReportOOM();
-                return NULL;
+                return (TADDR)0;
             }
 
             if (g_sos->GetAssemblyList(dadd.AppDomainPtr,dadd.AssemblyCount,pAsmArray, NULL)!=S_OK)
             {
                 ExtOut("Unable to get array of Assemblies\n");
-                return NULL;
+                return (TADDR)0;
             }
 
             for (LONG n = 0; n < dadd.AssemblyCount; n ++)
             {
                 if (IsInterrupt())
-                    return NULL;
+                    return (TADDR)0;
 
                 if (AssemblyPtr == pAsmArray[n])
                 {
-                    if (appDomain != NULL)
+                    if (appDomain != (TADDR)0)
                     {
                         // We have found more than one AppDomain that loaded this
                         // assembly, we must return NULL.
-                        return NULL;
+                        return (TADDR)0;
                     }
                     appDomain = dadd.AppDomainPtr;
                 }
@@ -1410,25 +1410,25 @@ CLRDATA_ADDRESS GetAppDomainForMT(CLRDATA_ADDRESS mtPtr)
     DacpMethodTableData mt;
     if (mt.Request(g_sos, mtPtr) != S_OK)
     {
-        return NULL;
+        return (TADDR)0;
     }
 
     DacpModuleData module;
     if (module.Request(g_sos, mt.Module) != S_OK)
     {
-        return NULL;
+        return (TADDR)0;
     }
 
     DacpAssemblyData assembly;
     if (assembly.Request(g_sos, module.Assembly) != S_OK)
     {
-        return NULL;
+        return (TADDR)0;
     }
 
     DacpAppDomainStoreData adstore;
     if (adstore.Request(g_sos) != S_OK)
     {
-        return NULL;
+        return (TADDR)0;
     }
 
     return (assembly.ParentDomain == adstore.sharedDomain) ?
@@ -1438,12 +1438,12 @@ CLRDATA_ADDRESS GetAppDomainForMT(CLRDATA_ADDRESS mtPtr)
 
 CLRDATA_ADDRESS GetAppDomain(CLRDATA_ADDRESS objPtr)
 {
-    CLRDATA_ADDRESS appDomain = NULL;
+    CLRDATA_ADDRESS appDomain = (TADDR)0;
 
     DacpObjectData objData;
     if (objData.Request(g_sos,objPtr) != S_OK)
     {
-        return NULL;
+        return (TADDR)0;
     }
 
     // First check  eeclass->module->assembly->domain.
@@ -1453,25 +1453,25 @@ CLRDATA_ADDRESS GetAppDomain(CLRDATA_ADDRESS objPtr)
     DacpMethodTableData mt;
     if (mt.Request(g_sos,objData.MethodTable) != S_OK)
     {
-        return NULL;
+        return (TADDR)0;
     }
 
     DacpModuleData module;
     if (module.Request(g_sos,mt.Module) != S_OK)
     {
-        return NULL;
+        return (TADDR)0;
     }
 
     DacpAssemblyData assembly;
     if (assembly.Request(g_sos,module.Assembly) != S_OK)
     {
-        return NULL;
+        return (TADDR)0;
     }
 
     DacpAppDomainStoreData adstore;
     if (adstore.Request(g_sos) != S_OK)
     {
-        return NULL;
+        return (TADDR)0;
     }
 
     if (assembly.ParentDomain == adstore.sharedDomain)
@@ -1480,7 +1480,7 @@ CLRDATA_ADDRESS GetAppDomain(CLRDATA_ADDRESS objPtr)
         ULONG value = 0;
         if (!obj.TryGetHeader(value))
         {
-            return NULL;
+            return (TADDR)0;
         }
 
         DWORD adIndex = (value >> SBLK_APPDOMAIN_SHIFT) & SBLK_MASK_APPDOMAININDEX;
@@ -1491,7 +1491,7 @@ CLRDATA_ADDRESS GetAppDomain(CLRDATA_ADDRESS objPtr)
             // being in domain X if the only other domain that has the assembly
             // loaded is domain X.
             appDomain = IsInOneDomainOnly(assembly.AssemblyPtr);
-            if (appDomain == NULL && ((value & BIT_SBLK_IS_HASH_OR_SYNCBLKINDEX) != 0))
+            if (appDomain == (TADDR)0 && ((value & BIT_SBLK_IS_HASH_OR_SYNCBLKINDEX) != 0))
             {
                 if ((value & BIT_SBLK_IS_HASHCODE) == 0)
                 {
@@ -1510,18 +1510,18 @@ CLRDATA_ADDRESS GetAppDomain(CLRDATA_ADDRESS objPtr)
             size_t AllocSize;
             if (!ClrSafeInt<size_t>::multiply(sizeof(CLRDATA_ADDRESS), adstore.DomainCount, AllocSize))
             {
-                return NULL;
+                return (TADDR)0;
             }
             // we know we have a non-zero adIndex. Find the appdomain.
             ArrayHolder<CLRDATA_ADDRESS> pArray = new CLRDATA_ADDRESS[adstore.DomainCount];
             if (pArray==NULL)
             {
-                return NULL;
+                return (TADDR)0;
             }
 
             if (g_sos->GetAppDomainList(adstore.DomainCount, pArray, NULL)!=S_OK)
             {
-                return NULL;
+                return (TADDR)0;
             }
 
             for (int i = 0; i < adstore.DomainCount; i++)
@@ -1529,7 +1529,7 @@ CLRDATA_ADDRESS GetAppDomain(CLRDATA_ADDRESS objPtr)
                 DacpAppDomainData dadd;
                 if (dadd.Request(g_sos, pArray[i]) != S_OK)
                 {
-                    return NULL;
+                    return (TADDR)0;
                 }
                 if (dadd.dwId == adIndex)
                 {
@@ -1611,7 +1611,7 @@ HRESULT FileNameForModule(const DacpModuleData* const pModuleData, __out_ecount(
 
 void AssemblyInfo(DacpAssemblyData *pAssembly)
 {
-    if ((ULONG64)pAssembly->AssemblySecDesc != NULL)
+    if ((ULONG64)pAssembly->AssemblySecDesc != (TADDR)0)
         ExtOut("SecurityDescriptor: %p\n", SOS_PTR(pAssembly->AssemblySecDesc));
     ExtOut("  Module\n");
 
@@ -1698,7 +1698,7 @@ void DomainInfo (DacpAppDomainData *pDomain)
     ExtOut("HighFrequencyHeap:  %p\n", SOS_PTR(pDomain->pHighFrequencyHeap));
     ExtOut("StubHeap:           %p\n", SOS_PTR(pDomain->pStubHeap));
     ExtOut("Stage:              %s\n", GetStageText(pDomain->appDomainStage));
-    if ((ULONG64)pDomain->AppSecDesc != NULL)
+    if ((ULONG64)pDomain->AppSecDesc != (TADDR)0)
         ExtOut("SecurityDescriptor: %p\n", SOS_PTR(pDomain->AppSecDesc));
     ExtOut("Name:               ");
 
@@ -1811,7 +1811,7 @@ WCHAR *CreateMethodTableName(TADDR mt, TADDR cmt)
         return res;
     }
 
-    if (mt == sos::MethodTable::GetArrayMT() && cmt != NULL)
+    if (mt == sos::MethodTable::GetArrayMT() && cmt != (TADDR)0)
     {
         mt = cmt;
         array = true;
@@ -1937,7 +1937,7 @@ BOOL IsObjectArray (DacpObjectData *pData)
 
 BOOL IsObjectArray (DWORD_PTR obj)
 {
-    DWORD_PTR mtAddr = NULL;
+    DWORD_PTR mtAddr = (TADDR)0;
     if (SUCCEEDED(GetMTOfObject(obj, &mtAddr)))
         return TO_TADDR(g_special_usefulGlobals.ArrayMethodTable) == mtAddr;
 
@@ -1946,7 +1946,7 @@ BOOL IsObjectArray (DWORD_PTR obj)
 
 BOOL IsStringObject (size_t obj)
 {
-    DWORD_PTR mtAddr = NULL;
+    DWORD_PTR mtAddr = (TADDR)0;
 
     if (SUCCEEDED(GetMTOfObject(obj, &mtAddr)))
         return TO_TADDR(g_special_usefulGlobals.StringMethodTable) == mtAddr;
@@ -1958,7 +1958,7 @@ BOOL IsDerivedFrom(CLRDATA_ADDRESS mtObj, __in_z LPCWSTR baseString)
 {
     DacpMethodTableData dmtd;
     CLRDATA_ADDRESS walkMT = mtObj;
-    while (walkMT != NULL)
+    while (walkMT != (TADDR)0)
     {
         if (dmtd.Request(g_sos, walkMT) != S_OK)
         {
@@ -1982,7 +1982,7 @@ BOOL IsDerivedFrom(CLRDATA_ADDRESS mtObj, DWORD_PTR modulePtr, mdTypeDef typeDef
     DacpMethodTableData dmtd;
 
     for (CLRDATA_ADDRESS walkMT = mtObj;
-         walkMT != NULL && dmtd.Request(g_sos, walkMT) == S_OK;
+         walkMT != (TADDR)0 && dmtd.Request(g_sos, walkMT) == S_OK;
          walkMT = dmtd.ParentMethodTable)
     {
         if (dmtd.Module == modulePtr && dmtd.cl == typeDef)
@@ -2010,7 +2010,7 @@ BOOL TryGetMethodDescriptorForDelegate(CLRDATA_ADDRESS delegateAddr, CLRDATA_ADD
         {
             CLRDATA_ADDRESS methodPtr;
             MOVE(methodPtr, delegateObj.GetAddress() + offset);
-            if (methodPtr != NULL)
+            if (methodPtr != (TADDR)0)
             {
                 if (g_sos->GetMethodDescPtrFromIP(methodPtr, pMD) == S_OK)
                 {
@@ -2157,7 +2157,7 @@ DWORD_PTR *ModuleFromName(__in_opt LPSTR mName, int *numModule)
     ArrayHolder<CLRDATA_ADDRESS> pAssemblyArray = NULL;
     ArrayHolder<CLRDATA_ADDRESS> pModules = NULL;
     int arrayLength = 0;
-    int numSpecialDomains = (adsData.sharedDomain != NULL) ? 2 : 1;
+    int numSpecialDomains = (adsData.sharedDomain != (TADDR)0) ? 2 : 1;
     if (!ClrSafeInt<int>::addition(adsData.DomainCount, numSpecialDomains, arrayLength))
     {
         ExtOut("<integer overflow>\n");
@@ -2171,7 +2171,7 @@ DWORD_PTR *ModuleFromName(__in_opt LPSTR mName, int *numModule)
     }
 
     pArray[0] = adsData.systemDomain;
-    if (adsData.sharedDomain != NULL)
+    if (adsData.sharedDomain != (TADDR)0)
     {
         pArray[1] = adsData.sharedDomain;
     }
@@ -2426,7 +2426,7 @@ HRESULT GetModuleFromAddress(___in CLRDATA_ADDRESS peAddress, ___out IXCLRDataMo
 \**********************************************************************/
 void GetInfoFromName(DWORD_PTR ModulePtr, const char* name, mdTypeDef* retMdTypeDef)
 {
-    DWORD_PTR ignoredModuleInfoRet = NULL;
+    DWORD_PTR ignoredModuleInfoRet = (TADDR)0;
     if (retMdTypeDef)
         *retMdTypeDef = 0;
 
@@ -2549,12 +2549,12 @@ void GetInfoFromName(DWORD_PTR ModulePtr, const char* name, mdTypeDef* retMdType
 DWORD_PTR GetMethodDescFromModule(DWORD_PTR ModuleAddr, ULONG token)
 {
     if (TypeFromToken(token) != mdtMethodDef)
-        return NULL;
+        return (TADDR)0;
 
     CLRDATA_ADDRESS md = 0;
     if (FAILED(g_sos->GetMethodDescFromToken(ModuleAddr, token, &md)))
     {
-        return NULL;
+        return (TADDR)0;
     }
     else if (0 == md)
     {
@@ -2563,7 +2563,7 @@ DWORD_PTR GetMethodDescFromModule(DWORD_PTR ModuleAddr, ULONG token)
     }
     else if ( !IsMethodDesc((DWORD_PTR)md))
     {
-        return NULL;
+        return (TADDR)0;
     }
 
     return (DWORD_PTR)md;
@@ -2672,9 +2672,9 @@ HRESULT GetMethodDescsFromName(TADDR ModulePtr, IXCLRDataModule* mod, const char
             {
                 mdTypeDef token;
                 if (pMeth->GetTokenAndScope(&token, NULL) != S_OK)
-                    (*pOut)[i] = NULL;
+                    (*pOut)[i] = (TADDR)0;
                 (*pOut)[i] = GetMethodDescFromModule(ModulePtr, token);
-                if ((*pOut)[i] == NULL)
+                if ((*pOut)[i] == (TADDR)0)
                 {
                     *numMethods = 0;
                     return E_FAIL;
@@ -3124,7 +3124,7 @@ void GetDomainList (DWORD_PTR *&domainList, int &numDomain)
     // Do prefast integer checks before the malloc.
     size_t AllocSize;
     LONG DomainAllocCount;
-    LONG NumExtraDomains = (adsData.sharedDomain != NULL) ? 2 : 1;
+    LONG NumExtraDomains = (adsData.sharedDomain != (TADDR)0) ? 2 : 1;
     if (!ClrSafeInt<LONG>::addition(adsData.DomainCount, NumExtraDomains, DomainAllocCount) ||
         !ClrSafeInt<size_t>::multiply(DomainAllocCount, sizeof(PVOID), AllocSize) ||
         (domainList = new DWORD_PTR[DomainAllocCount]) == NULL)
@@ -3133,7 +3133,7 @@ void GetDomainList (DWORD_PTR *&domainList, int &numDomain)
     }
 
     domainList[numDomain++] = (DWORD_PTR) adsData.systemDomain;
-    if (adsData.sharedDomain != NULL)
+    if (adsData.sharedDomain != (TADDR)0)
     {
         domainList[numDomain++] = (DWORD_PTR) adsData.sharedDomain;
     }
@@ -3188,7 +3188,7 @@ HRESULT GetThreadList(DWORD_PTR **threadList, int *numThread)
     }
 
     CLRDATA_ADDRESS CurThread = ThreadStore.firstThread;
-    while (CurThread != NULL)
+    while (CurThread != (TADDR)0)
     {
         if (IsInterrupt())
             return S_FALSE;
@@ -3221,7 +3221,7 @@ CLRDATA_ADDRESS GetCurrentManagedThread ()
         DacpThreadData Thread;
         if (Thread.Request(g_sos, CurThread) != S_OK)
         {
-            return NULL;
+            return (TADDR)0;
         }
 
         if (Thread.osThreadId == Tid)
@@ -3231,7 +3231,7 @@ CLRDATA_ADDRESS GetCurrentManagedThread ()
 
         CurThread = Thread.nextThread;
     }
-    return NULL;
+    return (TADDR)0;
 }
 
 #define MSCOREE_SHIM_A                "mscoree.dll"

--- a/src/SOS/Strike/util.h
+++ b/src/SOS/Strike/util.h
@@ -1554,7 +1554,7 @@ inline BOOL SafeReadMemory (CLRDATA_ADDRESS offset, PVOID lpBuffer, ULONG cb, PU
 BOOL NameForMD_s (DWORD_PTR pMD, __out_ecount (capacity_mdName) WCHAR *mdName, size_t capacity_mdName);
 BOOL NameForMT_s (DWORD_PTR MTAddr, __out_ecount (capacity_mdName) WCHAR *mdName, size_t capacity_mdName);
 
-WCHAR *CreateMethodTableName(TADDR mt, TADDR cmt = NULL);
+WCHAR *CreateMethodTableName(TADDR mt, TADDR cmt = (TADDR)0);
 
 void isRetAddr(DWORD_PTR retAddr, DWORD_PTR* whereCalled);
 DWORD_PTR GetValueFromExpression (___in __in_z const char *const str);
@@ -1647,7 +1647,7 @@ protected:
             info.GCInfo = NULL;
             info.ArrayOfVC = false;
             info.GCInfoBuffer = NULL;
-            info.LoaderAllocatorObjectHandle = NULL;
+            info.LoaderAllocatorObjectHandle = (TADDR)0;
         }
     };
     Node *head;
@@ -2056,7 +2056,7 @@ int  _ui64toa_s( unsigned __int64 inValue, char* outBuffer, size_t inDestBufferS
 
 struct MemRange
 {
-    MemRange (ULONG64 s = NULL, size_t l = 0, MemRange * n = NULL)
+    MemRange (ULONG64 s = (TADDR)0, size_t l = 0, MemRange * n = NULL)
         : start(s), len (l), next (n)
         {}
 

--- a/src/shared/inc/dacprivate.h
+++ b/src/shared/inc/dacprivate.h
@@ -467,7 +467,7 @@ struct MSLAYOUT DacpAssemblyData
 
     HRESULT Request(ISOSDacInterface *sos, CLRDATA_ADDRESS addr)
     {
-        return Request(sos, addr, NULL);
+        return Request(sos, addr, (TADDR)0);
     }
 };
 
@@ -577,7 +577,7 @@ struct MSLAYOUT DacpMethodDescData
     {
         return sos->GetMethodDescData(
             addr,
-            NULL,   // IP address
+            (TADDR)0,   // IP address
             this,
             0,      // cRejitData
             NULL,   // rejitData[]

--- a/src/shared/pal/src/include/pal/palinternal.h
+++ b/src/shared/pal/src/include/pal/palinternal.h
@@ -693,10 +693,10 @@ T* InterlockedCompareExchangePointerT(
 template <typename T>
 inline T* InterlockedExchangePointerT(
     T* volatile * target,
-    int           value) // When NULL is provided as argument.
+    std::nullptr_t           value) // When NULL is provided as argument.
 {
     //STATIC_ASSERT(value == 0);
-    return InterlockedExchangePointerT(target, reinterpret_cast<T*>(value));
+    return InterlockedExchangePointerT(target, (T*)(void*)value);
 }
 
 template <typename T>
@@ -713,10 +713,10 @@ template <typename T>
 inline T* InterlockedCompareExchangePointerT(
     T* volatile * destination,
     T*            exchange,
-    int           comparand) // When NULL is provided as argument.
+    std::nullptr_t           comparand) // When NULL is provided as argument.
 {
     //STATIC_ASSERT(comparand == 0);
-    return InterlockedCompareExchangePointerT(destination, exchange, reinterpret_cast<T*>(comparand));
+    return InterlockedCompareExchangePointerT(destination, exchange, (T*)(void*)comparand);
 }
 
 #undef InterlockedExchangePointer


### PR DESCRIPTION
This change fixes build on recent Alpine Linux where the NULL is defined as std::nullptr instead of the former 0.
I've hit the problem when trying to build it on Alpine arm32, but I believe all architectures would be affected the same way.