### PR TITLE
Run all SOS tests against cDAC with fallback

### DIFF
--- a/src/SOS/SOS.UnitTests/SOS.UnitTests.csproj
+++ b/src/SOS/SOS.UnitTests/SOS.UnitTests.csproj
@@ -61,14 +61,4 @@
       <FileWrites Include="$(SOSConfigFileName)" />
     </ItemGroup>
   </Target>
-
-  <Target Name="_ApplyTestCategoryFilter" 
-          Condition="'$(SOS_TEST_CDAC)' == 'true'"
-          BeforeTargets="RunTests">
-    <ItemGroup>
-      <TestToRun Include="@(TestToRun)">
-        <TestRunnerAdditionalArguments>-trait Category=CDACCompatible</TestRunnerAdditionalArguments>
-      </TestToRun>
-    </ItemGroup>
-  </Target>
 </Project>


### PR DESCRIPTION
Remove the cDAC test filter.

With the fallback, the cDAC should pass all the same tests as the DAC.