### PR TITLE
Update metrics to support OpenTelemetry specification

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -49,6 +49,7 @@
     <SystemCommandLineRenderingVersion>2.0.0-beta1.20074.1</SystemCommandLineRenderingVersion>
     <SystemComponentModelAnnotationsVersion>5.0.0</SystemComponentModelAnnotationsVersion>
     <SystemBuffersVersion>4.5.1</SystemBuffersVersion>
+    <SystemDiagnosticsDiagnosticSourceVersion>8.0.1</SystemDiagnosticsDiagnosticSourceVersion>
     <SystemMemoryVersion>4.5.5</SystemMemoryVersion>
     <SystemRuntimeLoaderVersion>4.3.0</SystemRuntimeLoaderVersion>
     <SystemThreadingTasksExtensionsVersion>4.5.4</SystemThreadingTasksExtensionsVersion>

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/CounterMetadata.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/CounterMetadata.cs
@@ -12,19 +12,21 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
                   counterName,
                   counterUnit: null,
                   counterDescription: null,
+                  instrumentId: null,
                   meterTags,
                   instrumentTags,
                   scopeHash)
         {
         }
 
-        public CounterMetadata(string providerName, string providerVersion, string counterName, string counterUnit, string counterDescription, string meterTags, string instrumentTags, string scopeHash)
+        public CounterMetadata(string providerName, string providerVersion, string counterName, string counterUnit, string counterDescription, int? instrumentId, string meterTags, string instrumentTags, string scopeHash)
         {
             ProviderName = providerName;
             ProviderVersion = providerVersion;
             CounterName = counterName;
             CounterUnit = counterUnit;
             CounterDescription = counterDescription;
+            InstrumentId = instrumentId;
             MeterTags = meterTags;
             InstrumentTags = instrumentTags;
             ScopeHash = scopeHash;
@@ -37,6 +39,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
         public string CounterName { get; private set; }
         public string CounterUnit { get; private set; }
         public string CounterDescription { get; private set; }
+        public int? InstrumentId { get; private set; }
         public string MeterTags { get; private set; }
         public string InstrumentTags { get; private set; }
         public string ScopeHash { get; private set; }

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/CounterMetadata.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/CounterMetadata.cs
@@ -5,17 +5,31 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
 {
     public class CounterMetadata
     {
-        public CounterMetadata(string providerName, string counterName, string meterTags, string instrumentTags, string scopeHash)
+        public CounterMetadata(string providerName, string counterName, string counterUnit)
             : this(
                   providerName,
                   providerVersion: null,
                   counterName,
-                  counterUnit: null,
+                  counterUnit,
+                  counterDescription: null,
+                  instrumentId: null,
+                  meterTags: null,
+                  instrumentTags: null,
+                  scopeHash: null)
+        {
+        }
+
+        public CounterMetadata(string providerName, string counterName, string counterUnit, string meterTags, string instrumentTags)
+            : this(
+                  providerName,
+                  providerVersion: null,
+                  counterName,
+                  counterUnit,
                   counterDescription: null,
                   instrumentId: null,
                   meterTags,
                   instrumentTags,
-                  scopeHash)
+                  scopeHash: null)
         {
         }
 

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/CounterMetadata.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/CounterMetadata.cs
@@ -6,17 +6,37 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
     public class CounterMetadata
     {
         public CounterMetadata(string providerName, string counterName, string meterTags, string instrumentTags, string scopeHash)
+            : this(
+                  providerName,
+                  providerVersion: null,
+                  counterName,
+                  counterUnit: null,
+                  counterDescription: null,
+                  meterTags,
+                  instrumentTags,
+                  scopeHash)
+        {
+        }
+
+        public CounterMetadata(string providerName, string providerVersion, string counterName, string counterUnit, string counterDescription, string meterTags, string instrumentTags, string scopeHash)
         {
             ProviderName = providerName;
+            ProviderVersion = providerVersion;
             CounterName = counterName;
+            CounterUnit = counterUnit;
+            CounterDescription = counterDescription;
             MeterTags = meterTags;
             InstrumentTags = instrumentTags;
             ScopeHash = scopeHash;
         }
 
         public CounterMetadata() { }
+
         public string ProviderName { get; private set; }
+        public string ProviderVersion { get; private set; }
         public string CounterName { get; private set; }
+        public string CounterUnit { get; private set; }
+        public string CounterDescription { get; private set; }
         public string MeterTags { get; private set; }
         public string InstrumentTags { get; private set; }
         public string ScopeHash { get; private set; }

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/CounterMetadata.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/CounterMetadata.cs
@@ -19,17 +19,31 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
         {
         }
 
-        public CounterMetadata(string providerName, string counterName, string counterUnit, string meterTags, string instrumentTags)
+        internal CounterMetadata(string providerName, string counterName, string meterTags, string instrumentTags)
             : this(
                   providerName,
                   providerVersion: null,
                   counterName,
-                  counterUnit,
+                  counterUnit: null,
                   counterDescription: null,
                   instrumentId: null,
                   meterTags,
                   instrumentTags,
                   scopeHash: null)
+        {
+        }
+
+        public CounterMetadata(string providerName, string counterName, string meterTags, string instrumentTags, string scopeHash)
+            : this(
+                  providerName,
+                  providerVersion: null,
+                  counterName,
+                  counterUnit: null,
+                  counterDescription: null,
+                  instrumentId: null,
+                  meterTags,
+                  instrumentTags,
+                  scopeHash)
         {
         }
 

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/CounterPayload.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/CounterPayload.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 
@@ -13,7 +14,8 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
     {
         private readonly string _DisplayUnits;
 
-        protected CounterPayload(DateTime timestamp,
+        protected CounterPayload(
+            DateTime timestamp,
             CounterMetadata counterMetadata,
             string displayName,
             string displayUnits,
@@ -24,6 +26,8 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
             string valueTags,
             EventType eventType)
         {
+            Debug.Assert(counterMetadata != null);
+
             Timestamp = timestamp;
             DisplayName = displayName;
             _DisplayUnits = displayUnits;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/CounterPayload.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/CounterPayload.cs
@@ -37,9 +37,9 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
 
         public string Unit { get; }
 
-        public double Value { get; }
+        public double Value { get; protected set; }
 
-        public DateTime Timestamp { get; }
+        public DateTime Timestamp { get; protected set; }
 
         public float Interval { get; }
 
@@ -86,7 +86,38 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
         {
         }
 
-        public override bool IsMeter => true;
+        public sealed override bool IsMeter => true;
+    }
+
+    internal abstract class MeterInstrumentDeltaMeasurementPayload : MeterPayload
+    {
+        protected MeterInstrumentDeltaMeasurementPayload(
+            DateTime timestamp,
+            CounterMetadata counterMetadata,
+            string displayName,
+            string unit,
+            double value,
+            CounterType counterType,
+            string valueTags,
+            EventType eventType)
+            : base(timestamp, counterMetadata, displayName, unit, value, counterType, valueTags, eventType)
+        {
+        }
+
+        public abstract bool SupportsDelta { get; }
+
+        public virtual void Combine(MeterInstrumentDeltaMeasurementPayload other)
+        {
+            if (other.Timestamp > Timestamp)
+            {
+                Timestamp = other.Timestamp;
+            }
+        }
+    }
+
+    internal interface IRatePayload
+    {
+        double Rate { get; }
     }
 
     internal sealed class GaugePayload : MeterPayload
@@ -100,14 +131,29 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
         }
     }
 
-    internal class UpDownCounterPayload : MeterPayload
+    internal class UpDownCounterPayload : MeterInstrumentDeltaMeasurementPayload, IRatePayload
     {
-        public UpDownCounterPayload(CounterMetadata counterMetadata, string displayName, string displayUnits, string valueTags, double value, DateTime timestamp) :
+        public UpDownCounterPayload(CounterMetadata counterMetadata, string displayName, string displayUnits, string valueTags, double rate, double value, DateTime timestamp) :
             base(timestamp, counterMetadata, displayName, displayUnits, value, CounterType.Metric, valueTags, EventType.UpDownCounter)
         {
             // In case these properties are not provided, set them to appropriate values.
             string counterName = string.IsNullOrEmpty(displayName) ? counterMetadata.CounterName : displayName;
             DisplayName = !string.IsNullOrEmpty(displayUnits) ? $"{counterName} ({displayUnits})" : counterName;
+            Rate = rate;
+        }
+
+        public double Rate { get; private set; }
+
+        public override bool SupportsDelta => false;
+
+        public override void Combine(MeterInstrumentDeltaMeasurementPayload other)
+        {
+            if (other is UpDownCounterPayload upDownCounterPayload)
+            {
+                Rate += upDownCounterPayload.Rate;
+            }
+
+            base.Combine(other);
         }
     }
 
@@ -131,9 +177,8 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
     /// This gets generated for Counter instruments from Meters. This is used for pre-.NET 8 versions of MetricsEventSource that only reported rate and not absolute value,
     /// or for any tools that haven't opted into using RateAndValuePayload in the CounterConfiguration settings.
     /// </summary>
-    internal sealed class RatePayload : MeterPayload
+    internal sealed class RatePayload : MeterInstrumentDeltaMeasurementPayload, IRatePayload
     {
-
         public RatePayload(CounterMetadata counterMetadata, string displayName, string displayUnits, string valueTags, double rate, double intervalSecs, DateTime timestamp) :
             base(timestamp, counterMetadata, displayName, displayUnits, rate, CounterType.Rate, valueTags, EventType.Rate)
         {
@@ -143,13 +188,24 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
             string intervalName = intervalSecs.ToString() + " sec";
             DisplayName = $"{counterName} ({unitsName} / {intervalName})";
         }
+
+        public double Rate => Value;
+
+        public override bool SupportsDelta => true;
+
+        public override void Combine(MeterInstrumentDeltaMeasurementPayload other)
+        {
+            Value += other.Value;
+
+            base.Combine(other);
+        }
     }
 
     /// <summary>
     /// Starting in .NET 8, MetricsEventSource reports counters with both absolute value and rate. If enabled in the CounterConfiguration and the new value field is present
     /// then this payload will be created rather than the older RatePayload. Unlike RatePayload, this one treats the absolute value as the primary statistic.
     /// </summary>
-    internal sealed class CounterRateAndValuePayload : MeterPayload
+    internal sealed class CounterRateAndValuePayload : MeterInstrumentDeltaMeasurementPayload, IRatePayload
     {
         public CounterRateAndValuePayload(CounterMetadata counterMetadata, string displayName, string displayUnits, string valueTags, double rate, double value, DateTime timestamp) :
             base(timestamp, counterMetadata, displayName, displayUnits, value, CounterType.Metric, valueTags, EventType.Rate)
@@ -162,6 +218,18 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
         }
 
         public double Rate { get; private set; }
+
+        public override bool SupportsDelta => true;
+
+        public override void Combine(MeterInstrumentDeltaMeasurementPayload other)
+        {
+            if (other is CounterRateAndValuePayload counterRateAndValuePayload)
+            {
+                Rate += counterRateAndValuePayload.Rate;
+            }
+
+            base.Combine(other);
+        }
     }
 
     internal record struct Quantile(double Percentage, double Value);
@@ -182,17 +250,36 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
     // dotnet-counters created a separate payload for each quantile (multiple payloads per TraceEvent).
     // AggregatePercentilePayload allows dotnet-monitor to construct a PercentilePayload for individual quantiles
     // like dotnet-counters, while still keeping the quantiles together as a unit.
-    internal sealed class AggregatePercentilePayload : MeterPayload
+    internal sealed class AggregatePercentilePayload : MeterInstrumentDeltaMeasurementPayload
     {
-        public AggregatePercentilePayload(CounterMetadata counterMetadata, string displayName, string displayUnits, string valueTags, IEnumerable<Quantile> quantiles, DateTime timestamp) :
+        public AggregatePercentilePayload(CounterMetadata counterMetadata, string displayName, string displayUnits, string valueTags, int count, double sum, IEnumerable<Quantile> quantiles, DateTime timestamp) :
             base(timestamp, counterMetadata, displayName, displayUnits, 0.0, CounterType.Metric, valueTags, EventType.Histogram)
         {
+            Count = count;
+            Sum = sum;
             //string counterName = string.IsNullOrEmpty(displayName) ? name : displayName;
             //DisplayName = !string.IsNullOrEmpty(displayUnits) ? $"{counterName} ({displayUnits})" : counterName;
             Quantiles = quantiles.ToArray();
         }
 
-        public Quantile[] Quantiles { get; }
+        public int Count { get; private set; }
+
+        public double Sum { get; private set; }
+
+        public Quantile[] Quantiles { get; private set; }
+
+        public override bool SupportsDelta => true;
+
+        public override void Combine(MeterInstrumentDeltaMeasurementPayload other)
+        {
+            if (other is AggregatePercentilePayload aggregatePercentilePayload)
+            {
+                Count += aggregatePercentilePayload.Count;
+                Sum += aggregatePercentilePayload.Sum;
+            }
+
+            base.Combine(other);
+        }
     }
 
     internal sealed class ErrorPayload : MeterPayload

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/CounterPayload.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/CounterPayload.cs
@@ -13,7 +13,6 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
         protected CounterPayload(DateTime timestamp,
             CounterMetadata counterMetadata,
             string displayName,
-            string unit,
             double value,
             CounterType counterType,
             float interval,
@@ -23,7 +22,6 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
         {
             Timestamp = timestamp;
             DisplayName = displayName;
-            Unit = unit;
             Value = value;
             CounterType = counterType;
             CounterMetadata = counterMetadata;
@@ -35,7 +33,6 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
 
         public string DisplayName { get; protected set; }
 
-        public string Unit { get; }
 
         public double Value { get; }
 
@@ -67,7 +64,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
             CounterType counterType,
             float interval,
             int series,
-            string valueTags) : base(timestamp, new(providerName, name, null, null, null), displayName, unit, value, counterType, interval, series, valueTags, EventType.Gauge)
+            string valueTags) : base(timestamp, new(providerName, name, unit), displayName, value, counterType, interval, series, valueTags, EventType.Gauge)
         {
         }
     }
@@ -77,12 +74,11 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
         protected MeterPayload(DateTime timestamp,
                     CounterMetadata counterMetadata,
                     string displayName,
-                    string unit,
                     double value,
                     CounterType counterType,
                     string valueTags,
                     EventType eventType)
-            : base(timestamp, counterMetadata, displayName, unit, value, counterType, 0.0f, 0, valueTags, eventType)
+            : base(timestamp, counterMetadata, displayName, value, counterType, 0.0f, 0, valueTags, eventType)
         {
         }
 
@@ -98,23 +94,23 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
 
     internal sealed class GaugePayload : MeterPayload
     {
-        public GaugePayload(CounterMetadata counterMetadata, string displayName, string displayUnits, string valueTags, double value, DateTime timestamp) :
-            base(timestamp, counterMetadata, displayName, displayUnits, value, CounterType.Metric, valueTags, EventType.Gauge)
+        public GaugePayload(CounterMetadata counterMetadata, string displayName, string valueTags, double value, DateTime timestamp) :
+            base(timestamp, counterMetadata, displayName, value, CounterType.Metric, valueTags, EventType.Gauge)
         {
             // In case these properties are not provided, set them to appropriate values.
             string counterName = string.IsNullOrEmpty(displayName) ? counterMetadata.CounterName : displayName;
-            DisplayName = !string.IsNullOrEmpty(displayUnits) ? $"{counterName} ({displayUnits})" : counterName;
+            DisplayName = !string.IsNullOrEmpty(counterMetadata.CounterUnit) ? $"{counterName} ({counterMetadata.CounterUnit})" : counterName;
         }
     }
 
     internal class UpDownCounterPayload : MeterPayload, IRatePayload
     {
-        public UpDownCounterPayload(CounterMetadata counterMetadata, string displayName, string displayUnits, string valueTags, double rate, double value, DateTime timestamp) :
-            base(timestamp, counterMetadata, displayName, displayUnits, value, CounterType.Metric, valueTags, EventType.UpDownCounter)
+        public UpDownCounterPayload(CounterMetadata counterMetadata, string displayName, string valueTags, double rate, double value, DateTime timestamp) :
+            base(timestamp, counterMetadata, displayName, value, CounterType.Metric, valueTags, EventType.UpDownCounter)
         {
             // In case these properties are not provided, set them to appropriate values.
             string counterName = string.IsNullOrEmpty(displayName) ? counterMetadata.CounterName : displayName;
-            DisplayName = !string.IsNullOrEmpty(displayUnits) ? $"{counterName} ({displayUnits})" : counterName;
+            DisplayName = !string.IsNullOrEmpty(counterMetadata.CounterUnit) ? $"{counterName} ({counterMetadata.CounterUnit})" : counterName;
             Rate = rate;
         }
 
@@ -124,7 +120,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
     internal sealed class BeginInstrumentReportingPayload : MeterPayload
     {
         public BeginInstrumentReportingPayload(CounterMetadata counterMetadata, DateTime timestamp)
-            : base(timestamp, counterMetadata, string.Empty, string.Empty, 0.0, CounterType.Metric, null, EventType.BeginInstrumentReporting)
+            : base(timestamp, counterMetadata, string.Empty, 0.0, CounterType.Metric, null, EventType.BeginInstrumentReporting)
         {
         }
     }
@@ -132,7 +128,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
     internal sealed class CounterEndedPayload : MeterPayload
     {
         public CounterEndedPayload(CounterMetadata counterMetadata, DateTime timestamp)
-            : base(timestamp, counterMetadata, string.Empty, string.Empty, 0.0, CounterType.Metric, null, EventType.CounterEnded)
+            : base(timestamp, counterMetadata, string.Empty, 0.0, CounterType.Metric, null, EventType.CounterEnded)
         {
         }
     }
@@ -143,12 +139,12 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
     /// </summary>
     internal sealed class RatePayload : MeterPayload, IRatePayload
     {
-        public RatePayload(CounterMetadata counterMetadata, string displayName, string displayUnits, string valueTags, double rate, double intervalSecs, DateTime timestamp) :
-            base(timestamp, counterMetadata, displayName, displayUnits, rate, CounterType.Rate, valueTags, EventType.Rate)
+        public RatePayload(CounterMetadata counterMetadata, string displayName, string valueTags, double rate, double intervalSecs, DateTime timestamp) :
+            base(timestamp, counterMetadata, displayName, rate, CounterType.Rate, valueTags, EventType.Rate)
         {
             // In case these properties are not provided, set them to appropriate values.
             string counterName = string.IsNullOrEmpty(displayName) ? counterMetadata.CounterName : displayName;
-            string unitsName = string.IsNullOrEmpty(displayUnits) ? "Count" : displayUnits;
+            string unitsName = string.IsNullOrEmpty(counterMetadata.CounterUnit) ? "Count" : counterMetadata.CounterUnit;
             string intervalName = intervalSecs.ToString() + " sec";
             DisplayName = $"{counterName} ({unitsName} / {intervalName})";
         }
@@ -164,12 +160,12 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
     /// </summary>
     internal sealed class CounterRateAndValuePayload : MeterPayload, IRatePayload
     {
-        public CounterRateAndValuePayload(CounterMetadata counterMetadata, string displayName, string displayUnits, string valueTags, double rate, double value, DateTime timestamp) :
-            base(timestamp, counterMetadata, displayName, displayUnits, value, CounterType.Metric, valueTags, EventType.Rate)
+        public CounterRateAndValuePayload(CounterMetadata counterMetadata, string displayName, string valueTags, double rate, double value, DateTime timestamp) :
+            base(timestamp, counterMetadata, displayName, value, CounterType.Metric, valueTags, EventType.Rate)
         {
             // In case these properties are not provided, set them to appropriate values.
             string counterName = string.IsNullOrEmpty(displayName) ? counterMetadata.CounterName : displayName;
-            string unitsName = string.IsNullOrEmpty(displayUnits) ? "Count" : displayUnits;
+            string unitsName = string.IsNullOrEmpty(counterMetadata.CounterUnit) ? "Count" : counterMetadata.CounterUnit;
             DisplayName = $"{counterName} ({unitsName})";
             Rate = rate;
         }
@@ -183,12 +179,12 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
 
     internal sealed class PercentilePayload : MeterPayload
     {
-        public PercentilePayload(CounterMetadata counterMetadata, string displayName, string displayUnits, string valueTags, double value, DateTime timestamp) :
-            base(timestamp, counterMetadata, displayName, displayUnits, value, CounterType.Metric, valueTags, EventType.Histogram)
+        public PercentilePayload(CounterMetadata counterMetadata, string displayName, string valueTags, double value, DateTime timestamp) :
+            base(timestamp, counterMetadata, displayName, value, CounterType.Metric, valueTags, EventType.Histogram)
         {
             // In case these properties are not provided, set them to appropriate values.
             string counterName = string.IsNullOrEmpty(displayName) ? counterMetadata.CounterName : displayName;
-            DisplayName = !string.IsNullOrEmpty(displayUnits) ? $"{counterName} ({displayUnits})" : counterName;
+            DisplayName = !string.IsNullOrEmpty(counterMetadata.CounterUnit) ? $"{counterName} ({counterMetadata.CounterUnit})" : counterName;
         }
     }
 
@@ -199,8 +195,8 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
     // like dotnet-counters, while still keeping the quantiles together as a unit.
     internal sealed class AggregatePercentilePayload : MeterPayload
     {
-        public AggregatePercentilePayload(CounterMetadata counterMetadata, string displayName, string displayUnits, string valueTags, int count, double sum, IEnumerable<Quantile> quantiles, DateTime timestamp) :
-            base(timestamp, counterMetadata, displayName, displayUnits, 0.0, CounterType.Metric, valueTags, EventType.Histogram)
+        public AggregatePercentilePayload(CounterMetadata counterMetadata, string displayName, string valueTags, int count, double sum, IEnumerable<Quantile> quantiles, DateTime timestamp) :
+            base(timestamp, counterMetadata, displayName, 0.0, CounterType.Metric, valueTags, EventType.Histogram)
         {
             Count = count;
             Sum = sum;
@@ -219,7 +215,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
     internal sealed class ErrorPayload : MeterPayload
     {
         public ErrorPayload(string errorMessage, DateTime timestamp, EventType eventType)
-            : base(timestamp, new(), string.Empty, string.Empty, 0.0, CounterType.Metric, null, eventType)
+            : base(timestamp, new(), string.Empty, 0.0, CounterType.Metric, null, eventType)
         {
             ErrorMessage = errorMessage;
         }

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/CounterPayload.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/CounterPayload.cs
@@ -37,9 +37,9 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
 
         public string Unit { get; }
 
-        public double Value { get; protected set; }
+        public double Value { get; }
 
-        public DateTime Timestamp { get; protected set; }
+        public DateTime Timestamp { get; }
 
         public float Interval { get; }
 

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/CounterPayload.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/CounterPayload.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
 
         public string DisplayName { get; protected set; }
 
+        public string Unit => CounterMetadata.CounterUnit;
 
         public double Value { get; }
 

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/ICounterPayload.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/ICounterPayload.cs
@@ -24,8 +24,6 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
 
         string DisplayName { get; }
 
-        string Unit { get; }
-
         DateTime Timestamp { get; }
 
         /// <summary>

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/ICounterPayload.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/ICounterPayload.cs
@@ -24,6 +24,8 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
 
         string DisplayName { get; }
 
+        string Unit => CounterMetadata.CounterUnit;
+
         DateTime Timestamp { get; }
 
         /// <summary>

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/TraceEventExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/TraceEventExtensions.cs
@@ -106,6 +106,17 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
             return AddCounterMetadata(providerName, counterName, id, null, null, null);
         }
 
+        public static bool TryGetCounterMetadata(string providerName, string counterName, int? instrumentId, out CounterMetadata counterMetadata)
+        {
+            if (instrumentId.HasValue && counterMetadataById.TryGetValue(instrumentId.Value, out counterMetadata))
+            {
+                return true;
+            }
+
+            ProviderAndCounter providerAndCounter = new(providerName, counterName);
+            return counterMetadataByName.TryGetValue(providerAndCounter, out counterMetadata);
+        }
+
         public static bool TryGetCounterPayload(this TraceEvent traceEvent, CounterConfiguration counterConfiguration, out ICounterPayload payload)
         {
             payload = null;

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/TraceEventExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/TraceEventExtensions.cs
@@ -454,8 +454,20 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
             //string unit = (string)obj.PayloadValue(4);
             string tags = (string)obj.PayloadValue(5);
             string quantilesText = (string)obj.PayloadValue(6);
-            int count = (int)obj.PayloadValue(7);
-            double sum = (double)obj.PayloadValue(8);
+
+            int count;
+            double sum;
+            if (obj.Version >= 1)
+            {
+                count = (int)obj.PayloadValue(7);
+                sum = (double)obj.PayloadValue(8);
+            }
+            else
+            {
+                count = 0;
+                sum = 0;
+            }
+
             int? id = null;
             if (obj.Version >= 2)
             {

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/TraceEventExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/TraceEventExtensions.cs
@@ -246,7 +246,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
             string meterName = (string)obj.PayloadValue(1);
             //string meterVersion = (string)obj.PayloadValue(2);
             string instrumentName = (string)obj.PayloadValue(3);
-            string unit = (string)obj.PayloadValue(4);
+            //string unit = (string)obj.PayloadValue(4);
             string tags = (string)obj.PayloadValue(5);
             string lastValueText = (string)obj.PayloadValue(6);
             int? id = null;
@@ -265,7 +265,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
             // the value might be an empty string indicating no measurement was provided this collection interval
             if (double.TryParse(lastValueText, NumberStyles.Number | NumberStyles.Float, CultureInfo.InvariantCulture, out double lastValue))
             {
-                payload = new GaugePayload(metadata, null, unit, tags, lastValue, obj.TimeStamp);
+                payload = new GaugePayload(metadata, null, tags, lastValue, obj.TimeStamp);
             }
             else
             {
@@ -345,7 +345,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
             string meterName = (string)traceEvent.PayloadValue(1);
             //string meterVersion = (string)obj.PayloadValue(2);
             string instrumentName = (string)traceEvent.PayloadValue(3);
-            string unit = (string)traceEvent.PayloadValue(4);
+            //string unit = (string)traceEvent.PayloadValue(4);
             string tags = (string)traceEvent.PayloadValue(5);
             string rateText = (string)traceEvent.PayloadValue(6);
             //Starting in .NET 8 we also publish the absolute value of these counters
@@ -371,11 +371,11 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
                     counterConfiguration.UseCounterRateAndValuePayload &&
                     double.TryParse(absoluteValueText, NumberStyles.Number | NumberStyles.Float, CultureInfo.InvariantCulture, out double value))
                 {
-                    payload = new CounterRateAndValuePayload(metadata, null, unit, tags, rate, value, traceEvent.TimeStamp);
+                    payload = new CounterRateAndValuePayload(metadata, null, tags, rate, value, traceEvent.TimeStamp);
                 }
                 else
                 {
-                    payload = new RatePayload(metadata, null, unit, tags, rate, counterConfiguration.CounterFilter.DefaultIntervalSeconds, traceEvent.TimeStamp);
+                    payload = new RatePayload(metadata, null, tags, rate, counterConfiguration.CounterFilter.DefaultIntervalSeconds, traceEvent.TimeStamp);
                 }
             }
             else
@@ -401,7 +401,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
             string meterName = (string)traceEvent.PayloadValue(1);
             //string meterVersion = (string)obj.PayloadValue(2);
             string instrumentName = (string)traceEvent.PayloadValue(3);
-            string unit = (string)traceEvent.PayloadValue(4);
+            //string unit = (string)traceEvent.PayloadValue(4);
             string tags = (string)traceEvent.PayloadValue(5);
             string rateText = (string)traceEvent.PayloadValue(6);
             string valueText = (string)traceEvent.PayloadValue(7);
@@ -426,7 +426,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
             if (double.TryParse(rateText, NumberStyles.Number | NumberStyles.Float, CultureInfo.InvariantCulture, out double rate)
                 && double.TryParse(valueText, NumberStyles.Number | NumberStyles.Float, CultureInfo.InvariantCulture, out double value))
             {
-                payload = new UpDownCounterPayload(metadata, null, unit, tags, rate, value, traceEvent.TimeStamp);
+                payload = new UpDownCounterPayload(metadata, null, tags, rate, value, traceEvent.TimeStamp);
             }
             else
             {
@@ -451,7 +451,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
             string meterName = (string)obj.PayloadValue(1);
             //string meterVersion = (string)obj.PayloadValue(2);
             string instrumentName = (string)obj.PayloadValue(3);
-            string unit = (string)obj.PayloadValue(4);
+            //string unit = (string)obj.PayloadValue(4);
             string tags = (string)obj.PayloadValue(5);
             string quantilesText = (string)obj.PayloadValue(6);
             int count = (int)obj.PayloadValue(7);
@@ -470,7 +470,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
             //Note quantiles can be empty.
             IList<Quantile> quantiles = ParseQuantiles(quantilesText);
             CounterMetadata metadata = GetCounterMetadata(meterName, instrumentName, id);
-            payload = new AggregatePercentilePayload(metadata, null, unit, tags, count, sum, quantiles, obj.TimeStamp);
+            payload = new AggregatePercentilePayload(metadata, null, tags, count, sum, quantiles, obj.TimeStamp);
         }
 
         private static void HandleHistogramLimitReached(TraceEvent obj, CounterConfiguration configuration, out ICounterPayload payload)

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/TraceEventExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/TraceEventExtensions.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
             }
 
             // no pre-existing counter metadata was found, create a new one
-            metadata = new CounterMetadata(providerName, providerVersion, counterName, counterUnit, counterDescription, meterTags, instrumentTags, scopeHash);
+            metadata = new CounterMetadata(providerName, providerVersion, counterName, counterUnit, counterDescription, id, meterTags, instrumentTags, scopeHash);
             if (id.HasValue)
             {
                 counterMetadataById.TryAdd(id.Value, metadata);

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/TraceEventExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/TraceEventExtensions.cs
@@ -265,7 +265,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
             // the value might be an empty string indicating no measurement was provided this collection interval
             if (double.TryParse(lastValueText, NumberStyles.Number | NumberStyles.Float, CultureInfo.InvariantCulture, out double lastValue))
             {
-                payload = new GaugePayload(metadata, null, tags, lastValue, obj.TimeStamp);
+                payload = new GaugePayload(metadata, displayName: null, displayUnits: null, tags, lastValue, obj.TimeStamp);
             }
             else
             {
@@ -371,11 +371,11 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
                     counterConfiguration.UseCounterRateAndValuePayload &&
                     double.TryParse(absoluteValueText, NumberStyles.Number | NumberStyles.Float, CultureInfo.InvariantCulture, out double value))
                 {
-                    payload = new CounterRateAndValuePayload(metadata, null, tags, rate, value, traceEvent.TimeStamp);
+                    payload = new CounterRateAndValuePayload(metadata, displayName: null, displayUnits: null, tags, rate, value, traceEvent.TimeStamp);
                 }
                 else
                 {
-                    payload = new RatePayload(metadata, null, tags, rate, counterConfiguration.CounterFilter.DefaultIntervalSeconds, traceEvent.TimeStamp);
+                    payload = new RatePayload(metadata, displayName: null, displayUnits: null, tags, rate, counterConfiguration.CounterFilter.DefaultIntervalSeconds, traceEvent.TimeStamp);
                 }
             }
             else
@@ -426,7 +426,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
             if (double.TryParse(rateText, NumberStyles.Number | NumberStyles.Float, CultureInfo.InvariantCulture, out double rate)
                 && double.TryParse(valueText, NumberStyles.Number | NumberStyles.Float, CultureInfo.InvariantCulture, out double value))
             {
-                payload = new UpDownCounterPayload(metadata, null, tags, rate, value, traceEvent.TimeStamp);
+                payload = new UpDownCounterPayload(metadata, displayName: null, displayUnits: null, tags, rate, value, traceEvent.TimeStamp);
             }
             else
             {
@@ -470,7 +470,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
             //Note quantiles can be empty.
             IList<Quantile> quantiles = ParseQuantiles(quantilesText);
             CounterMetadata metadata = GetCounterMetadata(meterName, instrumentName, id);
-            payload = new AggregatePercentilePayload(metadata, null, tags, count, sum, quantiles, obj.TimeStamp);
+            payload = new AggregatePercentilePayload(metadata, displayName: null, displayUnits: null, tags, count, sum, quantiles, obj.TimeStamp);
         }
 
         private static void HandleHistogramLimitReached(TraceEvent obj, CounterConfiguration configuration, out ICounterPayload payload)

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/TraceEventExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/TraceEventExtensions.cs
@@ -416,11 +416,16 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
                 return;
             }
 
+            if (rateText == string.Empty)
+            {
+                // Note: Observable counters report empty rate on the first measurement
+                rateText = valueText;
+            }
+
             CounterMetadata metadata = GetCounterMetadata(meterName, instrumentName, id);
             if (double.TryParse(rateText, NumberStyles.Number | NumberStyles.Float, CultureInfo.InvariantCulture, out double rate)
                 && double.TryParse(valueText, NumberStyles.Number | NumberStyles.Float, CultureInfo.InvariantCulture, out double value))
             {
-                // UpDownCounter reports the value, not the rate - this is different than how Counter behaves.
                 payload = new UpDownCounterPayload(metadata, null, unit, tags, rate, value, traceEvent.TimeStamp);
             }
             else

--- a/src/Tools/dotnet-counters/CounterMonitor.cs
+++ b/src/Tools/dotnet-counters/CounterMonitor.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 foreach (Quantile quantile in aggregatePayload.Quantiles)
                 {
                     (double key, double val) = quantile;
-                    PercentilePayload percentilePayload = new(payload.CounterMetadata, payload.DisplayName, AppendQuantile(payload.ValueTags, $"Percentile={key * 100}"), val, payload.Timestamp);
+                    PercentilePayload percentilePayload = new(payload.CounterMetadata, payload.DisplayName, payload.DisplayUnits, AppendQuantile(payload.ValueTags, $"Percentile={key * 100}"), val, payload.Timestamp);
                     _renderer.CounterPayloadReceived(percentilePayload, _pauseCmdSet);
                 }
 

--- a/src/Tools/dotnet-counters/CounterMonitor.cs
+++ b/src/Tools/dotnet-counters/CounterMonitor.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 foreach (Quantile quantile in aggregatePayload.Quantiles)
                 {
                     (double key, double val) = quantile;
-                    PercentilePayload percentilePayload = new(payload.CounterMetadata, payload.DisplayName, payload.Unit, AppendQuantile(payload.ValueTags, $"Percentile={key * 100}"), val, payload.Timestamp);
+                    PercentilePayload percentilePayload = new(payload.CounterMetadata, payload.DisplayName, AppendQuantile(payload.ValueTags, $"Percentile={key * 100}"), val, payload.Timestamp);
                     _renderer.CounterPayloadReceived(percentilePayload, _pauseCmdSet);
                 }
 

--- a/src/Tools/dotnet-counters/DotnetCountersCounterPayloadExtensions.cs
+++ b/src/Tools/dotnet-counters/DotnetCountersCounterPayloadExtensions.cs
@@ -11,12 +11,12 @@ namespace Microsoft.Diagnostics.Tools.Counters
         {
             if (!counterPayload.IsMeter)
             {
-                string unit = counterPayload.Unit == "count" ? "Count" : counterPayload.Unit;
+                string unit = counterPayload.CounterMetadata.CounterUnit == "count" ? "Count" : counterPayload.CounterMetadata.CounterUnit;
                 if (counterPayload.CounterType == CounterType.Rate)
                 {
                     return $"{counterPayload.DisplayName} ({unit} / {counterPayload.Series} sec)";
                 }
-                if (!string.IsNullOrEmpty(counterPayload.Unit))
+                if (!string.IsNullOrEmpty(counterPayload.CounterMetadata.CounterUnit))
                 {
                     return $"{counterPayload.DisplayName} ({unit})";
                 }

--- a/src/tests/EventPipeTracee/CustomMetrics.cs
+++ b/src/tests/EventPipeTracee/CustomMetrics.cs
@@ -12,19 +12,32 @@ namespace EventPipeTracee
     {
         private Meter _meter;
         private Counter<int> _counter;
+        private UpDownCounter<int> _upDownCounter;
         private Histogram<float> _histogram;
+        private ObservableCounter<int> _observableCounter;
+        private ObservableUpDownCounter<int> _observableUpDownCounter;
+        private ObservableGauge<double> _observableGauge;
 
         public CustomMetrics()
         {
             _meter = new(Constants.TestMeterName);
             _counter = _meter.CreateCounter<int>(Constants.TestCounter, "dollars");
+            _upDownCounter = _meter.CreateUpDownCounter<int>(Constants.TestUpDownCounter, "queue size");
             _histogram = _meter.CreateHistogram<float>(Constants.TestHistogram, "feet");
-            // consider adding gauge/etc. here
+            _observableCounter = _meter.CreateObservableCounter<int>(Constants.TestObservableCounter, () => Random.Shared.Next(), "dollars");
+            _observableUpDownCounter = _meter.CreateObservableUpDownCounter<int>(Constants.TestObservableUpDownCounter, () => Random.Shared.Next(), "queue size");
+            _observableGauge = _meter.CreateObservableGauge<double>(Constants.TestObservableGauge, () => Random.Shared.NextDouble(), "temperature");
         }
 
         public void IncrementCounter(int v = 1)
         {
             _counter.Add(v);
+        }
+
+
+        public void IncrementUpDownCounter(int v = 1)
+        {
+            _upDownCounter.Add(v);
         }
 
         public void RecordHistogram(float v = 10.0f)

--- a/src/tests/EventPipeTracee/EventPipeTracee.csproj
+++ b/src/tests/EventPipeTracee/EventPipeTracee.csproj
@@ -11,5 +11,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.EventSource" Version="$(MicrosoftExtensionsLoggingEventSourceVersion)" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(SystemDiagnosticsDiagnosticSourceVersion)" />
   </ItemGroup>
 </Project>

--- a/src/tests/EventPipeTracee/Program.cs
+++ b/src/tests/EventPipeTracee/Program.cs
@@ -86,6 +86,7 @@ namespace EventPipeTracee
                         recordMetricsCancellationTokenSource.Token.ThrowIfCancellationRequested();
 
                         metrics?.IncrementCounter();
+                        metrics?.IncrementUpDownCounter();
                         metrics?.RecordHistogram(10.0f);
 #if NET8_0_OR_GREATER
                         dupMetrics?.IncrementCounter();

--- a/src/tests/dotnet-counters/CSVExporterTests.cs
+++ b/src/tests/dotnet-counters/CSVExporterTests.cs
@@ -37,7 +37,7 @@ namespace DotnetCounters.UnitTests
             DateTime start = DateTime.Now;
             for (int i = 0; i < 100; i++)
             {
-                exporter.CounterPayloadReceived(new RatePayload(new CounterMetadata("myProvider", "incrementingCounterOne", counterUnit: string.Empty), "Incrementing Counter One", string.Empty, i, 1, start + TimeSpan.FromSeconds(i)), false);
+                exporter.CounterPayloadReceived(new RatePayload(new CounterMetadata("myProvider", "incrementingCounterOne", counterUnit: string.Empty), "Incrementing Counter One", string.Empty, string.Empty, i, 1, start + TimeSpan.FromSeconds(i)), false);
             }
             exporter.Stop();
 
@@ -82,7 +82,7 @@ namespace DotnetCounters.UnitTests
             {
                 exporter.CounterPayloadReceived(
                     new GaugePayload(
-                        new CounterMetadata("myProvider", "counterOne", string.Empty, meterTags, instrumentTags), "Counter One", tags, i, start + TimeSpan.FromSeconds(i)), false);
+                        new CounterMetadata("myProvider", "counterOne", meterTags, instrumentTags), "Counter One", string.Empty, tags, i, start + TimeSpan.FromSeconds(i)), false);
             }
             exporter.Stop();
 
@@ -123,7 +123,7 @@ namespace DotnetCounters.UnitTests
             DateTime start = DateTime.Now;
             for (int i = 0; i < 100; i++)
             {
-                exporter.CounterPayloadReceived(new CounterRateAndValuePayload(new CounterMetadata("myProvider", "counter", counterUnit: string.Empty), "Counter One", string.Empty, rate:0, i, start + TimeSpan.FromSeconds(i)), false);
+                exporter.CounterPayloadReceived(new CounterRateAndValuePayload(new CounterMetadata("myProvider", "counter", counterUnit: string.Empty), "Counter One", string.Empty, string.Empty, rate: 0, i, start + TimeSpan.FromSeconds(i)), false);
             }
             exporter.Stop();
 
@@ -161,9 +161,9 @@ namespace DotnetCounters.UnitTests
             DateTime start = DateTime.Now;
 
             exporter.CounterPayloadReceived(new GaugePayload(
-                new CounterMetadata("myProvider", "counterOne", counterUnit: string.Empty, $"{meterTag1},{meterTag2}", $"{instrumentTag1},{instrumentTag2}"), "Counter One", $"{tag1},{tag2}", 0, start + TimeSpan.FromSeconds(0)), false);
+                new CounterMetadata("myProvider", "counterOne", $"{meterTag1},{meterTag2}", $"{instrumentTag1},{instrumentTag2}"), "Counter One", string.Empty, $"{tag1},{tag2}", 0, start + TimeSpan.FromSeconds(0)), false);
             exporter.CounterPayloadReceived(new GaugePayload(
-                new CounterMetadata("myProvider", "counterTwo", counterUnit: string.Empty, $"{meterTag1},{meterTag2}", $"{otherInstrumentTag1},{otherInstrumentTag2}"), "Counter Two", $"{otherTag1},{otherTag2}", 1, start + TimeSpan.FromSeconds(1)), false);
+                new CounterMetadata("myProvider", "counterTwo", $"{meterTag1},{meterTag2}", $"{otherInstrumentTag1},{otherInstrumentTag2}"), "Counter Two", string.Empty, $"{otherTag1},{otherTag2}", 1, start + TimeSpan.FromSeconds(1)), false);
 
             exporter.Stop();
 
@@ -207,7 +207,7 @@ namespace DotnetCounters.UnitTests
             DateTime start = DateTime.Now;
             for (int i = 0; i < 100; i++)
             {
-                exporter.CounterPayloadReceived(new RatePayload(new CounterMetadata("myProvider", "incrementingCounterOne", counterUnit: string.Empty), "Incrementing Counter One", null, i, 60, start + TimeSpan.FromSeconds(i)), false);
+                exporter.CounterPayloadReceived(new RatePayload(new CounterMetadata("myProvider", "incrementingCounterOne", counterUnit: string.Empty), "Incrementing Counter One", string.Empty, null, i, 60, start + TimeSpan.FromSeconds(i)), false);
             }
             exporter.Stop();
 
@@ -245,7 +245,7 @@ namespace DotnetCounters.UnitTests
             DateTime start = DateTime.Now;
             for (int i = 0; i < 100; i++)
             {
-                exporter.CounterPayloadReceived(new RatePayload(new CounterMetadata("myProvider", "allocRateGen", "MB"), "Allocation Rate Gen", string.Empty, i, 60, start + TimeSpan.FromSeconds(i)), false);
+                exporter.CounterPayloadReceived(new RatePayload(new CounterMetadata("myProvider", "allocRateGen", "MB"), "Allocation Rate Gen", string.Empty, string.Empty, i, 60, start + TimeSpan.FromSeconds(i)), false);
             }
             exporter.Stop();
 
@@ -283,7 +283,7 @@ namespace DotnetCounters.UnitTests
             DateTime start = DateTime.Now;
             for (int i = 0; i < 100; i++)
             {
-                exporter.CounterPayloadReceived(new RatePayload(new CounterMetadata("myProvider", "allocRateGen", "MB"), "Allocation Rate Gen", "foo=bar,baz=7", i, 60, start + TimeSpan.FromSeconds(i)), false);
+                exporter.CounterPayloadReceived(new RatePayload(new CounterMetadata("myProvider", "allocRateGen", "MB"), "Allocation Rate Gen", string.Empty, "foo=bar,baz=7", i, 60, start + TimeSpan.FromSeconds(i)), false);
             }
             exporter.Stop();
 
@@ -321,7 +321,7 @@ namespace DotnetCounters.UnitTests
             DateTime start = DateTime.Now;
             for (int i = 0; i < 100; i++)
             {
-                exporter.CounterPayloadReceived(new PercentilePayload(new CounterMetadata("myProvider", "allocRateGen", "MB"), "Allocation Rate Gen", "foo=bar,Percentile=50", i, start + TimeSpan.FromSeconds(i)), false);
+                exporter.CounterPayloadReceived(new PercentilePayload(new CounterMetadata("myProvider", "allocRateGen", "MB"), "Allocation Rate Gen", string.Empty, "foo=bar,Percentile=50", i, start + TimeSpan.FromSeconds(i)), false);
             }
             exporter.Stop();
 

--- a/src/tests/dotnet-counters/CSVExporterTests.cs
+++ b/src/tests/dotnet-counters/CSVExporterTests.cs
@@ -37,7 +37,7 @@ namespace DotnetCounters.UnitTests
             DateTime start = DateTime.Now;
             for (int i = 0; i < 100; i++)
             {
-                exporter.CounterPayloadReceived(new RatePayload(new CounterMetadata("myProvider", "incrementingCounterOne", null, null, null), "Incrementing Counter One", string.Empty, string.Empty, i, 1, start + TimeSpan.FromSeconds(i)), false);
+                exporter.CounterPayloadReceived(new RatePayload(new CounterMetadata("myProvider", "incrementingCounterOne", counterUnit: string.Empty), "Incrementing Counter One", string.Empty, i, 1, start + TimeSpan.FromSeconds(i)), false);
             }
             exporter.Stop();
 
@@ -80,7 +80,9 @@ namespace DotnetCounters.UnitTests
             DateTime start = DateTime.Now;
             for (int i = 0; i < 10; i++)
             {
-                exporter.CounterPayloadReceived(new GaugePayload(new CounterMetadata("myProvider", "counterOne", meterTags, instrumentTags, null), "Counter One", string.Empty, tags, i, start + TimeSpan.FromSeconds(i)), false);
+                exporter.CounterPayloadReceived(
+                    new GaugePayload(
+                        new CounterMetadata("myProvider", "counterOne", string.Empty, meterTags, instrumentTags), "Counter One", tags, i, start + TimeSpan.FromSeconds(i)), false);
             }
             exporter.Stop();
 
@@ -121,7 +123,7 @@ namespace DotnetCounters.UnitTests
             DateTime start = DateTime.Now;
             for (int i = 0; i < 100; i++)
             {
-                exporter.CounterPayloadReceived(new CounterRateAndValuePayload(new CounterMetadata("myProvider", "counter", null, null, null), "Counter One", string.Empty, string.Empty, rate:0, i, start + TimeSpan.FromSeconds(i)), false);
+                exporter.CounterPayloadReceived(new CounterRateAndValuePayload(new CounterMetadata("myProvider", "counter", counterUnit: string.Empty), "Counter One", string.Empty, rate:0, i, start + TimeSpan.FromSeconds(i)), false);
             }
             exporter.Stop();
 
@@ -158,8 +160,10 @@ namespace DotnetCounters.UnitTests
             exporter.Initialize();
             DateTime start = DateTime.Now;
 
-            exporter.CounterPayloadReceived(new GaugePayload(new CounterMetadata("myProvider", "counterOne", $"{meterTag1},{meterTag2}", $"{instrumentTag1},{instrumentTag2}", "123"), "Counter One", string.Empty, $"{tag1},{tag2}", 0, start + TimeSpan.FromSeconds(0)), false);
-            exporter.CounterPayloadReceived(new GaugePayload(new CounterMetadata("myProvider", "counterTwo", $"{meterTag1},{meterTag2}", $"{otherInstrumentTag1},{otherInstrumentTag2}", "123"), "Counter Two", string.Empty, $"{otherTag1},{otherTag2}", 1, start + TimeSpan.FromSeconds(1)), false);
+            exporter.CounterPayloadReceived(new GaugePayload(
+                new CounterMetadata("myProvider", "counterOne", counterUnit: string.Empty, $"{meterTag1},{meterTag2}", $"{instrumentTag1},{instrumentTag2}"), "Counter One", $"{tag1},{tag2}", 0, start + TimeSpan.FromSeconds(0)), false);
+            exporter.CounterPayloadReceived(new GaugePayload(
+                new CounterMetadata("myProvider", "counterTwo", counterUnit: string.Empty, $"{meterTag1},{meterTag2}", $"{otherInstrumentTag1},{otherInstrumentTag2}"), "Counter Two", $"{otherTag1},{otherTag2}", 1, start + TimeSpan.FromSeconds(1)), false);
 
             exporter.Stop();
 
@@ -203,7 +207,7 @@ namespace DotnetCounters.UnitTests
             DateTime start = DateTime.Now;
             for (int i = 0; i < 100; i++)
             {
-                exporter.CounterPayloadReceived(new RatePayload(new CounterMetadata("myProvider", "incrementingCounterOne", null, null, null), "Incrementing Counter One", string.Empty, null, i, 60, start + TimeSpan.FromSeconds(i)), false);
+                exporter.CounterPayloadReceived(new RatePayload(new CounterMetadata("myProvider", "incrementingCounterOne", counterUnit: string.Empty), "Incrementing Counter One", null, i, 60, start + TimeSpan.FromSeconds(i)), false);
             }
             exporter.Stop();
 
@@ -241,7 +245,7 @@ namespace DotnetCounters.UnitTests
             DateTime start = DateTime.Now;
             for (int i = 0; i < 100; i++)
             {
-                exporter.CounterPayloadReceived(new RatePayload(new CounterMetadata("myProvider", "allocRateGen", null, null, null), "Allocation Rate Gen", "MB", string.Empty, i, 60, start + TimeSpan.FromSeconds(i)), false);
+                exporter.CounterPayloadReceived(new RatePayload(new CounterMetadata("myProvider", "allocRateGen", "MB"), "Allocation Rate Gen", string.Empty, i, 60, start + TimeSpan.FromSeconds(i)), false);
             }
             exporter.Stop();
 
@@ -279,7 +283,7 @@ namespace DotnetCounters.UnitTests
             DateTime start = DateTime.Now;
             for (int i = 0; i < 100; i++)
             {
-                exporter.CounterPayloadReceived(new RatePayload(new CounterMetadata("myProvider", "allocRateGen", null, null, null), "Allocation Rate Gen", "MB", "foo=bar,baz=7", i, 60, start + TimeSpan.FromSeconds(i)), false);
+                exporter.CounterPayloadReceived(new RatePayload(new CounterMetadata("myProvider", "allocRateGen", "MB"), "Allocation Rate Gen", "foo=bar,baz=7", i, 60, start + TimeSpan.FromSeconds(i)), false);
             }
             exporter.Stop();
 
@@ -317,7 +321,7 @@ namespace DotnetCounters.UnitTests
             DateTime start = DateTime.Now;
             for (int i = 0; i < 100; i++)
             {
-                exporter.CounterPayloadReceived(new PercentilePayload(new CounterMetadata("myProvider", "allocRateGen", null, null, null), "Allocation Rate Gen", "MB", "foo=bar,Percentile=50", i, start + TimeSpan.FromSeconds(i)), false);
+                exporter.CounterPayloadReceived(new PercentilePayload(new CounterMetadata("myProvider", "allocRateGen", "MB"), "Allocation Rate Gen", "foo=bar,Percentile=50", i, start + TimeSpan.FromSeconds(i)), false);
             }
             exporter.Stop();
 

--- a/src/tests/dotnet-counters/ConsoleExporterTests.cs
+++ b/src/tests/dotnet-counters/ConsoleExporterTests.cs
@@ -335,7 +335,7 @@ namespace DotnetCounters.UnitTests
             exporter.CounterPayloadReceived(CreateMeterCounterPreNet8("Provider1", "Counter1", "{widget}", "color=blue", 87), false);
             exporter.CounterPayloadReceived(CreateMeterCounterPreNet8("Provider1", "Counter2", "{widget}", "size=1", 14), false);
             exporter.CounterPayloadReceived(CreateMeterCounterPreNet8("Provider1", "Counter2", "{widget}", "temp=hot", 160), false);
-            
+
             console.AssertLinesEqual("Press p to pause, r to resume, q to quit.",
                                      "    Status: Running",
                                      "",
@@ -457,12 +457,12 @@ namespace DotnetCounters.UnitTests
 
         private static CounterPayload CreateMeterCounterPreNet8(string meterName, string instrumentName, string unit, string tags, double value)
         {
-            return new RatePayload(new CounterMetadata(meterName, instrumentName, null, null, null), instrumentName, unit, tags, value, 1, DateTime.MinValue);
+            return new RatePayload(new CounterMetadata(meterName, instrumentName, unit), instrumentName, tags, value, 1, DateTime.MinValue);
         }
 
         private static CounterPayload CreateMeterCounterPostNet8(string meterName, string instrumentName, string unit, string tags, double value)
         {
-            return new CounterRateAndValuePayload(new CounterMetadata(meterName, instrumentName, null, null, null), instrumentName, unit, tags, rate:double.NaN, value, DateTime.MinValue);
+            return new CounterRateAndValuePayload(new CounterMetadata(meterName, instrumentName, unit), instrumentName, tags, rate:double.NaN, value, DateTime.MinValue);
         }
     }
 }

--- a/src/tests/dotnet-counters/ConsoleExporterTests.cs
+++ b/src/tests/dotnet-counters/ConsoleExporterTests.cs
@@ -457,12 +457,12 @@ namespace DotnetCounters.UnitTests
 
         private static CounterPayload CreateMeterCounterPreNet8(string meterName, string instrumentName, string unit, string tags, double value)
         {
-            return new RatePayload(new CounterMetadata(meterName, instrumentName, unit), instrumentName, tags, value, 1, DateTime.MinValue);
+            return new RatePayload(new CounterMetadata(meterName, instrumentName, unit), displayName: null, displayUnits: null, tags, value, 1, DateTime.MinValue);
         }
 
         private static CounterPayload CreateMeterCounterPostNet8(string meterName, string instrumentName, string unit, string tags, double value)
         {
-            return new CounterRateAndValuePayload(new CounterMetadata(meterName, instrumentName, unit), instrumentName, tags, rate:double.NaN, value, DateTime.MinValue);
+            return new CounterRateAndValuePayload(new CounterMetadata(meterName, instrumentName, unit), displayName: null, displayUnits: null, tags, rate: double.NaN, value, DateTime.MinValue);
         }
     }
 }

