### PR TITLE
Bump `StyleCop.Analyzers` to `1.2.0-beta.556`

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -56,7 +56,7 @@
     <SystemTextJsonVersion>8.0.5</SystemTextJsonVersion>
     <XUnitAbstractionsVersion>2.0.3</XUnitAbstractionsVersion>
     <MicrosoftDotNetCodeAnalysisVersion>10.0.0-beta.25080.7</MicrosoftDotNetCodeAnalysisVersion>
-    <StyleCopAnalyzersVersion>1.2.0-beta.406</StyleCopAnalyzersVersion>
+    <StyleCopAnalyzersVersion>1.2.0-beta.556</StyleCopAnalyzersVersion>
     <MicrosoftDotNetRemoteExecutorVersion>7.0.0-beta.22316.2</MicrosoftDotNetRemoteExecutorVersion>
     <cdbsosversion>10.0.26100.1</cdbsosversion>
     <NewtonSoftJsonVersion>13.0.1</NewtonSoftJsonVersion>


### PR DESCRIPTION
https://github.com/DotNetAnalyzers/StyleCopAnalyzers/releases/tag/1.2.0-beta.556