### PR TITLE
Add CDAC support to SOS

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -37,7 +37,7 @@
     <SystemCollectionsImmutableVersion>8.0.0</SystemCollectionsImmutableVersion>
     <!-- Other libs -->
     <MicrosoftBclAsyncInterfacesVersion>6.0.0</MicrosoftBclAsyncInterfacesVersion>
-    <MicrosoftDiagnosticsRuntimeVersion>4.0.0-beta.25167.1</MicrosoftDiagnosticsRuntimeVersion>
+    <MicrosoftDiagnosticsRuntimeVersion>4.0.0-beta.25201.1</MicrosoftDiagnosticsRuntimeVersion>
     <MicrosoftDiaSymReaderNativeVersion>17.10.0-beta1.24272.1</MicrosoftDiaSymReaderNativeVersion>
     <MicrosoftDiagnosticsTracingTraceEventVersion>3.1.16</MicrosoftDiagnosticsTracingTraceEventVersion>
     <MicrosoftExtensionsLoggingVersion>6.0.0</MicrosoftExtensionsLoggingVersion>

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/Host.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/Host.cs
@@ -10,7 +10,7 @@ using Microsoft.Diagnostics.DebugServices;
 
 namespace Microsoft.Diagnostics.DebugServices.Implementation
 {
-    public class Host : IHost
+    public class Host : IHost, ISettingsService
     {
         private readonly ServiceManager _serviceManager;
         private ServiceContainer _serviceContainer;
@@ -49,6 +49,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
             _serviceContainer = _serviceManager.CreateServiceContainer(ServiceScope.Global, parent: null);
             _serviceContainer.AddService<IServiceManager>(_serviceManager);
             _serviceContainer.AddService<IHost>(this);
+            _serviceContainer.AddService<ISettingsService>(this);
 
             return _serviceContainer;
         }
@@ -100,6 +101,16 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
             }
             return _tempDirectory;
         }
+
+        #endregion
+
+        #region ISettingsService
+
+        public virtual bool DacSignatureVerificationEnabled { get; set; }
+
+        public bool UseContractReader { get; set; }
+
+        public bool ForceUseContractReader { get; set; }
 
         #endregion
 

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/Runtime.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/Runtime.cs
@@ -120,13 +120,10 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
             }
             if (_dacFilePath is null)
             {
-                if (_dacFilePath is null)
+                _dacFilePath = GetLibraryPath(DebugLibraryKind.Dac);
+                if (_dacFilePath is not null)
                 {
-                    _dacFilePath = GetLibraryPath(DebugLibraryKind.Dac);
-                    if (_dacFilePath is not null)
-                    {
-                        verifySignature = _settingsService.DacSignatureVerificationEnabled;
-                    }
+                    verifySignature = _settingsService.DacSignatureVerificationEnabled;
                 }
             }
             return _dacFilePath;

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/Runtime.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/Runtime.cs
@@ -20,10 +20,12 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
     public class Runtime : IRuntime, IDisposable
     {
         private readonly ClrInfo _clrInfo;
+        private readonly ISettingsService _settingsService;
         private readonly ISymbolService _symbolService;
         private Version _runtimeVersion;
         private ClrRuntime _clrRuntime;
         private string _dacFilePath;
+        private string _cdacFilePath;
         private string _dbiFilePath;
 
         protected readonly ServiceContainer _serviceContainer;
@@ -33,7 +35,8 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
             Target = services.GetService<ITarget>() ?? throw new DiagnosticsException("Dump or live session target required");
             Id = id;
             _clrInfo = clrInfo ?? throw new ArgumentNullException(nameof(clrInfo));
-            _symbolService = services.GetService<ISymbolService>();
+            _settingsService = services.GetService<ISettingsService>() ?? throw new ArgumentException("ISettingsService required");
+            _symbolService = services.GetService<ISymbolService>() ?? throw new ArgumentException("ISymbolService required");
 
             RuntimeType = RuntimeType.Unknown;
             if (clrInfo.Flavor == ClrFlavor.Core)
@@ -96,9 +99,36 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
             }
         }
 