--- a/src/tests/dotnet-counters/CounterMonitorPayloadTests.cs
+++ b/src/tests/dotnet-counters/CounterMonitorPayloadTests.cs
@@ -242,7 +242,15 @@ namespace DotnetCounters.UnitTests
             HashSet<string> expectedProviders = new() { Constants.TestMeterName };
             Assert.Equal(expectedProviders, metricComponents.Select(c => c.ProviderName).ToHashSet());
 
-            HashSet<string> expectedCounterNames = new() { Constants.TestHistogramName, Constants.TestCounterName };
+            HashSet<string> expectedCounterNames = new()
+            {
+                Constants.TestHistogramName,
+                Constants.TestCounterName,
+                Constants.TestUpDownCounterName,
+                Constants.TestObservableCounterName,
+                Constants.TestObservableUpDownCounterName,
+                Constants.TestObservableGaugeName
+            };
             Assert.Equal(expectedCounterNames, metricComponents.Select(c => c.CounterName).ToHashSet());
 
             Assert.Equal(ExpectedCounterTypes, metricComponents.Select(c => c.CounterType).ToHashSet());

--- a/src/tests/dotnet-counters/JSONExporterTests.cs
+++ b/src/tests/dotnet-counters/JSONExporterTests.cs
@@ -28,7 +28,7 @@ namespace DotnetCounters.UnitTests
             DateTime start = DateTime.Now;
             for (int i = 0; i < 10; i++)
             {
-                exporter.CounterPayloadReceived(new RatePayload(new CounterMetadata("myProvider", "incrementingCounterOne", counterUnit: string.Empty), "Incrementing Counter One", string.Empty, 1, 1, start + TimeSpan.FromSeconds(i)), false);
+                exporter.CounterPayloadReceived(new RatePayload(new CounterMetadata("myProvider", "incrementingCounterOne", counterUnit: string.Empty), "Incrementing Counter One", string.Empty, string.Empty, 1, 1, start + TimeSpan.FromSeconds(i)), false);
             }
             exporter.Stop();
 
