### PR TITLE
A small fix to preserve thread ids when parallel stack is shared

### DIFF
--- a/src/Microsoft.Diagnostics.ExtensionCommands/ParallelStacks.Runtime/RendererHelpers.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/ParallelStacks.Runtime/RendererHelpers.cs
@@ -29,6 +29,19 @@ namespace ParallelStacks.Runtime
                 return;
             }
 
+            // Sometimes a stack can be shared in a way where some threads top frame is the current frame but there are still frames/threads present in the stack
+            // In this case print the unique thread ids in the current stack frame e.g.
+            // ~~ Thread_T1 - this one is the unique thread id for the current frame
+            //   ~~ Thread_T2
+            //   1 Next_Stack_Frame
+            // 2 Current_Stack_Frame
+            if (stack.Stacks.Count == 1 && stack.Stacks[0].ThreadIds.Count != stack.ThreadIds.Count)
+            {
+                List<uint> uniqueThreads = stack.ThreadIds.Except(stack.Stacks[0].ThreadIds).ToList();
+                visitor.Write($"{Environment.NewLine}{alignment}");
+                visitor.WriteFrameSeparator($" ~~~~ {FormatThreadIdList(visitor, uniqueThreads)}");
+            }
+
             foreach (ParallelStack nextStackFrame in stack.Stacks.OrderBy(s => s.ThreadIds.Count))
             {
                 RenderStack(nextStackFrame, visitor,


### PR DESCRIPTION
Sometimes a stack can be shared in a way where some thread's top frame is the current frame but there are still frames/threads present in the stack
In this case print the unique thread ids in the current stack frame. Otherwise this information is lost:
```
~~ Thread_T1 - unique thread id(s) for the current frame, this thread id is not currently displayed
    ~~ Thread_T2
    1 Next_Stack_Frame
2 Current_Stack_Frame - this is actually a top frame for thread T1
```

Another way would be printing in a slightly different order but it will chop stack a little:
```
    ~~ Thread_T2
    1 Next_Stack_Frame
~~ Thread_T1
2 Current_Stack_Frame
```