### PR TITLE
Add cloud symweb support

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -27,6 +27,7 @@
   <PropertyGroup>
     <!-- Opt-in/out repo features -->
     <UsingToolXliff>false</UsingToolXliff>
+    <AzureIdentityVersion>1.11.4</AzureIdentityVersion>
     <!-- Uncomment this line to use the custom version of roslyn as needed. -->
     <!-- <UsingToolMicrosoftNetCompilers Condition="'$(DotNetBuildSourceOnly)' != 'true'">true</UsingToolMicrosoftNetCompilers> -->
     <!-- CoreFX -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -27,7 +27,7 @@
   <PropertyGroup>
     <!-- Opt-in/out repo features -->
     <UsingToolXliff>false</UsingToolXliff>
-    <AzureIdentityVersion>1.11.4</AzureIdentityVersion>
+    <AzureIdentityVersion>1.12.0</AzureIdentityVersion>
     <!-- Uncomment this line to use the custom version of roslyn as needed. -->
     <!-- <UsingToolMicrosoftNetCompilers Condition="'$(DotNetBuildSourceOnly)' != 'true'">true</UsingToolMicrosoftNetCompilers> -->
     <!-- CoreFX -->
@@ -49,6 +49,7 @@
     <SystemBuffersVersion>4.5.1</SystemBuffersVersion>
     <SystemMemoryVersion>4.5.5</SystemMemoryVersion>
     <SystemRuntimeLoaderVersion>4.3.0</SystemRuntimeLoaderVersion>
+    <SystemThreadingTasksExtensionsVersion>4.5.4</SystemThreadingTasksExtensionsVersion>
     <SystemTextEncodingsWebVersion>8.0.0</SystemTextEncodingsWebVersion>
     <SystemTextJsonVersion>8.0.4</SystemTextJsonVersion>
     <XUnitAbstractionsVersion>2.0.3</XUnitAbstractionsVersion>

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/Microsoft.Diagnostics.DebugServices.Implementation.csproj
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/Microsoft.Diagnostics.DebugServices.Implementation.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
     <PackageReference Include="System.Runtime.Loader" Version="$(SystemRuntimeLoaderVersion)" />
     <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="$(SystemThreadingTasksExtensionsVersion)" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/SymbolService.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/SymbolService.cs
@@ -257,11 +257,15 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
             int? retryCount = null)
         {
             TokenCredential tokenCredential = new DefaultAzureCredential(includeInteractiveCredentials);
+            AccessToken accessToken;
             async ValueTask<AuthenticationHeaderValue> authenticationFunc(CancellationToken token)
             {
                 try
                 {
-                    AccessToken accessToken = await tokenCredential.GetTokenAsync(new TokenRequestContext(["api://af9e1c69-e5e9-4331-8cc5-cdf93d57bafa/.default"]), token).ConfigureAwait(false);
+                    if (accessToken.ExpiresOn <= DateTimeOffset.UtcNow.AddMinutes(2))
+                    {
+                        accessToken = await tokenCredential.GetTokenAsync(new TokenRequestContext(["api://af9e1c69-e5e9-4331-8cc5-cdf93d57bafa/.default"]), token).ConfigureAwait(false);
+                    }
                     return new AuthenticationHeaderValue("Bearer", accessToken.Token);
                 }
                 catch (Exception ex) when (ex is CredentialUnavailableException or AuthenticationFailedException)

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/SymbolService.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/SymbolService.cs
@@ -7,11 +7,15 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Net.Http.Headers;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Identity;
 using Microsoft.FileFormats;
 using Microsoft.FileFormats.ELF;
 using Microsoft.FileFormats.MachO;
@@ -32,6 +36,9 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
         /// Symbol server URLs
         /// </summary>
         public const string MsdlSymbolServer = "https://msdl.microsoft.com/download/symbols/";
+        public const string SymwebSymbolServer = "https://symweb.azurefd.net/";
+
+        private static string _symwebHost = new Uri(SymwebSymbolServer).Host;
 
         private readonly IHost _host;
         private string _defaultSymbolCache;
@@ -207,9 +214,20 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
                     }
                     if (symbolServerPath != null)
                     {
-                        if (!AddSymbolServer(symbolServerPath: symbolServerPath.Trim()))
+                        symbolServerPath = symbolServerPath.Trim();
+                        if (IsSymweb(symbolServerPath))
                         {
-                            return false;
+                            if (!AddSymwebSymbolServer(includeInteractiveCredentials: false))
+                            {
+                                return false;
+                            }
+                        }
+                        else
+                        {
+                            if (!AddSymbolServer(symbolServerPath))
+                            {
+                                return false;
+                            }
                         }
                     }
                     foreach (string symbolCachePath in symbolCachePaths.Reverse<string>())
@@ -227,18 +245,84 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
         }
 
         /// <summary>
