### PR TITLE
dotnet-dump and dotnet-symbol returns 407 behind a proxy

### DIFF
--- a/src/Tools/dotnet-dump/Analyzer.cs
+++ b/src/Tools/dotnet-dump/Analyzer.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.IO;
+using System.Net;
+using System.Net.Http;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Security;
@@ -102,6 +104,7 @@ namespace Microsoft.Diagnostics.Tools.Dump
                 contextService.SetCurrentTarget(target);
 
                 // Automatically enable symbol server support, default cache and search for symbols in the dump directory
+                HttpClient.DefaultProxy.Credentials = CredentialCache.DefaultCredentials;
                 symbolService.AddSymbolServer(retryCount: 3);
                 symbolService.AddCachePath(symbolService.DefaultSymbolCache);
                 symbolService.AddDirectoryPath(Path.GetDirectoryName(dump_path.FullName));

--- a/src/Tools/dotnet-symbol/Program.cs
+++ b/src/Tools/dotnet-symbol/Program.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
+using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -68,7 +70,7 @@ namespace Microsoft.Diagnostics.Tools.Symbol
                         program.SymbolServers.Add(new ServerInfo { Uri = uri, PersonalAccessToken = null });
                         break;
 
-                     case "--internal-server":
+                    case "--internal-server":
                         Uri.TryCreate("https://symweb.azurefd.net/", UriKind.Absolute, out uri);
                         program.SymbolServers.Add(new ServerInfo { Uri = uri, PersonalAccessToken = null, InternalSymwebServer = true });
                         break;
@@ -263,7 +265,7 @@ namespace Microsoft.Diagnostics.Tools.Symbol
         private Microsoft.SymbolStore.SymbolStores.SymbolStore BuildSymbolStore()
         {
             Microsoft.SymbolStore.SymbolStores.SymbolStore store = null;
-
+            HttpClient.DefaultProxy.Credentials = CredentialCache.DefaultCredentials;
             foreach (ServerInfo server in ((IEnumerable<ServerInfo>)SymbolServers).Reverse())
             {
                 if (server.InternalSymwebServer)
@@ -597,8 +599,7 @@ namespace Microsoft.Diagnostics.Tools.Symbol
 
         private IEnumerable<string> GetInputFiles()
         {
-            IEnumerable<string> inputFiles = InputFilePaths.SelectMany((string file) =>
-            {
+            IEnumerable<string> inputFiles = InputFilePaths.SelectMany((string file) => {
                 string directory = Path.GetDirectoryName(file);
                 string pattern = Path.GetFileName(file);
                 return Directory.EnumerateFiles(string.IsNullOrWhiteSpace(directory) ? "." : directory, pattern,


### PR DESCRIPTION
dotnet-dump and dotnet-symbol returns HTTP 407 status code behind a proxy when downloading symbols. Setting the default network credentials before `HttpClient` is created. Optionally `HttpSymbolStore` could create a custom `HttpClientHandler` too (different solution because of netstandard2.0), but based on the [remarks]( https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpclienthandler.usedefaultcredentials?view=net-9.0) this is only desired for client applications. I am not sure how this project is used otherwise. Hence, *dotnet-dump* and *dotnet-symbol* sets the default proxy credentials before creating a `HttpSymbolStore`.