### PR TITLE
Fix error in dump requests command

### DIFF
--- a/src/Microsoft.Diagnostics.ExtensionCommands/DumpRequestsCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/DumpRequestsCommand.cs
@@ -63,10 +63,11 @@ namespace Microsoft.Diagnostics.ExtensionCommands
 
         public void PrintRequests(List<(ulong Address, string Method, string scheme, string Url)> requests)
         {
-            Column methodColumn = Text.GetAppropriateWidth(requests.Select(r => r.Method)).WithAlignment(Align.Left);
-            Column schemeColumn = Text.GetAppropriateWidth(requests.Select(r => r.scheme)).WithAlignment(Align.Left);
-            Column urlColumn = Text.GetAppropriateWidth(requests.Select(r => r.Url)).WithAlignment(Align.Left);
-            Table output = new(Console, DumpObj.WithAlignment(Align.Left), methodColumn, schemeColumn, urlColumn); ;
+            Column addressColumn = DumpObj.GetAppropriateWidth(requests.Select(r => r.Address), 7).WithAlignment(Align.Left);
+            Column methodColumn = Text.GetAppropriateWidth(requests.Select(r => r.Method), 6).WithAlignment(Align.Left);
+            Column schemeColumn = Text.GetAppropriateWidth(requests.Select(r => r.scheme), 6).WithAlignment(Align.Left);
+            Column urlColumn = Text.GetAppropriateWidth(requests.Select(r => r.Url), 3).WithAlignment(Align.Left);
+            Table output = new(Console, addressColumn, methodColumn, schemeColumn, urlColumn); ;
             output.WriteHeader("Address", "Method", "Scheme", "Url");
 
             foreach ((ulong address, string method, string scheme, string url) in requests)

--- a/src/Microsoft.Diagnostics.ExtensionCommands/DumpRequestsCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/DumpRequestsCommand.cs
@@ -30,9 +30,13 @@ namespace Microsoft.Diagnostics.ExtensionCommands
                     if (obj.Type?.Name?.Equals("Microsoft.AspNetCore.Http.DefaultHttpContext") ?? false)
                     {
                         ClrObject collection = obj.ReadValueTypeField("_features").ReadObjectField("<Collection>k__BackingField");
-                        if (!collection.IsNull)
+                        if (!collection.IsNull && collection.IsValid)
                         {
-                            string method = collection.ReadStringField("<Method>k__BackingField") ?? "";
+                            if (!collection.TryReadStringField("<Method>k__BackingField", default, out string method))
+                            {
+                                method = collection.ReadStringField("_methodText") ?? "";
+                            }
+
                             string scheme = collection.ReadStringField("<Scheme>k__BackingField") ?? "";
                             string path = collection.ReadStringField("<Path>k__BackingField") ?? "";
                             string query = collection.ReadStringField("<QueryString>k__BackingField") ?? "";


### PR DESCRIPTION
Fixed an issue with the `!dumprequests` command that was causing an error when reading dumps from a Kestrel host.

```
0:000> !dumprequests
Field 'Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.Http2Stream<Microsoft.AspNetCore.Hosting.HostingApplication+Context>.<Method>k__BackingField' is not of type 'string'.
```

In Kestrel host dumps, the `<Method>k__BackingField` field in the `HttpContext` object is of `Enum` type, whereas in IIS host dumps, it is of `String` type. To address this, the `_methodText` field in the `HttpContext` object is now read if the `<Method>k__BackingField` field is not of `String` type.

Also added min width for each column for better readability. 