### PR TITLE
[cDAC] Add support to run SOS tests against the cDAC

### DIFF
--- a/eng/InstallRuntimes.proj
+++ b/eng/InstallRuntimes.proj
@@ -20,6 +20,7 @@
   <PropertyGroup>
     <BuildArch Condition="'$(BuildArch)' == ''">$(Platform)</BuildArch>
     <BuildArch Condition="'$(BuildArch)' == 'AnyCpu'">$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant)</BuildArch>
+    <LiveRuntimeDir Condition="'$(LiveRuntimeDir)' != ''">$([MSBuild]::NormalizePath('$(LiveRuntimeDir)'))</LiveRuntimeDir>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(BuildArch)' != 'x86'">
@@ -57,7 +58,7 @@
 -->
 
   <Target Name="InstallTestRuntimes"
-          DependsOnTargets="CleanupVersionManifest;InstallRuntimesWindows;InstallRuntimesUnix;WriteTestVersionManifest;" />
+          DependsOnTargets="CleanupVersionManifest;InstallRuntimesWindows;InstallRuntimesUnix;WriteTestVersionManifest;OverrideLatestRuntime" />
 
 <!--
     Installs the test runtimes on Windows
@@ -95,7 +96,24 @@
     <Exec Command="bash $(DotnetInstallScriptCmd) $(CommonInstallArgs) %(RuntimeTestVersions.ExtraInstallArgs) -Version %(RuntimeTestVersions.AspNetDownload) -Runtime aspnetcore"
           IgnoreStandardErrorWarningFormat="true"
           Condition="'%(RuntimeTestVersions.AspNetDownload)' != ''" />
-   </Target>
+  </Target>
+
+  <Target Name="OverrideLatestRuntime"
+          Condition="'$(LiveRuntimeDir) != ''">
+    <Copy SourceFiles="$(LiveRuntimeDir)\**\*.*"
+          DestinationFolder="$(DotNetInstallDir)"
+          OverwriteReadOnlyFiles="true" />
+    <!--
+    <Copy SourceFiles="$(LiveRuntimeDir)\sharedFramework\*.*;
+                       $(LiveRuntimeDir)\System.Private.CoreLib.dll;
+                       $(LiveRuntimeDir)\cdacreader.dll;"
+          DestinationFolder="$(DotNetInstallDir)"
+          OverwriteReadOnlyFiles="true" />
+    <Copy SourceFiles="$(LiveRuntimeDir)\cdaclibs\**\*.*"
+          DestinationFolder="$(DotNetInstallDir)\cdaclibs"
+          OverwriteReadOnlyFiles="true" />
+    -->
+  </Target>
 
 <!--
     Writes the Debugger.Tests.Versions.txt file used by the SOS test harness

--- a/eng/InstallRuntimes.proj
+++ b/eng/InstallRuntimes.proj
@@ -58,7 +58,7 @@
 -->
 
   <Target Name="InstallTestRuntimes"
-          DependsOnTargets="CleanupVersionManifest;InstallRuntimesWindows;InstallRuntimesUnix;WriteTestVersionManifest;OverrideLatestRuntime" />
+          DependsOnTargets="CleanupVersionManifest;InstallRuntimesWindows;InstallRuntimesUnix;OverrideLatestRuntime;WriteTestVersionManifest" />
 
 <!--
     Installs the test runtimes on Windows
@@ -98,21 +98,18 @@
           Condition="'%(RuntimeTestVersions.AspNetDownload)' != ''" />
   </Target>
 
+  <!-- Overrides the latest runtime shared framework with local shared framework artifacts -->
   <Target Name="OverrideLatestRuntime"
-          Condition="'$(LiveRuntimeDir) != ''">
-    <Copy SourceFiles="$(LiveRuntimeDir)\**\*.*"
+          Condition="'$(LiveRuntimeDir)' != ''"
+          Inputs="$(VersionsPropsPath)"
+          Outputs="$(TestConfigFileName)">
+    
+    <ItemGroup>
+      <_LiveRuntimeFiles Include="$(LiveRuntimeDir)\**\*.*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(_LiveRuntimeFiles)"
           DestinationFolder="$(DotNetInstallDir)"
           OverwriteReadOnlyFiles="true" />
