### PR TITLE
[LoongArch64] Improve support for LoongArch64

### DIFF
--- a/src/SOS/SOS.Extensions/MemoryServiceFromDebuggerServices.cs
+++ b/src/SOS/SOS.Extensions/MemoryServiceFromDebuggerServices.cs
@@ -31,6 +31,7 @@ namespace SOS.Extensions
             {
                 case Architecture.X64:
                 case Architecture.Arm64:
+                case (Architecture)6 /* Architecture.LoongArch64 */:
                     PointerSize = 8;
                     break;
                 case Architecture.X86:

--- a/src/SOS/SOS.UnitTests/SOSRunner.cs
+++ b/src/SOS/SOS.UnitTests/SOSRunner.cs
@@ -1458,7 +1458,7 @@ public class SOSRunner : IDisposable
         {
             defines.Add("32BIT");
         }
-        else if (_config.TargetArchitecture.Equals("x64") || _config.TargetArchitecture.Equals("arm64"))
+        else if (_config.TargetArchitecture.Equals("x64") || _config.TargetArchitecture.Equals("arm64") || _config.TargetArchitecture.Equals("loongarch64"))
         {
             defines.Add("64BIT");
         }


### PR DESCRIPTION
 Improve support for LoongArch64 . Fix the issue where m_pLegacyTarget ->GetPointerSize (&ulPointerSize) cannot retrieve values and add testing support.@shushanhf