### PR TITLE
Clean up thread and thread service interfaces

### DIFF
--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/DataReader.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/DataReader.cs
@@ -54,11 +54,10 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
         {
             try
             {
-                byte[] registerContext = ThreadService.GetThreadFromId(threadId).GetThreadContext();
-                registerContext.AsSpan().Slice(0, context.Length).CopyTo(context);
+                ThreadService.GetThreadFromId(threadId).GetThreadContext(context);
                 return true;
             }
-            catch (Exception ex) when (ex is DiagnosticsException or ArgumentException)
+            catch (Exception ex) when (ex is DiagnosticsException or ArgumentOutOfRangeException)
             {
                 Trace.TraceError($"GetThreadContext: {threadId} exception {ex.Message}");
             }

--- a/src/Microsoft.Diagnostics.DebugServices/IThread.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/IThread.cs
@@ -3,8 +3,7 @@
 
 using System;
 
-namespace Microsoft.Diagnostics.DebugServices
-{
+namespace Microsoft.Diagnostics.DebugServices {
     /// <summary>
     /// Details about a thread
     /// </summary>
@@ -45,7 +44,7 @@ namespace Microsoft.Diagnostics.DebugServices
         /// </summary>
         /// <returns>register context</returns>
         /// <exception cref="DiagnosticsException">invalid thread</exception>
-        byte[] GetThreadContext();
+        ReadOnlySpan<byte> GetThreadContext();
 
         /// <summary>
         /// Returns the address of the Windows TEB or 0.

--- a/src/Microsoft.Diagnostics.DebugServices/IThreadService.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/IThreadService.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.Diagnostics.DebugServices
@@ -45,6 +46,17 @@ namespace Microsoft.Diagnostics.DebugServices
         /// <param name="info">RegisterInfo</param>
         /// <returns>true if index found</returns>
         bool TryGetRegisterInfo(int registerIndex, out RegisterInfo info);
+
+        /// <summary>
+        /// Returns the register value for the thread context and register index. This function
+        /// can only return register values that are 64 bits or less and currently the clrmd data
+        /// targets don't return any floating point or larger registers.
+        /// </summary>
+        /// <param name="context">thread context</param>
+        /// <param name="registerIndex">register index</param>
+        /// <param name="value">value returned</param>
+        /// <returns>true if value found</returns>
+        bool TryGetRegisterValue(ReadOnlySpan<byte> context, int registerIndex, out ulong value);
 
         /// <summary>
         /// Enumerate all the native threads

--- a/src/Microsoft.Diagnostics.DebugServices/IThreadUnwindService.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/IThreadUnwindService.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+
 namespace Microsoft.Diagnostics.DebugServices
 {
     /// <summary>
@@ -14,9 +16,8 @@ namespace Microsoft.Diagnostics.DebugServices
         /// return the context will be modified to reflect the parent frame's context.
         /// </summary>
         /// <param name="threadId">thread id to unwind</param>
-        /// <param name="contextSize">register context size</param>
         /// <param name="context">On input, the frame to unwind. On return, the context of the next frame</param>
         /// <returns>HRESULT</returns>
-        int Unwind(uint threadId, uint contextSize, byte[] context);
+        int Unwind(uint threadId, Span<byte> context);
     }
 }

--- a/src/Microsoft.Diagnostics.DebugServices/ThreadExtensions.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/ThreadExtensions.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Diagnostics.DebugServices
+{
+    public static class ThreadExtensions
+    {
+        public static unsafe void GetThreadContext(this IThread thread, IntPtr context, int contextSize)
+        {
+            GetThreadContext(thread, new(context.ToPointer(), contextSize));
+        }
+
+        public static void GetThreadContext(this IThread thread, Span<byte> context)
+        {
+            ReadOnlySpan<byte> registerContext = thread.GetThreadContext();
+            context.Clear();
+            registerContext.Slice(0, Math.Min(registerContext.Length, context.Length)).CopyTo(context);
+        }
+    }
+}

--- a/src/SOS/SOS.Extensions/DebuggerServices.cs
+++ b/src/SOS/SOS.Extensions/DebuggerServices.cs
@@ -284,15 +284,18 @@ namespace SOS.Extensions
 
         public HResult GetThreadTeb(uint threadId, out ulong teb)
         {
-            // The native code may zero out this return pointer
+            // The native code may not zero out this return pointer
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
+            teb = 0;
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
             return VTable.GetThreadTeb(Self, threadId, out teb);
         }
 
-        public HResult VirtualUnwind(uint threadId, uint contextSize, byte[] context)
+        public HResult VirtualUnwind(uint threadId, Span<byte> context)
         {
             fixed (byte* contextPtr = context)
             {
-                return VTable.VirtualUnwind(Self, threadId, contextSize, contextPtr);
+                return VTable.VirtualUnwind(Self, threadId, context.Length, contextPtr);
             }
         }
 
@@ -537,7 +540,7 @@ namespace SOS.Extensions
             public readonly delegate* unmanaged[Stdcall]<IntPtr, out uint, int> GetCurrentThreadSystemId;
             public readonly delegate* unmanaged[Stdcall]<IntPtr, uint, int> SetCurrentThreadSystemId;
             public readonly delegate* unmanaged[Stdcall]<IntPtr, uint, out ulong, int> GetThreadTeb;
-            public readonly delegate* unmanaged[Stdcall]<IntPtr, uint, uint, byte*, int> VirtualUnwind;
+            public readonly delegate* unmanaged[Stdcall]<IntPtr, uint, int, byte*, int> VirtualUnwind;
             public readonly delegate* unmanaged[Stdcall]<IntPtr, byte*, uint, out uint, int> GetSymbolPath;
             public readonly delegate* unmanaged[Stdcall]<IntPtr, int, ulong, byte*, int, out uint, out ulong, int> GetSymbolByOffset;
             public readonly delegate* unmanaged[Stdcall]<IntPtr, int, byte*, out ulong, int> GetOffsetBySymbol;

--- a/src/SOS/SOS.Extensions/ThreadUnwindServiceFromDebuggerServices.cs
+++ b/src/SOS/SOS.Extensions/ThreadUnwindServiceFromDebuggerServices.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using Microsoft.Diagnostics.DebugServices;
 
 namespace SOS.Extensions
@@ -14,9 +15,9 @@ namespace SOS.Extensions
             _debuggerServices = debuggerServices;
         }
 
-        public int Unwind(uint threadId, uint contextSize, byte[] context)
+        public int Unwind(uint threadId, Span<byte> context)
         {
-            return _debuggerServices.VirtualUnwind(threadId, contextSize, context);
+            return _debuggerServices.VirtualUnwind(threadId, context);
         }
     }
 }

