### PR TITLE
[dsrouter] fix web socket startup

### DIFF
--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsServerRouter/DiagnosticsServerRouterFactory.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsServerRouter/DiagnosticsServerRouterFactory.cs
@@ -356,9 +356,11 @@ namespace Microsoft.Diagnostics.NETCore.Client
 
         public WebSocketServerRouterFactory(string webSocketURL, int runtimeTimeoutMs, ILogger logger) : base(runtimeTimeoutMs, logger)
         {
-            _webSocketURL = string.IsNullOrEmpty(webSocketURL) ? "ws://127.0.0.1:8088/diagnostics" : webSocketURL;
+            Debug.Assert(!string.IsNullOrEmpty(webSocketURL));
 
-            _webSocketServer = new ReversedDiagnosticsServer(_webSocketURL, ReversedDiagnosticsServer.Kind.WebSocket);
+            _webSocketURL = webSocketURL;
+
+            _webSocketServer = new ReversedDiagnosticsServer(_webSocketURL, ReversedDiagnosticsServer.Kind.WebSocket, TimeSpan.FromMilliseconds(750));
             _webSocketServer.TransportCallback = this;
         }
 

--- a/src/Microsoft.Diagnostics.NETCore.Client/ReversedServer/ReversedDiagnosticsServer.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/ReversedServer/ReversedDiagnosticsServer.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
     {
         // The amount of time to allow parsing of the advertise data before cancelling. This allows the server to
         // remain responsive in case the advertise data is incomplete and the stream is not closed.
-        private static readonly TimeSpan ParseAdvertiseTimeout = TimeSpan.FromMilliseconds(250);
+        private static readonly TimeSpan ParseAdvertiseTimeout = TimeSpan.FromMilliseconds(750);
 
         private readonly CancellationTokenSource _disposalSource = new();
         private readonly HandleableCollection<IpcEndpointInfo> _endpointInfos = new();

--- a/src/Microsoft.Diagnostics.NETCore.Client/ReversedServer/ReversedDiagnosticsServer.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/ReversedServer/ReversedDiagnosticsServer.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
     {
         // The amount of time to allow parsing of the advertise data before cancelling. This allows the server to
         // remain responsive in case the advertise data is incomplete and the stream is not closed.
-        private static readonly TimeSpan ParseAdvertiseTimeout = TimeSpan.FromMilliseconds(750);
+        private readonly TimeSpan ParseAdvertiseTimeout;
 
         private readonly CancellationTokenSource _disposalSource = new();
         private readonly HandleableCollection<IpcEndpointInfo> _endpointInfos = new();
@@ -52,6 +52,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
         public ReversedDiagnosticsServer(string address)
         {
             _address = address;
+            ParseAdvertiseTimeout = TimeSpan.FromMilliseconds(750);
         }
 
         /// <summary>
@@ -69,12 +70,38 @@ namespace Microsoft.Diagnostics.NETCore.Client
         /// Otherwise if kind is TcpIp as a supported protocol for ReversedDiagnosticServer. When Kind is Tcp, address will
         /// be analyzed and if on format host:port, ReversedDiagnosticServer will try to bind
         /// a TcpIp listener to host and port, otherwise it will use a Unix domain socket or a Windows named pipe.
-        ///
         /// </param>
         public ReversedDiagnosticsServer(string address, Kind kind)
         {
             _address = address;
             _kind = kind;
+            ParseAdvertiseTimeout = TimeSpan.FromMilliseconds(750);
+        }
+
+        /// <summary>
+        /// Constructs the <see cref="ReversedDiagnosticsServer"/> instance with an endpoint bound
+        /// to the location specified by <paramref name="address"/>.
+        /// </summary>
+        /// <param name="address">
+        /// The server endpoint.
+        /// On Windows, this can be a full pipe path or the name without the "\\.\pipe\" prefix.
+        /// On all other systems, this must be the full file path of the socket.
+        /// </param>
+        /// <param name="kind">
+        /// If kind is WebSocket, start a Kestrel web server.
+        /// Otherwise if kind is TcpIp as a supported protocol for ReversedDiagnosticServer. When Kind is Tcp, address will
+        /// be analyzed and if on format host:port, ReversedDiagnosticServer will try to bind
+        /// a TcpIp listener to host and port, otherwise it will use a Unix domain socket or a Windows named pipe.
+        /// </param>
+        /// <param name="timeout">
+        /// The amount of time to allow parsing of the advertise data before cancelling. This allows the server to
+        /// remain responsive in case the advertise data is incomplete and the stream is not closed.
+        /// </param>
+        public ReversedDiagnosticsServer(string address, Kind kind, TimeSpan timeout)
+        {
+            _address = address;
+            _kind = kind;
+            ParseAdvertiseTimeout = timeout;
         }
 
         public async ValueTask DisposeAsync()

--- a/src/Microsoft.Diagnostics.NETCore.Client/ReversedServer/ReversedDiagnosticsServer.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/ReversedServer/ReversedDiagnosticsServer.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
         public ReversedDiagnosticsServer(string address)
         {
             _address = address;
-            ParseAdvertiseTimeout = TimeSpan.FromMilliseconds(750);
+            ParseAdvertiseTimeout = TimeSpan.FromMilliseconds(250);
         }
 
         /// <summary>
@@ -75,7 +75,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
         {
             _address = address;
             _kind = kind;
-            ParseAdvertiseTimeout = TimeSpan.FromMilliseconds(750);
+            ParseAdvertiseTimeout = TimeSpan.FromMilliseconds(250);
         }
 
         /// <summary>

--- a/src/Microsoft.Diagnostics.WebSocketServer/WebSocketServerImpl.cs
+++ b/src/Microsoft.Diagnostics.WebSocketServer/WebSocketServerImpl.cs
@@ -172,24 +172,24 @@ public class WebSocketServerImpl : IWebSocketServer
             uriToParse = endPoint;
         }
 
-        string[] supportedSchemes = new string[] { "ws", "wss", "http", "https" };
 
         if (!string.IsNullOrEmpty(uriToParse) && Uri.TryCreate(uriToParse, UriKind.Absolute, out uri))
         {
-            bool supported = false;
-            foreach (string scheme in supportedSchemes)
+            if (uri.Scheme == "ws")
             {
-                if (string.Equals(uri.Scheme, scheme, StringComparison.InvariantCultureIgnoreCase))
-                {
-                    supported = true;
-                    break;
-                }
+                uri = new UriBuilder(uri) { Scheme = "http" }.Uri;
+                return;
             }
-            if (!supported)
+            if (uri.Scheme == "wss")
             {
-                throw new ArgumentException(string.Format("Unsupported Uri schema, \"{0}\"", uri.Scheme));
+                uri = new UriBuilder(uri) { Scheme = "https" }.Uri;
+                return;
             }
-            return;
+            if (uri.Scheme == "http" || uri.Scheme == "https")
+            {
+                return;
+            }
+            throw new ArgumentException(string.Format("Unsupported Uri schema, \"{0}\"", uri.Scheme));
         }
         else
         {

--- a/src/Tools/dotnet-dsrouter/Program.cs
+++ b/src/Tools/dotnet-dsrouter/Program.cs
@@ -267,7 +267,8 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
             new("--web-socket", "-ws")
             {
                 Description = "The router WebSocket address using format ws://[host]:[port]/[path] or wss://[host]:[port]/[path]. " +
-                                "Launch app with WasmExtraConfig property specifying diagnostic_options with a server connect_url"
+                                "Launch app with WasmExtraConfig property specifying diagnostic_options with a server connect_url",
+                DefaultValueFactory = _ => "ws://127.0.0.1:8088/diagnostics"
             };
 
         private static readonly Option<int> RuntimeTimeoutOption =

--- a/src/Tools/dotnet-dsrouter/Program.cs
+++ b/src/Tools/dotnet-dsrouter/Program.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
             command.SetAction((parseResult, ct) => new DiagnosticsServerRouterCommands().RunIpcServerWebSocketServerRouter(
                 ct,
                 ipcServer: parseResult.GetValue(IpcServerAddressOption) ?? "",
-                webSocket: parseResult.GetValue(WebSocketURLAddressOption) ?? "",
+                webSocket: parseResult.GetValue(WebSocketURLAddressOption),
                 runtimeTimeout: parseResult.GetValue(RuntimeTimeoutOption),
                 verbose: parseResult.GetValue(VerboseOption)
             ));
@@ -117,7 +117,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
             command.SetAction((parseResult, ct) => new DiagnosticsServerRouterCommands().RunIpcClientWebSocketServerRouter(
                 ct,
                 ipcClient: parseResult.GetValue(IpcClientAddressOption) ?? "",
-                webSocket: parseResult.GetValue(WebSocketURLAddressOption) ?? "",
+                webSocket: parseResult.GetValue(WebSocketURLAddressOption),
                 runtimeTimeout: parseResult.GetValue(RuntimeTimeoutOption),
                 verbose: parseResult.GetValue(VerboseOption)
             ));


### PR DESCRIPTION
- make the default value valid `ws://127.0.0.1:8088/diagnostics`
- fix parsing the URL, so that HTTP server could be started based on `ws://` or `wss://` as it only accepts `http://` or `https://` schema

Contributes to https://github.com/dotnet/runtime/issues/76316