+        /// Add the cloud symweb symbol server with authentication.
+        /// </summary>
+        /// <param name="includeInteractiveCredentials">specifies whether credentials requiring user interaction will be included in the default authentication flow</param>
+        /// <param name="timeoutInMinutes">symbol server timeout in minutes (optional uses <see cref="DefaultTimeout"/> if null)</param>
+        /// <param name="retryCount">number of retries (optional uses <see cref="DefaultRetryCount"/> if null)</param>
+        /// <returns>if false, failure</returns>
+        public bool AddSymwebSymbolServer(
+            bool includeInteractiveCredentials = false,
+            int? timeoutInMinutes = null,
+            int? retryCount = null)
+        {
+            TokenCredential tokenCredential = new DefaultAzureCredential(includeInteractiveCredentials);
+            async Task<AuthenticationHeaderValue> authenticationFunc(CancellationToken token)
+            {
+                try
+                {
+                    AccessToken accessToken = await tokenCredential.GetTokenAsync(new TokenRequestContext(["api://af9e1c69-e5e9-4331-8cc5-cdf93d57bafa/.default"]), token).ConfigureAwait(false);
+                    return new AuthenticationHeaderValue("Bearer", accessToken.Token);
+                }
+                catch (Exception ex) when (ex is CredentialUnavailableException or AuthenticationFailedException)
+                {
+                    Trace.TraceError($"AddSymwebSymbolServer: {ex}");
+                    return null;
+                }
+            }
+            return AddSymbolServer(SymwebSymbolServer, timeoutInMinutes, retryCount, authenticationFunc);
+        }
+
+        /// <summary>
+        /// Add symbol server to search path. The server URL can be the cloud symweb.
+        /// </summary>
+        /// <param name="accessToken">PAT or access token</param>
+        /// <param name="symbolServerPath">symbol server url (optional, uses <see cref="DefaultSymbolPath"/> if null)</param>
+        /// <param name="timeoutInMinutes">symbol server timeout in minutes (optional uses <see cref="DefaultTimeout"/> if null)</param>
+        /// <param name="retryCount">number of retries (optional uses <see cref="DefaultRetryCount"/> if null)</param>
+        /// <returns>if false, failure</returns>
+        public bool AddAuthenticatedSymbolServer(
+            string accessToken,
+            string symbolServerPath = null,
+            int? timeoutInMinutes = null,
+            int? retryCount = null)
+        {
+            if (accessToken == null)
+            {
+                throw new ArgumentNullException(nameof(accessToken));
+            }
+            AuthenticationHeaderValue authenticationValue = new("Basic", Convert.ToBase64String(Encoding.ASCII.GetBytes($":{accessToken}")));
+            return AddSymbolServer(symbolServerPath, timeoutInMinutes, retryCount, (token) => Task.FromResult(authenticationValue));
+        }
+
+        /// <summary>
         /// Add symbol server to search path.
         /// </summary>
         /// <param name="symbolServerPath">symbol server url (optional, uses <see cref="DefaultSymbolPath"/> if null)</param>
-        /// <param name="authToken">PAT for secure symbol server (optional)</param>
         /// <param name="timeoutInMinutes">symbol server timeout in minutes (optional uses <see cref="DefaultTimeout"/> if null)</param>
         /// <param name="retryCount">number of retries (optional uses <see cref="DefaultRetryCount"/> if null)</param>
         /// <returns>if false, failure</returns>
         public bool AddSymbolServer(
             string symbolServerPath = null,
-            string authToken = null,
             int? timeoutInMinutes = null,
             int? retryCount = null)
