### PR TITLE
Fix arithmetic overflow when memory dump has too many objects.

### DIFF
--- a/src/Microsoft.Diagnostics.ExtensionCommands/LiveObjectService.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/LiveObjectService.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Diagnostics.ExtensionCommands
                     }
                     else
                     {
-                        Console.WriteLine($"Calculating live objects: {live.Count:n0} found - {(maxCount - todo.Count) * 100 / (float)maxCount:0.0}% complete");
+                        Console.WriteLine($"Calculating live objects: {live.Count:n0} found - {(maxCount - todo.Count) * 100.0f / maxCount:0.0}% complete");
                     }
 
                     maxCount = Math.Max(maxCount, todo.Count);


### PR DESCRIPTION
I have a dump with GiB size, and has more than 200M objects, and encountered arithmetic overflow when run `dumpheap -live -stat`.