-        public string GetDacFilePath()
+        public string GetCDacFilePath()
         {
-            _dacFilePath ??= GetLibraryPath(DebugLibraryKind.Dac);
+            if (_cdacFilePath is null)
+            {
+                if (_settingsService.UseContractReader || _settingsService.ForceUseContractReader)
+                {
+                    _cdacFilePath = GetLibraryPath(DebugLibraryKind.CDac);
+                }
+            }
+            return _cdacFilePath;
+        }
+
+        public string GetDacFilePath(out bool verifySignature)
+        {
+            verifySignature = false;
+            if (_settingsService.ForceUseContractReader)
+            {
+                return GetCDacFilePath();
+            }
+            if (_dacFilePath is null)
+            {
+                if (_dacFilePath is null)
+                {
+                    _dacFilePath = GetLibraryPath(DebugLibraryKind.Dac);
+                    if (_dacFilePath is not null)
+                    {
+                        verifySignature = _settingsService.DacSignatureVerificationEnabled;
+                    }
+                }
+            }
             return _dacFilePath;
         }
 
@@ -115,7 +145,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
         /// </summary>
         private ClrRuntime CreateRuntime()
         {
-            string dacFilePath = GetDacFilePath();
+            string dacFilePath = GetDacFilePath(out bool verifySignature);
             if (dacFilePath is not null)
             {
                 Trace.TraceInformation($"Creating ClrRuntime #{Id} {dacFilePath}");
@@ -123,7 +153,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
                 {
                     // Ignore the DAC version mismatch that can happen because the clrmd ELF dump reader
                     // returns 0.0.0.0 for the runtime module that the DAC is matched against.
-                    return _clrRuntime = _clrInfo.CreateRuntime(dacFilePath, ignoreMismatch: true);
+                    return _clrRuntime = _clrInfo.CreateRuntime(dacFilePath, ignoreMismatch: true, verifySignature);
                 }
                 catch (Exception ex) when
                    (ex is DllNotFoundException or
@@ -151,15 +181,18 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
             {
                 if (libraryInfo.Kind == kind && RuntimeInformation.IsOSPlatform(libraryInfo.Platform) && libraryInfo.TargetArchitecture == currentArch)
                 {
-                    libraryPath = GetLocalPath(libraryInfo.FileName);
+                    libraryPath = GetLocalPath(libraryInfo);
                     if (libraryPath is not null)
                     {
                         break;
                     }
-                    libraryPath = DownloadFile(libraryInfo);
-                    if (libraryPath is not null)
+                    if (libraryInfo.ArchivedUnder != SymbolProperties.None)
                     {
-                        break;
+                        libraryPath = DownloadFile(libraryInfo);
+                        if (libraryPath is not null)
+                        {
+                            break;
+                        }
                     }
                 }
             }
@@ -167,16 +200,23 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
             return libraryPath;
         }
 
-        private string GetLocalPath(string fileName)
+        private string GetLocalPath(DebugLibraryInfo libraryInfo)
         {
             string localFilePath;
-            if (!string.IsNullOrEmpty(RuntimeModuleDirectory))
+            if (libraryInfo.Kind == DebugLibraryKind.CDac)
             {
-                localFilePath = Path.Combine(RuntimeModuleDirectory, Path.GetFileName(fileName));
+                localFilePath = libraryInfo.FileName;
             }
             else
             {
-                localFilePath = Path.Combine(Path.GetDirectoryName(RuntimeModule.FileName), Path.GetFileName(fileName));
+                if (!string.IsNullOrEmpty(RuntimeModuleDirectory))
+                {
+                    localFilePath = Path.Combine(RuntimeModuleDirectory, Path.GetFileName(libraryInfo.FileName));
+                }
+                else
+                {
+                    localFilePath = Path.Combine(Path.GetDirectoryName(RuntimeModule.FileName), Path.GetFileName(libraryInfo.FileName));
+                }
             }
             if (!File.Exists(localFilePath))
             {
@@ -303,6 +343,11 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
             {
                 sb.AppendLine();
                 sb.Append($"    DAC: {_dacFilePath}");
+            }
+            if (_cdacFilePath is not null)
+            {
+                sb.AppendLine();
+                sb.Append($"    CDAC: {_cdacFilePath}");
             }
             if (_dbiFilePath is not null)
             {

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/RuntimeProvider.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/RuntimeProvider.cs
@@ -29,14 +29,12 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
         /// <param name="flags">Enumeration control flags</param>
         public IEnumerable<IRuntime> EnumerateRuntimes(int startingRuntimeId, RuntimeEnumerationFlags flags)
         {
-            ISettingsService settingsService = _services.GetService<ISettingsService>();
             // The ClrInfo and DataTarget instances are disposed when Runtime instance is disposed. Runtime instances are
             // not flushed when the Target/RuntimeService is flushed; they are all disposed and the list cleared. They are
             // all re-created the next time the IRuntime or ClrRuntime instance is queried.
             DataTarget dataTarget = new(new CustomDataTarget(_services.GetService<IDataReader>())
             {
                 ForceCompleteRuntimeEnumeration = (flags & RuntimeEnumerationFlags.All) != 0,
-                DacSignatureVerificationEnabled = settingsService is null || settingsService.DacSignatureVerificationEnabled,
                 FileLocator = null
             });
             for (int i = 0; i < dataTarget.ClrVersions.Length; i++)

--- a/src/Microsoft.Diagnostics.DebugServices/IRuntime.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/IRuntime.cs
@@ -62,7 +62,13 @@ namespace Microsoft.Diagnostics.DebugServices
         /// <summary>
         /// Returns the DAC file path
         /// </summary>
-        string GetDacFilePath();
+        /// <param name="verifySignature">returns if the DAC signature should be verified</param>
+        string GetDacFilePath(out bool verifySignature);
+
+        /// <summary>
+        /// Returns the CDac file path if enabled by global settings
+        /// </summary>
+        string GetCDacFilePath();
 
         /// <summary>
         /// Returns the DBI file path

--- a/src/Microsoft.Diagnostics.DebugServices/ISettingsService.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/ISettingsService.cs
@@ -15,5 +15,15 @@ namespace Microsoft.Diagnostics.DebugServices
         /// If true, enforces the proper DAC certificate signing when loaded
         /// </summary>
         bool DacSignatureVerificationEnabled { get; set; }
+
+        /// <summary>
+        /// If true, uses the CDAC contract reader if available.
+        /// </summary>
+        bool UseContractReader { get; set; }
+
+        /// <summary>
+        /// If true, always use the CDAC contract reader even when not requested
+        /// </summary>
+        bool ForceUseContractReader { get; set; }
     }
 }

--- a/src/Microsoft.Diagnostics.ExtensionCommands/Host/CommandFormatHelpers.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/Host/CommandFormatHelpers.cs
@@ -12,8 +12,9 @@ namespace Microsoft.Diagnostics.ExtensionCommands
 {
     public static class CommandFormatHelpers
     {
-        public const string DacTableSymbol = "g_dacTable";
-        public const string DebugHeaderSymbol = "DotNetRuntimeDebugHeader";
+        public const string DacTableExport = "g_dacTable";
+        public const string DebugHeaderExport = "DotNetRuntimeDebugHeader";
+        public const string ContractDescriptorExport = "DotNetRuntimeContractDescriptor";
 
         /// <summary>
         /// Displays the special diagnostics info header memory block (.NET Core 8 or later on Linux/MacOS)
@@ -127,28 +128,28 @@ namespace Microsoft.Diagnostics.ExtensionCommands
             IExportSymbols symbols = module.Services.GetService<IExportSymbols>();
             if (symbols != null && symbols.TryGetSymbolAddress(RuntimeInfo.RUNTIME_INFO_SYMBOL, out ulong infoAddress))
             {
-                Console().Write($"{indent}{RuntimeInfo.RUNTIME_INFO_SYMBOL,-24}: {infoAddress:X16}");
+                Console().Write($"{indent}{RuntimeInfo.RUNTIME_INFO_SYMBOL}: {infoAddress:X16}");
                 if (RuntimeInfo.TryRead(command.Services, infoAddress, out RuntimeInfo info))
                 {
                     Console().WriteLine(info.IsValid ? "" : " <INVALID>");
-                    Console().WriteLine($"{indent}    Signature:                  {info.Signature}");
-                    Console().WriteLine($"{indent}    Version:                    {info.Version}");
-                    Console().WriteLine($"{indent}    RuntimeModuleIndex:         {info.RawRuntimeModuleIndex.ToHex()}");
-                    Console().WriteLine($"{indent}    DacModuleIndex:             {info.RawDacModuleIndex.ToHex()}");
-                    Console().WriteLine($"{indent}    DbiModuleIndex:             {info.RawDbiModuleIndex.ToHex()}");
+                    Console().WriteLine($"{indent}    Signature:            {info.Signature}");
+                    Console().WriteLine($"{indent}    Version:              {info.Version}");
+                    Console().WriteLine($"{indent}    RuntimeModuleIndex:   {info.RawRuntimeModuleIndex.ToHex()}");
+                    Console().WriteLine($"{indent}    DacModuleIndex:       {info.RawDacModuleIndex.ToHex()}");
+                    Console().WriteLine($"{indent}    DbiModuleIndex:       {info.RawDbiModuleIndex.ToHex()}");
                     if (module.IsPEImage)
                     {
-                        Console().WriteLine($"{indent}    RuntimePEIndex:             {info.RuntimePEIIndex.timeStamp:X8}/{info.RuntimePEIIndex.fileSize:X}");
-                        Console().WriteLine($"{indent}    DacPEIndex:                 {info.DacPEIndex.timeStamp:X8}/{info.DacPEIndex.fileSize:X}");
-                        Console().WriteLine($"{indent}    DbiPEIndex:                 {info.DbiPEIndex.timeStamp:X8}/{info.DbiPEIndex.fileSize:X}");
+                        Console().WriteLine($"{indent}    RuntimePEIndex:       {info.RuntimePEIIndex.timeStamp:X8}/{info.RuntimePEIIndex.fileSize:X}");
+                        Console().WriteLine($"{indent}    DacPEIndex:           {info.DacPEIndex.timeStamp:X8}/{info.DacPEIndex.fileSize:X}");
+                        Console().WriteLine($"{indent}    DbiPEIndex:           {info.DbiPEIndex.timeStamp:X8}/{info.DbiPEIndex.fileSize:X}");
                     }
                     else
                     {
-                        Console().WriteLine($"{indent}    RuntimeBuildId:             {info.RuntimeBuildId.ToHex()}");
-                        Console().WriteLine($"{indent}    DacBuildId:                 {info.DacBuildId.ToHex()}");
-                        Console().WriteLine($"{indent}    DbiBuildId:                 {info.DbiBuildId.ToHex()}");
+                        Console().WriteLine($"{indent}    RuntimeBuildId:       {info.RuntimeBuildId.ToHex()}");
+                        Console().WriteLine($"{indent}    DacBuildId:           {info.DacBuildId.ToHex()}");
+                        Console().WriteLine($"{indent}    DbiBuildId:           {info.DbiBuildId.ToHex()}");
                     }
-                    Console().WriteLine($"{indent}    RuntimeVersion:             {info.RuntimeVersion?.ToString() ?? "<none>"}");
+                    Console().WriteLine($"{indent}    RuntimeVersion:       {info.RuntimeVersion?.ToString() ?? "<none>"}");
                 }
                 else
                 {
@@ -157,7 +158,7 @@ namespace Microsoft.Diagnostics.ExtensionCommands
             }
             else if (error)
             {
-                Console().WriteLine($"{indent}{RuntimeInfo.RUNTIME_INFO_SYMBOL,-24}: <NO SYMBOL>");
+                Console().WriteLine($"{indent}{RuntimeInfo.RUNTIME_INFO_SYMBOL}: <NO SYMBOL>");
             }
 
             // Print the Windows runtime engine metrics (.NET Core and .NET Framework)
@@ -166,13 +167,13 @@ namespace Microsoft.Diagnostics.ExtensionCommands
             {
                 if (symbols != null && symbols.TryGetSymbolAddress(ClrEngineMetrics.Symbol, out ulong metricsAddress))
                 {
-                    Console().Write($"{indent}{ClrEngineMetrics.Symbol,-24}: ({metricsAddress:X16})");
+                    Console().Write($"{indent}{ClrEngineMetrics.Symbol}: {metricsAddress:X16}");
                     if (ClrEngineMetrics.TryRead(command.Services, metricsAddress, out ClrEngineMetrics metrics))
                     {
                         Console().WriteLine();
-                        Console().WriteLine($"{indent}    Size:                   {metrics.Size} (0x{metrics.Size:X2})");
-                        Console().WriteLine($"{indent}    DbiVersion:             {metrics.DbiVersion}");
-                        Console().WriteLine($"{indent}    ContinueStartupEvent:   {((ulong)metrics.ContinueStartupEvent):X16}");
+                        Console().WriteLine($"{indent}    Size:                 {metrics.Size} (0x{metrics.Size:X2})");
+                        Console().WriteLine($"{indent}    DbiVersion:           {metrics.DbiVersion}");
+                        Console().WriteLine($"{indent}    ContinueStartupEvent: {((ulong)metrics.ContinueStartupEvent):X16}");
                     }
                     else
                     {
@@ -181,28 +182,38 @@ namespace Microsoft.Diagnostics.ExtensionCommands
                 }
                 else if (error)
                 {
-                    Console().WriteLine($"{indent}{ClrEngineMetrics.Symbol,-24}: <NO SYMBOL>");
+                    Console().WriteLine($"{indent}{ClrEngineMetrics.Symbol}: <NO SYMBOL>");
                 }
             }
 
             // Print the DAC table address (g_dacTable)
-            if (symbols != null && symbols.TryGetSymbolAddress(DacTableSymbol, out ulong dacTableAddress))
+            if (symbols != null && symbols.TryGetSymbolAddress(DacTableExport, out ulong dacTableAddress))
             {
-                Console().WriteLine($"{indent}{DacTableSymbol,-24}: {dacTableAddress:X16}");
+                Console().WriteLine($"{indent}{DacTableExport}: {dacTableAddress:X16}");
             }
             else if (error)
             {
-                Console().WriteLine($"{indent}{DacTableSymbol,-24}: <NO SYMBOL>");
+                Console().WriteLine($"{indent}{DacTableExport}: <NO SYMBOL>");
             }
 
             // Print the Native AOT contract data address (DotNetRuntimeDebugHeader)
-            if (symbols != null && symbols.TryGetSymbolAddress(DebugHeaderSymbol, out ulong debugHeaderAddress))
+            if (symbols != null && symbols.TryGetSymbolAddress(DebugHeaderExport, out ulong debugHeaderAddress))
             {
-                Console().WriteLine($"{indent}{DebugHeaderSymbol,-24}: {debugHeaderAddress:X16}");
+                Console().WriteLine($"{indent}{DebugHeaderExport}: {debugHeaderAddress:X16}");
             }
             else if (error)
             {
-                Console().WriteLine($"{indent}{DebugHeaderSymbol,-24}: <NO SYMBOL>");
+                Console().WriteLine($"{indent}{DebugHeaderExport}: <NO SYMBOL>");
+            }
+
+            // Print the CDAC contract data address (DotNetRuntimeContractDescriptor)
+            if (symbols != null && symbols.TryGetSymbolAddress(ContractDescriptorExport, out ulong contractDescriptorAddress))
+            {
+                Console().WriteLine($"{indent}{ContractDescriptorExport}: {contractDescriptorAddress:X16}");
+            }
+            else if (error)
+            {
+                Console().WriteLine($"{indent}{ContractDescriptorExport}: <NO SYMBOL>");
             }
         }
     }

--- a/src/Microsoft.Diagnostics.TestHelpers/TestHost/TestDataWriter.cs
+++ b/src/Microsoft.Diagnostics.TestHelpers/TestHost/TestDataWriter.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Diagnostics.TestHelpers
             {
                 XElement runtimeElement = new("Runtime");
                 runtimesElement.Add(runtimeElement);
-                AddMembers(runtimeElement, typeof(IRuntime), runtime, nameof(IRuntime.GetDacFilePath), nameof(IRuntime.GetDbiFilePath));
+                AddMembers(runtimeElement, typeof(IRuntime), runtime, nameof(IRuntime.GetDacFilePath), nameof(IRuntime.GetCDacFilePath), nameof(IRuntime.GetDbiFilePath));
 
                 XElement runtimeModuleElement = new("RuntimeModule");
                 runtimeElement.Add(runtimeModuleElement);

--- a/src/Microsoft.Diagnostics.TestHelpers/TestHost/TestDump.cs
+++ b/src/Microsoft.Diagnostics.TestHelpers/TestHost/TestDump.cs
@@ -8,7 +8,7 @@ using Microsoft.Diagnostics.DebugServices.Implementation;
 
 namespace Microsoft.Diagnostics.TestHelpers
 {
-    public class TestDump : TestHost, ISettingsService
+    public class TestDump : TestHost
     {
         private readonly Host _host;
         private readonly ContextService _contextService;
@@ -26,7 +26,6 @@ namespace Microsoft.Diagnostics.TestHelpers
 
             _contextService = new(_host);
             serviceContainer.AddService<IContextService>(_contextService);
-            serviceContainer.AddService<ISettingsService>(this);
 
             _commandService = new();
             serviceContainer.AddService<ICommandService>(_commandService);
@@ -53,11 +52,5 @@ namespace Microsoft.Diagnostics.TestHelpers
             _symbolService.AddDirectoryPath(Path.GetDirectoryName(DumpFile));
             return _dumpTargetFactory.OpenDump(DumpFile);
         }
-
-        #region ISettingsService
-
-        public bool DacSignatureVerificationEnabled { get; set; }
-
-        #endregion
     }
 }

--- a/src/SOS/SOS.Hosting/SOS.Hosting.csproj
+++ b/src/SOS/SOS.Hosting/SOS.Hosting.csproj
@@ -3,7 +3,10 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>SOS.Hosting</AssemblyName>
     <NoWarn>$(NoWarn);1591;1701;IDE0060</NoWarn>
-    <Description>SOS Hosting support</Description>
+    <IsPackable>true</IsPackable>
+    <Description>Diagnostic SOS hosting support</Description>
+    <PackageReleaseNotes>$(Description)</PackageReleaseNotes>
+    <PackageTags>SOS</PackageTags>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsShipping>true</IsShipping>
     <IsShippingPackage>false</IsShippingPackage>

--- a/src/SOS/Strike/clrma/managedanalysis.cpp
+++ b/src/SOS/Strike/clrma/managedanalysis.cpp
@@ -260,7 +260,7 @@ ClrmaManagedAnalysis::AssociateClient(
                     TraceError("AssociateClient GetRuntime FAILED %08x\n", hr);
                     return hr;
                 }
-                if (FAILED(hr = runtime->GetClrDataProcess(&m_clrData)))
+                if (FAILED(hr = runtime->GetClrDataProcess(IRuntime::ClrDataProcessFlags::UseCDac, &m_clrData)))
                 {
                     m_clrData = GetClrDataFromDbgEng();
                     if (m_clrData == nullptr)

--- a/src/SOS/Strike/platform/runtimeimpl.cpp
+++ b/src/SOS/Strike/platform/runtimeimpl.cpp
@@ -421,7 +421,7 @@ LPCSTR Runtime::GetRuntimeDirectory()
 /**********************************************************************\
  * Creates an instance of the DAC clr data process
 \**********************************************************************/
-HRESULT Runtime::GetClrDataProcess(IXCLRDataProcess** ppClrDataProcess)
+HRESULT Runtime::GetClrDataProcess(ClrDataProcessFlags flags, IXCLRDataProcess** ppClrDataProcess)
 {
     if (m_clrDataProcess == nullptr)
     {

--- a/src/SOS/Strike/platform/runtimeimpl.h
+++ b/src/SOS/Strike/platform/runtimeimpl.h
@@ -180,7 +180,7 @@ public:
 
     LPCSTR STDMETHODCALLTYPE GetRuntimeDirectory();
 
-    HRESULT STDMETHODCALLTYPE GetClrDataProcess(IXCLRDataProcess** ppClrDataProcess);
+    HRESULT STDMETHODCALLTYPE GetClrDataProcess(ClrDataProcessFlags flags, IXCLRDataProcess** ppClrDataProcess);
 
     HRESULT STDMETHODCALLTYPE GetCorDebugInterface(ICorDebugProcess** ppCorDebugProcess);
 

--- a/src/SOS/Strike/util.cpp
+++ b/src/SOS/Strike/util.cpp
@@ -4088,7 +4088,7 @@ public:
 HRESULT LoadClrDebugDll(void)
 {
     _ASSERTE(g_pRuntime != nullptr);
-    HRESULT hr = g_pRuntime->GetClrDataProcess(&g_clrData);
+    HRESULT hr = g_pRuntime->GetClrDataProcess(IRuntime::ClrDataProcessFlags::None, &g_clrData);
     if (FAILED(hr))
     {
         g_clrData = GetClrDataFromDbgEng();

--- a/src/SOS/inc/runtime.h
+++ b/src/SOS/inc/runtime.h
@@ -39,6 +39,22 @@ public:
     };
 
     /// <summary>
+    /// Flags to GetClrDataProcess when creating the DAC instance
+    /// </summary>
+    enum ClrDataProcessFlags
+    {
+        /// <summary>
+        /// No flags
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// Use the CDac if available and enabled by global setting
+        /// </summary>
+        UseCDac
+    };
+
+    /// <summary>
     /// Returns the runtime configuration 
     /// </summary>
     virtual RuntimeConfiguration STDMETHODCALLTYPE GetRuntimeConfiguration() const = 0;
@@ -66,7 +82,7 @@ public:
     /// <summary>
     /// Returns the DAC data process instance
     /// </summary>
-    virtual HRESULT STDMETHODCALLTYPE GetClrDataProcess(IXCLRDataProcess** ppClrDataProcess) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetClrDataProcess(ClrDataProcessFlags flags, IXCLRDataProcess** ppClrDataProcess) = 0;
 
     /// <summary>
     /// Initializes and returns the DBI debugging interface instance 

--- a/src/Tools/dotnet-dump/Analyzer.cs
+++ b/src/Tools/dotnet-dump/Analyzer.cs
@@ -17,7 +17,7 @@ using SOS.Hosting;
 
 namespace Microsoft.Diagnostics.Tools.Dump
 {
-    public class Analyzer : Host, ISettingsService
+    public class Analyzer : Host
     {
         private readonly ConsoleService _consoleService;
         private readonly FileLoggingConsoleService _fileLoggingConsoleService;
@@ -27,6 +27,7 @@ namespace Microsoft.Diagnostics.Tools.Dump
             : base(HostType.DotnetDump)
         {
             DiagnosticLoggingService.Initialize();
+            DacSignatureVerificationEnabled  = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? true : false;
 
             _consoleService = new ConsoleService();
             _fileLoggingConsoleService = new FileLoggingConsoleService(_consoleService);
@@ -85,7 +86,6 @@ namespace Microsoft.Diagnostics.Tools.Dump
             serviceContainer.AddService<IDiagnosticLoggingService>(DiagnosticLoggingService.Instance);
             serviceContainer.AddService<ICommandService>(_commandService);
             serviceContainer.AddService<CommandService>(_commandService);
-            serviceContainer.AddService<ISettingsService>(this);
 
             DumpTargetFactory dumpTargetFactory = new(this);
             serviceContainer.AddService<IDumpTargetFactory>(dumpTargetFactory);
@@ -175,11 +175,5 @@ namespace Microsoft.Diagnostics.Tools.Dump
             }
             return Task.FromResult(0);
         }
-
-        #region ISettingsService
-
-        public bool DacSignatureVerificationEnabled { get; set; } = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? true : false;
-
-        #endregion
     }
 }

--- a/src/shared/inc/clrdata.idl
+++ b/src/shared/inc/clrdata.idl
@@ -211,6 +211,20 @@ interface ICLRRuntimeLocator : IUnknown
     HRESULT GetRuntimeBase([out] CLRDATA_ADDRESS* baseAddress);
 };
 
+[
+    object,
+    local,
+    uuid(17d5b8c6-34a9-407f-af4f-a930201d4e02),
+    pointer_default(unique)
+]
+interface ICLRContractLocator : IUnknown
+{
+    /*
+     Returns the address of the runtime's contract descriptor.
+     */
+    HRESULT GetContractDescriptor([out] CLRDATA_ADDRESS* contractAddress);
+}
+
 /*
  * Interface used by the data access services layer to locate metadata
  * of assemblies in a target.

--- a/src/shared/pal/prebuilt/idl/clrdata_i.cpp
+++ b/src/shared/pal/prebuilt/idl/clrdata_i.cpp
@@ -8,10 +8,10 @@
 
  /* File created by MIDL compiler version 8.01.0626 */
 /* Compiler settings for clrdata.idl:
-    Oicf, W1, Zp8, env=Win64 (32b run), target_arch=AMD64 8.01.0626 
+    Oicf, W1, Zp8, env=Win64 (32b run), target_arch=AMD64 8.01.0626
     protocol : dce , ms_ext, c_ext, robust
-    error checks: allocation ref bounds_check enum stub_data 
-    VC __declspec() decoration level: 
+    error checks: allocation ref bounds_check enum stub_data
+    VC __declspec() decoration level:
          __declspec(uuid()), __declspec(selectany), __declspec(novtable)
          DECLSPEC_UUID(), MIDL_INTERFACE()
 */
@@ -22,7 +22,7 @@
 
 #ifdef __cplusplus
 extern "C"{
-#endif 
+#endif
 
 
 #include <rpc.h>
@@ -76,6 +76,9 @@ MIDL_DEFINE_GUID(IID, IID_ICLRDataTarget3,0xa5664f95,0x0af4,0x4a1b,0x96,0x0e,0x2
 
 
 MIDL_DEFINE_GUID(IID, IID_ICLRRuntimeLocator,0xb760bf44,0x9377,0x4597,0x8b,0xe7,0x58,0x08,0x3b,0xdc,0x51,0x46);
+
+
+MIDL_DEFINE_GUID(IID, IID_ICLRContractLocator,0x17d5b8c6,0x34a9,0x407f,0xaf,0x4f,0xa9,0x30,0x20,0x1d,0x4e,0x02);
 
 
 MIDL_DEFINE_GUID(IID, IID_ICLRMetadataLocator,0xaa8fa804,0xbc05,0x4642,0xb2,0xc5,0xc3,0x53,0xed,0x22,0xfc,0x63);

--- a/src/shared/pal/prebuilt/inc/clrdata.h
+++ b/src/shared/pal/prebuilt/inc/clrdata.h
@@ -77,7 +77,14 @@ typedef interface ICLRDataTarget3 ICLRDataTarget3;
 #define __ICLRRuntimeLocator_FWD_DEFINED__
 typedef interface ICLRRuntimeLocator ICLRRuntimeLocator;
 
-#endif 	/* __ICLRRuntimeLocator_FWD_DEFINED__ */
+
+#endif 	/* __ICLRContractLocator_FWD_DEFINED__ */
+
+#ifndef __ICLRContractLocator_FWD_DEFINED__
+#define __ICLRContractLocator_FWD_DEFINED__
+typedef interface ICLRContractLocator ICLRContractLocator;
+
+#endif 	/* __ICLRContractLocator_FWD_DEFINED__ */
 
 
 #ifndef __ICLRMetadataLocator_FWD_DEFINED__
@@ -910,6 +917,90 @@ EXTERN_C const IID IID_ICLRRuntimeLocator;
 
 #define ICLRRuntimeLocator_GetRuntimeBase(This,baseAddress)	\
     ( (This)->lpVtbl -> GetRuntimeBase(This,baseAddress) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __ICLRRuntimeLocator_INTERFACE_DEFINED__ */
+
+
+#ifndef __ICLRContractLocator_INTERFACE_DEFINED__
+#define __ICLRContractLocator_INTERFACE_DEFINED__
+
+/* interface ICLRContractLocator */
+/* [unique][uuid][local][object] */
+
+
+EXTERN_C const IID IID_ICLRContractLocator;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+
+    MIDL_INTERFACE("17d5b8c6-34a9-407f-af4f-a930201d4e02")
+    ICLRContractLocator : public IUnknown
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE GetContractDescriptor(
+            /* [out] */ CLRDATA_ADDRESS *contractAddress) = 0;
+
+    };
+
+
+#else 	/* C style interface */
+
+    typedef struct ICLRContractLocatorVtbl
+    {
+        BEGIN_INTERFACE
+
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )(
+            ICLRContractLocator * This,
+            /* [in] */ REFIID riid,
+            /* [annotation][iid_is][out] */
+            _COM_Outptr_  void **ppvObject);
+
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
+        ULONG ( STDMETHODCALLTYPE *AddRef )(
+            ICLRContractLocator * This);
+
+        DECLSPEC_XFGVIRT(IUnknown, Release)
+        ULONG ( STDMETHODCALLTYPE *Release )(
+            ICLRContractLocator * This);
+
+        DECLSPEC_XFGVIRT(ICLRContractLocator, GetContractDescriptor)
+        HRESULT ( STDMETHODCALLTYPE *GetContractDescriptor )(
+            ICLRContractLocator * This,
+            /* [out] */ CLRDATA_ADDRESS *contractAddress);
+
+        END_INTERFACE
+    } ICLRRuntimeLocatorVtbl;
+
+    interface ICLRContractLocator
+    {
+        CONST_VTBL struct ICLRRuntimeLocatorVtbl *lpVtbl;
+    };
+
+
+
+#ifdef COBJMACROS
+
+
+#define ICLRContractLocator_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) )
+
+#define ICLRContractLocator_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) )
+
+#define ICLRContractLocator_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) )
+
+
+#define ICLRContractLocator_GetContractDescriptor(This,contractAddress)	\
+    ( (This)->lpVtbl -> GetContractDescriptor(This,contractAddress) )
 
 #endif /* COBJMACROS */
 

--- a/src/tests/DbgShim.UnitTests/DbgShimTests.cs
+++ b/src/tests/DbgShim.UnitTests/DbgShimTests.cs
@@ -261,7 +261,7 @@ namespace Microsoft.Diagnostics
                 IRuntime runtime = runtimeService.EnumerateRuntimes().Single();
 
                 CorDebugDataTargetWrapper dataTarget = new(target.Services, runtime);
-                LibraryProviderWrapper libraryProvider = new(target.OperatingSystem, runtime.RuntimeModule.BuildId, runtime.GetDbiFilePath(), runtime.GetDacFilePath());
+                LibraryProviderWrapper libraryProvider = new(target.OperatingSystem, runtime.RuntimeModule.BuildId, runtime.GetDbiFilePath(), runtime.GetDacFilePath(out bool verifySignature));
                 ClrDebuggingVersion maxDebuggerSupportedVersion = new()
                 {
                     StructVersion = 0,


### PR DESCRIPTION
Add --usecdac and --forceusecdac options "runtimes" to control cdac loading.  Currently --usecdac enables using the CDAC for only the CLRMA APIs.  --forceusecdac forces all SOS to use the CDAC for testing.

Move ISettingsService impl's to Host class. Add UseContractReader property.

Add IRuntime.GetCDacFilePath() and add a "bool verifySignature" parameter to IRuntime.GetDacFilePath.

Add DotNetRuntimeContractDescriptor address to !runtimes info. Clean up the formatting a little.

Publish SOS.Hosting package