@@ -59,7 +59,7 @@ namespace DotnetCounters.UnitTests
             DateTime start = DateTime.Now;
             for (int i = 0; i < 10; i++)
             {
-                exporter.CounterPayloadReceived(new GaugePayload(new CounterMetadata("myProvider", "counterOne", counterUnit: string.Empty), "Counter One", string.Empty, 1, start + TimeSpan.FromSeconds(i)), false);
+                exporter.CounterPayloadReceived(new GaugePayload(new CounterMetadata("myProvider", "counterOne", counterUnit: string.Empty), "Counter One", string.Empty, string.Empty, 1, start + TimeSpan.FromSeconds(i)), false);
             }
             exporter.Stop();
 
@@ -93,7 +93,7 @@ namespace DotnetCounters.UnitTests
             DateTime start = DateTime.Now;
             for (int i = 0; i < 10; i++)
             {
-                exporter.CounterPayloadReceived(new GaugePayload(new CounterMetadata("myProvider", "counterOne", counterUnit: string.Empty, meterTags, instrumentTags), "Counter One", "f=abc,two=9", 1, start + TimeSpan.FromSeconds(i)), false);
+                exporter.CounterPayloadReceived(new GaugePayload(new CounterMetadata("myProvider", "counterOne", meterTags, instrumentTags), "Counter One", string.Empty, "f=abc,two=9", 1, start + TimeSpan.FromSeconds(i)), false);
             }
             exporter.Stop();
 
