### PR TITLE
Update Azure Linux tag name

### DIFF
--- a/eng/pipelines/pipeline-resources.yml
+++ b/eng/pipelines/pipeline-resources.yml
@@ -31,7 +31,7 @@ extends:
           ROOTFS_DIR: /crossrootfs/arm64
 
       linux_musl_x64:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-cross-amd64-alpine-net8.0
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-cross-amd64-alpine
         env:
           ROOTFS_DIR: /crossrootfs/x64
 


### PR DESCRIPTION
Updating the naming scheme for these images, see https://github.com/dotnet/dotnet-buildtools-prereqs-docker/issues/1176.