### PR TITLE
Enable TSA, nuget auditing, and necessary cleanup

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -15,5 +15,9 @@
     <!-- Standard feeds -->
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
   </packageSources>
+  <auditSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </auditSources>
   <disabledPackageSources />
 </configuration>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -28,6 +28,8 @@
     <!-- Opt-in/out repo features -->
     <UsingToolXliff>false</UsingToolXliff>
     <AzureIdentityVersion>1.12.0</AzureIdentityVersion>
+    <AzureCoreVersion>1.43.0</AzureCoreVersion>
+    <AzureStorageBlobsVersion>12.22.0</AzureStorageBlobsVersion>
     <!-- Uncomment this line to use the custom version of roslyn as needed. -->
     <!-- <UsingToolMicrosoftNetCompilers Condition="'$(DotNetBuildSourceOnly)' != 'true'">true</UsingToolMicrosoftNetCompilers> -->
     <!-- CoreFX -->

--- a/eng/pipelines/templateInternal.yml
+++ b/eng/pipelines/templateInternal.yml
@@ -24,6 +24,13 @@ extends:
       name: $(BuildPool)
       image: $(WindowsImage)
       os: windows
+    sdl:
+      policheck:
+        enabled: true
+      tsa:
+        enabled: true
+    featureFlags:
+      autoBaseline: true
 
     containers:
       ${{ parameters.containers }}

--- a/eng/release/DiagnosticsReleaseTool/DiagnosticsManifestGenerator.cs
+++ b/eng/release/DiagnosticsReleaseTool/DiagnosticsManifestGenerator.cs
@@ -15,7 +15,7 @@ using ReleaseTool.Core;
 
 namespace DiagnosticsReleaseTool.Impl
 {
-    internal sealed class DiagnosticsManifestGenerator : IManifestGenerator
+    internal sealed partial class DiagnosticsManifestGenerator : IManifestGenerator
     {
         private readonly ReleaseMetadata _productReleaseMetadata;
         private readonly JsonDocument _assetManifestManifestDom;
@@ -160,16 +160,12 @@ namespace DiagnosticsReleaseTool.Impl
             return $"{_productReleaseMetadata.ReleaseVersion}/{pathHash}/{fi.Name}";
         }
 
-        private static readonly Regex s_akaMsMetadataMatcher = new(
-                $@"<(?<metadata>[a-zA-Z]\w*)>",
-                RegexOptions.Compiled | RegexOptions.ExplicitCapture);
-
         private string GenerateLinkFromMetadata(FileReleaseData fileToRelease, string linkSchema)
         {
             FileInfo fi = new(fileToRelease.FileMap.LocalSourcePath);
             string link = linkSchema;
             //TODO: Revisit for perf if necessary...
-            MatchCollection results = s_akaMsMetadataMatcher.Matches(linkSchema);
+            MatchCollection results = AkamsMetadataMatcher().Matches(linkSchema);
             foreach (Match match in results)
             {
                 if (!match.Groups.TryGetValue("metadata", out Group metadataGroup))
@@ -219,5 +215,8 @@ namespace DiagnosticsReleaseTool.Impl
                 element.WriteTo(writer);
             }
         }
+
+        [GeneratedRegex(@"<(?<metadata>[a-zA-Z]\w*)>", RegexOptions.ExplicitCapture | RegexOptions.Compiled)]
+        private static partial Regex AkamsMetadataMatcher();
     }
 }

--- a/eng/release/DiagnosticsReleaseTool/DiagnosticsReleaseCommandLine.cs
+++ b/eng/release/DiagnosticsReleaseTool/DiagnosticsReleaseCommandLine.cs
@@ -4,6 +4,7 @@
 using System.CommandLine;
 using System.CommandLine.Builder;
 using System.CommandLine.Invocation;
+using System.CommandLine.NamingConventionBinder;
 using System.CommandLine.Parsing;
 using System.IO;
 using System.Threading;
