### PR TITLE
Provide info about PDB container type (MSF vs. MSFZ)

### DIFF
--- a/src/Microsoft.FileFormats/PDB/IMSFFile.cs
+++ b/src/Microsoft.FileFormats/PDB/IMSFFile.cs
@@ -19,5 +19,19 @@ namespace Microsoft.FileFormats.PDB
         /// <param name="stream">The index of the stream. This must be less than NumStreams.</param>
         /// <returns>A Reader which can read the stream.</returns>
         Reader GetStream(uint stream);
+
+        /// <summary>
+        /// Returns the container kind for this implementation.
+        /// </summary>
+        PDBContainerKind ContainerKind { get; }
+
+        /// <summary>
+        /// Returns a string which identifies the container kind, using a backward-compatible naming scheme.
+        /// <summary>
+        /// <para>
+        /// The existing PDB format is identified as "pdb", while PDZ (MSFZ) is identified as "msfz0".
+        /// This allows new versions of MSFZ to be identified and deployed without updating clients of this API.
+        /// </para>
+        public string ContainerKindSpecString { get; }
     }
 }

--- a/src/Microsoft.FileFormats/PDB/MSFFile.cs
+++ b/src/Microsoft.FileFormats/PDB/MSFFile.cs
@@ -67,5 +67,15 @@ namespace Microsoft.FileFormats.PDB
         {
             return _streams[index];
         }
+
+        public PDBContainerKind ContainerKind
+        {
+            get { return PDBContainerKind.MSF; }
+        }
+
+        public string ContainerKindSpecString
+        {
+            get { return "pdb"; }
+        }
     }
 }

--- a/src/Microsoft.FileFormats/PDB/MSFFile.cs
+++ b/src/Microsoft.FileFormats/PDB/MSFFile.cs
@@ -75,7 +75,7 @@ namespace Microsoft.FileFormats.PDB
 
         public string ContainerKindSpecString
         {
-            get { return "pdb"; }
+            get { return "msf"; }
         }
     }
 }

--- a/src/Microsoft.FileFormats/PDB/PDBFile.cs
+++ b/src/Microsoft.FileFormats/PDB/PDBFile.cs
@@ -146,6 +146,34 @@ namespace Microsoft.FileFormats.PDB
             }
             return streamReaders;
         }
+
+        /// <summary>
+        /// Returns the container kind used for this PDB file.
+        /// </summary>
+        public PDBContainerKind ContainerKind
+        {
+            get
+            {
+                CheckValid();
+                return _msfFile.ContainerKind;
+            }
+        }
+
+        /// <summary>
+        /// Returns a string which identifies the container kind, using a backward-compatible naming scheme.
+        /// <summary>
+        /// <para>
+        /// The existing PDB format is identified as "pdb", while PDZ (MSFZ) is identified as "msfz0".
+        /// This allows new versions of MSFZ to be identified and deployed without updating clients of this API.
+        /// </para>
+        public string ContainerKindSpecString
+        {
+            get
+            {
+                CheckValid();
+                return _msfFile.ContainerKindSpecString;
+            }
+        }
     }
 
     /// <summary>
@@ -251,5 +279,21 @@ namespace Microsoft.FileFormats.PDB
         }
 
         public DbiStreamHeader Header { get { _header.Value.IsHeaderValid.CheckThrowing(); return _header.Value; } }
+    }
+
+    /// <summary>
+    /// Specifies the kinds of PDB container formats.
+    /// </summary>
+    public enum PDBContainerKind
+    {
+        /// <summary>
+        /// An uncompressed PDB.
+        /// </summary>
+        MSF,
+
+        /// <summary>
+        /// A compressed PDB, also known as a PDBZ or "PDB using MSFZ container".
+        /// </summary>
+        MSFZ,
     }
 }

--- a/src/tests/Microsoft.FileFormats.UnitTests/PDB/Tests.cs
+++ b/src/tests/Microsoft.FileFormats.UnitTests/PDB/Tests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.FileFormats.PDB.Tests
                 Assert.Equal(Guid.Parse("99891B3E-D7AE-4C3B-ABFF-8A2B4A9B0C43"), pdb.Signature);
 
                 Assert.Equal(PDBContainerKind.MSF, pdb.ContainerKind);
-                Assert.Equal("pdb", pdb.ContainerKindSpecString);
+                Assert.Equal("msf", pdb.ContainerKindSpecString);
 
                 // Also read the PDBI stream directly, using the downlevel API.
 #pragma warning disable CS0618 // Type or member is obsolete

--- a/src/tests/Microsoft.FileFormats.UnitTests/PDB/Tests.cs
+++ b/src/tests/Microsoft.FileFormats.UnitTests/PDB/Tests.cs
@@ -22,6 +22,9 @@ namespace Microsoft.FileFormats.PDB.Tests
                 Assert.Equal((uint)1, pdb.Age);
                 Assert.Equal(Guid.Parse("99891B3E-D7AE-4C3B-ABFF-8A2B4A9B0C43"), pdb.Signature);
 
+                Assert.Equal(PDBContainerKind.MSF, pdb.ContainerKind);
+                Assert.Equal("pdb", pdb.ContainerKindSpecString);
+
                 // Also read the PDBI stream directly, using the downlevel API.
 #pragma warning disable CS0618 // Type or member is obsolete
                 var stream1 = pdb.Streams[1];
@@ -41,6 +44,9 @@ namespace Microsoft.FileFormats.PDB.Tests
                 PDBFile pdb = PDBFile.Open(fileContent);
                 Assert.Equal((uint)1, pdb.Age);
                 Assert.Equal(Guid.Parse("99891B3E-D7AE-4C3B-ABFF-8A2B4A9B0C43"), pdb.Signature);
+
+                Assert.Equal(PDBContainerKind.MSFZ, pdb.ContainerKind);
+                Assert.Equal("msfz0", pdb.ContainerKindSpecString);
 
                 // Also read the PDBI stream directly, using the downlevel API.
 #pragma warning disable CS0618 // Type or member is obsolete


### PR DESCRIPTION
This is a follow-on to my previous PR, #4868 . This allows users of the `PDBFile` class to query for the "kind" of the container that a given PDB file uses.  Normal (uncompressed) PDBs use a container format called "MSF".  Compressed PDBs use a container format called "MSFZ".

This adds two properties to `PDBFile`.  The `ContainerKind` property returns an enum which allows the caller to distinguish between MSF, and MSFZ. This also allows for new container formats (as yet unspecified) in the future.  However, the `ContainerKind` enum intentionally does not distinguish between the version of the container.  For that, the `ContainerKindSpecString` returns a string which contains a textual identifier ("msf" vs. "msfz") and for MSFZ, a version number.  For now, the only version number defined is 0.