### PR TITLE
[Tests] Update GC SegmentEvents validation

### DIFF
--- a/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventLogsPipelineUnitTests.cs
+++ b/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventLogsPipelineUnitTests.cs
@@ -95,14 +95,9 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
         /// <summary>
         /// Test that log events at the default level are collected for categories without a specified level.
         /// </summary>
-        [SkippableTheory(Skip = "Unreliable test https://github.com/dotnet/diagnostics/issues/3143"), MemberData(nameof(Configurations))]
+        [SkippableTheory(Skip = "Unreliable test https://github.com/dotnet/diagnostics/issues/2541"), MemberData(nameof(Configurations))]
         public async Task TestLogsAllCategoriesDefaultLevelFallback(TestConfiguration config)
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                throw new SkipTestException("https://github.com/dotnet/diagnostics/issues/2541");
-            }
-
             using Stream outputStream = await GetLogsAsync(config, settings => {
                 settings.UseAppFilters = false;
                 settings.LogLevel = LogLevel.Error;

--- a/src/tests/eventpipe/GCEvents.cs
+++ b/src/tests/eventpipe/GCEvents.cs
@@ -212,11 +212,6 @@ namespace EventPipe.UnitTests.GCEventsValidation
                     int GCAllocationTickEvents = 0;
                     source.Clr.GCAllocationTick += (eventData) => GCAllocationTickEvents += 1;
 
-                    int GCCreateConcurrentThreadEvents = 0;
-                    int GCTerminateConcurrentThreadEvents = 0;
-                    source.Clr.GCCreateConcurrentThread += (eventData) => GCCreateConcurrentThreadEvents += 1;
-                    source.Clr.GCTerminateConcurrentThread += (eventData) => GCTerminateConcurrentThreadEvents += 1;
-
                     return () => {
                         Logger.logger.Log("Event counts validation");
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/diagnostics/issues/3143

With the new GC introduced in .NET 7, there are no longer any GC segments being freed, so the GCFreeSegment event is no longer fired. As the GCFreeSegment event is [documented](https://github.com/dotnet/docs/blob/main/docs/fundamentals/diagnostics/runtime-garbage-collection-events.md#gcfreesegment_v1-event) to track when a garbage collection segment has been released, and because Perfview does not utilize GCFreeSegment/GCCreateSegment events, it seems more appropriate to adjust expectations for what GC events are fired rather than forcing GCFreeSegment events to fire for "analogous" events.

Moreover, there is a new `CommittedUsage` events that shows GC committed memory and breaks down what the memory is used for. As such, GCFreeSegment/GCCreateSegment is no longer needed.