### PR TITLE
Change SOS breaking change from warning to error; better dotnet-dump target errors

### DIFF
--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -2870,7 +2870,10 @@ DECLARE_API(PrintException)
         return E_INVALIDARG;
     }
 
-    CheckBreakingRuntimeChange();
+    if (CheckBreakingRuntimeChange())
+    {
+        return E_FAIL;
+    }
 
     if (bLineNumbers)
     {
@@ -4780,8 +4783,10 @@ DECLARE_API(Threads)
 
             if (bSupported)
             {
-                CheckBreakingRuntimeChange();
-
+                if (CheckBreakingRuntimeChange())
+                {
+                    return E_FAIL;
+                }
                 HRESULT Status2 = PrintSpecialThreads();
                 if (!SUCCEEDED(Status2))
                     Status = Status2;
@@ -7429,7 +7434,11 @@ DECLARE_API(DumpLog)
         return E_FAIL;
     }
 
-    CheckBreakingRuntimeChange();
+    if (CheckBreakingRuntimeChange())
+    {
+        return E_FAIL;
+    }
+
     LoadRuntimeSymbols();
 
     const char* fileName = "StressLog.txt";

--- a/src/SOS/Strike/util.cpp
+++ b/src/SOS/Strike/util.cpp
@@ -3391,9 +3391,9 @@ bool CheckBreakingRuntimeChange(int* pVersion)
             {
                 if (version > SOS_BREAKING_CHANGE_VERSION)
                 {
-                    ExtWarn("WARNING: SOS needs to be upgraded for this version of the runtime. Some commands may not work correctly.\n");
-                    ExtWarn("For more information see https://go.microsoft.com/fwlink/?linkid=2135652\n");
-                    ExtWarn("\n");
+                    ExtErr("SOS needs to be upgraded for this version of the runtime. Some commands may not work correctly.\n");
+                    ExtErr("For more information see https://go.microsoft.com/fwlink/?linkid=2135652\n");
+                    ExtErr("\n");
                     result = true;
                 }
             }

--- a/src/Tools/dotnet-dump/Analyzer.cs
+++ b/src/Tools/dotnet-dump/Analyzer.cs
@@ -118,11 +118,11 @@ namespace Microsoft.Diagnostics.Tools.Dump
                 OSPlatform targetPlatform = dataTarget.DataReader.TargetPlatform;
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && (targetPlatform != OSPlatform.OSX))
                 {
-                    throw new NotSupportedException("Windows or Linux dumps not supported on MacOS");
+                    throw new NotSupportedException("Analyzing Windows or Linux dumps not supported when running on MacOS");
                 }
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && (targetPlatform != OSPlatform.Linux))
                 {
-                    throw new NotSupportedException("Windows or MacOS dumps not supported on Linux");
+                    throw new NotSupportedException("Analyzing Windows or MacOS dumps not supported when running on Linux");
                 }
                 TargetFromDataReader target = new(dataTarget.DataReader, targetPlatform, this, _targetIdFactory++, dump_path.FullName);
                 contextService.SetCurrentTarget(target);

--- a/src/Tools/dotnet-dump/Analyzer.cs
+++ b/src/Tools/dotnet-dump/Analyzer.cs
@@ -115,13 +115,14 @@ namespace Microsoft.Diagnostics.Tools.Dump
             try
             {
                 using DataTarget dataTarget = DataTarget.LoadDump(dump_path.FullName);
-
                 OSPlatform targetPlatform = dataTarget.DataReader.TargetPlatform;
-                if (targetPlatform != OSPlatform.OSX &&
-                    (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ||
-                     dataTarget.DataReader.EnumerateModules().Any((module) => Path.GetExtension(module.FileName) == ".dylib")))
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && (targetPlatform != OSPlatform.OSX))
                 {
-                    targetPlatform = OSPlatform.OSX;
+                    throw new NotSupportedException("Windows or Linux dumps not supported on MacOS");
+                }
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && (targetPlatform != OSPlatform.Linux))
+                {
+                    throw new NotSupportedException("Windows or MacOS dumps not supported on Linux");
                 }
                 TargetFromDataReader target = new(dataTarget.DataReader, targetPlatform, this, _targetIdFactory++, dump_path.FullName);
                 contextService.SetCurrentTarget(target);


### PR DESCRIPTION
* Change DAC breaking change behavior from warning to error.

* Better dotnet-dump analyze error message for cross OS dumps.  Don't allow Linux and Windows dumps when running on MacOS; don't allow OSX and Windows dumps when running on Linux.