+        {
+            return AddSymbolServer(symbolServerPath, timeoutInMinutes, retryCount, authenticationFunc: null);
+        }
+
+        /// <summary>
+        /// Add symbol server to search path.
+        /// </summary>
+        /// <param name="symbolServerPath">symbol server url (optional, uses <see cref="DefaultSymbolPath"/> if null)</param>
+        /// <param name="timeoutInMinutes">symbol server timeout in minutes (optional uses <see cref="DefaultTimeout"/> if null)</param>
+        /// <param name="retryCount">number of retries (optional uses <see cref="DefaultRetryCount"/> if null)</param>
+        /// <param name="authenticationFunc">function that returns the authentication value for a request</param>
+        /// <returns>if false, failure</returns>
+        public bool AddSymbolServer(
+            string symbolServerPath,
+            int? timeoutInMinutes,
+            int? retryCount,
+            Func<CancellationToken, Task<AuthenticationHeaderValue>> authenticationFunc)
         {
             // Add symbol server URL if exists
             symbolServerPath ??= DefaultSymbolPath;
@@ -260,9 +344,11 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
                 if (!IsDuplicateSymbolStore<HttpSymbolStore>(store, (httpSymbolStore) => uri.Equals(httpSymbolStore.Uri)))
                 {
                     // Create http symbol server store
-                    HttpSymbolStore httpSymbolStore = new(Tracer.Instance, store, uri, personalAccessToken: authToken);
-                    httpSymbolStore.Timeout = TimeSpan.FromMinutes(timeoutInMinutes.GetValueOrDefault(DefaultTimeout));
-                    httpSymbolStore.RetryCount = retryCount.GetValueOrDefault(DefaultRetryCount);
+                    HttpSymbolStore httpSymbolStore = new(Tracer.Instance, store, uri, authenticationFunc)
+                    {
+                        Timeout = TimeSpan.FromMinutes(timeoutInMinutes.GetValueOrDefault(DefaultTimeout)),
+                        RetryCount = retryCount.GetValueOrDefault(DefaultRetryCount)
+                    };
                     SetSymbolStore(httpSymbolStore);
                 }
             }