@@ -130,8 +130,8 @@ namespace DotnetCounters.UnitTests
             exporter.Initialize();
             DateTime start = DateTime.Now;
 
-            exporter.CounterPayloadReceived(new GaugePayload(new CounterMetadata("myProvider", "counterOne", counterUnit: string.Empty, meterTags, instrumentTags), "Counter One", "f=abc,two=9", 1, start + TimeSpan.FromSeconds(1)), false);
-            exporter.CounterPayloadReceived(new GaugePayload(new CounterMetadata("myProvider", "counterTwo", counterUnit: string.Empty, meterTags, otherInstrumentTags), "Counter Two", "g=bcd,three=10", 1, start + TimeSpan.FromSeconds(2)), false);
+            exporter.CounterPayloadReceived(new GaugePayload(new CounterMetadata("myProvider", "counterOne", meterTags, instrumentTags), "Counter One", string.Empty, "f=abc,two=9", 1, start + TimeSpan.FromSeconds(1)), false);
+            exporter.CounterPayloadReceived(new GaugePayload(new CounterMetadata("myProvider", "counterTwo", meterTags, otherInstrumentTags), "Counter Two", string.Empty, "g=bcd,three=10", 1, start + TimeSpan.FromSeconds(2)), false);
 
             exporter.Stop();
 
