### PR TITLE
Supports collecting GCSettingsEvent for gc-collect profile

### DIFF
--- a/documentation/design-docs/ipc-protocol.md
+++ b/documentation/design-docs/ipc-protocol.md
@@ -349,6 +349,8 @@ enum class EventPipeCommandId : uint8_t
     StopTracing     = 0x01, // stop a given session
     CollectTracing  = 0x02, // create/start a given session
     CollectTracing2 = 0x03, // create/start a given session with/without rundown
+    CollectTracing3 = 0x04, // create/start a given session with/without collecting stacks
+    CollectTracing4 = 0x05, // create/start a given session with specific rundown keyword
 }
 ```
 See: [EventPipe Commands](#EventPipe-Commands)
@@ -402,6 +404,8 @@ enum class EventPipeCommandId : uint8_t
     StopTracing     = 0x01, // stop a given session
     CollectTracing  = 0x02, // create/start a given session
     CollectTracing2 = 0x03, // create/start a given session with/without rundown
+    CollectTracing3 = 0x04, // create/start a given session with/without collecting stacks
+    CollectTracing4 = 0x05, // create/start a given session with specific rundown keyword
 }
 ```
 EventPipe Payloads are encoded with the following rules:
@@ -566,7 +570,7 @@ A `provider_config` is composed of the following data:
 
 Header: `{ Magic; 28; 0xFF00; 0x0000; }`
 
-`CollectTracing2` returns:
+`CollectTracing3` returns:
 * `ulong sessionId`: the ID for the stream session starting on the current connection
 
 ##### Details:
@@ -578,6 +582,99 @@ Payload
     uint circularBufferMB,
     uint format,
     bool requestRundown,
+    bool requestStackwalk,
+    array<provider_config> providers
+}
+
+provider_config
+{
+    ulong keywords,
+    uint logLevel,
+    string provider_name,
+    string filter_data (optional)
+}
+```
+
+Returns:
+```c
+Payload
+{
+    ulong sessionId
+}
+```
+Followed by an Optional Continuation of a `nettrace` format stream of events.
+
+### `CollectTracing4`
+
+Command Code: `0x0205`
+
+The `CollectTracing4` command is an extension of the `CollectTracing3` command - its behavior is the same as `CollectTracing3` command, except the requestRundown field is replaced by the rundownKeyword field to allow customizing the set of rundown events to be fired.
+
+> Note available for .NET 9.0 and later.
+
+#### Inputs:
+
+Header: `{ Magic; Size; 0x0205; 0x0000 }`
+
+* `uint circularBufferMB`: The size of the circular buffer used for buffering event data while streaming
+* `uint format`: 0 for the legacy NetPerf format and 1 for the NetTrace format
+* `ulong rundownKeyword`: Indicates the keyword for the rundown provider
+* `array<provider_config> providers`: The providers to turn on for the streaming session
+
+A `provider_config` is composed of the following data:
+* `ulong keywords`: The keywords to turn on with this providers
+* `uint logLevel`: The level of information to turn on
+* `string provider_name`: The name of the provider
+* `string filter_data` (optional): Filter information
+
+> see ETW documentation for a more detailed explanation of Keywords, Filters, and Log Level.
+>
+#### Returns (as an IPC Message Payload):
+
+Header: `{ Magic; 28; 0xFF00; 0x0000; }`
+
+`CollectTracing4` returns:
+* `ulong sessionId`: the ID for the stream session starting on the current connection
+
+##### Details:
+
+Input:
+```
+Payload
+{
+    uint circularBufferMB,
+    uint format,
+    ulong rundownKeyword
+    array<provider_config> providers
+}
+
+provider_config
+{
+    ulong keywords,
+    uint logLevel,
+    string provider_name,
+    string filter_data (optional)
+}
+```
+
+Returns:
+```c
+Payload
+{
+    ulong sessionId
+}
+```
+Followed by an Optional Continuation of a `nettrace` format stream of events.
+
+##### Details:
+
+Input:
+```
+Payload
+{
+    uint circularBufferMB,
+    uint format,
+    ulong rundownKeyword,
     bool requestStackwalk,
     array<provider_config> providers
 }

