### PR TITLE
Fix DAC verify signature issue

### DIFF
--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/Runtime.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/Runtime.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
         private Version _runtimeVersion;
         private ClrRuntime _clrRuntime;
         private string _dacFilePath;
-        private bool _verifySignature;
+        private bool _verifySignature;      // This only applies to the regular DAC, not the CDAC
         private string _cdacFilePath;
         private string _dbiFilePath;
 
@@ -112,12 +112,13 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
             return _cdacFilePath;
         }
 
-
         public string GetDacFilePath(out bool verifySignature)
         {
             if (_settingsService.ForceUseContractReader)
             {
-                verifySignature = false;        // Don't verify signature when using the CDAC
+                // Don't verify signature when using the CDAC and don't change the cached value
+                // because it only applies to the regular DAC in _dacFilePath.
+                verifySignature = false;
                 return GetCDacFilePath();
             }
             if (_dacFilePath is null)

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/Runtime.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/Runtime.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
         private Version _runtimeVersion;
         private ClrRuntime _clrRuntime;
         private string _dacFilePath;
+        private bool _verifySignature;
         private string _cdacFilePath;
         private string _dbiFilePath;
 
@@ -111,11 +112,12 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
             return _cdacFilePath;
         }
 
+
         public string GetDacFilePath(out bool verifySignature)
         {
-            verifySignature = false;
             if (_settingsService.ForceUseContractReader)
             {
+                verifySignature = false;        // Don't verify signature when using the CDAC
                 return GetCDacFilePath();
             }
             if (_dacFilePath is null)
@@ -123,9 +125,10 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
                 _dacFilePath = GetLibraryPath(DebugLibraryKind.Dac);
                 if (_dacFilePath is not null)
                 {
-                    verifySignature = _settingsService.DacSignatureVerificationEnabled;
+                    _verifySignature = _settingsService.DacSignatureVerificationEnabled;
                 }
             }
+            verifySignature = _verifySignature;
             return _dacFilePath;
         }
 
@@ -339,7 +342,8 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
             if (_dacFilePath is not null)
             {
                 sb.AppendLine();
-                sb.Append($"    DAC: {_dacFilePath}");
+                string verify = _verifySignature ? "(verify)" : "(don't verify)";
+                sb.Append($"    DAC: {_dacFilePath} {verify}");
             }
             if (_cdacFilePath is not null)
             {

--- a/src/Microsoft.Diagnostics.ExtensionCommands/Host/CommandFormatHelpers.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/Host/CommandFormatHelpers.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Diagnostics.ExtensionCommands
         public const string DebugHeaderExport = "DotNetRuntimeDebugHeader";
         public const string ContractDescriptorExport = "DotNetRuntimeContractDescriptor";
 
-        public static void DisplaySetttingService(this CommandBase command)
+        public static void DisplaySettingService(this CommandBase command)
         {
             ISettingsService settingsService = command.Services.GetService<ISettingsService>() ?? throw new DiagnosticsException("Settings service required");
             command.Console.WriteLine("Settings:");

--- a/src/Microsoft.Diagnostics.ExtensionCommands/Host/CommandFormatHelpers.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/Host/CommandFormatHelpers.cs
@@ -16,6 +16,15 @@ namespace Microsoft.Diagnostics.ExtensionCommands
         public const string DebugHeaderExport = "DotNetRuntimeDebugHeader";
         public const string ContractDescriptorExport = "DotNetRuntimeContractDescriptor";
 
+        public static void DisplaySetttingService(this CommandBase command)
+        {
+            ISettingsService settingsService = command.Services.GetService<ISettingsService>() ?? throw new DiagnosticsException("Settings service required");
+            command.Console.WriteLine("Settings:");
+            command.Console.WriteLine($"-> Use CDAC contract reader: {settingsService.UseContractReader}");
+            command.Console.WriteLine($"-> Force use CDAC contract reader: {settingsService.ForceUseContractReader}");
+            command.Console.WriteLine($"-> DAC signature verification check enabled: {settingsService.DacSignatureVerificationEnabled}");
+        }
+
         /// <summary>
         /// Displays the special diagnostics info header memory block (.NET Core 8 or later on Linux/MacOS)
         /// </summary>

--- a/src/Microsoft.Diagnostics.ExtensionCommands/Host/RuntimesCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/Host/RuntimesCommand.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Diagnostics.ExtensionCommands
                     this.DisplayResources(runtime.RuntimeModule, all: false, indent: "    ");
                     this.DisplayRuntimeExports(runtime.RuntimeModule, error: true, indent: "    ");
                 }
-                this.DisplaySetttingService();
+                this.DisplaySettingService();
             }
         }
     }

--- a/src/Microsoft.Diagnostics.ExtensionCommands/Host/RuntimesCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/Host/RuntimesCommand.cs
@@ -128,10 +128,8 @@ namespace Microsoft.Diagnostics.ExtensionCommands
                     }
                     this.DisplayResources(runtime.RuntimeModule, all: false, indent: "    ");
                     this.DisplayRuntimeExports(runtime.RuntimeModule, error: true, indent: "    ");
