### PR TITLE
Add collocation option by default for manifest generation and improve error detection and logging

### DIFF
--- a/src/Microsoft.SymbolManifestGenerator/Microsoft.SymbolManifestGenerator.csproj
+++ b/src/Microsoft.SymbolManifestGenerator/Microsoft.SymbolManifestGenerator.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <NoWarn>$(NoWarn);CA1852</NoWarn>
     <IsPackable>true</IsPackable>
     <IsShipping>false</IsShipping>

--- a/src/Microsoft.SymbolManifestGenerator/SymbolManifestGenerator.cs
+++ b/src/Microsoft.SymbolManifestGenerator/SymbolManifestGenerator.cs
@@ -20,8 +20,6 @@ public static class SymbolManifestGenerator
     {
         ManifestDataV1 manifestData = new();
 
-        Dictionary<string, List<SymbolStoreKey>> directoriesWithRuntimes = new();
-
         FileInfo[] allFiles = dir.GetFiles("*", SearchOption.AllDirectories);
         foreach (FileInfo file in allFiles)
         {

--- a/src/Microsoft.SymbolManifestGenerator/SymbolManifestGenerator.cs
+++ b/src/Microsoft.SymbolManifestGenerator/SymbolManifestGenerator.cs
@@ -10,110 +10,109 @@ using System.Text.Json.Serialization;
 using Microsoft.SymbolStore;
 using Microsoft.SymbolStore.KeyGenerators;
 
-namespace Microsoft.SymbolManifestGenerator
+namespace Microsoft.SymbolManifestGenerator;
+
+public static class SymbolManifestGenerator
 {
-    public static class SymbolManifestGenerator
+    private const int Private = 340;
+
+    public static void GenerateManifest(ITracer tracer, DirectoryInfo dir, string manifestFileName)
     {
-        private const int Private = 340;
+        ManifestDataV1 manifestData = new();
 
-        public static void GenerateManifest(ITracer tracer, DirectoryInfo dir, string manifestFileName)
+        FileInfo[] allFiles = dir.GetFiles("*", SearchOption.AllDirectories);
+        foreach (FileInfo file in allFiles)
         {
-            ManifestDataV1 manifestData = new();
-
-            FileInfo[] allFiles = dir.GetFiles("*", SearchOption.AllDirectories);
-            foreach (FileInfo file in allFiles)
+            using FileStream fileStream = file.OpenRead();
+            SymbolStoreFile symbolStoreFile = new(fileStream, file.FullName);
+            FileKeyGenerator generator = new(tracer, symbolStoreFile);
+            if (!generator.IsValid())
             {
-                using FileStream fileStream = file.OpenRead();
-                SymbolStoreFile symbolStoreFile = new(fileStream, file.FullName);
-                FileKeyGenerator generator = new(tracer, symbolStoreFile);
-                if (!generator.IsValid())
+                tracer.Information($"Could not generate a valid FileKeyGenerator from file '{file.FullName}'. Skipping.");
+                continue;
+            }
+
+            foreach (SymbolStoreKey clrKey in generator.GetKeys(KeyTypeFlags.ClrKeys))
+            {
+                FileInfo specialFile = ResolveClrKeyToUniqueFileFromAllFiles(allFiles, clrKey);
+                if (specialFile == null)
                 {
-                    tracer.Information($"Could not generate a valid FileKeyGenerator from file '{file.FullName}'. Skipping.");
+                    tracer.Information($"Known special file '{clrKey.FullPathName}' for runtime module '{file.FullName}' does not exist in directory '{file.DirectoryName}'. Skipping.");
                     continue;
                 }
 
-                foreach (SymbolStoreKey clrKey in generator.GetKeys(KeyTypeFlags.ClrKeys))
+                string basedirRelativePath = specialFile.FullName.Replace(dir.FullName, string.Empty).TrimStart(Path.DirectorySeparatorChar);
+                string fileHash = CalculateSHA512(specialFile);
+
+                ManifestDataEntry manifestDataEntry = new()
                 {
-                    FileInfo specialFile = ResolveClrKeyToUniqueFileFromAllFiles(allFiles, clrKey);
-                    if (specialFile == null)
-                    {
-                        tracer.Information($"Known special file '{clrKey.FullPathName}' for runtime module '{file.FullName}' does not exist in directory '{file.DirectoryName}'. Skipping.");
-                        continue;
-                    }
+                    BasedirRelativePath = basedirRelativePath,
+                    SymbolKey = clrKey.Index,
+                    Sha512 = fileHash,
+                    DebugInformationLevel = Private,
+                    LegacyDebugInformationLevel = Private
+                };
 
-                    string basedirRelativePath = specialFile.FullName.Replace(dir.FullName, string.Empty).TrimStart(Path.DirectorySeparatorChar);
-                    string fileHash = CalculateSHA512(specialFile);
-
-                    ManifestDataEntry manifestDataEntry = new()
-                    {
-                        BasedirRelativePath = basedirRelativePath,
-                        SymbolKey = clrKey.Index,
-                        Sha512 = fileHash,
-                        DebugInformationLevel = Private,
-                        LegacyDebugInformationLevel = Private
-                    };
-
-                    manifestData.Entries.Add(manifestDataEntry);
-                }
-            }
-
-            JsonSerializerOptions serializeOptions = new()
-            {
-                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                WriteIndented = true
-            };
-            string manifestDataContent = JsonSerializer.Serialize(manifestData, serializeOptions);
-            File.WriteAllText(manifestFileName, manifestDataContent);
-        }
-
-        // Special files associated with a particular runtime module have not been guaranteed to be in the same directory as the runtime module.
-        // As such, the directory for which a manifest is being generated must guarantee that at most one file exists with the same name as the special file.
-        private static FileInfo ResolveClrKeyToUniqueFileFromAllFiles(FileInfo[] allFiles, SymbolStoreKey clrKey)
-        {
-            string clrKeyFileName = Path.GetFileName(clrKey.FullPathName);
-
-            FileInfo matchingSymbolFileOnDisk = allFiles.SingleOrDefault(file => FileHasClrKeyFileName(file, clrKeyFileName));
-
-            return matchingSymbolFileOnDisk;
-
-            static bool FileHasClrKeyFileName(FileInfo file, string clrKeyFileName)
-            {
-                return file.Name.Equals(clrKeyFileName, StringComparison.OrdinalIgnoreCase);
+                manifestData.Entries.Add(manifestDataEntry);
             }
         }
 
-        private static string CalculateSHA512(FileInfo file)
+        JsonSerializerOptions serializeOptions = new()
         {
-            using FileStream fileReadStream = file.OpenRead();
-            using System.Security.Cryptography.SHA512 sha = System.Security.Cryptography.SHA512.Create();
-            byte[] hashValueBytes = sha.ComputeHash(fileReadStream);
-            return BitConverter.ToString(hashValueBytes).Replace("-", "");
-        }
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = true
+        };
+        string manifestDataContent = JsonSerializer.Serialize(manifestData, serializeOptions);
+        File.WriteAllText(manifestFileName, manifestDataContent);
+    }
 
-        private class ManifestFileVersion
+    // Special files associated with a particular runtime module have not been guaranteed to be in the same directory as the runtime module.
+    // As such, the directory for which a manifest is being generated must guarantee that at most one file exists with the same name as the special file.
+    private static FileInfo ResolveClrKeyToUniqueFileFromAllFiles(FileInfo[] allFiles, SymbolStoreKey clrKey)
+    {
+        string clrKeyFileName = Path.GetFileName(clrKey.FullPathName);
+
+        FileInfo matchingSymbolFileOnDisk = allFiles.SingleOrDefault(file => FileHasClrKeyFileName(file, clrKeyFileName));
+
+        return matchingSymbolFileOnDisk;
+
+        static bool FileHasClrKeyFileName(FileInfo file, string clrKeyFileName)
         {
-            public string Version { get; set; }
+            return file.Name.Equals(clrKeyFileName, StringComparison.OrdinalIgnoreCase);
         }
+    }
 
-        private class ManifestDataV1 : ManifestFileVersion
+    private static string CalculateSHA512(FileInfo file)
+    {
+        using FileStream fileReadStream = file.OpenRead();
+        using System.Security.Cryptography.SHA512 sha = System.Security.Cryptography.SHA512.Create();
+        byte[] hashValueBytes = sha.ComputeHash(fileReadStream);
+        return BitConverter.ToString(hashValueBytes).Replace("-", "");
+    }
+
+    private class ManifestFileVersion
+    {
+        public string Version { get; set; }
+    }
+
+    private class ManifestDataV1 : ManifestFileVersion
+    {
+        public List<ManifestDataEntry> Entries { get; set; }
+
+        public ManifestDataV1()
         {
-            public List<ManifestDataEntry> Entries { get; set; }
-
-            public ManifestDataV1()
-            {
-                Version = "1";
-                Entries = new List<ManifestDataEntry>();
-            }
+            Version = "1";
+            Entries = new List<ManifestDataEntry>();
         }
+    }
 
-        private class ManifestDataEntry
-        {
-            public string BasedirRelativePath { get; set; }
-            public string SymbolKey { get; set; }
-            public string Sha512 { get; set; }
-            public int DebugInformationLevel { get; set; }
-            [JsonPropertyName("DebugInformationLevel")]
-            public int LegacyDebugInformationLevel { get; set; }
-        }
+    private class ManifestDataEntry
+    {
+        public string BasedirRelativePath { get; set; }
+        public string SymbolKey { get; set; }
+        public string Sha512 { get; set; }
+        public int DebugInformationLevel { get; set; }
+        [JsonPropertyName("DebugInformationLevel")]
+        public int LegacyDebugInformationLevel { get; set; }
     }
 }


### PR DESCRIPTION
- Change signature of `GenerateManifest` to return success or failure and take a parameter requesting manifest generation to consider only special indexes for files collocated to runtime modules.
- Improved detection of layouts we can't handle: multiple runtimes where special files can't be unambiguously correlated.
- Improved logging on error cases.