### PR TITLE
Add extension loaded service manager property

### DIFF
--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/ServiceManager.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/ServiceManager.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.Loader;
@@ -20,7 +21,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
     {
         private readonly Dictionary<Type, ServiceFactory>[] _factories;
         private readonly Dictionary<Type, List<ServiceFactory>> _providerFactories;
-        private readonly List<object> _extensions;
+        private readonly List<(Assembly assembly, ExtensionLoadContext extension)> _extensions;
         private bool _finalized;
 
         /// <summary>
@@ -51,7 +52,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
         {
             _factories = new Dictionary<Type, ServiceFactory>[(int)ServiceScope.Max];
             _providerFactories = new Dictionary<Type, List<ServiceFactory>>();
-            _extensions = new List<object>();
+            _extensions = new List<(Assembly assembly, ExtensionLoadContext extension)>();
             NotifyExtensionLoad = new ServiceEvent<Assembly>();
             NotifyExtensionLoadFailure = new ServiceEvent<Exception>();
             for (int i = 0; i < (int)ServiceScope.Max; i++)
@@ -299,6 +300,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
                 if (RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework"))
                 {
                     assembly = Assembly.LoadFile(extensionPath);
+                    _extensions.Add((assembly, null));
                 }
                 else
                 {
@@ -322,6 +324,11 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
         }
 
         /// <summary>
+        /// Returns the extensions loaded
+        /// </summary>
+        public IEnumerable<Assembly> ExtensionsLoaded => _extensions.Select(((Assembly assembly, ExtensionLoadContext extension) entry) => entry.assembly);
+
+        /// <summary>
         /// Load the extension using an assembly load context. This needs to be in
         /// a separate method so ExtensionLoadContext class doesn't get referenced
         /// when running on desktop Framework.
@@ -334,8 +341,8 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
             Assembly assembly = extension.LoadFromAssemblyPath(extensionPath);
             if (assembly is not null)
             {
-                // This list is just to keep the load context alive
-                _extensions.Add(extension);
+                // This list to track the assemblies loaded and to keep the load context alive (ExtensionLoadContext)
+                _extensions.Add((assembly, extension));
             }
             return assembly;
         }

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/ServiceManager.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/ServiceManager.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
     {
         private readonly Dictionary<Type, ServiceFactory>[] _factories;
         private readonly Dictionary<Type, List<ServiceFactory>> _providerFactories;
-        private readonly List<(Assembly assembly, ExtensionLoadContext extension)> _extensions;
+        private readonly List<(Assembly assembly, object extension)> _extensions;
         private bool _finalized;
 
         /// <summary>
@@ -52,7 +52,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
         {
             _factories = new Dictionary<Type, ServiceFactory>[(int)ServiceScope.Max];
             _providerFactories = new Dictionary<Type, List<ServiceFactory>>();
-            _extensions = new List<(Assembly assembly, ExtensionLoadContext extension)>();
+            _extensions = new List<(Assembly assembly, object extension)>();
             NotifyExtensionLoad = new ServiceEvent<Assembly>();
             NotifyExtensionLoadFailure = new ServiceEvent<Exception>();
             for (int i = 0; i < (int)ServiceScope.Max; i++)
@@ -310,6 +310,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
             catch (Exception ex) when
                 (ex is IOException
                  or ArgumentException
+                 or NotSupportedException
                  or InvalidOperationException
                  or BadImageFormatException
                  or System.Security.SecurityException)
@@ -326,7 +327,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
         /// <summary>
         /// Returns the extensions loaded
         /// </summary>
-        public IEnumerable<Assembly> ExtensionsLoaded => _extensions.Select(((Assembly assembly, ExtensionLoadContext extension) entry) => entry.assembly);
+        public IEnumerable<Assembly> ExtensionsLoaded => _extensions.Select(static ((Assembly assembly, object extension) entry) => entry.assembly);
 
         /// <summary>
         /// Load the extension using an assembly load context. This needs to be in

--- a/src/Microsoft.Diagnostics.DebugServices/IServiceManager.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/IServiceManager.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace Microsoft.Diagnostics.DebugServices
 {
@@ -22,5 +23,10 @@ namespace Microsoft.Diagnostics.DebugServices
         /// <param name="providerType">type or interface</param>
         /// <returns>the provider factories for the type</returns>
         IEnumerable<ServiceFactory> EnumerateProviderFactories(Type providerType);
+
+        /// <summary>
+        /// Returns the extensions loaded
+        /// </summary>
+        public IEnumerable<Assembly> ExtensionsLoaded { get; }
     }
 }

--- a/src/Microsoft.Diagnostics.ExtensionCommands/Host/StatusCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/Host/StatusCommand.cs
@@ -2,7 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
+using System.Reflection;
 using Microsoft.Diagnostics.DebugServices;
 
 namespace Microsoft.Diagnostics.ExtensionCommands
@@ -13,6 +16,9 @@ namespace Microsoft.Diagnostics.ExtensionCommands
     {
         [ServiceImport]
         public IHost Host { get; set; }
+
+        [ServiceImport]
+        public IServiceManager ServiceManager { get; set; }
 
         [ServiceImport]
         public ISymbolService SymbolService { get; set; }
@@ -57,6 +63,18 @@ namespace Microsoft.Diagnostics.ExtensionCommands
                 }
                 this.DisplaySpecialInfo();
                 Write(SymbolService.ToString());
+
+                List<Assembly> extensions = new(ServiceManager.ExtensionsLoaded);
+                extensions.Insert(0, Assembly.GetExecutingAssembly());
+
+                WriteLine("Extensions loaded:");
+                foreach (Assembly extension in extensions)
+                {
+                    string path = extension.Location;
+                    FileVersionInfo versionInfo = FileVersionInfo.GetVersionInfo(path);
+                    WriteLine($"-> {versionInfo.ProductVersion} {path}");
+                }
+
                 long memoryUsage = GC.GetTotalMemory(forceFullCollection: true);
                 WriteLine($"GC memory usage for managed SOS components: {memoryUsage:##,#} bytes");
             }


### PR DESCRIPTION
Add loaded extension version display to !sosstatus

Example:

```
Extensions loaded:
-> 8.0.0-dev.24525.1+64eecc7e689a42bf979dd1339e90cd92a9843021 c:\diagnostics\artifacts\bin\Windows_NT.x64.Debug\Microsoft.Diagnostics.ExtensionCommands.dll 
-> 8.0.552406+f5de0a8ffe15b5aa596a8089c5d6a1c9472ac54b c:\diagnostics\artifacts\bin\Windows_NT.x64.Debug\extensions\Microsoft.Diagnostics.DataContractReader.dll
-> 8.0.552406+f5de0a8ffe15b5aa596a8089c5d6a1c9472ac54b c:\diagnostics\artifacts\bin\Windows_NT.x64.Debug\extensions\Microsoft.Diagnostics.DataContractReader.Extension.dll
-> 8.0.552406+f5de0a8ffe15b5aa596a8089c5d6a1c9472ac54b c:\diagnostics\artifacts\bin\Windows_NT.x64.Debug\extensions\Microsoft.Diagnostics.DebuggerCommands.dll
```
