### PR TITLE
Update TraceEvent

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -39,7 +39,7 @@
     <MicrosoftBclAsyncInterfacesVersion>6.0.0</MicrosoftBclAsyncInterfacesVersion>
     <MicrosoftDiagnosticsRuntimeVersion>4.0.0-beta.25228.1</MicrosoftDiagnosticsRuntimeVersion>
     <MicrosoftDiaSymReaderNativeVersion>17.10.0-beta1.24272.1</MicrosoftDiaSymReaderNativeVersion>
-    <MicrosoftDiagnosticsTracingTraceEventVersion>3.1.16</MicrosoftDiagnosticsTracingTraceEventVersion>
+    <MicrosoftDiagnosticsTracingTraceEventVersion>3.1.21</MicrosoftDiagnosticsTracingTraceEventVersion>
     <MicrosoftExtensionsLoggingVersion>6.0.0</MicrosoftExtensionsLoggingVersion>
     <MicrosoftExtensionsLoggingAbstractionsVersion>6.0.4</MicrosoftExtensionsLoggingAbstractionsVersion>
     <MicrosoftExtensionsLoggingConsoleVersion>6.0.0</MicrosoftExtensionsLoggingConsoleVersion>

--- a/src/Tools/dotnet-gcdump/DotNetHeapDump/GCHeapDump.cs
+++ b/src/Tools/dotnet-gcdump/DotNetHeapDump/GCHeapDump.cs
@@ -13,17 +13,17 @@ using Graphs;
 using Address = System.UInt64;
 
 /// <summary>
