### PR TITLE
Fix `pathto` SOS command.

### DIFF
--- a/src/Microsoft.Diagnostics.ExtensionCommands/PathToCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/PathToCommand.cs
@@ -21,14 +21,14 @@ namespace Microsoft.Diagnostics.ExtensionCommands
 
         public override void Invoke()
         {
-            if (TryParseAddress(SourceAddress, out ulong source))
+            if (!TryParseAddress(SourceAddress, out ulong source))
             {
                 throw new ArgumentException($"Could not parse argument 'source': {source}");
             }
 
-            if (TryParseAddress(TargetAddress, out ulong target))
+            if (!TryParseAddress(TargetAddress, out ulong target))
             {
-                throw new ArgumentException($"Could not parse argument 'source': {target}");
+                throw new ArgumentException($"Could not parse argument 'target': {target}");
             }
 
             ClrHeap heap = Runtime.Heap;


### PR DESCRIPTION
Fix `pathto` SOS command arguments parsing logic.

Current status:
```
> pathto 0x1234
ERROR: Could not parse argument 'source': 4660
> pathto 0x4444
ERROR: Could not parse argument 'source': 17476
```
With this changes:
```
> pathto 0x003f1d1182d8
ERROR: Could not parse argument 'target': 0
> pathto 0x003f1d1182d8 0x003f1d1182d8
ERROR: Object reference not set to an instance of an object.
> pathto 0x003f1d1182d8 0x003b7180bfc0
Could not find a path from 3f1d1182d8 to 3b7180bfc0
```

CC @clamp03 @wscho77 @HJLeee @gbalykov