### PR TITLE
Remove the symweb symbol server support

### DIFF
--- a/src/Microsoft.Diagnostics.DebugServices/ISymbolService.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/ISymbolService.cs
@@ -19,8 +19,12 @@ namespace Microsoft.Diagnostics.DebugServices
         bool IsSymbolStoreEnabled { get; }
 
         /// <summary>
+        /// The default symbol server URL (normally msdl) when not overridden in AddSymbolServer.
+        /// </summary>
+        string DefaultSymbolPath { get; set; }
+
+        /// <summary>
         /// The default symbol cache path:
-        ///
         /// * dbgeng on Windows uses the dbgeng symbol cache path: %PROGRAMDATA%\dbg\sym
         /// * dotnet-dump on Windows uses the VS symbol cache path: %TEMPDIR%\SymbolCache
         /// * dotnet-dump/lldb on Linux/MacOS uses: $HOME/.dotnet/symbolcache
@@ -52,14 +56,12 @@ namespace Microsoft.Diagnostics.DebugServices
         /// <summary>
         /// Add symbol server to search path.
         /// </summary>
-        /// <param name="msdl">if true, use the public Microsoft server</param>
-        /// <param name="symweb">if true, use symweb internal server and protocol (file.ptr)</param>
-        /// <param name="symbolServerPath">symbol server url (optional)</param>
+        /// <param name="symbolServerPath">symbol server url (optional, uses <see cref="DefaultSymbolPath"/> if null)</param>
         /// <param name="authToken">PAT for secure symbol server (optional)</param>
-        /// <param name="timeoutInMinutes">symbol server timeout in minutes (optional uses <see cref="DefaultTimeout"/> if null)</param>
-        /// <param name="retryCount">number of retries (optional uses <see cref="DefaultRetryCount"/> if null)</param>
+        /// <param name="timeoutInMinutes">symbol server timeout in minutes (optional, uses <see cref="DefaultTimeout"/> if null)</param>
+        /// <param name="retryCount">number of retries (optional, uses <see cref="DefaultRetryCount"/> if null)</param>
         /// <returns>if false, failure</returns>
-        bool AddSymbolServer(bool msdl, bool symweb, string symbolServerPath = null, string authToken = null, int? timeoutInMinutes = null, int? retryCount = null);
+        bool AddSymbolServer(string symbolServerPath = null, string authToken = null, int? timeoutInMinutes = null, int? retryCount = null);
 
         /// <summary>
         /// Add cache path to symbol search path

--- a/src/Microsoft.Diagnostics.DebugServices/ISymbolService.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/ISymbolService.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Diagnostics.DebugServices
         /// <summary>
         /// The default symbol server URL (normally msdl) when not overridden in AddSymbolServer.
         /// </summary>
-        string DefaultSymbolPath { get; set; }
+        string DefaultSymbolPath { get; }
 
         /// <summary>
         /// The default symbol cache path:
@@ -29,17 +29,17 @@ namespace Microsoft.Diagnostics.DebugServices
         /// * dotnet-dump on Windows uses the VS symbol cache path: %TEMPDIR%\SymbolCache
         /// * dotnet-dump/lldb on Linux/MacOS uses: $HOME/.dotnet/symbolcache
         /// </summary>
-        string DefaultSymbolCache { get; set; }
+        string DefaultSymbolCache { get; }
 
         /// <summary>
         /// The time out in minutes passed to the HTTP symbol store when not overridden in AddSymbolServer.
         /// </summary>
-        int DefaultTimeout { get; set; }
+        int DefaultTimeout { get; }
 
         /// <summary>
         /// The retry count passed to the HTTP symbol store when not overridden in AddSymbolServer.
         /// </summary>
-        int DefaultRetryCount { get; set; }
+        int DefaultRetryCount { get; }
 
         /// <summary>
         /// Reset any HTTP symbol stores marked with a client failure

--- a/src/Microsoft.Diagnostics.ExtensionCommands/Host/SetSymbolServerCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/Host/SetSymbolServerCommand.cs
@@ -18,9 +18,6 @@ namespace Microsoft.Diagnostics.ExtensionCommands
         [Option(Name = "--ms", Aliases = new string[] { "-ms" }, Help = "Use the public Microsoft symbol server.")]
         public bool MicrosoftSymbolServer { get; set; }
 
-        [Option(Name = "--mi", Aliases = new string[] { "-mi" }, Help = "Use the internal symweb symbol server.")]
-        public bool InternalSymbolServer { get; set; }
-
         [Option(Name = "--disable", Aliases = new string[] { "-disable" }, Help = "Clear or disable symbol download support.")]
         public bool Disable { get; set; }
 
