### PR TITLE
Fix build issue with clang18

### DIFF
--- a/eng/native/configurecompiler.cmake
+++ b/eng/native/configurecompiler.cmake
@@ -549,6 +549,11 @@ if (CLR_CMAKE_HOST_UNIX)
     add_compile_options(-Wimplicit-fallthrough)
   endif()
 
+  # VLAs are non standard in C++, aren't available on Windows and
+  # are a warning by default since clang 18.
+  # For consistency, enable warnings for all compiler versions.
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wvla>)
+
   #These seem to indicate real issues
   add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-invalid-offsetof>)
 
@@ -591,6 +596,9 @@ if (CLR_CMAKE_HOST_UNIX)
     # other clang 16.0 suppressions
     add_compile_options(-Wno-single-bit-bitfield-constant-conversion)
     add_compile_options(-Wno-cast-function-type-strict)
+
+    # clang 18.1 supressions
+    add_compile_options(-Wno-switch-default)
   else()
     add_compile_options(-Wno-uninitialized)
     add_compile_options(-Wno-strict-aliasing)

--- a/src/shared/minipal/getexepath.h
+++ b/src/shared/minipal/getexepath.h
@@ -37,7 +37,7 @@ static inline char* minipal_getexepath(void)
         return NULL;
     }
 
-    char path_buf[path_length];
+    char* path_buf = (char*)alloca(path_length);
     if (_NSGetExecutablePath(path_buf, &path_length) != 0)
     {
         errno = EINVAL;

--- a/src/shared/pal/src/file/path.cpp
+++ b/src/shared/pal/src/file/path.cpp
@@ -401,8 +401,8 @@ GetTempPathW(
         return 0;
     }
 
-    char TempBuffer[nBufferLength > 0 ? nBufferLength : 1];
-    DWORD dwRetVal = GetTempPathA( nBufferLength, TempBuffer );
+    char* tempBuffer = (char*)alloca(nBufferLength > 0 ? nBufferLength : 1);
+    DWORD dwRetVal = GetTempPathA( nBufferLength, tempBuffer );
 
     if ( dwRetVal >= nBufferLength )
     {
@@ -413,7 +413,7 @@ GetTempPathW(
     else if ( dwRetVal != 0 )
     {
         /* Convert to wide. */
-        if ( 0 == MultiByteToWideChar( CP_ACP, 0, TempBuffer, -1,
+        if ( 0 == MultiByteToWideChar( CP_ACP, 0, tempBuffer, -1,
                                        lpBuffer, dwRetVal + 1 ) )
         {
             ASSERT( "An error occurred while converting the string to wide.\n" );

--- a/src/shared/pal/src/include/pal/palinternal.h
+++ b/src/shared/pal/src/include/pal/palinternal.h
@@ -431,6 +431,7 @@ function_name() to call the system's implementation
 #undef va_start
 #undef va_end
 #undef va_copy
+#undef va_arg
 #undef stdin
 #undef stdout
 #undef stderr


### PR DESCRIPTION
Clang 18 introduced some changes that prevent building CoreCLR:

The warning for VLAs being a C++ extension is now on by default which causes errors with -Werror. https://github.com/llvm/llvm-project/issues/62836
stdarg.h now has a guard that depends on va_arg not being defined, currently the PAL internal doesn't undefined that macro (despite PAL defining it) which prevent stdarg.h from being included again and causes missing symbols (va_start, va_end, va_arg).
This PR fixes the warning by disabling it to match the behaviour of previous clang versions and undefines va_arg in palinternal.h.

Related PR : https://github.com/dotnet/runtime/pull/94782