### PR TITLE
Update System.CommandLine to beta5

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -45,7 +45,7 @@
     <MicrosoftExtensionsLoggingConsoleVersion>6.0.0</MicrosoftExtensionsLoggingConsoleVersion>
     <!-- Need version that understands UseAppFilters sentinel. -->
     <MicrosoftExtensionsLoggingEventSourceVersion>5.0.1</MicrosoftExtensionsLoggingEventSourceVersion>
-    <SystemCommandLineVersion>2.0.0-beta4.25153.1</SystemCommandLineVersion>
+    <SystemCommandLineVersion>2.0.0-beta5.25210.1</SystemCommandLineVersion>
     <SystemComponentModelAnnotationsVersion>5.0.0</SystemComponentModelAnnotationsVersion>
     <SystemBuffersVersion>4.5.1</SystemBuffersVersion>
     <SystemDiagnosticsDiagnosticSourceVersion>8.0.1</SystemDiagnosticsDiagnosticSourceVersion>


### PR DESCRIPTION
This update contain just a few fixes related to VMR. It's not must have for the diagnostics repo, but since I am aligning all the repos I thought it would be nice to update diagnostics too.