### PR TITLE
Update source-build team references

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,5 +7,5 @@
 # have proper ownership.
 /src/                       @dotnet/dotnet-diag
 /documentation/             @dotnet/dotnet-diag
-/eng/SourceBuild.props      @dotnet/product-construction
+/eng/DotNetBuild.props      @dotnet/product-construction
 /eng/SourceBuildPrebuiltBaseline.xml  @dotnet/source-build

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,5 +7,5 @@
 # have proper ownership.
 /src/                       @dotnet/dotnet-diag
 /documentation/             @dotnet/dotnet-diag
-/eng/SourceBuild.props      @dotnet/source-build-internal
-/eng/SourceBuildPrebuiltBaseline.xml  @dotnet/source-build-internal
+/eng/SourceBuild.props      @dotnet/product-construction
+/eng/SourceBuildPrebuiltBaseline.xml  @dotnet/source-build

--- a/eng/DotNetBuild.props
+++ b/eng/DotNetBuild.props
@@ -1,4 +1,4 @@
-<!-- Whenever altering this or other Source Build files, please include @dotnet/source-build-internal as a reviewer. -->
+<!-- When altering this file, include @dotnet/product-construction as a reviewer. -->
 
 <Project>
 

--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -1,4 +1,4 @@
-<!-- Whenever altering this or other Source Build files, please include @dotnet/source-build-internal as a reviewer. -->
+<!-- When altering this file or making other Source Build related changes, include @dotnet/source-build as a reviewer. -->
 <!-- See aka.ms/dotnet/prebuilts for guidance on what pre-builts are and how to eliminate them. -->
 
 <UsageData>


### PR DESCRIPTION
The @dotnet/source-build-internal team is being deprecated. All references to it were updated.

Included the renaming of SourceBuild.props to the new naming convention, DotNetBuild.props.

Related to dotnet/source-build#4645

Repo admins, please grant write access to @dotnet/product-construction and @dotnet/source-build.  This is needed for the CODEOWNERS changes.  Write access can be removed for @dotnet/source-build-internal.