### PR TITLE
Fix alpine-arm64 build

### DIFF
--- a/src/SOS/Strike/eeheap.cpp
+++ b/src/SOS/Strike/eeheap.cpp
@@ -436,7 +436,7 @@ size_t AlignLarge(size_t nbytes)
 size_t GetNumComponents(TADDR obj)
 {
     // The number of components is always the second pointer in the object.
-    DWORD Value = NULL;
+    DWORD Value = 0;
     HRESULT hr = MOVE(Value, obj + sizeof(size_t));
 
     // If we fail to read out the number of components, let's assume 0 so we don't try to


### PR DESCRIPTION
```sh
$ ./build.sh
...
[ 97%] Building CXX object src/SOS/Strike/CMakeFiles/sos.dir/platform/hostimpl.cpp.o
/foo77/diagnostics/src/SOS/Strike/eeheap.cpp:439:11: error: cannot initialize a variable of type 'DWORD' (aka 'unsigned int') with an rvalue of type 'std::nullptr_t'
    DWORD Value = NULL;
          ^       ~~~~
```