--- a/documentation/design-docs/ipc-protocol.md
+++ b/documentation/design-docs/ipc-protocol.md
@@ -666,38 +666,6 @@ Payload
 ```
 Followed by an Optional Continuation of a `nettrace` format stream of events.
 
-##### Details:
-
-Input:
-```
-Payload
-{
-    uint circularBufferMB,
-    uint format,
-    ulong rundownKeyword,
-    bool requestStackwalk,
-    array<provider_config> providers
-}
-
-provider_config
-{
-    ulong keywords,
-    uint logLevel,
-    string provider_name,
-    string filter_data (optional)
-}
-```
-
-Returns:
-```c
-Payload
-{
-    ulong sessionId
-}
-```
-Followed by an Optional Continuation of a `nettrace` format stream of events.
-
-
 ### `StopTracing`
 
 Command Code: `0x0201`

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/AggregateSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/AggregateSourceConfiguration.cs
@@ -29,9 +29,35 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
             set => throw new NotSupportedException();
         }
 
-        public override long? RundownKeyword
+        public override long RundownKeyword
         {
             get => _configurations.Select(c => c.RundownKeyword).Aggregate((x, y) => x | y);
+            set => throw new NotSupportedException();
+        }
+
+        public override RetryStrategy RetryStrategy
+        {
+            get
+            {
+                RetryStrategy result = RetryStrategy.DoNotRetry;
+                foreach (MonitoringSourceConfiguration configurations in _configurations)
+                {
+                    if (result == RetryStrategy.DoNotRetry)
+                    {
+                        // Anything overrides DoNotRetry
+                        result = configurations.RetryStrategy;
+                    }
+                    else if (result == RetryStrategy.DropKeywordDropRundown)
+                    {
+                        if (configurations.RetryStrategy == RetryStrategy.DropKeywordKeepRundown)
+                        {
+                            // DropKeywordKeepRundown overrides DropKeywordDropRundown
+                            result = RetryStrategy.DropKeywordKeepRundown;
+                        }
+                    }
+                }
+                return result;
+            }
             set => throw new NotSupportedException();
         }
     }

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/AggregateSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/AggregateSourceConfiguration.cs
@@ -33,13 +33,18 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
         {
             get
             {
-                RetryStrategy result = RetryStrategy.DropKeywordDropRundown;
+                RetryStrategy result = RetryStrategy.NothingToRetry;
                 foreach (MonitoringSourceConfiguration configuration in _configurations)
                 {
-                    if (result == RetryStrategy.DoNotRetry)
+                    if (configuration.RetryStrategy == RetryStrategy.ForbiddenToRetry)
                     {
-                        // Nothing overrides DoNotRetry
-                        return RetryStrategy.DoNotRetry;
+                        // Nothing overrides ForbiddenToRetry
+                        return RetryStrategy.ForbiddenToRetry;
+                    }
+                    else if (result == RetryStrategy.NothingToRetry)
+                    {
+                        // Anything override NothingToRetry
+                        result  = configuration.RetryStrategy;
                     }
                     else if (result == RetryStrategy.DropKeywordDropRundown)
                     {

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/AggregateSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/AggregateSourceConfiguration.cs
@@ -28,5 +28,11 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
             get => _configurations.Any(c => c.RequestRundown);
             set => throw new NotSupportedException();
         }
+
+        public override long? RundownKeyword
+        {
+            get => _configurations.Select(c => c.RundownKeyword).Aggregate((x, y) => x | y);
+            set => throw new NotSupportedException();
+        }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/AggregateSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/AggregateSourceConfiguration.cs
@@ -23,12 +23,6 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
             return _configurations.SelectMany(c => c.GetProviders()).ToList();
         }
 
-        public override bool RequestRundown
-        {
-            get => _configurations.Any(c => c.RequestRundown);
-            set => throw new NotSupportedException();
-        }
-
         public override long RundownKeyword
         {
             get => _configurations.Select(c => c.RundownKeyword).Aggregate((x, y) => x | y);
@@ -39,17 +33,17 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
         {
             get
             {
-                RetryStrategy result = RetryStrategy.DoNotRetry;
-                foreach (MonitoringSourceConfiguration configurations in _configurations)
+                RetryStrategy result = RetryStrategy.DropKeywordDropRundown;
+                foreach (MonitoringSourceConfiguration configuration in _configurations)
                 {
                     if (result == RetryStrategy.DoNotRetry)
                     {
-                        // Anything overrides DoNotRetry
-                        result = configurations.RetryStrategy;
+                        // Nothing overrides DoNotRetry
+                        return RetryStrategy.DoNotRetry;
                     }
                     else if (result == RetryStrategy.DropKeywordDropRundown)
                     {
-                        if (configurations.RetryStrategy == RetryStrategy.DropKeywordKeepRundown)
+                        if (configuration.RetryStrategy == RetryStrategy.DropKeywordKeepRundown)
                         {
                             // DropKeywordKeepRundown overrides DropKeywordDropRundown
                             result = RetryStrategy.DropKeywordKeepRundown;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/AspNetTriggerSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/AspNetTriggerSourceConfiguration.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
 
         public AspNetTriggerSourceConfiguration(float? heartbeatIntervalSeconds = null)
         {
-            RequestRundown = false;
+            RundownKeyword = 0;
             _heartbeatIntervalSeconds = heartbeatIntervalSeconds;
         }
 

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/EventPipeProviderSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/EventPipeProviderSourceConfiguration.cs
@@ -12,10 +12,10 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
         private readonly IEnumerable<EventPipeProvider> _providers;
         private readonly int _bufferSizeInMB;
 
-        public EventPipeProviderSourceConfiguration(bool requestRundown = true, int bufferSizeInMB = 256, params EventPipeProvider[] providers)
+        public EventPipeProviderSourceConfiguration(long rundownKeyword = EventPipeSession.DefaultRundownKeyword, int bufferSizeInMB = 256, params EventPipeProvider[] providers)
         {
             _providers = providers;
-            RequestRundown = requestRundown;
+            RundownKeyword = rundownKeyword;
             _bufferSizeInMB = bufferSizeInMB;
         }
 

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/GCDumpSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/GCDumpSourceConfiguration.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
     {
         public GCDumpSourceConfiguration()
         {
-            RequestRundown = false;
+            RundownKeyword = 0;
         }
 
         public override IList<EventPipeProvider> GetProviders()

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/GcCollectConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/GcCollectConfiguration.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
     {
         public GcCollectConfiguration()
         {
-            RequestRundown = false;
+            RundownKeyword = (long)Tracing.Parsers.ClrTraceEventParser.Keywords.GC;
         }
 
         public override IList<EventPipeProvider> GetProviders() =>

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/GcCollectConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/GcCollectConfiguration.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
         public GcCollectConfiguration()
         {
             RundownKeyword = (long)Tracing.Parsers.ClrTraceEventParser.Keywords.GC;
+            RetryStrategy = RetryStrategy.DropKeywordDropRundown;
         }
 
         public override IList<EventPipeProvider> GetProviders() =>

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/HttpRequestSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/HttpRequestSourceConfiguration.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
         public HttpRequestSourceConfiguration()
         {
             //CONSIDER removing rundown for this scenario.
-            RequestRundown = true;
+            RundownKeyword = EventPipeSession.DefaultRundownKeyword;
         }
 
         // This string is shared between HttpRequestSourceConfiguration and AspNetTriggerSourceConfiguration

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/LoggingSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/LoggingSourceConfiguration.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
         public LoggingSourceConfiguration(LogLevel level, LogMessageType messageType, IDictionary<string, LogLevel?> filterSpecs, bool useAppFilters,
             bool collectScopes)
         {
-            RequestRundown = false;
+            RundownKeyword = 0;
             _filterSpecs = ToFilterSpecsString(filterSpecs, useAppFilters);
             _keywords = (long)ToKeywords(messageType);
             _level = ToEventLevel(level);

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/MetricSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/MetricSourceConfiguration.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
                 throw new ArgumentNullException(nameof(providers));
             }
 
-            RequestRundown = false;
+            RundownKeyword = 0;
 
             _eventPipeProviders = providers.Where(provider => provider.Type.HasFlag(MetricType.EventCounter))
                 .Select((MetricEventPipeProvider provider) => new EventPipeProvider(provider.Provider,

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/MonitoringSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/MonitoringSourceConfiguration.cs
@@ -34,6 +34,8 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
 
         public virtual bool RequestRundown { get; set; } = true;
 
+        public virtual long? RundownKeyword { get; set; }
+
         public virtual int BufferSizeInMB => 256;
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/MonitoringSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/MonitoringSourceConfiguration.cs
@@ -28,52 +28,11 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
         public const string EventPipeProviderName = "Microsoft-DotNETCore-EventPipe";
         public const string SystemDiagnosticsMetricsProviderName = "System.Diagnostics.Metrics";
 
-        private bool _requestRundown = true;
-        private long _rundownKeyword = EventPipeSession.DefaultRundownKeyword;
-
         public static IEnumerable<string> DefaultMetricProviders => new[] { SystemRuntimeEventSourceName, MicrosoftAspNetCoreHostingEventSourceName, GrpcAspNetCoreServer };
 
         public abstract IList<EventPipeProvider> GetProviders();
 
-        public virtual bool RequestRundown
-        {
-            get => _requestRundown;
-            set
-            {
-                _requestRundown = value;
-                if (_requestRundown)
-                {
-                    if (_rundownKeyword == 0)
-                    {
-                        _rundownKeyword = EventPipeSession.DefaultRundownKeyword;
-                    }
-                }
-                else
-                {
-                    _rundownKeyword = 0;
-                    RetryStrategy = RetryStrategy.DoNotRetry;
-                }
-            }
-        }
-
-        public virtual long RundownKeyword
-        {
-            get => _rundownKeyword;
-            set
-            {
-                _rundownKeyword = value;
-                if (_rundownKeyword == 0)
-                {
-                    _requestRundown = false;
-                    RetryStrategy = RetryStrategy.DoNotRetry;
-                }
-                else
-                {
-                    RetryStrategy = RetryStrategy.DropKeywordKeepRundown;
-                    _requestRundown = true;
-                }
-            }
-        }
+        public virtual long RundownKeyword { get; set; } = EventPipeSession.DefaultRundownKeyword;
 
         public virtual int BufferSizeInMB => 256;
 

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/MonitoringSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/MonitoringSourceConfiguration.cs
@@ -36,6 +36,6 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
 
         public virtual int BufferSizeInMB => 256;
 
-        public virtual RetryStrategy RetryStrategy { get; set; } = RetryStrategy.DropKeywordKeepRundown;
+        public virtual RetryStrategy RetryStrategy { get; set; } = RetryStrategy.NothingToRetry;
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/MonitoringSourceConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/MonitoringSourceConfiguration.cs
@@ -28,14 +28,55 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
         public const string EventPipeProviderName = "Microsoft-DotNETCore-EventPipe";
         public const string SystemDiagnosticsMetricsProviderName = "System.Diagnostics.Metrics";
 
+        private bool _requestRundown = true;
+        private long _rundownKeyword = EventPipeSession.DefaultRundownKeyword;
+
         public static IEnumerable<string> DefaultMetricProviders => new[] { SystemRuntimeEventSourceName, MicrosoftAspNetCoreHostingEventSourceName, GrpcAspNetCoreServer };
 
         public abstract IList<EventPipeProvider> GetProviders();
 
-        public virtual bool RequestRundown { get; set; } = true;
+        public virtual bool RequestRundown
+        {
+            get => _requestRundown;
+            set
+            {
+                _requestRundown = value;
+                if (_requestRundown)
+                {
+                    if (_rundownKeyword == 0)
+                    {
+                        _rundownKeyword = EventPipeSession.DefaultRundownKeyword;
+                    }
+                }
+                else
+                {
+                    _rundownKeyword = 0;
+                    RetryStrategy = RetryStrategy.DoNotRetry;
+                }
+            }
+        }
 
-        public virtual long? RundownKeyword { get; set; }
+        public virtual long RundownKeyword
+        {
+            get => _rundownKeyword;
+            set
+            {
+                _rundownKeyword = value;
+                if (_rundownKeyword == 0)
+                {
+                    _requestRundown = false;
+                    RetryStrategy = RetryStrategy.DoNotRetry;
+                }
+                else
+                {
+                    RetryStrategy = RetryStrategy.DropKeywordKeepRundown;
+                    _requestRundown = true;
+                }
+            }
+        }
 
         public virtual int BufferSizeInMB => 256;
+
+        public virtual RetryStrategy RetryStrategy { get; set; } = RetryStrategy.DropKeywordKeepRundown;
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/RetryStrategies.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/RetryStrategies.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+//
+// This class describes the various strategies for retrying a command.
+// The rough idea is that these numbers form a state machine.
+// Any time a command execution fails, a retry will be attempted by matching the
+// condition of the config as well as this strategy number to generate a
+// modified config as well as a modified strategy.
+//
+// This is designed with forward compatibility in mind. We might have newer
+// capabilities that only exists in newer runtimes, but we will never know exactly
+// how we should retry. So this give us a way to encode the retry strategy in the
+// profiles without having to introducing new concepts.
+//
+namespace Microsoft.Diagnostics.Monitoring.EventPipe
+{
+    public enum RetryStrategy
+    {
+        DoNotRetry = 0,
+        DropKeywordKeepRundown = 1,
+        DropKeywordDropRundown = 2,
+    }
+}

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/RetryStrategies.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/RetryStrategies.cs
@@ -17,8 +17,9 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
 {
     public enum RetryStrategy
     {
-        DoNotRetry = 0,
+        NothingToRetry = 0,
         DropKeywordKeepRundown = 1,
         DropKeywordDropRundown = 2,
+        ForbiddenToRetry = 3
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/SampleProfilerConfiguration.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/SampleProfilerConfiguration.cs
@@ -10,6 +10,11 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
 {
     public sealed class SampleProfilerConfiguration : MonitoringSourceConfiguration
     {
+        public SampleProfilerConfiguration()
+        {
+            RundownKeyword = 0;
+        }
+
         public override IList<EventPipeProvider> GetProviders() =>
             new EventPipeProvider[]
             {
@@ -17,11 +22,5 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
             };
 
         public override int BufferSizeInMB => 1;
-
-        public override bool RequestRundown
-        {
-            get => false;
-            set => throw new NotSupportedException();
-        }
     }
 }

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/EventPipeStreamProvider.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/EventPipeStreamProvider.cs
@@ -41,15 +41,31 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
                 }
                 catch (UnsupportedCommandException) when (retryStrategy == RetryStrategy.DropKeywordKeepRundown)
                 {
-                    Debug.Assert(rundownKeyword != 0);
-                    Debug.Assert(rundownKeyword != EventPipeSession.DefaultRundownKeyword);
+                    //
+                    // If you are building new profiles or options, you can test with these asserts to make sure you are writing
+                    // the retry strategies correctly.
+                    //
+                    // If these assert ever fires, it means something is wrong with the option generation logic leading to unnecessary retries.
+                    // unnecessary retries is not fatal.
+                    //
+                    // Debug.Assert(rundownKeyword != 0);
+                    // Debug.Assert(rundownKeyword != EventPipeSession.DefaultRundownKeyword);
+                    //
                     EventPipeSessionConfiguration config = new(providers, bufferSizeInMB, EventPipeSession.DefaultRundownKeyword, true);
                     session = await client.StartEventPipeSessionAsync(config, cancellationToken).ConfigureAwait(false);
                 }
                 catch (UnsupportedCommandException) when (retryStrategy == RetryStrategy.DropKeywordDropRundown)
                 {
-                    Debug.Assert(rundownKeyword != 0);
-                    Debug.Assert(rundownKeyword != EventPipeSession.DefaultRundownKeyword);
+                    //
+                    // If you are building new profiles or options, you can test with these asserts to make sure you are writing
+                    // the retry strategies correctly.
+                    //
+                    // If these assert ever fires, it means something is wrong with the option generation logic leading to unnecessary retries.
+                    // unnecessary retries is not fatal.
+                    //
+                    // Debug.Assert(rundownKeyword != 0);
+                    // Debug.Assert(rundownKeyword != EventPipeSession.DefaultRundownKeyword);
+                    //
                     EventPipeSessionConfiguration config = new(providers, bufferSizeInMB, 0, true);
                     session = await client.StartEventPipeSessionAsync(config, cancellationToken).ConfigureAwait(false);
                 }

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/EventPipeStreamProvider.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/EventPipeStreamProvider.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
             EventPipeSession session = null;
             try
             {
-                session = await client.StartEventPipeSessionAsync(_sourceConfig.GetProviders(), _sourceConfig.RequestRundown, _sourceConfig.BufferSizeInMB, cancellationToken).ConfigureAwait(false);
+                session = await client.StartEventPipeSessionAsync(_sourceConfig.GetProviders(), _sourceConfig.RequestRundown, _sourceConfig.BufferSizeInMB, _sourceConfig.RundownKeyword, cancellationToken).ConfigureAwait(false);
                 if (resumeRuntime)
                 {
                     try

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/EventPipeStreamProvider.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/EventPipeStreamProvider.cs
@@ -50,20 +50,19 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
                             Debug.Assert(rundownKeyword != 0);
                             Debug.Assert(rundownKeyword != EventPipeSession.DefaultRundownKeyword);
                             retry = true;
-                            retryStrategy = RetryStrategy.DoNotRetry;
-                            rundownKeyword = 0;
+                            retryStrategy = RetryStrategy.NothingToRetry;
+                            rundownKeyword = EventPipeSession.DefaultRundownKeyword;
                         }
                         else if (retryStrategy == RetryStrategy.DropKeywordDropRundown)
                         {
                             Debug.Assert(rundownKeyword != 0);
                             Debug.Assert(rundownKeyword != EventPipeSession.DefaultRundownKeyword);
                             retry = true;
-                            retryStrategy = RetryStrategy.DoNotRetry;
+                            retryStrategy = RetryStrategy.NothingToRetry;
                             rundownKeyword = 0;
                         }
                         else
                         {
-                            Debug.Assert((rundownKeyword == 0) || (rundownKeyword == EventPipeSession.DefaultRundownKeyword));
                             throw e;
                         }
                     }

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/EventPipeStreamProvider.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/EventPipeStreamProvider.cs
@@ -36,21 +36,21 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
                 RetryStrategy retryStrategy = _sourceConfig.RetryStrategy;
                 try
                 {
-                    EventPipeSessionConfiguration config = new(providers, bufferSizeInMB, (rundownKeyword != 0), true, rundownKeyword);
+                    EventPipeSessionConfiguration config = new(providers, bufferSizeInMB, rundownKeyword, true);
                     session = await client.StartEventPipeSessionAsync(config, cancellationToken).ConfigureAwait(false);
                 }
                 catch (UnsupportedCommandException) when (retryStrategy == RetryStrategy.DropKeywordKeepRundown)
                 {
                     Debug.Assert(rundownKeyword != 0);
                     Debug.Assert(rundownKeyword != EventPipeSession.DefaultRundownKeyword);
-                    EventPipeSessionConfiguration config = new(providers, bufferSizeInMB, true, true, EventPipeSession.DefaultRundownKeyword);
+                    EventPipeSessionConfiguration config = new(providers, bufferSizeInMB, EventPipeSession.DefaultRundownKeyword, true);
                     session = await client.StartEventPipeSessionAsync(config, cancellationToken).ConfigureAwait(false);
                 }
                 catch (UnsupportedCommandException) when (retryStrategy == RetryStrategy.DropKeywordDropRundown)
                 {
                     Debug.Assert(rundownKeyword != 0);
                     Debug.Assert(rundownKeyword != EventPipeSession.DefaultRundownKeyword);
-                    EventPipeSessionConfiguration config = new(providers, bufferSizeInMB, false, true, 0);
+                    EventPipeSessionConfiguration config = new(providers, bufferSizeInMB, 0, true);
                     session = await client.StartEventPipeSessionAsync(config, cancellationToken).ConfigureAwait(false);
                 }
                 if (resumeRuntime)

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
@@ -65,12 +65,13 @@ namespace Microsoft.Diagnostics.NETCore.Client
         /// <param name="providers">An IEnumerable containing the list of Providers to turn on.</param>
         /// <param name="requestRundown">If true, request rundown events from the runtime</param>
         /// <param name="circularBufferMB">The size of the runtime's buffer for collecting events in MB</param>
+        /// <param name="rundownKeyword">If not null, override the default keyword for rundown events.</param>
         /// <returns>
         /// An EventPipeSession object representing the EventPipe session that just started.
         /// </returns>
-        public EventPipeSession StartEventPipeSession(IEnumerable<EventPipeProvider> providers, bool requestRundown = true, int circularBufferMB = DefaultCircularBufferMB)
+        public EventPipeSession StartEventPipeSession(IEnumerable<EventPipeProvider> providers, bool requestRundown = true, int circularBufferMB = DefaultCircularBufferMB, long? rundownKeyword = null)
         {
-            EventPipeSessionConfiguration config = new(providers, circularBufferMB, requestRundown: requestRundown, requestStackwalk: true);
+            EventPipeSessionConfiguration config = new(providers, circularBufferMB, requestRundown: requestRundown, requestStackwalk: true, rundownKeyword: rundownKeyword);
             return EventPipeSession.Start(_endpoint, config);
         }
 
@@ -80,12 +81,13 @@ namespace Microsoft.Diagnostics.NETCore.Client
         /// <param name="provider">An EventPipeProvider to turn on.</param>
         /// <param name="requestRundown">If true, request rundown events from the runtime</param>
         /// <param name="circularBufferMB">The size of the runtime's buffer for collecting events in MB</param>
+        /// <param name="rundownKeyword">If not null, override the default keyword for rundown events.</param>
         /// <returns>
         /// An EventPipeSession object representing the EventPipe session that just started.
         /// </returns>
-        public EventPipeSession StartEventPipeSession(EventPipeProvider provider, bool requestRundown = true, int circularBufferMB = DefaultCircularBufferMB)
+        public EventPipeSession StartEventPipeSession(EventPipeProvider provider, bool requestRundown = true, int circularBufferMB = DefaultCircularBufferMB, long? rundownKeyword = null)
         {
-            EventPipeSessionConfiguration config = new(new[] {provider}, circularBufferMB, requestRundown: requestRundown, requestStackwalk: true);
+            EventPipeSessionConfiguration config = new(new[] {provider}, circularBufferMB, requestRundown: requestRundown, requestStackwalk: true, rundownKeyword: rundownKeyword);
             return EventPipeSession.Start(_endpoint, config);
         }
 
@@ -95,14 +97,15 @@ namespace Microsoft.Diagnostics.NETCore.Client
         /// <param name="providers">An IEnumerable containing the list of Providers to turn on.</param>
         /// <param name="requestRundown">If true, request rundown events from the runtime</param>
         /// <param name="circularBufferMB">The size of the runtime's buffer for collecting events in MB</param>
+        /// <param name="rundownKeyword">If not null, override the default keyword for rundown events.</param>
         /// <param name="token">The token to monitor for cancellation requests.</param>
         /// <returns>
         /// An EventPipeSession object representing the EventPipe session that just started.
         /// </returns>
         public Task<EventPipeSession> StartEventPipeSessionAsync(IEnumerable<EventPipeProvider> providers, bool requestRundown,
-            int circularBufferMB = DefaultCircularBufferMB, CancellationToken token = default)
+            int circularBufferMB = DefaultCircularBufferMB, long? rundownKeyword = null, CancellationToken token = default)
         {
-            EventPipeSessionConfiguration config = new(providers, circularBufferMB, requestRundown: requestRundown, requestStackwalk: true);
+            EventPipeSessionConfiguration config = new(providers, circularBufferMB, requestRundown: requestRundown, requestStackwalk: true, rundownKeyword: rundownKeyword);
             return EventPipeSession.StartAsync(_endpoint, config, token);
         }
 
@@ -112,14 +115,15 @@ namespace Microsoft.Diagnostics.NETCore.Client
         /// <param name="provider">An EventPipeProvider to turn on.</param>
         /// <param name="requestRundown">If true, request rundown events from the runtime</param>
         /// <param name="circularBufferMB">The size of the runtime's buffer for collecting events in MB</param>
+        /// <param name="rundownKeyword">If not null, override the default keyword for rundown events.</param>
         /// <param name="token">The token to monitor for cancellation requests.</param>
         /// <returns>
         /// An EventPipeSession object representing the EventPipe session that just started.
         /// </returns>
         public Task<EventPipeSession> StartEventPipeSessionAsync(EventPipeProvider provider, bool requestRundown,
-            int circularBufferMB = DefaultCircularBufferMB, CancellationToken token = default)
+            int circularBufferMB = DefaultCircularBufferMB, long? rundownKeyword = null, CancellationToken token = default)
         {
-            EventPipeSessionConfiguration config = new(new[] {provider}, circularBufferMB, requestRundown: requestRundown, requestStackwalk: true);
+            EventPipeSessionConfiguration config = new(new[] {provider}, circularBufferMB, requestRundown: requestRundown, requestStackwalk: true, rundownKeyword: rundownKeyword);
             return EventPipeSession.StartAsync(_endpoint, config, token);
         }
 

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
@@ -65,13 +65,12 @@ namespace Microsoft.Diagnostics.NETCore.Client
         /// <param name="providers">An IEnumerable containing the list of Providers to turn on.</param>
         /// <param name="requestRundown">If true, request rundown events from the runtime</param>
         /// <param name="circularBufferMB">The size of the runtime's buffer for collecting events in MB</param>
-        /// <param name="rundownKeyword">If not null, override the default keyword for rundown events.</param>
         /// <returns>
         /// An EventPipeSession object representing the EventPipe session that just started.
         /// </returns>
-        public EventPipeSession StartEventPipeSession(IEnumerable<EventPipeProvider> providers, bool requestRundown = true, int circularBufferMB = DefaultCircularBufferMB, long? rundownKeyword = null)
+        public EventPipeSession StartEventPipeSession(IEnumerable<EventPipeProvider> providers, bool requestRundown = true, int circularBufferMB = DefaultCircularBufferMB)
         {
-            EventPipeSessionConfiguration config = new(providers, circularBufferMB, requestRundown: requestRundown, requestStackwalk: true, rundownKeyword: rundownKeyword);
+            EventPipeSessionConfiguration config = new(providers, circularBufferMB, requestRundown: requestRundown, requestStackwalk: true);
             return EventPipeSession.Start(_endpoint, config);
         }
 
@@ -81,13 +80,24 @@ namespace Microsoft.Diagnostics.NETCore.Client
         /// <param name="provider">An EventPipeProvider to turn on.</param>
         /// <param name="requestRundown">If true, request rundown events from the runtime</param>
         /// <param name="circularBufferMB">The size of the runtime's buffer for collecting events in MB</param>
-        /// <param name="rundownKeyword">If not null, override the default keyword for rundown events.</param>
         /// <returns>
         /// An EventPipeSession object representing the EventPipe session that just started.
         /// </returns>
-        public EventPipeSession StartEventPipeSession(EventPipeProvider provider, bool requestRundown = true, int circularBufferMB = DefaultCircularBufferMB, long? rundownKeyword = null)
+        public EventPipeSession StartEventPipeSession(EventPipeProvider provider, bool requestRundown = true, int circularBufferMB = DefaultCircularBufferMB)
         {
-            EventPipeSessionConfiguration config = new(new[] {provider}, circularBufferMB, requestRundown: requestRundown, requestStackwalk: true, rundownKeyword: rundownKeyword);
+            EventPipeSessionConfiguration config = new(new[] {provider}, circularBufferMB, requestRundown: requestRundown, requestStackwalk: true);
+            return EventPipeSession.Start(_endpoint, config);
+        }
+
+        /// <summary>
+        /// Start tracing the application and return an EventPipeSession object
+        /// </summary>
+        /// <param name="config">The configuration for start tracing.</param>
+        /// <returns>
+        /// An EventPipeSession object representing the EventPipe session that just started.
+        /// </returns>
+        public EventPipeSession StartEventPipeSession(EventPipeSessionConfiguration config)
+        {
             return EventPipeSession.Start(_endpoint, config);
         }
 
@@ -97,15 +107,14 @@ namespace Microsoft.Diagnostics.NETCore.Client
         /// <param name="providers">An IEnumerable containing the list of Providers to turn on.</param>
         /// <param name="requestRundown">If true, request rundown events from the runtime</param>
         /// <param name="circularBufferMB">The size of the runtime's buffer for collecting events in MB</param>
-        /// <param name="rundownKeyword">If not null, override the default keyword for rundown events.</param>
         /// <param name="token">The token to monitor for cancellation requests.</param>
         /// <returns>
         /// An EventPipeSession object representing the EventPipe session that just started.
         /// </returns>
         public Task<EventPipeSession> StartEventPipeSessionAsync(IEnumerable<EventPipeProvider> providers, bool requestRundown,
-            int circularBufferMB = DefaultCircularBufferMB, long? rundownKeyword = null, CancellationToken token = default)
+            int circularBufferMB = DefaultCircularBufferMB, CancellationToken token = default)
         {
-            EventPipeSessionConfiguration config = new(providers, circularBufferMB, requestRundown: requestRundown, requestStackwalk: true, rundownKeyword: rundownKeyword);
+            EventPipeSessionConfiguration config = new(providers, circularBufferMB, requestRundown: requestRundown, requestStackwalk: true);
             return EventPipeSession.StartAsync(_endpoint, config, token);
         }
 
@@ -115,15 +124,14 @@ namespace Microsoft.Diagnostics.NETCore.Client
         /// <param name="provider">An EventPipeProvider to turn on.</param>
         /// <param name="requestRundown">If true, request rundown events from the runtime</param>
         /// <param name="circularBufferMB">The size of the runtime's buffer for collecting events in MB</param>
-        /// <param name="rundownKeyword">If not null, override the default keyword for rundown events.</param>
         /// <param name="token">The token to monitor for cancellation requests.</param>
         /// <returns>
         /// An EventPipeSession object representing the EventPipe session that just started.
         /// </returns>
         public Task<EventPipeSession> StartEventPipeSessionAsync(EventPipeProvider provider, bool requestRundown,
-            int circularBufferMB = DefaultCircularBufferMB, long? rundownKeyword = null, CancellationToken token = default)
+            int circularBufferMB = DefaultCircularBufferMB, CancellationToken token = default)
         {
-            EventPipeSessionConfiguration config = new(new[] {provider}, circularBufferMB, requestRundown: requestRundown, requestStackwalk: true, rundownKeyword: rundownKeyword);
+            EventPipeSessionConfiguration config = new(new[] {provider}, circularBufferMB, requestRundown: requestRundown, requestStackwalk: true);
             return EventPipeSession.StartAsync(_endpoint, config, token);
         }
 

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/EventPipeSession.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/EventPipeSession.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
         //!  unused_keyword                     (0x00000100)
         //!  JittedMethodILToNativeMapKeyword   (0x00020000)
         //!  ThreadTransferKeyword              (0x80000000)
-        public const long DefaultRundownKeyword = 0x80020139;
+        internal const long DefaultRundownKeyword = 0x80020139;
 
         private ulong _sessionId;
         private IpcEndpoint _endpoint;
@@ -97,7 +97,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
             // To keep backward compatibility with older runtimes we only use newer serialization format when needed
             EventPipeCommandId command;
             byte[] payload;
-            if (config.RundownKeyword.HasValue && config.RundownKeyword.Value != DefaultRundownKeyword && config.RundownKeyword.Value != 0)
+            if (config.RundownKeyword != DefaultRundownKeyword && config.RundownKeyword != 0)
             {
                 // V4 has added support to specify rundown keyword
                 command = EventPipeCommandId.CollectTracing4;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/EventPipeSessionConfiguration.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/EventPipeSessionConfiguration.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
         public bool RequestStackwalk { get; }
 
         /// <summary>
-        /// If not null, override the default keyword for rundown events.
+        /// The keywords enabled for the rundown provider.
         /// </summary>
         public long RundownKeyword { get; internal set; }
 

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcCommands.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcCommands.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
         CollectTracing = 0x02,
         CollectTracing2 = 0x03,
         CollectTracing3 = 0x04,
+        CollectTracing4 = 0x05,
     }
 
     internal enum DumpCommandId : byte

--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
@@ -149,7 +149,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                     if (rundown.Value)
                     {
                         rundownKeyword |= EventPipeSession.DefaultRundownKeyword;
-                        retryStrategy = RetryStrategy.DropKeywordKeepRundown;
+                        retryStrategy = (rundownKeyword == EventPipeSession.DefaultRundownKeyword) ? RetryStrategy.NothingToRetry : RetryStrategy.DropKeywordKeepRundown;
                     }
                     else
                     {
@@ -290,16 +290,32 @@ namespace Microsoft.Diagnostics.Tools.Trace
                             if (retryStrategy == RetryStrategy.DropKeywordKeepRundown)
                             {
                                 Console.Error.WriteLine("The runtime version being traced doesn't support the custom rundown feature used by this tracing configuration, retrying with the standard rundown keyword");
-                                Debug.Assert(rundownKeyword != 0);
-                                Debug.Assert(rundownKeyword != EventPipeSession.DefaultRundownKeyword);
+                                //
+                                // If you are building new profiles or options, you can test with these asserts to make sure you are writing
+                                // the retry strategies correctly.
+                                //
+                                // If these assert ever fires, it means something is wrong with the option generation logic leading to unnecessary retries.
+                                // unnecessary retries is not fatal.
+                                //
+                                // Debug.Assert(rundownKeyword != 0);
+                                // Debug.Assert(rundownKeyword != EventPipeSession.DefaultRundownKeyword);
+                                //
                                 EventPipeSessionConfiguration config = new(providerCollection, (int)buffersize, rundownKeyword: EventPipeSession.DefaultRundownKeyword, requestStackwalk: true);
                                 session = diagnosticsClient.StartEventPipeSession(config);
                             }
                             else if (retryStrategy == RetryStrategy.DropKeywordDropRundown)
                             {
                                 Console.Error.WriteLine("The runtime version being traced doesn't support the custom rundown feature used by this tracing configuration, retrying with the rundown omitted");
-                                Debug.Assert(rundownKeyword != 0);
-                                Debug.Assert(rundownKeyword != EventPipeSession.DefaultRundownKeyword);
+                                //
+                                // If you are building new profiles or options, you can test with these asserts to make sure you are writing
+                                // the retry strategies correctly.
+                                //
+                                // If these assert ever fires, it means something is wrong with the option generation logic leading to unnecessary retries.
+                                // unnecessary retries is not fatal.
+                                //
+                                // Debug.Assert(rundownKeyword != 0);
+                                // Debug.Assert(rundownKeyword != EventPipeSession.DefaultRundownKeyword);
+                                //
                                 EventPipeSessionConfiguration config = new(providerCollection, (int)buffersize, rundownKeyword: 0, requestStackwalk: true);
                                 session = diagnosticsClient.StartEventPipeSession(config);
                             }

--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 }
 
                 long rundownKeyword = EventPipeSession.DefaultRundownKeyword;
-                RetryStrategy retryStrategy = RetryStrategy.DoNotRetry;
+                RetryStrategy retryStrategy = RetryStrategy.NothingToRetry;
 
                 if (profile.Length != 0)
                 {
@@ -148,13 +148,13 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 {
                     if (rundown.Value)
                     {
-                        rundownKeyword = EventPipeSession.DefaultRundownKeyword;
+                        rundownKeyword |= EventPipeSession.DefaultRundownKeyword;
                         retryStrategy = RetryStrategy.DropKeywordKeepRundown;
                     }
                     else
                     {
                         rundownKeyword = 0;
-                        retryStrategy = RetryStrategy.DoNotRetry;
+                        retryStrategy = RetryStrategy.NothingToRetry;
                     }
                 }
 
@@ -293,25 +293,24 @@ namespace Microsoft.Diagnostics.Tools.Trace
                             {
                                 if (retryStrategy == RetryStrategy.DropKeywordKeepRundown)
                                 {
-                                    Console.Error.WriteLine("The runtime is too old to support this tracing config, retrying with the standard rundown keyword");
+                                    Console.Error.WriteLine("The runtime version being traced doesn't support the custom rundown feature used by this tracing configuration, retrying with the standard rundown keyword");
                                     Debug.Assert(rundownKeyword != 0);
                                     Debug.Assert(rundownKeyword != EventPipeSession.DefaultRundownKeyword);
                                     retry = true;
-                                    retryStrategy = RetryStrategy.DoNotRetry;
+                                    retryStrategy = RetryStrategy.NothingToRetry;
                                     rundownKeyword = EventPipeSession.DefaultRundownKeyword;
                                 }
                                 else if (retryStrategy == RetryStrategy.DropKeywordDropRundown)
                                 {
-                                    Console.Error.WriteLine("The runtime is too old to support this tracing config, retrying with the rundown omitted");
+                                    Console.Error.WriteLine("The runtime version being traced doesn't support the custom rundown feature used by this tracing configuration, retrying with the rundown omitted");
                                     Debug.Assert(rundownKeyword != 0);
                                     Debug.Assert(rundownKeyword != EventPipeSession.DefaultRundownKeyword);
                                     retry = true;
-                                    retryStrategy = RetryStrategy.DoNotRetry;
+                                    retryStrategy = RetryStrategy.NothingToRetry;
                                     rundownKeyword = 0;
                                 }
                                 else
                                 {
-                                    Debug.Assert((rundownKeyword == 0) || (rundownKeyword == EventPipeSession.DefaultRundownKeyword));
                                     Console.Error.WriteLine($"Unable to start a tracing session: {e}");
                                     return (int)ReturnCode.SessionCreationError;
                                 }

--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
@@ -282,7 +282,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                         EventPipeSession session = null;
                         try
                         {
-                            EventPipeSessionConfiguration config = new(providerCollection, (int)buffersize, requestRundown: (rundownKeyword != 0), requestStackwalk: true, rundownKeyword: rundownKeyword);
+                            EventPipeSessionConfiguration config = new(providerCollection, (int)buffersize, rundownKeyword: rundownKeyword, requestStackwalk: true);
                             session = diagnosticsClient.StartEventPipeSession(config);
                         }
                         catch (UnsupportedCommandException e)
@@ -292,7 +292,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                                 Console.Error.WriteLine("The runtime version being traced doesn't support the custom rundown feature used by this tracing configuration, retrying with the standard rundown keyword");
                                 Debug.Assert(rundownKeyword != 0);
                                 Debug.Assert(rundownKeyword != EventPipeSession.DefaultRundownKeyword);
-                                EventPipeSessionConfiguration config = new(providerCollection, (int)buffersize, requestRundown: true, requestStackwalk: true, rundownKeyword: EventPipeSession.DefaultRundownKeyword);
+                                EventPipeSessionConfiguration config = new(providerCollection, (int)buffersize, rundownKeyword: EventPipeSession.DefaultRundownKeyword, requestStackwalk: true);
                                 session = diagnosticsClient.StartEventPipeSession(config);
                             }
                             else if (retryStrategy == RetryStrategy.DropKeywordDropRundown)
@@ -300,7 +300,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                                 Console.Error.WriteLine("The runtime version being traced doesn't support the custom rundown feature used by this tracing configuration, retrying with the rundown omitted");
                                 Debug.Assert(rundownKeyword != 0);
                                 Debug.Assert(rundownKeyword != EventPipeSession.DefaultRundownKeyword);
-                                EventPipeSessionConfiguration config = new(providerCollection, (int)buffersize, requestRundown: false, requestStackwalk: true, rundownKeyword: 0);
+                                EventPipeSessionConfiguration config = new(providerCollection, (int)buffersize, rundownKeyword: 0, requestStackwalk: true);
                                 session = diagnosticsClient.StartEventPipeSession(config);
                             }
                             else

--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
@@ -126,6 +126,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 }
 
                 bool collectRundownEvents = true;
+                long? rundownKeyword = null;
 
                 if (profile.Length != 0)
                 {
@@ -138,6 +139,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                     }
 
                     collectRundownEvents = selectedProfile.Rundown;
+                    rundownKeyword = selectedProfile.RundownKeyword;
 
                     Profile.MergeProfileAndProviders(selectedProfile, providerCollection, enabledBy);
                 }
@@ -271,7 +273,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                         EventPipeSession session = null;
                         try
                         {
-                            session = diagnosticsClient.StartEventPipeSession(providerCollection, collectRundownEvents, (int)buffersize);
+                            session = diagnosticsClient.StartEventPipeSession(providerCollection, collectRundownEvents, (int)buffersize, rundownKeyword);
                             if (resumeRuntime)
                             {
                                 try

--- a/src/Tools/dotnet-trace/CommandLine/Commands/ListProfilesCommandHandler.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/ListProfilesCommandHandler.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                         keywords: (long)ClrTraceEventParser.Keywords.GC |
                                   (long)ClrTraceEventParser.Keywords.GCHandle |
                                   (long)ClrTraceEventParser.Keywords.Exception
-                    ),
+                    )
                 },
                 "Tracks GC collections and samples object allocations."),
             new Profile(
@@ -75,7 +75,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                         keywords: (long)ClrTraceEventParser.Keywords.GC
                     )
                 },
-                "Tracks GC collections only at very low overhead.") { Rundown = false },
+                "Tracks GC collections only at very low overhead.") { RundownKeyword = (long)ClrTraceEventParser.Keywords.GC },
             new Profile(
                 "database",
                 new EventPipeProvider[] {

--- a/src/Tools/dotnet-trace/CommandLine/Commands/ListProfilesCommandHandler.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/ListProfilesCommandHandler.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                         keywords: (long)ClrTraceEventParser.Keywords.GC
                     )
                 },
-                "Tracks GC collections only at very low overhead.") { RundownKeyword = (long)ClrTraceEventParser.Keywords.GC },
+                "Tracks GC collections only at very low overhead.") { RundownKeyword = (long)ClrTraceEventParser.Keywords.GC, RetryStrategy = RetryStrategy.DropKeywordDropRundown },
             new Profile(
                 "database",
                 new EventPipeProvider[] {

--- a/src/Tools/dotnet-trace/Profile.cs
+++ b/src/Tools/dotnet-trace/Profile.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
 
         public long RundownKeyword { get; set; }
 
-        public RetryStrategy RetryStrategy { get; set; } = RetryStrategy.DropKeywordKeepRundown;
+        public RetryStrategy RetryStrategy { get; set; } = RetryStrategy.NothingToRetry;
 
         public static void MergeProfileAndProviders(Profile selectedProfile, List<EventPipeProvider> providerCollection, Dictionary<string, string> enabledBy)
         {

--- a/src/Tools/dotnet-trace/Profile.cs
+++ b/src/Tools/dotnet-trace/Profile.cs
@@ -24,6 +24,8 @@ namespace Microsoft.Diagnostics.Tools.Trace
 
         public bool Rundown { get; set; } = true;
 
+        public long? RundownKeyword { get; set; } = 0;
+
         public static void MergeProfileAndProviders(Profile selectedProfile, List<EventPipeProvider> providerCollection, Dictionary<string, string> enabledBy)
         {
             List<EventPipeProvider> profileProviders = new();

--- a/src/Tools/dotnet-trace/Profile.cs
+++ b/src/Tools/dotnet-trace/Profile.cs
@@ -22,9 +22,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
 
         public string Description { get; }
 
-        public bool Rundown { get; set; } = true;
-
-        public long? RundownKeyword { get; set; }
+        public long RundownKeyword { get; set; }
 
         public RetryStrategy RetryStrategy { get; set; } = RetryStrategy.DropKeywordKeepRundown;
 

--- a/src/Tools/dotnet-trace/Profile.cs
+++ b/src/Tools/dotnet-trace/Profile.cs
@@ -24,7 +24,9 @@ namespace Microsoft.Diagnostics.Tools.Trace
 
         public bool Rundown { get; set; } = true;
 
-        public long? RundownKeyword { get; set; } = 0;
+        public long? RundownKeyword { get; set; }
+
+        public RetryStrategy RetryStrategy { get; set; } = RetryStrategy.DropKeywordKeepRundown;
 
         public static void MergeProfileAndProviders(Profile selectedProfile, List<EventPipeProvider> providerCollection, Dictionary<string, string> enabledBy)
         {

--- a/src/Tools/dotnet-trace/RetryStrategies.cs
+++ b/src/Tools/dotnet-trace/RetryStrategies.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+//
+// This class describes the various strategies for retrying a command.
+// The rough idea is that these numbers form a state machine.
+// Any time a command execution fails, a retry will be attempted by matching the
+// condition of the config as well as this strategy number to generate a
+// modified config as well as a modified strategy.
+//
+// This is designed with forward compatibility in mind. We might have newer
+// capabilities that only exists in newer runtimes, but we will never know exactly
+// how we should retry. So this give us a way to encode the retry strategy in the
+// profiles without having to introducing new concepts.
+//
+internal enum RetryStrategy
+{
+    DoNotRetry = 0,
+    DropKeywordKeepRundown = 1,
+    DropKeywordDropRundown = 2,
+}

--- a/src/Tools/dotnet-trace/RetryStrategies.cs
+++ b/src/Tools/dotnet-trace/RetryStrategies.cs
@@ -13,10 +13,13 @@
 // how we should retry. So this give us a way to encode the retry strategy in the
 // profiles without having to introducing new concepts.
 //
-internal enum RetryStrategy
+namespace Microsoft.Diagnostics.Tools.Trace
 {
+    internal enum RetryStrategy
+    {
         NothingToRetry = 0,
         DropKeywordKeepRundown = 1,
         DropKeywordDropRundown = 2,
         ForbiddenToRetry = 3
+    }
 }

--- a/src/Tools/dotnet-trace/RetryStrategies.cs
+++ b/src/Tools/dotnet-trace/RetryStrategies.cs
@@ -15,7 +15,8 @@
 //
 internal enum RetryStrategy
 {
-    DoNotRetry = 0,
-    DropKeywordKeepRundown = 1,
-    DropKeywordDropRundown = 2,
+        NothingToRetry = 0,
+        DropKeywordKeepRundown = 1,
+        DropKeywordDropRundown = 2,
+        ForbiddenToRetry = 3
 }

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClientApiShim.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClientApiShim.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
             if (_useAsync)
             {
                 CancellationTokenSource cancellation = new(timeout);
-                return await _client.StartEventPipeSessionAsync(providers, true, circularBufferMB: 256, cancellation.Token).ConfigureAwait(false);
+                return await _client.StartEventPipeSessionAsync(providers, true, circularBufferMB: 256, rundownKeyword: null, cancellation.Token).ConfigureAwait(false);
             }
             else
             {
@@ -92,7 +92,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
             if (_useAsync)
             {
                 CancellationTokenSource cancellation = new(timeout);
-                return await _client.StartEventPipeSessionAsync(provider, true, circularBufferMB: 256, cancellation.Token).ConfigureAwait(false);
+                return await _client.StartEventPipeSessionAsync(provider, true, circularBufferMB: 256, rundownKeyword: null, cancellation.Token).ConfigureAwait(false);
             }
             else
             {

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClientApiShim.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClientApiShim.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
             if (_useAsync)
             {
                 CancellationTokenSource cancellation = new(timeout);
-                return await _client.StartEventPipeSessionAsync(providers, true, circularBufferMB: 256, rundownKeyword: null, cancellation.Token).ConfigureAwait(false);
+                return await _client.StartEventPipeSessionAsync(providers, true, circularBufferMB: 256, cancellation.Token).ConfigureAwait(false);
             }
             else
             {
@@ -92,7 +92,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
             if (_useAsync)
             {
                 CancellationTokenSource cancellation = new(timeout);
-                return await _client.StartEventPipeSessionAsync(provider, true, circularBufferMB: 256, rundownKeyword: null, cancellation.Token).ConfigureAwait(false);
+                return await _client.StartEventPipeSessionAsync(provider, true, circularBufferMB: 256, cancellation.Token).ConfigureAwait(false);
             }
             else
             {


### PR DESCRIPTION
This change supports collecting GCSettingsEvent for gc-collect profile. The change will work for both dotnet-trace and dotnet-monitor.

The depends on the underlying mechanism built in https://github.com/dotnet/runtime/pull/101189