### PR TITLE
dotnet-trace: don't fail if the trace file has no method calls

### DIFF
--- a/src/Tools/dotnet-trace/CommandLine/PrintReportHelper.cs
+++ b/src/Tools/dotnet-trace/CommandLine/PrintReportHelper.cs
@@ -96,6 +96,11 @@ namespace Microsoft.Diagnostics.Tools.Trace.CommandLine
             }
 
             int n = nodesToReport.Count;
+            if (n == 0) {
+                Console.Error.WriteLine("[WARNING] No method calls found");
+                return;
+            }
+
             int maxDigit = (int)Math.Log10(n) + 1;
             string extra = new(' ', maxDigit - 1);
 

--- a/src/Tools/dotnet-trace/CommandLine/PrintReportHelper.cs
+++ b/src/Tools/dotnet-trace/CommandLine/PrintReportHelper.cs
@@ -96,7 +96,8 @@ namespace Microsoft.Diagnostics.Tools.Trace.CommandLine
             }
 
             int n = nodesToReport.Count;
-            if (n == 0) {
+            if (n == 0)
+            {
                 Console.Error.WriteLine("[WARNING] No method calls found");
                 return;
             }


### PR DESCRIPTION
Before:

```
> dotnet-trace report dotnet_tracing_20240802_082746.nettrace topN -n 10
[ERROR] System.OverflowException: Arithmetic operation resulted in an overflow.
   at Microsoft.Diagnostics.Tools.Trace.CommandLine.PrintReportHelper.TopNWriteToStdOut(List`1 nodesToReport, Boolean isInclusive, Boolean isVerbose) in /_/src/Tools/dotnet-trace/CommandLine/PrintReportHelper.cs:line 99
   at Microsoft.Diagnostics.Tools.Trace.ReportCommandHandler.TopNReport(CancellationToken ct, IConsole console, String traceFile, Int32 number, Boolean inclusive, Boolean verbose) in /_/src/Tools/dotnet-trace/CommandLine/Commands/ReportCommand.cs:line 93
```

After:

```
> /home/gukov/diagnostics/artifacts/bin/dotnet-trace/Debug/net6.0/dotnet-trace report dotnet_tracing_20240802_082746.nettrace topN -n 10 -v
[WARNING] No method calls found
```

(written to stderr)