@@ -173,7 +173,7 @@ namespace DotnetCounters.UnitTests
             DateTime start = DateTime.Now;
             for (int i = 0; i < 20; i++)
             {
-                exporter.CounterPayloadReceived(new GaugePayload(new CounterMetadata("myProvider", "heapSize", "MB"), "Heap Size", string.Empty, i, start + TimeSpan.FromSeconds(i)), false);
+                exporter.CounterPayloadReceived(new GaugePayload(new CounterMetadata("myProvider", "heapSize", "MB"), "Heap Size", string.Empty, string.Empty, i, start + TimeSpan.FromSeconds(i)), false);
             }
             exporter.Stop();
 
@@ -207,7 +207,7 @@ namespace DotnetCounters.UnitTests
             DateTime start = DateTime.Now;
             for (int i = 0; i < 20; i++)
             {
-                exporter.CounterPayloadReceived(new RatePayload(new CounterMetadata("myProvider", "heapSize", "MB"), "Heap Size", string.Empty, 0, 60, start + TimeSpan.FromSeconds(i)), false);
+                exporter.CounterPayloadReceived(new RatePayload(new CounterMetadata("myProvider", "heapSize", "MB"), "Heap Size", string.Empty, string.Empty, 0, 60, start + TimeSpan.FromSeconds(i)), false);
             }
             exporter.Stop();
 
