### PR TITLE
Check for process exit as well as pipe message in test runners

### DIFF
--- a/src/SOS/SOS.UnitTests/SOSRunner.cs
+++ b/src/SOS/SOS.UnitTests/SOSRunner.cs
@@ -378,9 +378,10 @@ public class SOSRunner : IDisposable
                         if (pipeServer != null)
                         {
                             dotnetDumpOutputHelper.WriteLine("Waiting for connection on pipe {0}", pipeName);
-                            CancellationTokenSource source = new(TimeSpan.FromMinutes(5));
+                            using CancellationTokenSource source = new(TimeSpan.FromMinutes(5));
 
                             // Wait for debuggee to connect/write to pipe or if the process exits on some other failure/abnormally
+                            // TODO: This is a resiliency issue - we'll try to collect the dump even if the debuggee fails to connect.
                             await Task.WhenAny(pipeServer.WaitForConnectionAsync(source.Token), processRunner.WaitForExit());
                         }
 


### PR DESCRIPTION
https://github.com/dotnet/diagnostics/pull/5473 surfaced an issue of test resiliency.

Per test we wait for a process to start and send a notification. If the process exits quickly, we'll wait for 5 min per test trying to see the message. This considers process exits as an error path eagerly. 