### PR TITLE
Update thread statics format

### DIFF
--- a/src/SOS/Strike/util.cpp
+++ b/src/SOS/Strike/util.cpp
@@ -825,7 +825,10 @@ void DisplayThreadStatic (DacpModuleData* pModule, CLRDATA_ADDRESS cdaMT, DacpMe
     DacpThreadStoreData ThreadStore;
     ThreadStore.Request(g_sos);
 
-    ExtOut("    >> Thread:Value");
+#define INDENT "    "
+#define INDENT_DATA INDENT INDENT
+
+    ExtOut(INDENT "Thread static values (Thread:Value)\n");
     CLRDATA_ADDRESS CurThread = ThreadStore.firstThread;
     while (CurThread)
     {
@@ -850,8 +853,9 @@ void DisplayThreadStatic (DacpModuleData* pModule, CLRDATA_ADDRESS cdaMT, DacpMe
                 pSOS14->Release();
                 if (SUCCEEDED(hr) && (Flags&4))
                 {
-                    ExtOut(" %x:", vThread.osThreadId);
+                    ExtOut(INDENT_DATA "%x:", vThread.osThreadId);
                     DisplayDataMember(pFD, dwTmp, FALSE);
+                    ExtOut("\n");
                 }
             }
             else
@@ -917,15 +921,19 @@ void DisplayThreadStatic (DacpModuleData* pModule, CLRDATA_ADDRESS cdaMT, DacpMe
                     continue;
                 }
 
-                ExtOut(" %x:", vThread.osThreadId);
+                ExtOut(INDENT_DATA "%x:", vThread.osThreadId);
                 DisplayDataMember(pFD, dwTmp, FALSE);
+                ExtOut("\n");
             }
         }
 
         // Go to next thread
         CurThread = vThread.nextThread;
     }
-    ExtOut(" <<\n");
+    ExtOut("\n");
+
+#undef INDENT
+#undef INDENT_DATA
 }
 
 const char * ElementTypeName(unsigned type)
@@ -3961,7 +3969,7 @@ class SOSDacInterface15Simulator : public ISOSDacInterface15
             return S_OK;
         }
 
-        virtual HRESULT STDMETHODCALLTYPE Next( 
+        virtual HRESULT STDMETHODCALLTYPE Next(
             /* [in] */ unsigned int count,
             /* [length_is][size_is][out] */ SOSMethodData methods[  ],
             /* [out] */ unsigned int *pFetched)
@@ -4051,7 +4059,7 @@ public:
         return E_NOINTERFACE;
     }
 
-    virtual HRESULT STDMETHODCALLTYPE GetMethodTableSlotEnumerator( 
+    virtual HRESULT STDMETHODCALLTYPE GetMethodTableSlotEnumerator(
             CLRDATA_ADDRESS mt,
             ISOSMethodEnum **enumerator)
     {


### PR DESCRIPTION
Update the display of `ThreadStatic` values.

Before
```
00007ff95fe14b10  4000008       10        System.Object  0 TLstatic  MyStatic
    >> Thread:Value 8274:0000027e5dccb088 8b68:0000027e5dcc3008 9db4:0000027e5dcc9068 7bf8:0000027e5dcc5028 2d6c:0000027e5dcd0fe8 9818:0000027e5dccf0c8 9104:0000027e5dcc7048 6680:0000027e5dccd0a8 313c:0000027e5dcd3008 9f78:0000027e5dcd5028 <<
```

After
```
00007ff95fe14b10  4000008       10        System.Object  0 TLstatic  MyStatic
    Thread static values (Thread:Value)
        8274:0000027e5dccb088
        8b68:0000027e5dcc3008
        9db4:0000027e5dcc9068
        7bf8:0000027e5dcc5028
        2d6c:0000027e5dcd0fe8
        9818:0000027e5dccf0c8
        9104:0000027e5dcc7048
        6680:0000027e5dccd0a8
        313c:0000027e5dcd3008
        9f78:0000027e5dcd5028
```