### PR TITLE
Add support for weak interior pointer GC handles

### DIFF
--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -8887,6 +8887,8 @@ public:
                 mType = HNDTYPE_DEPENDENT;
             else if (_stricmp(type, "WeakWinRT") == 0)
                 mType = HNDTYPE_WEAK_WINRT;
+            else if (_stricmp(type, "WeakInteriorPointer") == 0)
+                mType = HNDTYPE_WEAK_INTERIOR_POINTER;
             else
                 sos::Throw<sos::Exception>("Unknown handle type '%s'.", type.GetPtr());
         }
@@ -9055,6 +9057,10 @@ private:
                     type = "WeakWinRT";
                     if (pStats) pStats->weakWinRTHandleCount++;
                     break;
+                case HNDTYPE_WEAK_INTERIOR_POINTER:
+                    type = "WeakInteriorPointer";
+                    if (pStats) pStats->weakInteriorPointerHandleCount++;
+                    break;
                 default:
                     DebugBreak();
                     type = "Unknown";
@@ -9073,6 +9079,8 @@ private:
                 else if (data[i].Type == HNDTYPE_DEPENDENT)
                     mOut.WriteRow(data[i].Handle, type, ObjectPtr(objAddr), Decimal(size), ObjectPtr(data[i].Secondary), mtName);
                 else if (data[i].Type == HNDTYPE_WEAK_WINRT)
+                    mOut.WriteRow(data[i].Handle, type, ObjectPtr(objAddr), Decimal(size), Pointer(data[i].Secondary), mtName);
+                else if (data[i].Type == HNDTYPE_WEAK_INTERIOR_POINTER)
                     mOut.WriteRow(data[i].Handle, type, ObjectPtr(objAddr), Decimal(size), Pointer(data[i].Secondary), mtName);
                 else
                     mOut.WriteRow(data[i].Handle, type, ObjectPtr(objAddr), Decimal(size), "", mtName);
@@ -9098,6 +9106,7 @@ private:
         PrintHandleRow("Weak Long Handles:", pStats->weakLongHandleCount);
         PrintHandleRow("Weak Short Handles:", pStats->weakShortHandleCount);
         PrintHandleRow("Weak WinRT Handles:", pStats->weakWinRTHandleCount);
+        PrintHandleRow("Weak Interior Pointer Handles:", pStats->weakInteriorPointerHandleCount);
         PrintHandleRow("Variable Handles:", pStats->variableCount);
         PrintHandleRow("SizedRef Handles:", pStats->sizedRefCount);
         PrintHandleRow("Dependent Handles:", pStats->dependentCount);

--- a/src/SOS/Strike/util.h
+++ b/src/SOS/Strike/util.h
@@ -122,6 +122,8 @@ class MethodTable;
 #define HNDTYPE_ASYNCPINNED                     (7)
 #define HNDTYPE_SIZEDREF                        (8)
 #define HNDTYPE_WEAK_WINRT                      (9)
+#define HNDTYPE_WEAK_INTERIOR_POINTER           (10)
+
 
 class BaseObject
 {
@@ -1722,11 +1724,12 @@ struct GCHandleStatistics
     DWORD sizedRefCount;
     DWORD dependentCount;
     DWORD weakWinRTHandleCount;
+    DWORD weakInteriorPointerHandleCount;
     DWORD unknownHandleCount;
     GCHandleStatistics()
         : strongHandleCount(0), pinnedHandleCount(0), asyncPinnedHandleCount(0), refCntHandleCount(0),
           weakLongHandleCount(0), weakShortHandleCount(0), variableCount(0), sizedRefCount(0),
-          dependentCount(0), weakWinRTHandleCount(0), unknownHandleCount(0)
+          dependentCount(0), weakWinRTHandleCount(0), weakInteriorPointerHandleCount(0), unknownHandleCount(0)
     {}
     ~GCHandleStatistics()
     {


### PR DESCRIPTION
.NET 9 adds a new GC handle type which is used in the collectible assemblies implementation. This PR adds support for it.