### PR TITLE
Add useCdac and liveRuntimeDir build switches for non-windows

### DIFF
--- a/eng/build.sh
+++ b/eng/build.sh
@@ -30,13 +30,15 @@ __InstallRuntimes=0
 __PrivateBuild=0
 __Test=0
 __UnprocessedBuildArgs=
+__UseCdac=0
+__LiveRuntimeDir=
 
 usage_list+=("-skipmanaged: do not build managed components.")
 usage_list+=("-skipnative: do not build native components.")
 usage_list+=("-test: run xunit tests")
 
 handle_arguments() {
-
+    
     lowerI="$(echo "${1/--/-}" | tr "[:upper:]" "[:lower:]")"
     case "$lowerI" in
         architecture|-architecture|-a)
@@ -79,6 +81,11 @@ handle_arguments() {
             __ShiftArgs=1
              ;;
 
+        liveruntimedir|-liveruntimedir)
+            __LiveRuntimeDir="$2"
+            __ShiftArgs=1
+            ;;
+
         skipmanaged|-skipmanaged)
             __ManagedBuild=0
             ;;
@@ -97,6 +104,10 @@ handle_arguments() {
 
         test|-test)
             __Test=1
+            ;;
+
+        usecdac|-usecdac)
+            __UseCdac=1
             ;;
 
         -warnaserror|-nodereuse)
@@ -248,7 +259,8 @@ if [[ "$__InstallRuntimes" == 1 || "$__PrivateBuild" == 1 ]]; then
         /bl:"$__LogsDir/InstallRuntimes.binlog" \
         /p:PrivateBuildTesting="$__privateBuildTesting" \
         /p:BuildArch="$__TargetArch" \
-        /p:TestArchitectures="$__TargetArch"
+        /p:TestArchitectures="$__TargetArch" \
+        /p:LiveRuntimeDir="$__LiveRuntimeDir" 
 fi
 
 #
@@ -295,6 +307,10 @@ if [[ "$__Test" == 1 ]]; then
 
       echo "lldb: '$LLDB_PATH' gdb: '$GDB_PATH'"
 
+      if [[ "$__UseCdac" == 1 ]]; then
+          export SOS_TEST_CDAC="true"
+      fi
+
       "$__RepoRootDir/eng/common/build.sh" \
         --test \
         --configuration "$__BuildType" \
@@ -304,6 +320,7 @@ if [[ "$__Test" == 1 ]]; then
         /p:DotnetRuntimeDownloadVersion="$__DotnetRuntimeDownloadVersion" \
         /p:RuntimeSourceFeed="$__RuntimeSourceFeed" \
         /p:RuntimeSourceFeedKey="$__RuntimeSourceFeedKey" \
+        /p:LiveRuntimeDir="$__LiveRuntimeDir" \
         $__CommonMSBuildArgs
 
       if [ $? != 0 ]; then


### PR DESCRIPTION
Follow up to https://github.com/dotnet/diagnostics/pull/5350 that adds the ability to use the cdac and patch a local copy of the shared framework on non-windows hosts.