@@ -50,13 +47,9 @@ namespace Microsoft.Diagnostics.ExtensionCommands
 
         public override void Invoke()
         {
-            if (MicrosoftSymbolServer && InternalSymbolServer)
+            if (MicrosoftSymbolServer && !string.IsNullOrEmpty(SymbolServerUrl))
             {
-                throw new DiagnosticsException("Cannot have both -ms and -mi options");
-            }
-            if ((MicrosoftSymbolServer || InternalSymbolServer) && !string.IsNullOrEmpty(SymbolServerUrl))
-            {
-                throw new DiagnosticsException("Cannot have -ms or -mi option and a symbol server path");
+                throw new DiagnosticsException("Cannot have -ms option and a symbol server path");
             }
             if (Disable)
             {
@@ -66,13 +59,13 @@ namespace Microsoft.Diagnostics.ExtensionCommands
             {
                 SymbolService.Reset();
             }
-            if (MicrosoftSymbolServer || InternalSymbolServer || !string.IsNullOrEmpty(SymbolServerUrl))
+            if (MicrosoftSymbolServer || !string.IsNullOrEmpty(SymbolServerUrl))
             {
                 if (string.IsNullOrEmpty(Cache))
                 {
                     Cache = SymbolService.DefaultSymbolCache;
                 }
-                SymbolService.AddSymbolServer(MicrosoftSymbolServer, InternalSymbolServer, SymbolServerUrl, AccessToken, Timeout, RetryCount);
+                SymbolService.AddSymbolServer(SymbolServerUrl, AccessToken, Timeout, RetryCount);
             }
             if (!string.IsNullOrEmpty(Cache))
             {

--- a/src/Microsoft.Diagnostics.TestHelpers/TestHost/TestDump.cs
+++ b/src/Microsoft.Diagnostics.TestHelpers/TestHost/TestDump.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Diagnostics.TestHelpers
             _serviceContainer.AddService<ISymbolService>(_symbolService);
 
             // Automatically enable symbol server support
-            _symbolService.AddSymbolServer(msdl: true, symweb: false, timeoutInMinutes: 6, retryCount: 5);
+            _symbolService.AddSymbolServer(timeoutInMinutes: 6, retryCount: 5);
             _symbolService.AddCachePath(_symbolService.DefaultSymbolCache);
         }
 

--- a/src/Microsoft.SymbolStore/SymbolStores/SymwebSymbolStore.cs
+++ b/src/Microsoft.SymbolStore/SymbolStores/SymwebSymbolStore.cs
@@ -11,6 +11,7 @@ namespace Microsoft.SymbolStore.SymbolStores
     /// <summary>
     /// The symbol store for the internal symweb symbol server that handles the "file.ptr" support.
     /// </summary>
+    [Obsolete]
     public sealed class SymwebHttpSymbolStore : HttpSymbolStore
     {
         /// <summary>

--- a/src/SOS/SOS.Hosting/SymbolServiceWrapper.cs
+++ b/src/SOS/SOS.Hosting/SymbolServiceWrapper.cs
@@ -336,54 +336,9 @@ namespace SOS.Hosting
         #region Symbol service delegates
 
         [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate bool IsSymbolStoreEnabledDelegate(
-            [In] IntPtr self);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate bool InitializeSymbolStoreDelegate(
-            [In] IntPtr self,
-            [In] bool msdl,
-            [In] bool symweb,
-            [In] string symbolServerPath,
-            [In] string authToken,
-            [In] int timeoutInMinutes,
-            [In] string symbolCachePath,
-            [In] string symbolDirectoryPath);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate bool ParseSymbolPathDelegate(
             [In] IntPtr self,
             [In] string windowsSymbolPath);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate void DisplaySymbolStoreDelegate(
-            [In] IntPtr self,
-            [In] WriteLine writeLine);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate void DisableSymbolStoreDelegate(
-            [In] IntPtr self);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate void LoadNativeSymbolsDelegate(
-            [In] IntPtr self,
-            [In] SymbolFileCallback callback,
-            [In] IntPtr parameter,
-            [In] RuntimeConfiguration config,
-            [In] string moduleFilePath,
-            [In] ulong address,
-            [In] uint size);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate void LoadNativeSymbolsFromIndexDelegate(
-            [In] IntPtr self,
-            [In] SymbolFileCallback callback,
-            [In] IntPtr parameter,
-            [In] RuntimeConfiguration config,
-            [In] string moduleFilePath,
-            [In] bool specialKeys,
-            [In] int moduleIndexSize,
-            [In] IntPtr moduleIndex);
 
         [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate IntPtr LoadSymbolsForModuleDelegate(

--- a/src/Tools/dotnet-dump/Analyzer.cs
+++ b/src/Tools/dotnet-dump/Analyzer.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Diagnostics.Tools.Dump
                 contextService.SetCurrentTarget(target);
 
                 // Automatically enable symbol server support, default cache and search for symbols in the dump directory
-                symbolService.AddSymbolServer(msdl: true, symweb: false, retryCount: 3);
+                symbolService.AddSymbolServer(retryCount: 3);
                 symbolService.AddCachePath(symbolService.DefaultSymbolCache);
                 symbolService.AddDirectoryPath(Path.GetDirectoryName(dump_path.FullName));
 

--- a/src/Tools/dotnet-symbol/Program.cs
+++ b/src/Tools/dotnet-symbol/Program.cs
@@ -25,7 +25,6 @@ namespace Microsoft.Diagnostics.Tools.Symbol
         {
             public Uri Uri;
             public string PersonalAccessToken;
-            public bool InternalSymwebServer;
         }
 
         private readonly List<string> InputFilePaths = new();
@@ -62,11 +61,6 @@ namespace Microsoft.Diagnostics.Tools.Symbol
                     case "--microsoft-symbol-server":
                         Uri.TryCreate("https://msdl.microsoft.com/download/symbols/", UriKind.Absolute, out uri);
                         program.SymbolServers.Add(new ServerInfo { Uri = uri, PersonalAccessToken = null });
-                        break;
-
-                    case "--internal-server":
-                        Uri.TryCreate("https://symweb/", UriKind.Absolute, out uri);
-                        program.SymbolServers.Add(new ServerInfo { Uri = uri, PersonalAccessToken = null, InternalSymwebServer = true });
                         break;
 
                     case "--authenticated-server-path":
@@ -262,14 +256,7 @@ namespace Microsoft.Diagnostics.Tools.Symbol
 
             foreach (ServerInfo server in ((IEnumerable<ServerInfo>)SymbolServers).Reverse())
             {
-                if (server.InternalSymwebServer)
-                {
-                    store = new SymwebHttpSymbolStore(Tracer, store, server.Uri, server.PersonalAccessToken);
-                }
-                else
-                {
-                    store = new HttpSymbolStore(Tracer, store, server.Uri, server.PersonalAccessToken);
-                }
+                store = new HttpSymbolStore(Tracer, store, server.Uri, server.PersonalAccessToken);
                 if (Timeout.HasValue && store is HttpSymbolStore http)
                 {
                     http.Timeout = Timeout.Value;

--- a/src/Tools/dotnet-symbol/Properties/Resources.Designer.cs
+++ b/src/Tools/dotnet-symbol/Properties/Resources.Designer.cs
@@ -113,9 +113,10 @@ namespace Microsoft.Diagnostic.Tools.Symbol.Properties {
         ///
         ///Options:
         ///  --microsoft-symbol-server                         Add &apos;https://msdl.microsoft.com/download/symbols&apos; symbol server path (default).
-        ///  --internal-server                                 Add &apos;https://symweb&apos; internal symbol server path.
         ///  --server-path &lt;symbol server path&gt;                Add a http server path.
-        ///  --authenticated-server-path &lt;pat&gt; &lt;server path&gt;   Add a http PAT authenticated s [rest of string was truncated]&quot;;.
+        ///  --authenticated-server-path &lt;pat&gt; &lt;server path&gt;   Add a http PAT authenticated server path.
+        ///  --cache-directory &lt;file cache directory&gt;          Add a cache directory.
+        ///  --timeout &lt;m [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string UsageOptions {
             get {

--- a/src/Tools/dotnet-symbol/Properties/Resources.resx
+++ b/src/Tools/dotnet-symbol/Properties/Resources.resx
@@ -140,7 +140,6 @@ Arguments:
 
 Options:
   --microsoft-symbol-server                         Add 'https://msdl.microsoft.com/download/symbols' symbol server path (default).
-  --internal-server                                 Add 'https://symweb' internal symbol server path.
   --server-path &lt;symbol server path&gt;                Add a http server path.
   --authenticated-server-path &lt;pat&gt; &lt;server path&gt;   Add a http PAT authenticated server path.
   --cache-directory &lt;file cache directory&gt;          Add a cache directory.

--- a/src/Tools/dotnet-symbol/README.md
+++ b/src/Tools/dotnet-symbol/README.md
@@ -9,7 +9,6 @@ This tool can download all the files needed for debugging (symbols, modules, SOS
 
     Options:
       --microsoft-symbol-server                         Add 'https://msdl.microsoft.com/download/symbols' symbol server path (default).
-      --internal-server                                 Add 'https://symweb' internal symbol server path.
       --server-path <symbol server path>                Add a http server path.
       --authenticated-server-path <pat> <server path>   Add a http PAT authenticated server path.
       --cache-directory <file cache directory>          Add a cache directory.
@@ -45,7 +44,7 @@ This downloads just the host program needed to load a core dump on Linux or macO
 
 To download the symbol files for a specific assembly:
 
-    dotnet-symbol --symbols --cache-directory c:\temp\symcache --server-path https://symweb --output c:\temp\symout System.Threading.dll
+    dotnet-symbol --symbols --cache-directory c:\temp\symcache --server-path https://msdl.microsoft.com/download/symbols --output c:\temp\symout System.Threading.dll
 
 Downloads all the symbol files for the shared runtime:
 

--- a/src/tests/DbgShim.UnitTests/LibraryProviderWrapper.cs
+++ b/src/tests/DbgShim.UnitTests/LibraryProviderWrapper.cs
@@ -482,7 +482,7 @@ namespace SOS.Hosting
                 if (_symbolService is null)
                 {
                     _symbolService = new SymbolService(this);
-                    _symbolService.AddSymbolServer(msdl: true, symweb: false, timeoutInMinutes: 6, retryCount: 5);
+                    _symbolService.AddSymbolServer(timeoutInMinutes: 6, retryCount: 5);
                     _symbolService.AddCachePath(SymbolService.DefaultSymbolCache);
                 }
                 return _symbolService;

--- a/src/tests/Microsoft.Diagnostics.DebugServices.UnitTests/SymbolServiceTests.cs
+++ b/src/tests/Microsoft.Diagnostics.DebugServices.UnitTests/SymbolServiceTests.cs
@@ -55,8 +55,8 @@ namespace Microsoft.Diagnostics.DebugServices.UnitTests
             Assert.Equal(defaultPath, symbolService.FormatSymbolStores());
             symbolService.DisableSymbolStore();
 
-            Assert.True(symbolService.ParseSymbolPath($"srv*{localSymbolCache}*{SymbolService.SymwebSymbolServer}"));
-            string testpath1 = $"Cache: {localSymbolCache} Server: {SymbolService.SymwebSymbolServer}";
+            Assert.True(symbolService.ParseSymbolPath($"srv*{localSymbolCache}*https://symweb/"));
+            string testpath1 = $"Cache: {localSymbolCache} Server: https://symweb/";
             Assert.Equal(testpath1, symbolService.FormatSymbolStores());
             symbolService.DisableSymbolStore();
 

--- a/src/tests/Microsoft.SymbolStore.UnitTests/SymbolStoreTests.cs
+++ b/src/tests/Microsoft.SymbolStore.UnitTests/SymbolStoreTests.cs
@@ -97,34 +97,18 @@ namespace Microsoft.SymbolStore.Tests
             {
                 using (Stream compareStream = File.OpenRead("TestBinaries/dir1/System.Threading.Thread.pdb"))
                 {
-                    await DownloadFile(downloadStream, compareStream, ms: true, mi: false, KeyTypeFlags.SymbolKey);
+                    await DownloadFile(downloadStream, compareStream, flags: KeyTypeFlags.SymbolKey);
                 }
             }
         }
 
-        [Fact]
-        public async Task SymwebHttpSymbolStore()
-        {
-            using (FileStream downloadStream = File.OpenRead("TestBinaries/dir2/System.Threading.Thread.dll"))
-            {
-                await DownloadFile(downloadStream, downloadStream, ms: false, mi: true, KeyTypeFlags.IdentityKey);
-            }
-        }
-
-        private async Task DownloadFile(FileStream downloadStream, Stream compareStream, bool ms, bool mi, KeyTypeFlags flags)
+        private async Task DownloadFile(FileStream downloadStream, Stream compareStream, KeyTypeFlags flags)
         {
             SymbolStoreFile file = new SymbolStoreFile(downloadStream, downloadStream.Name);
-            SymbolStores.SymbolStore store = null;
-            if (ms)
-            {
-                Uri.TryCreate("https://msdl.microsoft.com/download/symbols/", UriKind.Absolute, out Uri uri);
-                store = new HttpSymbolStore(_tracer, store, uri);
-            }
-            if (mi)
-            {
-                Uri.TryCreate("https://symweb/", UriKind.Absolute, out Uri uri);
-                store = new SymwebHttpSymbolStore(_tracer, store, uri);
-            }
+
+            Uri.TryCreate("https://msdl.microsoft.com/download/symbols/", UriKind.Absolute, out Uri uri);
+            SymbolStores.SymbolStore store = new HttpSymbolStore(_tracer, backingStore: null, uri);
+
             var generator = new FileKeyGenerator(_tracer, file);
 
             IEnumerable<SymbolStoreKey> keys = generator.GetKeys(flags);


### PR DESCRIPTION
Removes the dotnet-symbol --internal-server option. Use the --authenticated-server-path option instead.

Removes the internal server/symweb options from the setsymbolserver command and ISymbolService interface.