### PR TITLE
Update Microsoft.Diagnostics.Tracing.TraceEvent version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -39,7 +39,7 @@
     <MicrosoftBclAsyncInterfacesVersion>6.0.0</MicrosoftBclAsyncInterfacesVersion>
     <MicrosoftDiagnosticsRuntimeVersion>4.0.0-beta.24568.1</MicrosoftDiagnosticsRuntimeVersion>
     <MicrosoftDiaSymReaderNativeVersion>17.10.0-beta1.24272.1</MicrosoftDiaSymReaderNativeVersion>
-    <MicrosoftDiagnosticsTracingTraceEventVersion>3.0.7</MicrosoftDiagnosticsTracingTraceEventVersion>
+    <MicrosoftDiagnosticsTracingTraceEventVersion>3.1.16</MicrosoftDiagnosticsTracingTraceEventVersion>
     <MicrosoftExtensionsLoggingVersion>6.0.0</MicrosoftExtensionsLoggingVersion>
     <MicrosoftExtensionsLoggingAbstractionsVersion>6.0.4</MicrosoftExtensionsLoggingAbstractionsVersion>
     <MicrosoftExtensionsLoggingConsoleVersion>6.0.0</MicrosoftExtensionsLoggingConsoleVersion>

--- a/src/Tools/dotnet-gcdump/DotNetHeapDump/DotNetHeapDumpGraphReader.cs
+++ b/src/Tools/dotnet-gcdump/DotNetHeapDump/DotNetHeapDumpGraphReader.cs
@@ -186,7 +186,7 @@ public class DotNetHeapDumpGraphReader
             }
         };
 
-        source.Clr.GCGenAwareStart += delegate (GenAwareBeginTraceData data)
+        source.Clr.GCGenAwareBegin += delegate (GenAwareTemplateTraceData data)
         {
             m_seenStart = true;
             m_ignoreEvents = false;
@@ -270,7 +270,7 @@ public class DotNetHeapDumpGraphReader
             }
         };
 
-        source.Clr.GCGenAwareEnd += delegate (GenAwareEndTraceData data)
+        source.Clr.GCGenAwareEnd += delegate (GenAwareTemplateTraceData data)
         {
             m_ignoreEvents = true;
             if (m_nodeBlocks.Count == 0 && m_typeBlocks.Count == 0 && m_edgeBlocks.Count == 0)

--- a/src/tests/EventPipeStress/Orchestrator/Orchestrator.csproj
+++ b/src/tests/EventPipeStress/Orchestrator/Orchestrator.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.137102" />
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.58" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="$(MicrosoftDiagnosticsTracingTraceEventVersion)" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
     <PackageReference Include="System.Security.Principal.Windows" Version="4.7.0" />
   </ItemGroup>

--- a/src/tests/Grape/Grape.csproj
+++ b/src/tests/Grape/Grape.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <ProjectReference Include="../Tracee/Tracee.csproj" PrivateAssets="all" />
     <ProjectReference Include="../../Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj" />
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.47" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="$(MicrosoftDiagnosticsTracingTraceEventVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests.csproj
+++ b/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="$(MicrosoftDiagnosticsTracingTraceEventVersion)" />
     <PackageReference Include="xunit.abstractions" Version="$(XUnitAbstractionsVersion)" />
     <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
   </ItemGroup>


### PR DESCRIPTION
The referenced Microsoft.Diagnostics.Tracing.TraceEvent package version is fairly old and newer versions have bug fixes and other feature updates.

Another motivation to update this reference is that downstream consumers of the Microsoft.Diagnostics.NETCore.Client library cannot transitively update the Microsoft.Diagnostics.Tracing.TraceEvent version. Starting with the 3.1.14 release, the Microsoft.Diagnostics.Tracing.TraceEvent assembly itself has a dependency on Microsoft.Diagnostics.NETCore.Client. Projects that prerelease versions of Microsoft.Diagnostics.NETCore.Client are blocked from updating to the latest version of Microsoft.Diagnostics.Tracing.TraceEvent because the prerelease version of Microsoft.Diagnostics.NETCore.Client is a lower version (e.g. 0.2.0-preview.24564.1) than the latest release version (e.g. 0.2.547301) despite the prerelease version having been built more recently. This causes package downgrade errors such as:

```
error NU1109: Detected package downgrade: Microsoft.Diagnostics.NETCore.Client from 0.2.510501 to centrally defined
0.2.0-preview.24564.1. Update the centrally managed package version to a higher version.
```

Allowing transitive update using prerelease versions should be fixed separately, but I wanted to highlight one of the motivations for the version update of the Microsoft.Diagnostics.Tracing.TraceEvent library.