### PR TITLE
Remove counter_list support from dotnet-counters

### DIFF
--- a/src/Tools/dotnet-counters/CounterMonitor.cs
+++ b/src/Tools/dotnet-counters/CounterMonitor.cs
@@ -166,7 +166,6 @@ namespace Microsoft.Diagnostics.Tools.Counters
 
         public async Task<ReturnCode> Monitor(
             CancellationToken ct,
-            List<string> counter_list,
             string counters,
             int processId,
             int refreshInterval,
@@ -206,7 +205,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
                     {
                         // the launch command may misinterpret app arguments as the old space separated
                         // provider list so we need to ignore it in that case
-                        _counterList = ConfigureCounters(counters, _processId != 0 ? counter_list : null);
+                        _counterList = ConfigureCounters(counters);
                         _renderer = new ConsoleWriter(new DefaultConsole(useAnsi), showDeltaColumn:showDeltas);
                         _diagnosticsClient = holder.Client;
                         _settings = new MetricsPipelineSettings();
@@ -251,7 +250,6 @@ namespace Microsoft.Diagnostics.Tools.Counters
         }
         public async Task<ReturnCode> Collect(
             CancellationToken ct,
-            List<string> counter_list,
             string counters,
             int processId,
             int refreshInterval,
@@ -291,7 +289,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
                     {
                         // the launch command may misinterpret app arguments as the old space separated
                         // provider list so we need to ignore it in that case
-                        _counterList = ConfigureCounters(counters, _processId != 0 ? counter_list : null);
+                        _counterList = ConfigureCounters(counters);
                         _settings = new MetricsPipelineSettings();
                         _settings.Duration = duration == TimeSpan.Zero ? Timeout.InfiniteTimeSpan : duration;
                         _settings.MaxHistograms = maxHistograms;
@@ -362,7 +360,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
             }
         }
 
-        internal List<EventPipeCounterGroup> ConfigureCounters(string commaSeparatedProviderListText, List<string> providerList)
+        internal List<EventPipeCounterGroup> ConfigureCounters(string commaSeparatedProviderListText)
         {
             List<EventPipeCounterGroup> counters = new();
             try
@@ -377,23 +375,6 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 // the FormatException message strings thrown by ParseProviderList are controlled
                 // by us and anticipate being integrated into the command-line error text.
                 throw new CommandLineErrorException("Error parsing --counters argument: " + e.Message);
-            }
-
-            if (providerList != null)
-            {
-                try
-                {
-                    foreach (string providerText in providerList)
-                    {
-                        ParseCounterProvider(providerText, counters);
-                    }
-                }
-                catch (FormatException e)
-                {
-                    // the FormatException message strings thrown by ParseCounterProvider are controlled
-                    // by us and anticipate being integrated into the command-line error text.
-                    throw new CommandLineErrorException("Error parsing counter_list: " + e.Message);
-                }
             }
 
             if (counters.Count == 0)

--- a/src/Tools/dotnet-counters/Program.cs
+++ b/src/Tools/dotnet-counters/Program.cs
@@ -24,7 +24,6 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 name: "monitor",
                 description: "Start monitoring a .NET application")
             {
-                CounterList,
                 CounterOption,
                 ProcessIdOption,
                 RefreshIntervalOption,
@@ -39,9 +38,8 @@ namespace Microsoft.Diagnostics.Tools.Counters
 
             monitorCommand.TreatUnmatchedTokensAsErrors = false; // see the logic in Main
 
-            monitorCommand.SetAction((parseResult, ct) => new CounterMonitor(parseResult.Configuration.Output, parseResult.Configuration.Error).Monitor(
+            monitorCommand.SetAction(static (parseResult, ct) => new CounterMonitor(parseResult.Configuration.Output, parseResult.Configuration.Error).Monitor(
                 ct,
-                counter_list: parseResult.GetValue(CounterList),
                 counters: parseResult.GetValue(CounterOption),
                 processId: parseResult.GetValue(ProcessIdOption),
                 refreshInterval: parseResult.GetValue(RefreshIntervalOption),
@@ -64,7 +62,6 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 name: "collect",
                 description: "Monitor counters in a .NET application and export the result into a file")
             {
-                CounterList,
                 CounterOption,
                 ProcessIdOption,
                 RefreshIntervalOption,
@@ -82,7 +79,6 @@ namespace Microsoft.Diagnostics.Tools.Counters
 
             collectCommand.SetAction((parseResult, ct) => new CounterMonitor(parseResult.Configuration.Output, parseResult.Configuration.Error).Collect(
                 ct,
-                counter_list: parseResult.GetValue(CounterList),
                 counters: parseResult.GetValue(CounterOption),
                 processId: parseResult.GetValue(ProcessIdOption),
                 refreshInterval: parseResult.GetValue(RefreshIntervalOption),
@@ -141,14 +137,6 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 " names can either refer to the name of a Meter for the System.Diagnostics.Metrics API or the name of an EventSource for the EventCounters API. If the monitored application has both" +
                 " a Meter and an EventSource with the same name, the Meter is automatically preferred. Use the prefix \'EventCounters\\\' in front of a provider name to only show the EventCounters." +
                 " To discover well-known provider and counter names, please visit https://learn.microsoft.com/dotnet/core/diagnostics/built-in-metrics."
-            };
-
-        private static readonly Argument<List<string>> CounterList =
-            new(name: "counter_list")
-            {
-                Description = @"A space separated list of counter providers. Counters can be specified <provider_name> or <provider_name>[comma_separated_counter_names]. If the provider_name is used without a qualifying counter_names then all counters will be shown. To discover provider and counter names, use the list command.",
-                Hidden = true,
-                DefaultValueFactory = _ => new List<string>()
             };
 
         private static Command ListCommand()

--- a/src/tests/dotnet-counters/CounterMonitorPayloadTests.cs
+++ b/src/tests/dotnet-counters/CounterMonitorPayloadTests.cs
@@ -206,8 +206,7 @@ namespace DotnetCounters.UnitTests
                     return Task.Run(async () =>
                         await monitor.Collect(
                             ct: ct,
-                            counter_list: counterList,
-                            counters: null,
+                            counters: string.Join(',', counterList),
                             processId: testRunner.Pid,
                             refreshInterval: 1,
                             format: exportFormat,

--- a/src/tests/dotnet-counters/CounterMonitorTests.cs
+++ b/src/tests/dotnet-counters/CounterMonitorTests.cs
@@ -80,25 +80,10 @@ namespace DotnetCounters.UnitTests
         public void GenerateCounterListWithOptionAndArgumentsTest()
         {
             CounterMonitor monitor = new(TextWriter.Null, TextWriter.Null);
-            List<string> commandLineProviderArgs = new() { "System.Runtime", "MyEventSource" };
             string countersOptionText = "MyEventSource1,MyEventSource2";
-            List<EventPipeCounterGroup> counters = monitor.ConfigureCounters(countersOptionText, commandLineProviderArgs);
-            Assert.Contains("MyEventSource", counters.Select(g => g.ProviderName));
+            List<EventPipeCounterGroup> counters = monitor.ConfigureCounters(countersOptionText);
             Assert.Contains("MyEventSource1", counters.Select(g => g.ProviderName));
             Assert.Contains("MyEventSource2", counters.Select(g => g.ProviderName));
-            Assert.Contains("System.Runtime", counters.Select(g => g.ProviderName));
-        }
-
-        [Fact]
-        public void GenerateCounterListWithOptionAndArgumentsTestWithDupEntries()
-        {
-            CounterMonitor monitor = new(TextWriter.Null, TextWriter.Null);
-            List<string> commandLineProviderArgs = new() { "System.Runtime", "MyEventSource" };
-            string countersOptionText = "System.Runtime,MyEventSource";
-            List<EventPipeCounterGroup> counters = monitor.ConfigureCounters(countersOptionText, commandLineProviderArgs);
-            Assert.Equal(2, counters.Count());
-            Assert.Contains("MyEventSource", counters.Select(g => g.ProviderName));
-            Assert.Contains("System.Runtime", counters.Select(g => g.ProviderName));
         }
 
         [Fact]
@@ -106,18 +91,8 @@ namespace DotnetCounters.UnitTests
         {
             CounterMonitor monitor = new(TextWriter.Null, TextWriter.Null);
             string countersOptionText = "System.Runtime[cpu-usage,MyEventSource";
-            CommandLineErrorException e = Assert.Throws<CommandLineErrorException>(() => monitor.ConfigureCounters(countersOptionText, null));
+            CommandLineErrorException e = Assert.Throws<CommandLineErrorException>(() => monitor.ConfigureCounters(countersOptionText));
             Assert.Equal("Error parsing --counters argument: Expected to find closing ']' in counter_provider", e.Message);
-        }
-
-        [Fact]
-        public void ParseErrorUnbalancedBracketsInCounterList()
-        {
-            CounterMonitor monitor = new(TextWriter.Null, TextWriter.Null);
-            string countersOptionText = "System.Runtime,MyEventSource";
-            List<string> commandLineProviderArgs = new() { "System.Runtime[cpu-usage", "MyEventSource" };
-            CommandLineErrorException e = Assert.Throws<CommandLineErrorException>(() => monitor.ConfigureCounters(countersOptionText, commandLineProviderArgs));
-            Assert.Equal("Error parsing counter_list: Expected to find closing ']' in counter_provider", e.Message);
         }
 
         [Fact]
@@ -125,7 +100,7 @@ namespace DotnetCounters.UnitTests
         {
             CounterMonitor monitor = new(TextWriter.Null, TextWriter.Null);
             string countersOptionText = "System.Runtime[cpu-usage]hello,MyEventSource";
-            CommandLineErrorException e = Assert.Throws<CommandLineErrorException>(() => monitor.ConfigureCounters(countersOptionText, null));
+            CommandLineErrorException e = Assert.Throws<CommandLineErrorException>(() => monitor.ConfigureCounters(countersOptionText));
             Assert.Equal("Error parsing --counters argument: Unexpected characters after closing ']' in counter_provider", e.Message);
         }
 
@@ -134,7 +109,7 @@ namespace DotnetCounters.UnitTests
         {
             CounterMonitor monitor = new(TextWriter.Null, TextWriter.Null);
             string countersOptionText = ",MyEventSource";
-            CommandLineErrorException e = Assert.Throws<CommandLineErrorException>(() => monitor.ConfigureCounters(countersOptionText, null));
+            CommandLineErrorException e = Assert.Throws<CommandLineErrorException>(() => monitor.ConfigureCounters(countersOptionText));
             Assert.Equal("Error parsing --counters argument: Expected non-empty counter_provider", e.Message);
         }
 
@@ -143,7 +118,7 @@ namespace DotnetCounters.UnitTests
         {
             CounterMonitor monitor = new(TextWriter.Null, TextWriter.Null);
             string countersOptionText = "System.Runtime[cpu-usage][working-set],MyEventSource";
-            CommandLineErrorException e = Assert.Throws<CommandLineErrorException>(() => monitor.ConfigureCounters(countersOptionText, null));
+            CommandLineErrorException e = Assert.Throws<CommandLineErrorException>(() => monitor.ConfigureCounters(countersOptionText));
             Assert.Equal("Error parsing --counters argument: Expected at most one '[' in counter_provider", e.Message);
         }
 
@@ -152,7 +127,7 @@ namespace DotnetCounters.UnitTests
         {
             CounterMonitor monitor = new(TextWriter.Null, TextWriter.Null);
             string countersOptionText = "System.Runtime,MyEventSource,EventCounters\\System.Runtime";
-            CommandLineErrorException e = Assert.Throws<CommandLineErrorException>(() => monitor.ConfigureCounters(countersOptionText, null));
+            CommandLineErrorException e = Assert.Throws<CommandLineErrorException>(() => monitor.ConfigureCounters(countersOptionText));
             Assert.Equal("Error parsing --counters argument: Using the same provider name with and without the EventCounters\\ prefix in the counter list is not supported.", e.Message);
         }
     }


### PR DESCRIPTION
We've had --counters for a while, and handling two argument lists (one for counter_list,
and the other one for the launch params) is pretty gnarly with the new version of system.commandline
as https://github.com/dotnet/command-line-api/commit/4b605851d45131db2374ba711f2443040521d702 dropped the
flag that enabled this parsing mode.

Since dotnet/diagnostics#1770 we've said that the option was hidden, and we'd eventually deprecate it.
This commit removes the counter_list argument from dotnet-counters and we assume that all arguments are
for the launch params.

Fixes https://github.com/dotnet/diagnostics/issues/5317