### PR TITLE
Permit the Module address to be optional for sig parsing.

### DIFF
--- a/src/SOS/Strike/metadata.cpp
+++ b/src/SOS/Strike/metadata.cpp
@@ -375,13 +375,13 @@ const WCHAR *g_wszCalling[] =
 void MDInfo::GetMethodName(mdMethodDef token, CQuickBytes *fullName)
 {
     HRESULT hr = E_FAIL;
-    mdTypeDef memTypeDef;
-    ULONG nameLen;
-    DWORD flags;
-    PCCOR_SIGNATURE pbSigBlob;
-    ULONG ulSigBlob;
-    ULONG ulCodeRVA;
-    ULONG ulImplFlags;
+    mdTypeDef memTypeDef = mdTypeDefNil;
+    ULONG nameLen = 0;
+    DWORD flags = 0;
+    PCCOR_SIGNATURE pbSigBlob = NULL;
+    ULONG ulSigBlob = 0;
+    ULONG ulCodeRVA = 0;
+    ULONG ulImplFlags = 0;
 
     m_pSigBuf = fullName;
     InitSigBuffer();

--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -844,8 +844,7 @@ DECLARE_API(DumpIL)
     return Status;
 }
 
-
-void DumpSigWorker (
+static void DumpSigWorker (
         DWORD_PTR dwSigAddr,
         DWORD_PTR dwModuleAddr,
         BOOL fMethod)
@@ -946,20 +945,23 @@ DECLARE_API(DumpSig)
     {
         return E_INVALIDARG;
     }
-    if (nArg != 2)
+
+    if (nArg < 1 || nArg > 2)
     {
-        ExtOut("%sdumpsig <sigaddr> <moduleaddr>\n", SOSPrefix);
+        ExtOut("%sdumpsig <sigaddr> [<moduleaddr>]?\n", SOSPrefix);
         return E_INVALIDARG;
     }
 
     DWORD_PTR dwSigAddr = GetExpression(sigExpr.data);
-    DWORD_PTR dwModuleAddr = GetExpression(moduleExpr.data);
-
-    if (dwSigAddr == 0 || dwModuleAddr == 0)
+    if (dwSigAddr == 0)
     {
-        ExtOut("Invalid parameters %s %s\n", sigExpr.data, moduleExpr.data);
+        ExtOut("Invalid parameter %s\n", sigExpr.data);
         return Status;
     }
+
+    DWORD_PTR dwModuleAddr = 0;
+    if (nArg == 2)
+        dwModuleAddr = GetExpression(moduleExpr.data);
 
     DumpSigWorker(dwSigAddr, dwModuleAddr, TRUE);
     return Status;
@@ -994,20 +996,22 @@ DECLARE_API(DumpSigElem)
         return E_INVALIDARG;
     }
 
-    if (nArg != 2)
+    if (nArg < 1 || nArg > 2)
     {
-        ExtOut("%sdumpsigelem <sigaddr> <moduleaddr>\n", SOSPrefix);
+        ExtOut("%sdumpsigelem <sigaddr> [<moduleaddr>]?\n", SOSPrefix);
         return E_INVALIDARG;
     }
 
     DWORD_PTR dwSigAddr = GetExpression(sigExpr.data);
-    DWORD_PTR dwModuleAddr = GetExpression(moduleExpr.data);
-
-    if (dwSigAddr == 0 || dwModuleAddr == 0)
+    if (dwSigAddr == 0)
     {
-        ExtOut("Invalid parameters %s %s\n", sigExpr.data, moduleExpr.data);
-        return E_INVALIDARG;
+        ExtOut("Invalid parameter %s\n", sigExpr.data);
+        return Status;
     }
+
+    DWORD_PTR dwModuleAddr = 0;
+    if (nArg == 2)
+        dwModuleAddr = GetExpression(moduleExpr.data);
 
     DumpSigWorker(dwSigAddr, dwModuleAddr, FALSE);
     return Status;
@@ -8073,9 +8077,9 @@ DECLARE_API(EEVersion)
             }
         }
         else
+        {
             ExtOut("Workstation mode\n");
-
-        
+        }
 
         if (!GetGcStructuresValid())
         {

--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -956,7 +956,7 @@ DECLARE_API(DumpSig)
     if (dwSigAddr == 0)
     {
         ExtOut("Invalid parameter %s\n", sigExpr.data);
-        return Status;
+        return E_INVALIDARG;
     }
 
     DWORD_PTR dwModuleAddr = 0;
@@ -1006,7 +1006,7 @@ DECLARE_API(DumpSigElem)
     if (dwSigAddr == 0)
     {
         ExtOut("Invalid parameter %s\n", sigExpr.data);
-        return Status;
+        return E_INVALIDARG;
     }
 
     DWORD_PTR dwModuleAddr = 0;


### PR DESCRIPTION
It isn't uncommon to want to examine a .NET signature, but not care about resolving tokens. This change makes providing the associated module optional and emits the token value instead. This change also makes this behavior the failure case in the event the associated `IMetaDataImport` returns a failure code.

View without whitespace diffs - https://github.com/dotnet/diagnostics/pull/5480/files?diff=split&w=1