### PR TITLE
Update SOS breaking change version for Exception's _stackTrace changes in .NET 9

### DIFF
--- a/src/shared/inc/sospriv.idl
+++ b/src/shared/inc/sospriv.idl
@@ -444,7 +444,7 @@ interface ISOSDacInterface8 : IUnknown
 // Increment anytime there is a change in the data structures that SOS depends on like
 // stress log structs (StressMsg, StressLogChunck, ThreadStressLog, etc), exception
 // stack traces (StackTraceElement), the PredefinedTlsSlots enums, etc.
-cpp_quote("#define SOS_BREAKING_CHANGE_VERSION 4")
+cpp_quote("#define SOS_BREAKING_CHANGE_VERSION 5")
 
 [
     object,

--- a/src/shared/pal/prebuilt/inc/sospriv.h
+++ b/src/shared/pal/prebuilt/inc/sospriv.h
@@ -2802,7 +2802,7 @@ EXTERN_C const IID IID_ISOSDacInterface8;
 /* interface __MIDL_itf_sospriv_0000_0012 */
 /* [local] */
 
-#define SOS_BREAKING_CHANGE_VERSION 4
+#define SOS_BREAKING_CHANGE_VERSION 5
 
 
 extern RPC_IF_HANDLE __MIDL_itf_sospriv_0000_0012_v0_0_c_ifspec;


### PR DESCRIPTION
/cc: @janvorli 