### PR TITLE
Remove prerelease label from Microsoft.Diagnostics.NETCore.Client

### DIFF
--- a/src/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj
+++ b/src/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj
@@ -14,6 +14,7 @@
     <IsShipping>true</IsShipping>
     <BuildingOutsideDiagnostics>false</BuildingOutsideDiagnostics>
     <BuildingOutsideDiagnostics Condition="'$(GitHubRepositoryName)' != 'diagnostics'">true</BuildingOutsideDiagnostics>
+    <PreReleaseVersionLabel />
   </PropertyGroup>
 
   <PropertyGroup Condition="$(BuildingOutsideDiagnostics)">


### PR DESCRIPTION
This change ensures that newer builds of the Microsoft.Diagnostics.NETCore.Client package have a higher version than previously built versions. This change has no effect on released version as this library already adopts the lack of prerelease label in the `release/stable` branch; it effectively only changes the non-release builds to align the versioning scheme to be the same as the release build (always increasing, no prerelease versions). This is the same behavior that the other `dotnet-*` tools have in this repository.

Fixes #5085