@@ -17,8 +18,7 @@ namespace DiagnosticsReleaseTool.CommandLine
     {
         private static async Task<int> Main(string[] args)
         {
-            Parser parser = new CommandLineBuilder()
-                .AddCommand(PrepareRelease())
+            Parser parser = new CommandLineBuilder(PrepareRelease())
                 .CancelOnProcessTermination()
                 .UseDefaults()
                 .Build();
@@ -58,7 +58,7 @@ namespace DiagnosticsReleaseTool.CommandLine
 
         private static Option<bool> ToolManifestVerificationOption() =>
             new(
-                alias: "--verify-tool-manifest",
+                aliases: ["--verify-tool-manifest"],
                 description: "Verifies that the assets being published match the manifest",
                 getDefaultValue: () => true);
 

--- a/eng/release/DiagnosticsReleaseTool/DiagnosticsReleaseTool.csproj
+++ b/eng/release/DiagnosticsReleaseTool/DiagnosticsReleaseTool.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>$(NoWarn);CA2007</NoWarn>
   </PropertyGroup>
 
@@ -14,24 +14,19 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
 
-    <PackageReference Include="Azure.Identity" Version="[1.11.4]" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="[12.20.0]" />
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20468.1" />
+    <PackageReference Include="Azure.Core" Version="$(AzureCoreVersion)" />
+    <PackageReference Include="Azure.Identity" Version="$(AzureIdentityVersion)" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="$(AzureStorageBlobsVersion)" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />
+    <!-- Upgrade STJ to avoid https://github.com/advisories/GHSA-hh2w-p6rv-4g7w (Azure.Core and Extensions bring a vuln version) -->
+    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
   </ItemGroup>
-
-  <ItemGroup>
-    <AdditionalFiles Remove="E:\NuGetCaches\.nuget\packages\microsoft.dotnet.codeanalysis\8.0.0-beta.23120.1\build\..\content\PinvokeAnalyzer_Win32Apis.txt" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <AdditionalFiles Remove="E:\NuGetCaches\.nuget\packages\microsoft.dotnet.codeanalysis\8.0.0-beta.23120.1\build\..\content\PinvokeAnalyzer_Win32Apis.txt" />
-  </ItemGroup>
-
 </Project>

--- a/eng/release/DiagnosticsReleaseTool/DiagnosticsRepoHelpers.cs
+++ b/eng/release/DiagnosticsReleaseTool/DiagnosticsRepoHelpers.cs
@@ -8,7 +8,7 @@ using ReleaseTool.Core;
 
 namespace DiagnosticsReleaseTool.Util
 {
-    public static class DiagnosticsRepoHelpers
+    public static partial class DiagnosticsRepoHelpers
     {
         public static readonly string[] ProductNames = ["diagnostics", "dotnet-diagnostics"];
         public static readonly string[] RepositoryUrls = ["https://github.com/dotnet/diagnostics", "https://dev.azure.com/dnceng/internal/_git/dotnet-diagnostics"];
@@ -17,13 +17,9 @@ namespace DiagnosticsReleaseTool.Util
         public const string BundledToolsCategory = "ToolBundleAssets";
         public const string PdbCategory = "PdbAssets";
 
-        private static readonly Regex s_ridBundledToolsMatcher = new(
-                $@"{BundledToolsPrefix}(?<rid>(\w+-)+\w+)\.zip",
-                RegexOptions.Compiled | RegexOptions.ExplicitCapture);
-
         private static string GetRidFromBundleZip(FileInfo zipFile)
         {
-            MatchCollection matches = s_ridBundledToolsMatcher.Matches(zipFile.Name);
+            MatchCollection matches = RidBundledToolsRegex().Matches(zipFile.Name);
 
             if (matches.Count != 1)
             {
@@ -83,5 +79,8 @@ namespace DiagnosticsReleaseTool.Util
             byte[] checksum = sha.ComputeHash(stream);
             return Convert.ToHexString(checksum);
         }
+
+        [GeneratedRegex(@"diagnostic-tools-(?<rid>(\w+-)+\w+)\.zip", RegexOptions.ExplicitCapture | RegexOptions.Compiled)]
+        private static partial Regex RidBundledToolsRegex();
     }
 }

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/Microsoft.Diagnostics.DebugServices.Implementation.csproj
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/Microsoft.Diagnostics.DebugServices.Implementation.csproj
@@ -13,17 +13,19 @@
     <IsShipping>true</IsShipping>
     <IsShippingPackage>false</IsShippingPackage>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="$(MicrosoftDiagnosticsRuntimeVersion)" />
     <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
     <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
     <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
     <PackageReference Include="System.Runtime.Loader" Version="$(SystemRuntimeLoaderVersion)" />
+    <!-- Needed to avoid the reference from System.Runtime.Loader to version 4.3.0 with vuln https://github.com/advisories/GHSA-5f2m-466j-3848 -->
+    <PackageReference Include="System.Private.Uri" Version="4.3.2" />
     <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="$(SystemThreadingTasksExtensionsVersion)" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\Microsoft.Diagnostics.DebugServices\Microsoft.Diagnostics.DebugServices.csproj" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\Microsoft.SymbolStore\Microsoft.SymbolStore.csproj" />

--- a/src/SOS/SOS.UnitTests/Debuggees/SymbolTestApp/SymbolTestApp/SymbolTestApp.csproj
+++ b/src/SOS/SOS.UnitTests/Debuggees/SymbolTestApp/SymbolTestApp/SymbolTestApp.csproj
@@ -14,7 +14,4 @@
     <ProjectReference Include="..\SymbolTestDll\SymbolTestDll.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Condition="'$(TargetFramework)' != 'net462'" Include="System.Runtime.Loader" Version="4.3.0" />
-  </ItemGroup>
 </Project>

--- a/src/SOS/Strike/clrma/thread.cpp
+++ b/src/SOS/Strike/clrma/thread.cpp
@@ -403,7 +403,7 @@ ClrmaThread::NestedException(
 
     HRESULT hr;
     USHORT nCount = 0;
-    if (hr = get_NestedExceptionCount(&nCount))
+    if (FAILED(hr = get_NestedExceptionCount(&nCount)))
     {
         return hr;
     }

--- a/src/Tools/dotnet-dump/dotnet-dump.csproj
+++ b/src/Tools/dotnet-dump/dotnet-dump.csproj
@@ -12,10 +12,6 @@
     <SOSPackagePathPrefix>tools/$(TargetFramework)/any</SOSPackagePathPrefix>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <DefineConstants>ClrMD2</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="$(MicrosoftDiagnosticsRuntimeVersion)" />
   </ItemGroup>
@@ -27,7 +23,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)..\Common\ProcessNativeMethods\ProcessNativeMethods.cs" Link="ProcessNativeMethods.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\Common\WindowsProcessExtension\WindowsProcessExtension.cs" Link="WindowsProcessExtension.cs" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Microsoft.Diagnostics.Repl\Microsoft.Diagnostics.Repl.csproj" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Microsoft.Diagnostics.NETCore.Client\Microsoft.Diagnostics.NETCore.Client.csproj" />

--- a/src/Tools/dotnet-symbol/dotnet-symbol.csproj
+++ b/src/Tools/dotnet-symbol/dotnet-symbol.csproj
@@ -8,7 +8,7 @@
     <PackageReleaseNotes>$(Description)</PackageReleaseNotes>
     <NoWarn>;1591;1701</NoWarn>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Microsoft.SymbolStore\Microsoft.SymbolStore.csproj">
       <PrivateAssets>All</PrivateAssets>
@@ -16,9 +16,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Core" Version="$(AzureCoreVersion)" />
     <PackageReference Include="Azure.Identity" Version="$(AzureIdentityVersion)" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">
       <DesignTime>True</DesignTime>
@@ -26,7 +27,7 @@
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
   </ItemGroup>
-  
+
   <ItemGroup>
     <EmbeddedResource Update="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>


### PR DESCRIPTION
- Turn on nuget audit
- Enable TSA
- Fix audit issues and retarget release tool
