### PR TITLE
Make DiagnosticsClient.ApplyStartupHook public

### DIFF
--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
@@ -337,8 +337,6 @@ namespace Microsoft.Diagnostics.NETCore.Client
         /// </summary>
         /// <param name="startupHookPath">The path to the assembly containing the StartupHook.</param>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="startupHookPath"/> is null or empty.</exception>
-        /// <exception cref="FileNotFoundException">Thrown when the specified assembly does not exist.</exception>
-        /// <exception cref="NotSupportedException">Thrown when the runtime version is less than 8.0.</exception>
         public void ApplyStartupHook(string startupHookPath)
         {
             if (string.IsNullOrEmpty(startupHookPath))
@@ -357,8 +355,6 @@ namespace Microsoft.Diagnostics.NETCore.Client
         /// <param name="startupHookPath">The path to the assembly containing the StartupHook.</param>
         /// <param name="token">The token to monitor for cancellation requests.</param>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="startupHookPath"/> is null or empty.</exception>
-        /// <exception cref="FileNotFoundException">Thrown when the specified assembly does not exist.</exception>
-        /// <exception cref="NotSupportedException">Thrown when the runtime version is less than 8.0.</exception>
         public async Task ApplyStartupHookAsync(string startupHookPath, CancellationToken token)
         {
             if (string.IsNullOrEmpty(startupHookPath))

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
@@ -346,11 +346,6 @@ namespace Microsoft.Diagnostics.NETCore.Client
                 throw new ArgumentNullException(nameof(startupHookPath));
             }
 
-            if (!File.Exists(startupHookPath))
-            {
-                throw new FileNotFoundException($"Startup hook file not found: {startupHookPath}");
-            }
-
             ProcessInfo processInfo = GetProcessInfo();
             if (!processInfo.TryGetProcessClrVersion(out Version version) || version.Major < 8)
             {
@@ -375,11 +370,6 @@ namespace Microsoft.Diagnostics.NETCore.Client
             if (string.IsNullOrEmpty(startupHookPath))
             {
                 throw new ArgumentNullException(nameof(startupHookPath));
-            }
-
-            if (!File.Exists(startupHookPath))
-            {
-                throw new FileNotFoundException($"Startup hook file not found: {startupHookPath}");
             }
 
             ProcessInfo processInfo = await GetProcessInfoAsync(token).ConfigureAwait(false);

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
@@ -346,12 +346,6 @@ namespace Microsoft.Diagnostics.NETCore.Client
                 throw new ArgumentNullException(nameof(startupHookPath));
             }
 
-            ProcessInfo processInfo = GetProcessInfo();
-            if (!processInfo.TryGetProcessClrVersion(out Version version) || version.Major < 8)
-            {
-                throw new NotSupportedException($"Startup hooks are only supported on .NET 8.0 and later. Runtime Version: {version}.");
-            }
-
             IpcMessage message = CreateApplyStartupHookMessage(startupHookPath);
             IpcMessage response = IpcClient.SendMessage(_endpoint, message);
             ValidateResponseMessage(response, nameof(ApplyStartupHook));
@@ -370,12 +364,6 @@ namespace Microsoft.Diagnostics.NETCore.Client
             if (string.IsNullOrEmpty(startupHookPath))
             {
                 throw new ArgumentNullException(nameof(startupHookPath));
-            }
-
-            ProcessInfo processInfo = await GetProcessInfoAsync(token).ConfigureAwait(false);
-            if (!processInfo.TryGetProcessClrVersion(out Version version) || version.Major < 8)
-            {
-                throw new NotSupportedException($"Startup hooks are only supported on .NET 8.0 and later. Runtime Version: {version}.");
             }
 
             IpcMessage message = CreateApplyStartupHookMessage(startupHookPath);


### PR DESCRIPTION
The PR #3918 introduced `ApplyStartupHook`. This PR is making the API public.

It seems that the only client of this API today is dotnet-monitor [here](https://github.com/dotnet/dotnet-monitor/blob/ef3b48791edc90be54297155ccfb092aed71581b/src/Tools/dotnet-monitor/StartupHook/StartupHookApplicator.cs#L73-L85)

This API is particularly useful for loading assemblies in the target process that could add additional capabilities in what is being traced.

cc: @jander-msft 