-    <!--
-    <Copy SourceFiles="$(LiveRuntimeDir)\sharedFramework\*.*;
-                       $(LiveRuntimeDir)\System.Private.CoreLib.dll;
-                       $(LiveRuntimeDir)\cdacreader.dll;"
-          DestinationFolder="$(DotNetInstallDir)"
-          OverwriteReadOnlyFiles="true" />
-    <Copy SourceFiles="$(LiveRuntimeDir)\cdaclibs\**\*.*"
-          DestinationFolder="$(DotNetInstallDir)\cdaclibs"
-          OverwriteReadOnlyFiles="true" />
-    -->
   </Target>
 
 <!--

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -10,6 +10,7 @@ Param(
     [switch] $skipmanaged,
     [switch] $skipnative,
     [switch] $bundletools,
+    [switch] $useCdac,
     [ValidatePattern("(default|\d+\.\d+.\d+(-[a-z0-9\.]+)?)")][string] $dotnetruntimeversion = 'default',
     [ValidatePattern("(default|\d+\.\d+.\d+(-[a-z0-9\.]+)?)")][string] $dotnetruntimedownloadversion= 'default',
     [string] $runtimesourcefeed = '',
@@ -81,12 +82,17 @@ if ($installruntimes -or $privatebuild) {
       /bl:$logdir\InstallRuntimes.binlog `
       /p:PrivateBuildTesting=$privatebuildtesting `
       /p:BuildArch=$architecture `
-      /p:TestArchitectures=$architecture
+      /p:TestArchitectures=$architecture `
+      /p:LiveRuntimeDir="$liveRuntimeDir"
 }
 
 # Run the xunit tests
 if ($test) {
     if (-not $crossbuild) {
+        if ($useCdac) {
+            $env:SOS_TEST_CDAC="true"
+        }
+
         & "$engroot\common\build.ps1" `
           -test `
           -configuration $configuration `
@@ -98,8 +104,8 @@ if ($test) {
           /p:DotnetRuntimeVersion="$dotnetruntimeversion" `
           /p:DotnetRuntimeDownloadVersion="$dotnetruntimedownloadversion" `
           /p:RuntimeSourceFeed="$runtimesourcefeed" `
-          /p:RuntimeSourceFeedKey="$runtimesourcefeedkey"
-          /p:LiveRuntimeDir="$liveRuntimeDir" `
+          /p:RuntimeSourceFeedKey="$runtimesourcefeedkey" `
+          /p:LiveRuntimeDir="$liveRuntimeDir" 
 
         if ($lastExitCode -ne 0) {
             exit $lastExitCode

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -14,6 +14,7 @@ Param(
     [ValidatePattern("(default|\d+\.\d+.\d+(-[a-z0-9\.]+)?)")][string] $dotnetruntimedownloadversion= 'default',
     [string] $runtimesourcefeed = '',
     [string] $runtimesourcefeedkey = '',
+    [string] $liveRuntimeDir = '',
     [Parameter(ValueFromRemainingArguments=$true)][String[]] $remainingargs
 )
 
@@ -98,6 +99,7 @@ if ($test) {
           /p:DotnetRuntimeDownloadVersion="$dotnetruntimedownloadversion" `
           /p:RuntimeSourceFeed="$runtimesourcefeed" `
           /p:RuntimeSourceFeedKey="$runtimesourcefeedkey"
+          /p:LiveRuntimeDir="$liveRuntimeDir" `
 
         if ($lastExitCode -ne 0) {
             exit $lastExitCode

--- a/eng/testsoscdac.cmd
+++ b/eng/testsoscdac.cmd
@@ -1,0 +1,2 @@
+set SOS_TEST_CDAC=true
+%~dp0..\.dotnet\dotnet.exe test --no-build --logger "console;verbosity=detailed" %~dp0..\src\SOS\SOS.UnitTests\SOS.UnitTests.csproj --filter "Category=CDACCompatible"

--- a/eng/testsoscdac.sh
+++ b/eng/testsoscdac.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+source="${BASH_SOURCE[0]}"
+
+# resolve $SOURCE until the file is no longer a symlink
+while [[ -h $source ]]; do
+  scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
+  source="$(readlink "$source")"
+
+  # if $source was a relative symlink, we need to resolve it relative to the path where the
+  # symlink file was located
+  [[ $source != /* ]] && source="$scriptroot/$source"
+done
+
+scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
+export LLDB_PATH=/usr/bin/lldb
+export SOS_TEST_CDAC=true
+$scriptroot/../.dotnet/dotnet test --no-build --logger "console;verbosity=detailed" $scriptroot/../src/SOS/SOS.UnitTests/SOS.UnitTests.csproj --filter "Category=CDACCompatible"

--- a/src/Microsoft.Diagnostics.TestHelpers/TestConfiguration.cs
+++ b/src/Microsoft.Diagnostics.TestHelpers/TestConfiguration.cs
@@ -79,7 +79,8 @@ namespace Microsoft.Diagnostics.TestHelpers
                 ["IsAlpine"] = OS.IsAlpine.ToString().ToLowerInvariant(),
                 ["TargetRid"] = GetRid(),
                 ["TargetArchitecture"] = OS.TargetArchitecture.ToString().ToLowerInvariant(),
-                ["NuGetPackageCacheDir"] = nugetPackages
+                ["NuGetPackageCacheDir"] = nugetPackages,
+                ["TestCDAC"] = Environment.GetEnvironmentVariable("SOS_TEST_CDAC")
             };
             if (OS.Kind == OSKind.Windows)
             {
@@ -461,6 +462,10 @@ namespace Microsoft.Diagnostics.TestHelpers
             {
                 sb.Append(".singlefile");
             }
+            if (TestCDAC)
+            {
+                sb.Append(".cdac");
+            }
             if (!string.IsNullOrEmpty(version))
             {
                 sb.Append('.');
@@ -553,6 +558,14 @@ namespace Microsoft.Diagnostics.TestHelpers
         public bool IsDesktop
         {
             get { return TestProduct.Equals("desktop"); }
+        }
+
+        /// <summary>
+        /// Returns true if test should use the cDAC.
+        /// </summary>
+        public bool TestCDAC
+        {
+            get { return string.Equals(GetValue("TestCDAC"), "true", StringComparison.InvariantCultureIgnoreCase); }
         }
 
         /// <summary>

--- a/src/SOS/SOS.UnitTests/SOS.UnitTests.csproj
+++ b/src/SOS/SOS.UnitTests/SOS.UnitTests.csproj
@@ -62,4 +62,13 @@
     </ItemGroup>
   </Target>
 
+  <Target Name="_ApplyTestCategoryFilter" 
+          Condition="'$(SOS_TEST_CDAC)' == 'true'"
+          BeforeTargets="RunTests">
+    <ItemGroup>
+      <TestToRun Include="@(TestToRun)">
+        <TestRunnerAdditionalArguments>-trait Category=CDACCompatible</TestRunnerAdditionalArguments>
+      </TestToRun>
+    </ItemGroup>
+  </Target>
 </Project>

--- a/src/SOS/SOS.UnitTests/SOS.cs
+++ b/src/SOS/SOS.UnitTests/SOS.cs
@@ -32,6 +32,14 @@ public static class SOSTestHelpers
         }
     }
 
+    internal static void SkipIfWinX86(TestConfiguration config)
+    {
+        if (config.TargetArchitecture == "x86" && OS.Kind == OSKind.Windows)
+        {
+            throw new SkipTestException("Test does not support x86 on Windows");
+        }
+    }
+
     internal static async Task RunTest(
         string scriptName,
         SOSRunner.TestInformation information,
@@ -199,6 +207,9 @@ public class SOS
         {
             throw new SkipTestException("This test validates SoftwareExceptionFrame handling, before .NET10, these aren't used in this debuggee scenario.");
         }
+
+        SOSTestHelpers.SkipIfWinX86(config);
+
         await SOSTestHelpers.RunTest(
             config,
             debuggeeName: "SimpleThrow",
@@ -223,6 +234,8 @@ public class SOS
     [SkippableTheory, MemberData(nameof(Configurations))]
     public async Task DivZero(TestConfiguration config)
     {
+        SOSTestHelpers.SkipIfWinX86(config);
+
         await SOSTestHelpers.RunTest(
             config,
             debuggeeName: "DivZero",

--- a/src/SOS/SOS.UnitTests/SOS.cs
+++ b/src/SOS/SOS.UnitTests/SOS.cs
@@ -222,6 +222,8 @@ public class SOS
     [SkippableTheory, MemberData(nameof(Configurations)), Trait("Category", "CDACCompatible")]
     public async Task StackTraceFaultingExceptionFrame(TestConfiguration config)
     {
+        SOSTestHelpers.SkipIfWinX86(config);
+
         await SOSTestHelpers.RunTest(
             config,
             debuggeeName: "DivZero",
@@ -234,8 +236,6 @@ public class SOS
     [SkippableTheory, MemberData(nameof(Configurations))]
     public async Task DivZero(TestConfiguration config)
     {
-        SOSTestHelpers.SkipIfWinX86(config);
-
         await SOSTestHelpers.RunTest(
             config,
             debuggeeName: "DivZero",

--- a/src/SOS/SOS.UnitTests/SOS.cs
+++ b/src/SOS/SOS.UnitTests/SOS.cs
@@ -192,6 +192,30 @@ public class SOS
 
     public static IEnumerable<object[]> Configurations => SOSTestHelpers.GetConfigurations("TestName", value: null);
 
+    [SkippableTheory, MemberData(nameof(SOSTestHelpers.GetConfigurations), "TestCDAC", "true", MemberType = typeof(SOSTestHelpers)), Trait("Category", "CDACCompatible")]
+    public async Task StackTraceSoftwareExceptionFrame(TestConfiguration config)
+    {
+        await SOSTestHelpers.RunTest(
+            config,
+            debuggeeName: "SimpleThrow",
+            scriptName: "StackTraceSoftwareExceptionFrame.script",
+            Output,
+            testName: "SOS.StackTraceSoftwareExceptionFrame",
+            testTriage: true);
+    }
+
+    [SkippableTheory, MemberData(nameof(SOSTestHelpers.GetConfigurations), "TestCDAC", "true", MemberType = typeof(SOSTestHelpers)), Trait("Category", "CDACCompatible")]
+    public async Task StackTraceFaultingExceptionFrame(TestConfiguration config)
+    {
+        await SOSTestHelpers.RunTest(
+            config,
+            debuggeeName: "DivZero",
+            scriptName: "StackTraceFaultingExceptionFrame.script",
+            Output,
+            testName: "SOS.StackTraceFaultingExceptionFrame",
+            testTriage: true);
+    }
+
     [SkippableTheory, MemberData(nameof(Configurations))]
     public async Task DivZero(TestConfiguration config)
     {

--- a/src/SOS/SOS.UnitTests/SOS.cs
+++ b/src/SOS/SOS.UnitTests/SOS.cs
@@ -192,7 +192,7 @@ public class SOS
 
     public static IEnumerable<object[]> Configurations => SOSTestHelpers.GetConfigurations("TestName", value: null);
 
-    [SkippableTheory, MemberData(nameof(SOSTestHelpers.GetConfigurations), "TestCDAC", "true", MemberType = typeof(SOSTestHelpers)), Trait("Category", "CDACCompatible")]
+    [SkippableTheory, MemberData(nameof(Configurations)), Trait("Category", "CDACCompatible")]
     public async Task StackTraceSoftwareExceptionFrame(TestConfiguration config)
     {
         await SOSTestHelpers.RunTest(
@@ -204,7 +204,7 @@ public class SOS
             testTriage: true);
     }
 
-    [SkippableTheory, MemberData(nameof(SOSTestHelpers.GetConfigurations), "TestCDAC", "true", MemberType = typeof(SOSTestHelpers)), Trait("Category", "CDACCompatible")]
+    [SkippableTheory, MemberData(nameof(Configurations)), Trait("Category", "CDACCompatible")]
     public async Task StackTraceFaultingExceptionFrame(TestConfiguration config)
     {
         await SOSTestHelpers.RunTest(

--- a/src/SOS/SOS.UnitTests/SOS.cs
+++ b/src/SOS/SOS.UnitTests/SOS.cs
@@ -195,6 +195,10 @@ public class SOS
     [SkippableTheory, MemberData(nameof(Configurations)), Trait("Category", "CDACCompatible")]
     public async Task StackTraceSoftwareExceptionFrame(TestConfiguration config)
     {
+        if (config.RuntimeFrameworkVersionMajor < 10)
+        {
+            throw new SkipTestException("This test validates SoftwareExceptionFrame handling, before .NET10, these aren't used in this debuggee scenario.");
+        }
         await SOSTestHelpers.RunTest(
             config,
             debuggeeName: "SimpleThrow",

--- a/src/SOS/SOS.UnitTests/SOSRunner.cs
+++ b/src/SOS/SOS.UnitTests/SOSRunner.cs
@@ -682,6 +682,11 @@ public class SOSRunner : IDisposable
                 WithLog(scriptLogger).
                 WithTimeout(TimeSpan.FromMinutes(10));
 
+            if (config.TestCDAC)
+            {
+                processRunner.WithEnvironmentVariable("DOTNET_ENABLE_CDAC", "1");
+            }
+
             // Exit codes on Windows should always be 0, but not on Linux/OSX for the faulting debuggees.
             if (OS.Kind == OSKind.Windows)
             {
@@ -699,7 +704,7 @@ public class SOSRunner : IDisposable
 
             // Setup the extension environment variable
             string extensions = config.DotNetDiagnosticExtensions();
-            if (!string.IsNullOrEmpty(extensions)) 
+            if (!string.IsNullOrEmpty(extensions))
             {
                 processRunner.WithEnvironmentVariable("DOTNET_DIAGNOSTIC_EXTENSIONS", extensions);
             }

--- a/src/SOS/SOS.UnitTests/Scripts/StackTraceFaultingExceptionFrame.script
+++ b/src/SOS/SOS.UnitTests/Scripts/StackTraceFaultingExceptionFrame.script
@@ -1,0 +1,45 @@
+# Divide By Zero debugging scenario
+# 1) Load the executable
+# 2) Run the executable and wait for it to crash
+# 3) Take a dump of the executable.
+# 4) Open the dump and compare the output
+
+CONTINUE
+
+LOADSOS
+
+# Verifying that PrintException gives us the right exception in the format above.
+SOSCOMMAND:PrintException
+VERIFY:Exception object:\s+<HEXVAL>\s+
+VERIFY:Exception type:\s+System\.DivideByZeroException\s+
+VERIFY:Message:\s+(<Invalid Object>|Attempted to divide by zero\.)\s+
+VERIFY:InnerException:\s+<none>\s+
+VERIFY:StackTrace \(generated\):\s+
+VERIFY:\s+SP\s+IP\s+\s+Function\s+
+VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+[Dd]iv[Zz]ero.*!C\.DivideByZero(\(.*\))?\+0x<HEXVAL>\s+
+VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+[Dd]iv[Zz]ero.*!C\.F3(\(.*\))?\+0x<HEXVAL>\s+
+VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+[Dd]iv[Zz]ero.*!C\.F2(\(.*\))?\+0x<HEXVAL>\s+
+VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+[Dd]iv[Zz]ero.*!C\.Main(\(.*\))?\+0x<HEXVAL>\s+
+VERIFY:(StackTraceString: <none>\s+)?\s+
+VERIFY:HResult:\s+80020012\s+
+
+# Verify that Threads (clrthreads) works
+SOSCOMMAND:clrthreads
+VERIFY:\s*ThreadCount:\s+<DECVAL>\s+
+VERIFY:\s+UnstartedThread:\s+<DECVAL>\s+
+VERIFY:\s+BackgroundThread:\s+<DECVAL>\s+
+VERIFY:\s+PendingThread:\s+<DECVAL>\s+
+VERIFY:\s+DeadThread:\s+<DECVAL>\s+
+VERIFY:\s+Hosted Runtime:\s+no\s+
+VERIFY:\s+ID\s+OSID\s+ThreadOBJ\s+State.*\s+
+VERIFY:\s+<DECVAL>\s+<DECVAL>\s+<HEXVAL>\s+<HEXVAL>.*\s+
+
+# Verify that ClrStack with no options works
+SOSCOMMAND:ClrStack
+VERIFY:.*OS Thread Id:\s+0x<HEXVAL>\s+.*
+VERIFY:\s+Child\s+SP\s+IP\s+Call Site\s+
+VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+[FaultingExceptionFrame: <HEXVAL>]\s+
+VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+(\*\*\* WARNING: Unable to verify checksum for DivZero.exe\s*)?
+VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+C\.F3(\(.*\))?\s+
+VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+C\.F2(\(.*\))?\s+
+VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+C\.Main(\(.*\))?\s+

--- a/src/SOS/SOS.UnitTests/Scripts/StackTraceSoftwareExceptionFrame.script
+++ b/src/SOS/SOS.UnitTests/Scripts/StackTraceSoftwareExceptionFrame.script
@@ -1,0 +1,42 @@
+# SoftwareExceptionFrame debugging scenario
+# 1) Load the executable
+# 2) Run the executable and wait for it to crash
+# 3) Take a dump of the executable.
+# 4) Open the dump and compare the output
+
+CONTINUE
+
+LOADSOS
+
+# Verifying that PrintException gives us the right exception in the format above.
+SOSCOMMAND:PrintException
+VERIFY:Exception object:\s+<HEXVAL>\s+
+VERIFY:Exception type:\s+System\.InvalidOperationException\s+
+VERIFY:Message:\s+Throwing an invalid operation....\s+
+VERIFY:InnerException:\s+<none>\s+
+VERIFY:StackTrace \(generated\):\s+
+VERIFY:\s+SP\s+IP\s+\s+Function\s+
+VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+.*!UserObject\.UseObject(\(.*\))?\+0x<HEXVAL>\s+
+VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+.*!Simple\.Main(\(.*\))?\+0x<HEXVAL>\s+
+VERIFY:(StackTraceString: <none>\s+)?\s+
+VERIFY:HResult:\s+80131509\s+
+
+# Verify that Threads (clrthreads) works
+SOSCOMMAND:clrthreads
+VERIFY:\s*ThreadCount:\s+<DECVAL>\s+
+VERIFY:\s+UnstartedThread:\s+<DECVAL>\s+
+VERIFY:\s+BackgroundThread:\s+<DECVAL>\s+
+VERIFY:\s+PendingThread:\s+<DECVAL>\s+
+VERIFY:\s+DeadThread:\s+<DECVAL>\s+
+VERIFY:\s+Hosted Runtime:\s+no\s+
+VERIFY:\s+ID\s+OSID\s+ThreadOBJ\s+State.*\s+
+VERIFY:\s+<DECVAL>\s+<DECVAL>\s+<HEXVAL>\s+<HEXVAL>.*\s+
+
+# Verify that ClrStack with no options works
+SOSCOMMAND:ClrStack
+VERIFY:.*OS Thread Id:\s+0x<HEXVAL>\s+.*
+VERIFY:\s+Child\s+SP\s+IP\s+Call Site\s+
+VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+[InlinedCallFrame: <HEXVAL>]\s+
+VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+[SoftwareExceptionFrame: <HEXVAL>]\s+
+VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+UserObject\.UseObject(\(.*\))?\s+
+VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+Simple\.Main(\(.*\))?\s+

--- a/src/SOS/SOS.UnitTests/Scripts/StackTraceSoftwareExceptionFrame.script
+++ b/src/SOS/SOS.UnitTests/Scripts/StackTraceSoftwareExceptionFrame.script
@@ -12,7 +12,7 @@ LOADSOS
 SOSCOMMAND:PrintException
 VERIFY:Exception object:\s+<HEXVAL>\s+
 VERIFY:Exception type:\s+System\.InvalidOperationException\s+
-VERIFY:Message:\s+Throwing an invalid operation....\s+
+VERIFY:Message:\s+(<Invalid Object>|Throwing an invalid operation\.\.\.\.)\s+
 VERIFY:InnerException:\s+<none>\s+
 VERIFY:StackTrace \(generated\):\s+
 VERIFY:\s+SP\s+IP\s+\s+Function\s+

--- a/src/SOS/SOS.UnitTests/Scripts/StackTraceSoftwareExceptionFrame.script
+++ b/src/SOS/SOS.UnitTests/Scripts/StackTraceSoftwareExceptionFrame.script
@@ -1,4 +1,4 @@
-# SoftwareExceptionFrame debugging scenario
+# Simple Throw debugging scenario
 # 1) Load the executable
 # 2) Run the executable and wait for it to crash
 # 3) Take a dump of the executable.


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/110758

Given the cDAC only supports a small subset of the DAC apis, I have created some pared down tests that are `CDACCompatible`.

Steps to run tests with cDAC:

1. Build diagnostics repo.
2. Build runtime repo.
3. Run `eng\privatebuild.cmd` in the diagnostics repo
4. Copy over relevant files from runtime repo to `.\dotnet-test`. See https://github.com/dotnet/diagnostics/blob/main/documentation/privatebuildtesting.md for example.
Note, with the addition of the cDAC, `cdacreader.dll` and all of the dll's under `cdaclibs` must be copied over as well.
5. Run `eng\testsoscdac.cmd` in the diagnostics repo.

The cDAC can be debugged in these tests by running the tests script with `$env:VSTEST_HOST_DEBUG=1` which waits for a debugger to attach to the test host. Use VS with the [Child Process Debugging Power Tool](https://marketplace.visualstudio.com/items?itemName=vsdbgplat.MicrosoftChildProcessDebuggingPowerTool2022) to selectively debug `cdb.exe` child process. Note this requires using mixed mode debugging.