-/// Represents a .GCDump file.  You can open it for reading with the construtor
+/// Represents a .GCDump file.  You can open it for reading with the constructor
 /// and you can write one with WriteMemoryGraph
 /// </summary>
 public class GCHeapDump : IFastSerializable, IFastSerializableVersion
 {
     public GCHeapDump(string inputFileName) :
-        this(new Deserializer(inputFileName, new SerializationConfiguration() { StreamLabelWidth = StreamLabelWidth.FourBytes }))
+        this(new Deserializer(inputFileName, SerializationSettings.Default.WithStreamLabelWidth(StreamLabelWidth.FourBytes)))
     { }
 
     public GCHeapDump(Stream inputStream, string streamName) :
-        this(new Deserializer(inputStream, streamName, new SerializationConfiguration() { StreamLabelWidth = StreamLabelWidth.FourBytes }))
+        this(new Deserializer(inputStream, streamName, SerializationSettings.Default.WithStreamLabelWidth(StreamLabelWidth.FourBytes)))
     { }
 
     /// <summary>
@@ -193,7 +193,7 @@ public class GCHeapDump : IFastSerializable, IFastSerializableVersion
     private void Write(string outputFileName)
     {
         Debug.Assert(MemoryGraph != null);
-        Serializer serializer = new(new IOStreamStreamWriter(outputFileName, config: new SerializationConfiguration() { StreamLabelWidth = StreamLabelWidth.FourBytes }), this);
+        Serializer serializer = new(new IOStreamStreamWriter(outputFileName, settings: SerializationSettings.Default.WithStreamLabelWidth(StreamLabelWidth.FourBytes)), this);
         serializer.Close();
     }
 

--- a/src/Tools/dotnet-gcdump/DotNetHeapDump/Graph.cs
+++ b/src/Tools/dotnet-gcdump/DotNetHeapDump/Graph.cs
@@ -469,7 +469,7 @@ namespace Graphs
         {
             RootIndex = NodeIndex.Invalid;
             m_writer ??= new SegmentedMemoryStreamWriter(m_expectedNodeCount * 8,
-                    m_isVeryLargeGraph ? new SerializationConfiguration() { StreamLabelWidth = StreamLabelWidth.EightBytes } : null);
+                    m_isVeryLargeGraph ? SerializationSettings.Default.WithStreamLabelWidth(StreamLabelWidth.EightBytes) : SerializationSettings.Default);
 
             m_totalSize = 0;
             m_totalRefs = 0;
@@ -597,7 +597,7 @@ namespace Graphs
             // TODO be lazy about reading in the blobs.
             int blobCount = deserializer.ReadInt();
             SegmentedMemoryStreamWriter writer = new(blobCount,
-                m_isVeryLargeGraph ? new SerializationConfiguration() { StreamLabelWidth = StreamLabelWidth.EightBytes } : null);
+                m_isVeryLargeGraph ? SerializationSettings.Default.WithStreamLabelWidth(StreamLabelWidth.EightBytes) : SerializationSettings.Default);
 
             while (8 <= blobCount)
             {

--- a/src/Tools/dotnet-gcdump/DotNetHeapDump/MemoryGraph.cs
+++ b/src/Tools/dotnet-gcdump/DotNetHeapDump/MemoryGraph.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using FastSerialization;
@@ -36,8 +37,30 @@ namespace Graphs
         }
         public static MemoryGraph ReadFromBinaryFile(string inputFileName)
         {
-            Deserializer deserializer = new(inputFileName);
-            deserializer.TypeResolver = typeName => System.Type.GetType(typeName);  // resolve types in this assembly (and mscorlib)
+            Deserializer deserializer = new(inputFileName, SerializationSettings.Default);
+
+            Func<Type, IFastSerializable> defaultFactory = (Type type) => {
+                try
+                {
+                    return (IFastSerializable)Activator.CreateInstance(type);
+                }
+                catch (MissingMethodException)
+                {
+                    throw new SerializationException(
+                        $"Unable to create an object of type {type.FullName}. It must either have a parameterless constructor or have been registered with the deserializer via RegisterFactory.");
+                }
+            };
+
+            deserializer.OnUnregisteredType = (string name) =>
+            {
+                Type type = Type.GetType(name, false);
+                if (type == null)
+                {
+                    return null;
+                }
+
+                return () => defaultFactory(type);
+            };
             deserializer.RegisterFactory(typeof(MemoryGraph), delegate { return new MemoryGraph(1); });
             deserializer.RegisterFactory(typeof(Module), delegate { return new Module(0); });
             return (MemoryGraph)deserializer.GetEntryObject();

--- a/src/Tools/dotnet-gcdump/DotNetHeapDump/MemoryGraph.cs
+++ b/src/Tools/dotnet-gcdump/DotNetHeapDump/MemoryGraph.cs
@@ -38,29 +38,6 @@ namespace Graphs
         public static MemoryGraph ReadFromBinaryFile(string inputFileName)
         {
             Deserializer deserializer = new(inputFileName, SerializationSettings.Default);
-
-            Func<Type, IFastSerializable> defaultFactory = (Type type) => {
-                try
-                {
-                    return (IFastSerializable)Activator.CreateInstance(type);
-                }
-                catch (MissingMethodException)
-                {
-                    throw new SerializationException(
-                        $"Unable to create an object of type {type.FullName}. It must either have a parameterless constructor or have been registered with the deserializer via RegisterFactory.");
-                }
-            };
-
-            deserializer.OnUnregisteredType = (string name) =>
-            {
-                Type type = Type.GetType(name, false);
-                if (type == null)
-                {
-                    return null;
-                }
-
-                return () => defaultFactory(type);
-            };
             deserializer.RegisterFactory(typeof(MemoryGraph), delegate { return new MemoryGraph(1); });
             deserializer.RegisterFactory(typeof(Module), delegate { return new Module(0); });
             return (MemoryGraph)deserializer.GetEntryObject();


### PR DESCRIPTION
Code updates are based on https://github.com/microsoft/perfview/pull/2121

Would like to incorporate https://github.com/microsoft/perfview/pull/2180 into dotnet-monitor, to potentially improve memory usage.

~~Test failures are most likely due to changes from https://github.com/microsoft/perfview/pull/2170~~ Fixed with newest version
