### PR TITLE
Target Debian 12 for testing

### DIFF
--- a/diagnostics.yml
+++ b/diagnostics.yml
@@ -253,22 +253,22 @@ extends:
             - configuration: Debug
               architecture: x64
 
-      - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-        - template: /eng/pipelines/build.yml
-          parameters:
-            jobTemplate: ${{ variables.jobTemplate }}
-            name: Debian_Bullseye
-            osGroup: Linux
-            container: test_debian_11_amd64
-            dependsOn: Linux
-            testOnly: true
-            buildConfigs:
-            - configuration: Release
+      - template: /eng/pipelines/build.yml
+        parameters:
+          jobTemplate: ${{ variables.jobTemplate }}
+          name: Debian_Bookworm
+          osGroup: Linux
+          container: test_debian_12_amd64
+          dependsOn: Linux
+          testOnly: true
+          buildConfigs:
+          - configuration: Release
+            architecture: x64
+          - ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
+            - configuration: Debug
               architecture: x64
-            - ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
-              - configuration: Debug
-                architecture: x64
 
+      - ${{ if ne(variables['System.TeamProject'], 'public') }}:
         - template: /eng/pipelines/build.yml
           parameters:
             jobTemplate: ${{ variables.jobTemplate }}

--- a/eng/pipelines/pipeline-resources.yml
+++ b/eng/pipelines/pipeline-resources.yml
@@ -75,8 +75,8 @@ extends:
         options: --cap-add=SYS_PTRACE
 
       test_debian_12_amd64:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-12-helix-amd64
-        options: '--env PYTHONPATH=/usr/bin/python3.9'
+        image: dotnetdockerdev.azurecr.io/dotnet-buildtools/prereqs:debian-12-helix-amd64
+        options: '--env PYTHONPATH=/usr/bin/python3.11'
 
       test_fedora:
         image: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-41

--- a/eng/pipelines/pipeline-resources.yml
+++ b/eng/pipelines/pipeline-resources.yml
@@ -74,8 +74,8 @@ extends:
         image: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.19-WithNode
         options: --cap-add=SYS_PTRACE
 
-      test_debian_11_amd64:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-amd64
+      test_debian_12_amd64:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-12-helix-amd64
         options: '--env PYTHONPATH=/usr/bin/python3.9'
 
       test_fedora:


### PR DESCRIPTION
Related to the discussion at https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/1276. I want to see if using the Debian 12 Helix image works.