@@ -231,7 +231,7 @@ namespace DotnetCounters.UnitTests
             DateTime start = DateTime.Now;
             for (int i = 0; i < 10; i++)
             {
-                exporter.CounterPayloadReceived(new GaugePayload(new CounterMetadata("myProvider", "counterOne", counterUnit: ""), "Counter One", "f=abc,two=9", 1, start + TimeSpan.FromSeconds(i)), false);
+                exporter.CounterPayloadReceived(new GaugePayload(new CounterMetadata("myProvider", "counterOne", counterUnit: ""), "Counter One", string.Empty, "f=abc,two=9", 1, start + TimeSpan.FromSeconds(i)), false);
             }
             exporter.Stop();
 
@@ -263,7 +263,7 @@ namespace DotnetCounters.UnitTests
             DateTime start = DateTime.Now;
             for (int i = 0; i < 10; i++)
             {
-                exporter.CounterPayloadReceived(new GaugePayload(new CounterMetadata("myProvider\\", "counterOne\f", counterUnit: ""), "CounterOne\f", "f\b\"\n=abc\r\\,\ttwo=9", 1, start + TimeSpan.FromSeconds(i)), false);
+                exporter.CounterPayloadReceived(new GaugePayload(new CounterMetadata("myProvider\\", "counterOne\f", counterUnit: ""), "CounterOne\f", string.Empty, "f\b\"\n=abc\r\\,\ttwo=9", 1, start + TimeSpan.FromSeconds(i)), false);
             }
             exporter.Stop();
 