@@ -951,6 +1037,23 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
                 }
             });
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if cloud symweb server
+        /// </summary>
+        /// <param name="server"></param>
+        private static bool IsSymweb(string server)
+        {
+            try
+            {
+                Uri uri = new(server);
+                return uri.Host.Equals(_symwebHost, StringComparison.OrdinalIgnoreCase);
+            }
+            catch (Exception ex) when (ex is UriFormatException or InvalidOperationException)
+            {
+                return false;
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/SymbolService.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/SymbolService.cs
@@ -257,7 +257,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
             int? retryCount = null)
         {
             TokenCredential tokenCredential = new DefaultAzureCredential(includeInteractiveCredentials);
-            async Task<AuthenticationHeaderValue> authenticationFunc(CancellationToken token)
+            async ValueTask<AuthenticationHeaderValue> authenticationFunc(CancellationToken token)
             {
                 try
                 {
@@ -292,7 +292,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
                 throw new ArgumentNullException(nameof(accessToken));
             }
             AuthenticationHeaderValue authenticationValue = new("Basic", Convert.ToBase64String(Encoding.ASCII.GetBytes($":{accessToken}")));
-            return AddSymbolServer(symbolServerPath, timeoutInMinutes, retryCount, (token) => Task.FromResult(authenticationValue));
+            return AddSymbolServer(symbolServerPath, timeoutInMinutes, retryCount, (_) => new ValueTask<AuthenticationHeaderValue>(authenticationValue));
         }
 
         /// <summary>
@@ -322,7 +322,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
             string symbolServerPath,
             int? timeoutInMinutes,
             int? retryCount,
-            Func<CancellationToken, Task<AuthenticationHeaderValue>> authenticationFunc)
+            Func<CancellationToken, ValueTask<AuthenticationHeaderValue>> authenticationFunc)
         {
             // Add symbol server URL if exists
             symbolServerPath ??= DefaultSymbolPath;

--- a/src/Microsoft.Diagnostics.DebugServices/ISymbolService.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/ISymbolService.cs
@@ -54,14 +54,42 @@ namespace Microsoft.Diagnostics.DebugServices
         bool ParseSymbolPath(string symbolPath);
 
         /// <summary>
+        /// Add the cloud symweb symbol server with authentication.
+        /// </summary>
+        /// <param name="includeInteractiveCredentials">specifies whether credentials requiring user interaction will be included in the default authentication flow</param>
+        /// <param name="timeoutInMinutes">symbol server timeout in minutes (optional uses <see cref="DefaultTimeout"/> if null)</param>
+        /// <param name="retryCount">number of retries (optional uses <see cref="DefaultRetryCount"/> if null)</param>
+        /// <returns>if false, failure</returns>
+        public bool AddSymwebSymbolServer(
+            bool includeInteractiveCredentials = false,
+            int? timeoutInMinutes = null,
+            int? retryCount = null);
+
+        /// <summary>
+        /// Add symbol server to search path with a PAT.
+        /// </summary>
+        /// <param name="accessToken">PAT or access token</param>
+        /// <param name="symbolServerPath">symbol server url (optional, uses <see cref="DefaultSymbolPath"/> if null)</param>
+        /// <param name="timeoutInMinutes">symbol server timeout in minutes (optional uses <see cref="DefaultTimeout"/> if null)</param>
+        /// <param name="retryCount">number of retries (optional uses <see cref="DefaultRetryCount"/> if null)</param>
+        /// <returns>if false, failure</returns>
+        public bool AddAuthenticatedSymbolServer(
+            string accessToken,
+            string symbolServerPath = null,
+            int? timeoutInMinutes = null,
+            int? retryCount = null);
+
+        /// <summary>
         /// Add symbol server to search path.
         /// </summary>
         /// <param name="symbolServerPath">symbol server url (optional, uses <see cref="DefaultSymbolPath"/> if null)</param>
-        /// <param name="authToken">PAT for secure symbol server (optional)</param>
-        /// <param name="timeoutInMinutes">symbol server timeout in minutes (optional, uses <see cref="DefaultTimeout"/> if null)</param>
-        /// <param name="retryCount">number of retries (optional, uses <see cref="DefaultRetryCount"/> if null)</param>
+        /// <param name="timeoutInMinutes">symbol server timeout in minutes (optional uses <see cref="DefaultTimeout"/> if null)</param>
+        /// <param name="retryCount">number of retries (optional uses <see cref="DefaultRetryCount"/> if null)</param>
         /// <returns>if false, failure</returns>
-        bool AddSymbolServer(string symbolServerPath = null, string authToken = null, int? timeoutInMinutes = null, int? retryCount = null);
+        public bool AddSymbolServer(
+            string symbolServerPath = null,
+            int? timeoutInMinutes = null,
+            int? retryCount = null);
 
         /// <summary>
         /// Add cache path to symbol search path

--- a/src/Microsoft.SymbolStore/KeyGenerators/PEFileKeyGenerator.cs
+++ b/src/Microsoft.SymbolStore/KeyGenerators/PEFileKeyGenerator.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -61,7 +62,7 @@ namespace Microsoft.SymbolStore.KeyGenerators
                     {
                         pdbs = _peFile.Pdbs.ToArray();
                     }
-                    catch (InvalidVirtualAddressException ex)
+                    catch (Exception ex) when (ex is InvalidVirtualAddressException || ex is BadInputFormatException)
                     {
                         Tracer.Error("Reading PDB records for {0}: {1}", _path, ex.Message);
                     }

--- a/src/Microsoft.SymbolStore/Microsoft.SymbolStore.csproj
+++ b/src/Microsoft.SymbolStore/Microsoft.SymbolStore.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="$(SystemThreadingTasksExtensionsVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.SymbolStore/Microsoft.SymbolStore.csproj
+++ b/src/Microsoft.SymbolStore/Microsoft.SymbolStore.csproj
@@ -15,10 +15,6 @@
 
   <ItemGroup>
     <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
-<!--
-    <PackageReference Condition="'$(TargetFramework)' != 'net462'" Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
-    <PackageReference Condition="'$(TargetFramework)' == 'net462'" Include="System.Reflection.Metadata" Version="1.6.0" />
--->
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.SymbolStore/SymbolStores/HttpSymbolStore.cs
+++ b/src/Microsoft.SymbolStore/SymbolStores/HttpSymbolStore.cs
@@ -16,12 +16,12 @@ using System.Threading.Tasks;
 namespace Microsoft.SymbolStore.SymbolStores
 {
     /// <summary>
-    /// Basic http symbol store. The request can be authentication with a PAT for VSTS symbol stores.
+    /// Basic http symbol store. The request can be authentication with a PAT or bearer token for Azure symbol stores.
     /// </summary>
     public class HttpSymbolStore : SymbolStore
     {
         private readonly HttpClient _client;
-        private readonly HttpClient _authenticatedClient;
+        private readonly Func<CancellationToken, Task<AuthenticationHeaderValue>> _authenticationFunc;
         private bool _clientFailure;
 
         /// <summary>
@@ -41,10 +41,6 @@ namespace Microsoft.SymbolStore.SymbolStores
             set
             {
                 _client.Timeout = value;
-                if (_authenticatedClient != null)
-                {
-                    _authenticatedClient.Timeout = value;
-                }
             }
         }
 
@@ -59,36 +55,25 @@ namespace Microsoft.SymbolStore.SymbolStores
         /// <param name="tracer">logger</param>
         /// <param name="backingStore">next symbol store or null</param>
         /// <param name="symbolServerUri">symbol server url</param>
-        /// <param name="hasPAT">flag to indicate to create an authenticatedClient if there is a PAT</param>
-        private HttpSymbolStore(ITracer tracer, SymbolStore backingStore, Uri symbolServerUri, bool hasPAT)
+        /// <param name="authenticationFunc">function that returns the authentication value for a request</param>
+        public HttpSymbolStore(ITracer tracer, SymbolStore backingStore, Uri symbolServerUri, Func<CancellationToken, Task<AuthenticationHeaderValue>> authenticationFunc)
             : base(tracer, backingStore)
         {
             Uri = symbolServerUri ?? throw new ArgumentNullException(nameof(symbolServerUri));
             if (!symbolServerUri.IsAbsoluteUri || symbolServerUri.IsFile)
             {
-                throw new ArgumentException(nameof(symbolServerUri));
+                throw new ArgumentException(null, nameof(symbolServerUri));
             }
+            _authenticationFunc = authenticationFunc;
 
-            // Normal unauthenticated client
+            // Create client
             _client = new HttpClient
             {
                 Timeout = TimeSpan.FromMinutes(4)
             };
 
-            if (hasPAT)
-            {
-                HttpClientHandler handler = new()
-                {
-                    AllowAutoRedirect = false
-                };
-                HttpClient client = new(handler)
-                {
-                    Timeout = TimeSpan.FromMinutes(4)
-                };
-                client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-                // Authorization is set in associated constructors.
-                _authenticatedClient = client;
-            }
+            // Force redirect logins to fail.
+            _client.DefaultRequestHeaders.Add("X-TFS-FedAuthRedirect", "Suppress");
         }
 
         /// <summary>
@@ -96,16 +81,11 @@ namespace Microsoft.SymbolStore.SymbolStores
         /// </summary>
         /// <param name="tracer">logger</param>
         /// <param name="backingStore">next symbol store or null</param>
-        /// <param name="symbolServerUri">symbol server url</param>
-        /// <param name="personalAccessToken">optional Basic Auth PAT or null if no authentication</param>
-        public HttpSymbolStore(ITracer tracer, SymbolStore backingStore, Uri symbolServerUri, string personalAccessToken = null)
-            : this(tracer, backingStore, symbolServerUri, !string.IsNullOrEmpty(personalAccessToken))
+        /// <param name="symbolServerUri">symbol server url or null</param>
+        /// <param name="accessToken">optional Basic Auth PAT or null if no authentication</param>
+        public HttpSymbolStore(ITracer tracer, SymbolStore backingStore, Uri symbolServerUri, string accessToken = null)
+            : this(tracer, backingStore, symbolServerUri, string.IsNullOrEmpty(accessToken) ? null : GetAuthenticationFunc("Basic", Convert.ToBase64String(Encoding.ASCII.GetBytes($":{accessToken}"))))
         {
-            // If PAT, create authenticated client with Basic Auth
-            if (!string.IsNullOrEmpty(personalAccessToken))
-            {
-                _authenticatedClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(ASCIIEncoding.ASCII.GetBytes(string.Format("{0}:{1}", "", personalAccessToken))));
-            }
         }
 
         /// <summary>
@@ -113,26 +93,26 @@ namespace Microsoft.SymbolStore.SymbolStores
         /// </summary>
         /// <param name="tracer">logger</param>
         /// <param name="backingStore">next symbol store or null</param>
-        /// <param name="symbolServerUri">symbol server url</param>
+        /// <param name="symbolServerUri">symbol server url or null</param>
         /// <param name="scheme">The scheme information to use for the AuthenticationHeaderValue</param>
         /// <param name="parameter">The parameter information to use for the AuthenticationHeaderValue</param>
         public HttpSymbolStore(ITracer tracer, SymbolStore backingStore, Uri symbolServerUri, string scheme, string parameter)
-            : this(tracer, backingStore, symbolServerUri, true)
+            : this(tracer, backingStore, symbolServerUri, GetAuthenticationFunc(scheme, parameter))
         {
             if (string.IsNullOrEmpty(scheme))
             {
                 throw new ArgumentNullException(nameof(scheme));
             }
-
             if (string.IsNullOrEmpty(parameter))
             {
                 throw new ArgumentNullException(nameof(parameter));
             }
+        }
 
-            // Create authenticated header with given SymbolAuthHeader
-            _authenticatedClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(scheme, parameter);
-            // Force redirect logins to fail.
-            _authenticatedClient.DefaultRequestHeaders.Add("X-TFS-FedAuthRedirect", "Suppress");
+        private static Func<CancellationToken, Task<AuthenticationHeaderValue>> GetAuthenticationFunc(string scheme, string parameter)
+        {
+            AuthenticationHeaderValue authenticationValue = new(scheme, parameter);
+            return (_) => Task.FromResult(authenticationValue);
         }
 
         /// <summary>
@@ -149,13 +129,11 @@ namespace Microsoft.SymbolStore.SymbolStores
             Uri uri = GetRequestUri(key.Index);
 
             bool needsChecksumMatch = key.PdbChecksums.Any();
-
             if (needsChecksumMatch)
             {
                 string checksumHeader = string.Join(";", key.PdbChecksums);
-                HttpClient client = _authenticatedClient ?? _client;
                 Tracer.Information($"SymbolChecksum: {checksumHeader}");
-                client.DefaultRequestHeaders.Add("SymbolChecksum", checksumHeader);
+                _client.DefaultRequestHeaders.Add("SymbolChecksum", checksumHeader);
             }
 
             Stream stream = await GetFileStream(key.FullPathName, uri, token).ConfigureAwait(false);
@@ -193,7 +171,6 @@ namespace Microsoft.SymbolStore.SymbolStores
                 return null;
             }
             string fileName = Path.GetFileName(path);
