### PR TITLE
Fix metrics caching

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/MetricsPipeline.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Counters/MetricsPipeline.cs
@@ -68,10 +68,12 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
         {
             await ExecuteCounterLoggerActionAsync((metricLogger) => metricLogger.PipelineStarted(token)).ConfigureAwait(false);
 
+            CounterMetadataCache cache = new();
+
             eventSource.Dynamic.All += traceEvent => {
                 try
                 {
-                    if (traceEvent.TryGetCounterPayload(_counterConfiguration, out ICounterPayload counterPayload))
+                    if (traceEvent.TryGetCounterPayload(cache, _counterConfiguration, out ICounterPayload counterPayload))
                     {
                         ExecuteCounterLoggerAction((metricLogger) => metricLogger.Log(counterPayload));
                     }


### PR DESCRIPTION
The introduction of static caches for metric data in https://github.com/dotnet/diagnostics/pull/4324 combined with https://github.com/dotnet/diagnostics/pull/5120 causes metrics with the same name but different units across two processes to fail. This was observed in 10.0 when a different bug caused metrics to have no units.