### PR TITLE
Fix enumerating loaded process modules on Apple platforms

### DIFF
--- a/src/shared/pal/src/thread/process.cpp
+++ b/src/shared/pal/src/thread/process.cpp
@@ -2372,26 +2372,9 @@ CreateProcessModules(
         }
 
         // Does the offset in the module correspond to a valid MachO header?
-        bool isMachO = false;
-        int fd = open(moduleName, O_RDONLY);
-        if (fd != -1)
-        {
-            if (lseek(fd, rwpi.prp_prinfo.pri_offset, SEEK_SET) != (off_t)-1)
-            {
-                uint32_t magic = 0;
-                ssize_t bytesRead = read(fd, &magic, sizeof(magic));
-                if (bytesRead == sizeof(magic))
-                {
-                    if (magic == 0xFEEDFACF)
-                    {
-                        isMachO = true;
-                    }
-                }
-            }
-            close(fd);
-        }
+        bool mightBeMachOHeader = rwpi.prp_prinfo.pri_offset == 0;
 
-        if (!dup && isMachO)
+        if (!dup && mightBeMachOHeader)
         {
             int cbModuleName = strlen(moduleName) + 1;
             ProcessModules *entry = (ProcessModules *)malloc(sizeof(ProcessModules) + cbModuleName);


### PR DESCRIPTION
- This logic always assumed that the lowest address of a mapped file was its "base address", but in the presence of dotnet/runtime#114462 that is no longer correct. We may map stubs at lower addresses.
- Fix by checking the start of the mapped region for the magic value for the start of a MachO binary