-            HttpClient client = _authenticatedClient ?? _client;
             int retries = 0;
             while (true)
             {
@@ -203,25 +180,19 @@ namespace Microsoft.SymbolStore.SymbolStores
                 {
                     // Can not dispose the response (like via using) on success because then the content stream
                     // is disposed and it is returned by this function.
-                    HttpResponseMessage response = await client.GetAsync(requestUri, token).ConfigureAwait(false);
+                    using HttpRequestMessage request = new(HttpMethod.Get, requestUri);
+                    if (_authenticationFunc is not null)
+                    {
+                        request.Headers.Authorization = await _authenticationFunc(token).ConfigureAwait(false);
+                    }
+                    using HttpResponseMessage response = await _client.SendAsync(request, token).ConfigureAwait(false);
                     if (response.StatusCode == HttpStatusCode.OK)
                     {
-                        return await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
-                    }
-                    if (response.StatusCode == HttpStatusCode.Found)
-                    {
-                        Uri location = response.Headers.Location;
-                        response.Dispose();
-
-                        response = await _client.GetAsync(location, token).ConfigureAwait(false);
-                        if (response.StatusCode == HttpStatusCode.OK)
-                        {
-                            return await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
-                        }
+                        byte[] buffer = await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+                        return new MemoryStream(buffer);
                     }
                     HttpStatusCode statusCode = response.StatusCode;
                     string reasonPhrase = response.ReasonPhrase;
-                    response.Dispose();
 
                     // The GET failed
 
@@ -287,7 +258,6 @@ namespace Microsoft.SymbolStore.SymbolStores
         public override void Dispose()
         {
             _client.Dispose();
-            _authenticatedClient?.Dispose();
             base.Dispose();
         }
 

--- a/src/Tools/dotnet-symbol/Program.cs
+++ b/src/Tools/dotnet-symbol/Program.cs
@@ -5,9 +5,12 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net.Http.Headers;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Identity;
 using Microsoft.Diagnostic.Tools.Symbol.Properties;
 using Microsoft.FileFormats;
 using Microsoft.FileFormats.ELF;
@@ -25,11 +28,13 @@ namespace Microsoft.Diagnostics.Tools.Symbol
         {
             public Uri Uri;
             public string PersonalAccessToken;
+            public bool InternalSymwebServer;
         }
 
         private readonly List<string> InputFilePaths = new();
         private readonly List<string> CacheDirectories = new();
         private readonly List<ServerInfo> SymbolServers = new();
+        private TokenCredential TokenCredential = new DefaultAzureCredential(includeInteractiveCredentials: true);
         private string OutputDirectory;
         private TimeSpan? Timeout;
         private bool Overwrite;
@@ -61,6 +66,11 @@ namespace Microsoft.Diagnostics.Tools.Symbol
                     case "--microsoft-symbol-server":
                         Uri.TryCreate("https://msdl.microsoft.com/download/symbols/", UriKind.Absolute, out uri);
                         program.SymbolServers.Add(new ServerInfo { Uri = uri, PersonalAccessToken = null });
+                        break;
+
+                     case "--internal-server":
+                        Uri.TryCreate("https://symweb.azurefd.net/", UriKind.Absolute, out uri);
+                        program.SymbolServers.Add(new ServerInfo { Uri = uri, PersonalAccessToken = null, InternalSymwebServer = true });
                         break;
 
                     case "--authenticated-server-path":
@@ -256,7 +266,14 @@ namespace Microsoft.Diagnostics.Tools.Symbol
 
             foreach (ServerInfo server in ((IEnumerable<ServerInfo>)SymbolServers).Reverse())
             {
-                store = new HttpSymbolStore(Tracer, store, server.Uri, server.PersonalAccessToken);
+                if (server.InternalSymwebServer)
+                {
+                    store = new HttpSymbolStore(Tracer, store, server.Uri, SymwebAuthenticationFunc);
+                }
+                else
+                {
+                    store = new HttpSymbolStore(Tracer, store, server.Uri, server.PersonalAccessToken);
+                }
                 if (Timeout.HasValue && store is HttpSymbolStore http)
                 {
                     http.Timeout = Timeout.Value;
@@ -275,6 +292,19 @@ namespace Microsoft.Diagnostics.Tools.Symbol
             }
 
             return store;
+        }
+
+        private async Task<AuthenticationHeaderValue> SymwebAuthenticationFunc(CancellationToken token)
+        {
+            try
+            {
+                AccessToken accessToken = await TokenCredential.GetTokenAsync(new TokenRequestContext(["api://af9e1c69-e5e9-4331-8cc5-cdf93d57bafa/.default"]), token).ConfigureAwait(false);
+                return new AuthenticationHeaderValue("Bearer", accessToken.Token);
+            }
+            catch (Exception ex) when (ex is CredentialUnavailableException or AuthenticationFailedException)
+            {
+                return null;
+            }
         }
 
         private sealed class SymbolStoreKeyWrapper

--- a/src/Tools/dotnet-symbol/Program.cs
+++ b/src/Tools/dotnet-symbol/Program.cs
@@ -294,7 +294,7 @@ namespace Microsoft.Diagnostics.Tools.Symbol
             return store;
         }
 
-        private async Task<AuthenticationHeaderValue> SymwebAuthenticationFunc(CancellationToken token)
+        private async ValueTask<AuthenticationHeaderValue> SymwebAuthenticationFunc(CancellationToken token)
         {
             try
             {

--- a/src/Tools/dotnet-symbol/dotnet-symbol.csproj
+++ b/src/Tools/dotnet-symbol/dotnet-symbol.csproj
@@ -14,6 +14,10 @@
       <PrivateAssets>All</PrivateAssets>
     </ProjectReference>
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="$(AzureIdentityVersion)" />
+  </ItemGroup>
   
   <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">


### PR DESCRIPTION
Add back -mi (add symweb symbol server), -nocache and -interface options to setsymbolserver command.

Add back --internal-server support to dotnet-symbol.

Clean up the HttpSymbolStore.cs - fix HttpResponse not being properly disposed. Removed the separate authenticated client instance/var.

Fix dotnet-symbol for some heap dumps. Some didn't have coreclr.dll's debug directory contents. Catch error and continue downloading files.