-                    WriteLine($"Use CDAC contract reader: {SettingsService.UseContractReader}");
-                    WriteLine($"Force use CDAC contract reader: {SettingsService.ForceUseContractReader}");
-                    WriteLine($"DAC signature verification check enabled: {SettingsService.DacSignatureVerificationEnabled}");
                 }
+                this.DisplaySetttingService();
             }
         }
     }

--- a/src/Microsoft.Diagnostics.ExtensionCommands/Host/StatusCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/Host/StatusCommand.cs
@@ -63,6 +63,7 @@ namespace Microsoft.Diagnostics.ExtensionCommands
                     }
                 }
                 this.DisplaySpecialInfo();
+                this.DisplaySetttingService();
                 Write(SymbolService.ToString());
 
                 List<Assembly> extensions = new(ServiceManager.ExtensionsLoaded);

--- a/src/Microsoft.Diagnostics.ExtensionCommands/Host/StatusCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/Host/StatusCommand.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Diagnostics.ExtensionCommands
                     }
                 }
                 this.DisplaySpecialInfo();
-                this.DisplaySetttingService();
+                this.DisplaySettingService();
                 Write(SymbolService.ToString());
 
                 List<Assembly> extensions = new(ServiceManager.ExtensionsLoaded);

--- a/src/SOS/SOS.Extensions/HostServices.cs
+++ b/src/SOS/SOS.Extensions/HostServices.cs
@@ -356,6 +356,10 @@ namespace SOS.Extensions
             {
                 return HResult.E_INVALIDARG;
             }
+            if (_commandService is null)
+            {
+                return HResult.E_FAIL;
+            }
             try
             {
                 _commandService.Execute(commandName, commandArguments, string.Equals(commandName, "help", StringComparison.OrdinalIgnoreCase) ?  _contextServiceFromDebuggerServices.Services : _servicesWithManagedOnlyFilter);

--- a/src/SOS/SOS.Hosting/RuntimeWrapper.cs
+++ b/src/SOS/SOS.Hosting/RuntimeWrapper.cs
@@ -383,11 +383,9 @@ namespace SOS.Hosting
         private IntPtr CreateCorDebugProcess()
         {
             string dbiFilePath = _runtime.GetDbiFilePath();
-            // The DAC will be verified in the GetDacHandle call below. Ignore the verifySignature parameter here.
-            string dacFilePath = _runtime.GetDacFilePath(out bool _);
-            if (dbiFilePath == null || dacFilePath == null)
+            if (dbiFilePath == null)
             {
-                Trace.TraceError($"Could not find matching DBI {dbiFilePath ?? ""} or DAC {dacFilePath ?? ""} for this runtime: {_runtime.RuntimeModule.FileName}");
+                Trace.TraceError($"Could not find matching DBI {dbiFilePath ?? ""} for this runtime: {_runtime.RuntimeModule.FileName}");
                 return IntPtr.Zero;
             }
             if (_dbiHandle == IntPtr.Zero)
@@ -416,6 +414,9 @@ namespace SOS.Hosting
             int hresult = 0;
             try
             {
+                // The DAC will be verified in the GetDacHandle call below. Ignore the verifySignature parameter here.
+                string dacFilePath = _runtime.GetDacFilePath(out bool _);
+
                 // This will verify the DAC signature if needed before DBI is passed the DAC path or handle
                 IntPtr dacHandle = GetDacHandle();
                 if (dacHandle == IntPtr.Zero)

--- a/src/SOS/SOS.Hosting/RuntimeWrapper.cs
+++ b/src/SOS/SOS.Hosting/RuntimeWrapper.cs
@@ -414,15 +414,15 @@ namespace SOS.Hosting
             int hresult = 0;
             try
             {
-                // The DAC will be verified in the GetDacHandle call below. Ignore the verifySignature parameter here.
-                string dacFilePath = _runtime.GetDacFilePath(out bool _);
-
                 // This will verify the DAC signature if needed before DBI is passed the DAC path or handle
                 IntPtr dacHandle = GetDacHandle();
                 if (dacHandle == IntPtr.Zero)
                 {
                     return IntPtr.Zero;
                 }
+
+                // The DAC was verified in the GetDacHandle call above. Ignore the verifySignature parameter here.
+                string dacFilePath = _runtime.GetDacFilePath(out bool _);
 
                 OpenVirtualProcessImpl2Delegate openVirtualProcessImpl2 = SOSHost.GetDelegateFunction<OpenVirtualProcessImpl2Delegate>(_dbiHandle, "OpenVirtualProcessImpl2");
                 if (openVirtualProcessImpl2 != null)


### PR DESCRIPTION
Running `clrstack` a second time after a verify DAC failure succeeds.

Runtime.GetDacFilePath wasn't caching the verifySignature parameter so the DAC wasn't being verified once the dac path was cached.

Verify the DAC path passed to the DBI entry points for the `clrstack -i` path in RuntimeWrapper.CreateCorDebugProcess.

Display the ISettingsService values in both `runtimes` and `sosstatus`.