### PR TITLE
Move DotNetBuild defines into Build.props

### DIFF
--- a/eng/Build.props
+++ b/eng/Build.props
@@ -1,5 +1,11 @@
 <Project>
+
+  <ItemGroup Condition="'$(DotNetBuild)' == 'true'">
+    <ProjectToBuild Include="$(RepoRoot)src/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj" />
+  </ItemGroup>
+
   <ItemGroup Condition=" '$(BundleTools)' == 'true' ">
     <ProjectToBuild Include="$(RepoRoot)src/singlefile-tools.proj" />
   </ItemGroup>
+
 </Project>

--- a/eng/DotNetBuild.props
+++ b/eng/DotNetBuild.props
@@ -1,14 +1,9 @@
 <!-- When altering this file, include @dotnet/product-construction as a reviewer. -->
-
 <Project>
 
   <PropertyGroup>
     <GitHubRepositoryName>diagnostics</GitHubRepositoryName>
     <SourceBuildManagedOnly>true</SourceBuildManagedOnly>
   </PropertyGroup>
-
-  <ItemGroup>
-    <ProjectToBuild Include="$(RepoRoot)src/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj" />
-  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This allows to eventually remove the DotNetBuild.props file and just use the standard entry point.