--- a/src/SOS/SOS.Hosting/CorDebugDataTargetWrapper.cs
+++ b/src/SOS/SOS.Hosting/CorDebugDataTargetWrapper.cs
@@ -7,8 +7,7 @@ using System.Runtime.InteropServices;
 using Microsoft.Diagnostics.DebugServices;
 using Microsoft.Diagnostics.Runtime.Utilities;
 
-namespace SOS.Hosting
-{
+namespace SOS.Hosting {
     public sealed unsafe class CorDebugDataTargetWrapper : COMCallableIUnknown
     {
         private static readonly Guid IID_ICorDebugDataTarget = new("FE06DC28-49FB-4636-A4A3-E80DB4AE116C");
@@ -137,7 +136,7 @@ namespace SOS.Hosting
                 address &= _ignoreAddressBitsMask;
                 if (!_memoryService.ReadMemory(address, buffer, unchecked((int)bytesRequested), out read))
                 {
-                    Trace.TraceError("CorDebugDataTargetWrappter.ReadVirtual FAILED address {0:X16} size {1:X8}", address, bytesRequested);
+                    Trace.TraceError("CorDebugDataTargetWrapper.ReadVirtual FAILED address {0:X16} size {1:X8}", address, bytesRequested);
                     return HResult.E_FAIL;
                 }
             }
@@ -152,21 +151,13 @@ namespace SOS.Hosting
             int contextSize,
             IntPtr context)
         {
-            byte[] registerContext;
             try
             {
-                registerContext = _threadService.GetThreadFromId(threadId).GetThreadContext();
+                _threadService.GetThreadFromId(threadId).GetThreadContext(context, contextSize);
             }
-            catch (DiagnosticsException)
+            catch (Exception ex) when (ex is DiagnosticsException or ArgumentOutOfRangeException)
             {
-                return HResult.E_FAIL;
-            }
-            try
-            {
-                Marshal.Copy(registerContext, 0, context, Math.Min(registerContext.Length, contextSize));
-            }
-            catch (Exception ex) when (ex is ArgumentOutOfRangeException or ArgumentNullException)
-            {
+                Trace.TraceError($"CorDebugDataTargetWrapper.GetThreadContext({threadId:X8}) FAILED");
                 return HResult.E_INVALIDARG;
             }
             return HResult.S_OK;
@@ -188,7 +179,7 @@ namespace SOS.Hosting
                 {
                     return HResult.E_NOTIMPL;
                 }
-                return _threadUnwindService.Unwind(threadId, contextSize, context);
+                return _threadUnwindService.Unwind(threadId, context.AsSpan(0, (int)contextSize));
             }
             catch (DiagnosticsException)
             {

--- a/src/SOS/SOS.Hosting/CorDebugDataTargetWrapper.cs
+++ b/src/SOS/SOS.Hosting/CorDebugDataTargetWrapper.cs
@@ -170,7 +170,7 @@ namespace SOS.Hosting {
         private int VirtualUnwind(
             IntPtr self,
             uint threadId,
-            uint contextSize,
+            int contextSize,
             byte[] context)
         {
             try
@@ -179,7 +179,7 @@ namespace SOS.Hosting {
                 {
                     return HResult.E_NOTIMPL;
                 }
-                return _threadUnwindService.Unwind(threadId, context.AsSpan(0, (int)contextSize));
+                return _threadUnwindService.Unwind(threadId, context.AsSpan(0, contextSize));
             }
             catch (DiagnosticsException)
             {
@@ -254,7 +254,7 @@ namespace SOS.Hosting {
         private delegate int VirtualUnwindDelegate(
             [In] IntPtr self,
             [In] uint threadId,
-            [In] uint contextSize,
+            [In] int contextSize,
             [In, Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)] byte[] context);
 
         #endregion

--- a/src/SOS/SOS.Hosting/DataTargetWrapper.cs
+++ b/src/SOS/SOS.Hosting/DataTargetWrapper.cs
@@ -9,8 +9,7 @@ using Microsoft.Diagnostics.DebugServices;
 using Microsoft.Diagnostics.Runtime.Utilities;
 using SOS.Hosting.DbgEng.Interop;
 
-namespace SOS.Hosting
-{
+namespace SOS.Hosting {
     internal sealed unsafe class DataTargetWrapper : COMCallableIUnknown
     {
         private static readonly Guid IID_ICLRDataTarget = new("3E11CCEE-D08B-43e5-AF01-32717A64DA03");
@@ -221,23 +220,13 @@ namespace SOS.Hosting
             int contextSize,
             IntPtr context)
         {
-            byte[] registerContext;
             try
             {
-                registerContext = _threadService.GetThreadFromId(threadId).GetThreadContext();
+                _threadService.GetThreadFromId(threadId).GetThreadContext(context, contextSize);
             }
-            catch (DiagnosticsException)
+            catch (Exception ex) when (ex is DiagnosticsException or ArgumentOutOfRangeException)
             {
                 Trace.TraceError($"DataTargetWrapper.GetThreadContext({threadId:X8}) FAILED");
-                return HResult.E_FAIL;
-            }
-            try
-            {
-                Marshal.Copy(registerContext, 0, context, Math.Min(registerContext.Length, contextSize));
-            }
-            catch (Exception ex) when (ex is ArgumentOutOfRangeException or ArgumentNullException)
-            {
-                Trace.TraceError($"DataTargetWrapper.GetThreadContext Marshal.Copy FAILED {ex}");
                 return HResult.E_INVALIDARG;
             }
             return HResult.S_OK;
@@ -320,7 +309,7 @@ namespace SOS.Hosting
                 {
                     return HResult.E_NOTIMPL;
                 }
-                return _threadUnwindService.Unwind(threadId, contextSize, context);
+                return _threadUnwindService.Unwind(threadId, context.AsSpan(0, (int)contextSize));
             }
             catch (DiagnosticsException)
             {

--- a/src/SOS/SOS.Hosting/DataTargetWrapper.cs
+++ b/src/SOS/SOS.Hosting/DataTargetWrapper.cs
@@ -300,7 +300,7 @@ namespace SOS.Hosting {
         private int VirtualUnwind(
             IntPtr self,
             uint threadId,
-            uint contextSize,
+            int contextSize,
             byte[] context)
         {
             try
@@ -309,7 +309,7 @@ namespace SOS.Hosting {
                 {
                     return HResult.E_NOTIMPL;
                 }
-                return _threadUnwindService.Unwind(threadId, context.AsSpan(0, (int)contextSize));
+                return _threadUnwindService.Unwind(threadId, context.AsSpan(0, contextSize));
             }
             catch (DiagnosticsException)
             {
@@ -455,7 +455,7 @@ namespace SOS.Hosting {
         private delegate int VirtualUnwindDelegate(
             [In] IntPtr self,
             [In] uint threadId,
-            [In] uint contextSize,
+            [In] int contextSize,
             [In, Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)] byte[] context);
 
         #endregion

--- a/src/SOS/SOS.Hosting/LLDBServices.cs
+++ b/src/SOS/SOS.Hosting/LLDBServices.cs
@@ -107,7 +107,7 @@ namespace SOS.Hosting
         private int VirtualUnwind(
             IntPtr self,
             uint threadId,
-            uint contextSize,
+            int contextSize,
             byte[] context)
         {
             return HResult.E_NOTIMPL;
@@ -226,7 +226,7 @@ namespace SOS.Hosting
         private delegate int VirtualUnwindDelegate(
             IntPtr self,
             uint threadId,
-            uint contextSize,
+            int contextSize,
             byte[] context);
 
         [UnmanagedFunctionPointer(CallingConvention.Winapi)]

--- a/src/SOS/SOS.Hosting/SOSHost.cs
+++ b/src/SOS/SOS.Hosting/SOSHost.cs
@@ -13,8 +13,7 @@ using SOS.Hosting.DbgEng;
 using SOS.Hosting.DbgEng.Interop;
 using Architecture = System.Runtime.InteropServices.Architecture;
 
-namespace SOS.Hosting
-{
+namespace SOS.Hosting {
     /// <summary>
     /// Helper code to hosting the native SOS code
     /// </summary>
@@ -581,21 +580,13 @@ namespace SOS.Hosting
             int contextSize,
             IntPtr context)
         {
-            byte[] registerContext;
             try
             {
-                registerContext = ThreadService.GetThreadFromId(threadId).GetThreadContext();
+                ThreadService.GetThreadFromId(threadId).GetThreadContext(context, contextSize);
             }
-            catch (DiagnosticsException)
+            catch (Exception ex) when (ex is DiagnosticsException or ArgumentOutOfRangeException)
             {
-                return HResult.E_FAIL;
-            }
-            try
-            {
-                Marshal.Copy(registerContext, 0, context, Math.Min(registerContext.Length, contextSize));
-            }
-            catch (Exception ex) when (ex is ArgumentOutOfRangeException or ArgumentNullException)
-            {
+                Trace.TraceError($"SOSHost.GetThreadContext({threadId:X8}) FAILED");
                 return HResult.E_INVALIDARG;
             }
             return HResult.S_OK;


### PR DESCRIPTION
Change GetThreadContext to return an ReadOnlySpan because the original API allowed the array returned to be changed. Fixed a couple of other APIs to that a ReadOnlySpan.

Added some common GetThreadContext extensions