@@ -295,7 +295,7 @@ namespace DotnetCounters.UnitTests
             DateTime start = DateTime.Now;
             for (int i = 0; i < 10; i++)
             {
-                exporter.CounterPayloadReceived(new PercentilePayload(new CounterMetadata("myProvider", "counterOne", counterUnit: ""), "Counter One", "f=abc,Percentile=50", 1, start + TimeSpan.FromSeconds(1)), false);
+                exporter.CounterPayloadReceived(new PercentilePayload(new CounterMetadata("myProvider", "counterOne", counterUnit: ""), "Counter One", string.Empty, "f=abc,Percentile=50", 1, start + TimeSpan.FromSeconds(1)), false);
             }
             exporter.Stop();
 
@@ -331,7 +331,7 @@ namespace DotnetCounters.UnitTests
             DateTime start = DateTime.Now;
             for (int i = 0; i < 20; i++)
             {
-                exporter.CounterPayloadReceived(new CounterRateAndValuePayload(new CounterMetadata("myProvider", "heapSize", "MB"), "Heap Size", string.Empty, rate: 0, i, start + TimeSpan.FromSeconds(i)), false);
+                exporter.CounterPayloadReceived(new CounterRateAndValuePayload(new CounterMetadata("myProvider", "heapSize", "MB"), "Heap Size", string.Empty, string.Empty, rate: 0, i, start + TimeSpan.FromSeconds(i)), false);
             }
             exporter.Stop();
 

--- a/src/tests/dotnet-counters/JSONExporterTests.cs
+++ b/src/tests/dotnet-counters/JSONExporterTests.cs
@@ -28,7 +28,7 @@ namespace DotnetCounters.UnitTests
             DateTime start = DateTime.Now;
             for (int i = 0; i < 10; i++)
             {
-                exporter.CounterPayloadReceived(new RatePayload(new CounterMetadata("myProvider", "incrementingCounterOne", null, null, null), "Incrementing Counter One", string.Empty, string.Empty, 1, 1, start + TimeSpan.FromSeconds(i)), false);
+                exporter.CounterPayloadReceived(new RatePayload(new CounterMetadata("myProvider", "incrementingCounterOne", counterUnit: string.Empty), "Incrementing Counter One", string.Empty, 1, 1, start + TimeSpan.FromSeconds(i)), false);
             }
             exporter.Stop();
 
@@ -59,7 +59,7 @@ namespace DotnetCounters.UnitTests
             DateTime start = DateTime.Now;
             for (int i = 0; i < 10; i++)
             {
-                exporter.CounterPayloadReceived(new GaugePayload(new CounterMetadata("myProvider", "counterOne", null, null, null), "Counter One", string.Empty, string.Empty, 1, start + TimeSpan.FromSeconds(i)), false);
+                exporter.CounterPayloadReceived(new GaugePayload(new CounterMetadata("myProvider", "counterOne", counterUnit: string.Empty), "Counter One", string.Empty, 1, start + TimeSpan.FromSeconds(i)), false);
             }
             exporter.Stop();
 
