### PR TITLE
Migrate off of Debian 11 

### DIFF
--- a/diagnostics.yml
+++ b/diagnostics.yml
@@ -259,7 +259,7 @@ extends:
             jobTemplate: ${{ variables.jobTemplate }}
             name: Debian_Bullseye
             osGroup: Linux
-            container: test_debian_11_amd64
+            container: test_debian_12_amd64
             dependsOn: Linux
             testOnly: true
             buildConfigs:

--- a/eng/pipelines/pipeline-resources.yml
+++ b/eng/pipelines/pipeline-resources.yml
@@ -74,8 +74,8 @@ extends:
         image: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.19-WithNode
         options: --cap-add=SYS_PTRACE
 
-      test_debian_11_amd64:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-amd64
+      test_debian_12_amd64:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-12-amd64
         options: '--env PYTHONPATH=/usr/bin/python3.9'
 
       test_fedora:


### PR DESCRIPTION
The pipeline references a Debian 11 image that is EOL (see https://github.com/dotnet/core/issues/9625):

https://github.com/dotnet/diagnostics/blob/208833b32f1f33ae230b25fca344bc9f33b2fc2a/diagnostics.yml#L262
https://github.com/dotnet/diagnostics/blob/208833b32f1f33ae230b25fca344bc9f33b2fc2a/eng/pipelines/pipeline-resources.yml#L77
https://github.com/dotnet/diagnostics/blob/208833b32f1f33ae230b25fca344bc9f33b2fc2a/eng/pipelines/pipeline-resources.yml#L78

Update Debian 11 -> 12