### PR TITLE
Update alias for `dumplocks` command

### DIFF
--- a/src/SOS/Strike/sos.def
+++ b/src/SOS/Strike/sos.def
@@ -52,7 +52,7 @@ EXPORTS
     DumpIL
     dumpil=DumpIL
     dumplocks
-    dumplocks=DumpLocks
+    DumpLocks=dumplocks
     DumpLog
     dumplog=DumpLog
     Dumplog=DumpLog


### PR DESCRIPTION
- Sets `DumpLocks` as an alias for `dumplocks`
- Alternatively, `DumpLocks` could be made the main command and `dumplocks` an alias