@@ -86,7 +86,6 @@ namespace DotnetCounters.UnitTests
         {
             string meterTags = "MeterTagKey=MeterTagValue,MeterTagKey2=MeterTagValue2";
             string instrumentTags = "InstrumentTagKey=InstrumentTagValue,InstrumentTagKey2=InstrumentTagValue2";
-            string scopeHash = "123";
 
             string fileName = "CounterTest.json";
             JSONExporter exporter = new(fileName, "myProcess.exe");
@@ -94,7 +93,7 @@ namespace DotnetCounters.UnitTests
             DateTime start = DateTime.Now;
             for (int i = 0; i < 10; i++)
             {
-                exporter.CounterPayloadReceived(new GaugePayload(new CounterMetadata("myProvider", "counterOne", meterTags, instrumentTags, scopeHash), "Counter One", string.Empty, "f=abc,two=9", 1, start + TimeSpan.FromSeconds(i)), false);
+                exporter.CounterPayloadReceived(new GaugePayload(new CounterMetadata("myProvider", "counterOne", counterUnit: string.Empty, meterTags, instrumentTags), "Counter One", "f=abc,two=9", 1, start + TimeSpan.FromSeconds(i)), false);
             }
             exporter.Stop();
 
@@ -125,15 +124,14 @@ namespace DotnetCounters.UnitTests
             string meterTags = "MeterTagKey=MeterTagValue,MeterTagKey2=MeterTagValue2";
             string instrumentTags = "InstrumentTagKey=InstrumentTagValue,InstrumentTagKey2=InstrumentTagValue2";
             string otherInstrumentTags = "OtherInstrumentTagKey=OtherInstrumentTagValue,OtherInstrumentTagKey2=OtherInstrumentTagValue2";
-            string scopeHash = "123";
 
             string fileName = "CounterTest.json";
             JSONExporter exporter = new(fileName, "myProcess.exe");
             exporter.Initialize();
             DateTime start = DateTime.Now;
 
-            exporter.CounterPayloadReceived(new GaugePayload(new CounterMetadata("myProvider", "counterOne", meterTags, instrumentTags, scopeHash), "Counter One", string.Empty, "f=abc,two=9", 1, start + TimeSpan.FromSeconds(1)), false);
-            exporter.CounterPayloadReceived(new GaugePayload(new CounterMetadata("myProvider", "counterTwo", meterTags, otherInstrumentTags, scopeHash), "Counter Two", string.Empty, "g=bcd,three=10", 1, start + TimeSpan.FromSeconds(2)), false);
+            exporter.CounterPayloadReceived(new GaugePayload(new CounterMetadata("myProvider", "counterOne", counterUnit: string.Empty, meterTags, instrumentTags), "Counter One", "f=abc,two=9", 1, start + TimeSpan.FromSeconds(1)), false);
+            exporter.CounterPayloadReceived(new GaugePayload(new CounterMetadata("myProvider", "counterTwo", counterUnit: string.Empty, meterTags, otherInstrumentTags), "Counter Two", "g=bcd,three=10", 1, start + TimeSpan.FromSeconds(2)), false);
 
             exporter.Stop();
 
@@ -175,7 +173,7 @@ namespace DotnetCounters.UnitTests
             DateTime start = DateTime.Now;
             for (int i = 0; i < 20; i++)
             {
-                exporter.CounterPayloadReceived(new GaugePayload(new CounterMetadata("myProvider", "heapSize", null, null, null), "Heap Size", "MB", string.Empty, i, start + TimeSpan.FromSeconds(i)), false);
+                exporter.CounterPayloadReceived(new GaugePayload(new CounterMetadata("myProvider", "heapSize", "MB"), "Heap Size", string.Empty, i, start + TimeSpan.FromSeconds(i)), false);
             }
             exporter.Stop();
 
@@ -209,7 +207,7 @@ namespace DotnetCounters.UnitTests
             DateTime start = DateTime.Now;
             for (int i = 0; i < 20; i++)
             {
-                exporter.CounterPayloadReceived(new RatePayload(new CounterMetadata("myProvider", "heapSize", null, null, null), "Heap Size", "MB", string.Empty, 0, 60, start + TimeSpan.FromSeconds(i)), false);
+                exporter.CounterPayloadReceived(new RatePayload(new CounterMetadata("myProvider", "heapSize", "MB"), "Heap Size", string.Empty, 0, 60, start + TimeSpan.FromSeconds(i)), false);
             }
             exporter.Stop();
 
@@ -233,7 +231,7 @@ namespace DotnetCounters.UnitTests
             DateTime start = DateTime.Now;
             for (int i = 0; i < 10; i++)
             {
-                exporter.CounterPayloadReceived(new GaugePayload(new CounterMetadata("myProvider", "counterOne", null, null, null), "Counter One", "", "f=abc,two=9", 1, start + TimeSpan.FromSeconds(i)), false);
+                exporter.CounterPayloadReceived(new GaugePayload(new CounterMetadata("myProvider", "counterOne", counterUnit: ""), "Counter One", "f=abc,two=9", 1, start + TimeSpan.FromSeconds(i)), false);
             }
             exporter.Stop();
 
@@ -265,7 +263,7 @@ namespace DotnetCounters.UnitTests
             DateTime start = DateTime.Now;
             for (int i = 0; i < 10; i++)
             {
-                exporter.CounterPayloadReceived(new GaugePayload(new CounterMetadata("myProvider\\", "counterOne\f", null, null, null), "CounterOne\f", "", "f\b\"\n=abc\r\\,\ttwo=9", 1, start + TimeSpan.FromSeconds(i)), false);
+                exporter.CounterPayloadReceived(new GaugePayload(new CounterMetadata("myProvider\\", "counterOne\f", counterUnit: ""), "CounterOne\f", "f\b\"\n=abc\r\\,\ttwo=9", 1, start + TimeSpan.FromSeconds(i)), false);
             }
             exporter.Stop();
 
@@ -297,7 +295,7 @@ namespace DotnetCounters.UnitTests
             DateTime start = DateTime.Now;
             for (int i = 0; i < 10; i++)
             {
-                exporter.CounterPayloadReceived(new PercentilePayload(new CounterMetadata("myProvider", "counterOne", null, null, null), "Counter One", "", "f=abc,Percentile=50", 1, start + TimeSpan.FromSeconds(1)), false);
+                exporter.CounterPayloadReceived(new PercentilePayload(new CounterMetadata("myProvider", "counterOne", counterUnit: ""), "Counter One", "f=abc,Percentile=50", 1, start + TimeSpan.FromSeconds(1)), false);
             }
             exporter.Stop();
 
@@ -333,7 +331,7 @@ namespace DotnetCounters.UnitTests
             DateTime start = DateTime.Now;
             for (int i = 0; i < 20; i++)
             {
-                exporter.CounterPayloadReceived(new CounterRateAndValuePayload(new CounterMetadata("myProvider", "heapSize", null, null, null), "Heap Size", "MB", string.Empty, rate: 0, i, start + TimeSpan.FromSeconds(i)), false);
+                exporter.CounterPayloadReceived(new CounterRateAndValuePayload(new CounterMetadata("myProvider", "heapSize", "MB"), "Heap Size", string.Empty, rate: 0, i, start + TimeSpan.FromSeconds(i)), false);
             }
             exporter.Stop();
 

--- a/src/tests/dotnet-counters/TestConstants.cs
+++ b/src/tests/dotnet-counters/TestConstants.cs
@@ -7,8 +7,16 @@ namespace DotnetCounters.UnitTests
     {
         public const string TestCounter = "TestCounter";
         public const string TestCounterName = TestCounter + " (dollars / 1 sec)";
+        public const string TestUpDownCounter = "TestUpDownCounter";
+        public const string TestUpDownCounterName = TestUpDownCounter + " (queue size)";
         public const string TestHistogram = "TestHistogram";
         public const string TestHistogramName = TestHistogram + " (feet)";
+        public const string TestObservableCounter = "TestObservableCounter";
+        public const string TestObservableCounterName = TestObservableCounter + " (dollars / 1 sec)";
+        public const string TestObservableUpDownCounter = "TestObservableUpDownCounter";
+        public const string TestObservableUpDownCounterName = TestObservableUpDownCounter + " (queue size)";
+        public const string TestObservableGauge = "TestObservableGauge";
+        public const string TestObservableGaugeName = TestObservableGauge + " (temperature)";
         public const string PercentileKey = "Percentile";
         public const string TagKey = "TestTag";
         public const string TagValue = "5";


### PR DESCRIPTION
This PR expands the metrics artifacts to support OpenTelemetry.

To see how this will be used, I did a proof-of-concept. The final work will change somewhat, but this should explain the changes.

* Listener is here: https://github.com/CodeBlanch/dotnet-monitor/blob/b84ba9229f5996d99f934ef862008c138d294b0e/src/Tools/dotnet-monitor/OpenTelemetry/OpenTelemetryService.cs#L374

* MetricsStore gains an OTel-style snapshot which understands how to do proper delta aggregation using some of these changes: https://github.com/CodeBlanch/dotnet-monitor/blob/b84ba9229f5996d99f934ef862008c138d294b0e/src/Microsoft.Diagnostics.Monitoring.WebApi/Metrics/MetricsStore.cs#L161-L178

* The aggregated data is exported periodically as a "metrics producer" in the OTel world: https://github.com/CodeBlanch/dotnet-monitor/blob/b84ba9229f5996d99f934ef862008c138d294b0e/src/Tools/dotnet-monitor/OpenTelemetry/OpenTelemetryService.cs#L378

/cc @noahfalk @samsp-msft @rajkumar-rangaraj @wiktork