### PR TITLE
stop using System.CommandLine types that won't be public anymore

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -9,6 +9,10 @@
       <Uri>https://github.com/microsoft/clrmd</Uri>
       <Sha>d724947392626b66e39b525998a8817447d50380</Sha>
     </Dependency>
+    <Dependency Name="System.Commandline" Version="2.0.0-beta7.25365.101">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>78061f4bcc414fa2054be6237b1fd3813d8edf6b</Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25351.106">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -56,7 +56,7 @@
     <MicrosoftExtensionsLoggingConsoleVersion>6.0.0</MicrosoftExtensionsLoggingConsoleVersion>
     <!-- Need version that understands UseAppFilters sentinel. -->
     <MicrosoftExtensionsLoggingEventSourceVersion>5.0.1</MicrosoftExtensionsLoggingEventSourceVersion>
-    <SystemCommandLineVersion>2.0.0-beta5.25210.1</SystemCommandLineVersion>
+    <SystemCommandLineVersion>2.0.0-beta7.25365.101</SystemCommandLineVersion>
     <SystemComponentModelAnnotationsVersion>5.0.0</SystemComponentModelAnnotationsVersion>
     <SystemBuffersVersion>4.5.1</SystemBuffersVersion>
     <SystemDiagnosticsDiagnosticSourceVersion>8.0.1</SystemDiagnosticsDiagnosticSourceVersion>

--- a/src/Tools/Common/Commands/ProcessStatus.cs
+++ b/src/Tools/Common/Commands/ProcessStatus.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Internal.Common.Commands
         public static Command ProcessStatusCommand(string description)
         {
             Command statusCommand = new(name: "ps", description);
-            statusCommand.SetAction((parseResult, ct) => Task.FromResult(ProcessStatus(parseResult.Configuration.Output, parseResult.Configuration.Error)));
+            statusCommand.SetAction((parseResult, ct) => Task.FromResult(ProcessStatus(parseResult.InvocationConfiguration.Output, parseResult.InvocationConfiguration.Error)));
             return statusCommand;
         }
 

--- a/src/Tools/Common/ProcessTerminationHandler.cs
+++ b/src/Tools/Common/ProcessTerminationHandler.cs
@@ -24,15 +24,14 @@ namespace Microsoft.Internal.Common.Utils
 
         internal static async Task<int> InvokeAsync(ParseResult parseResult, string blockedSignals = "")
         {
-            using ProcessTerminationHandler terminationHandler = ConfigureTerminationHandler(parseResult, blockedSignals);
-            return await parseResult.InvokeAsync(terminationHandler.GetToken).ConfigureAwait(false);
-        }
-
-        private static ProcessTerminationHandler ConfigureTerminationHandler(ParseResult parseResult, string blockedSignals)
-        {
-            // Use custom process terminate handler for the command line tool parse result.
-            parseResult.Configuration.ProcessTerminationTimeout = null;
-            return new ProcessTerminationHandler(blockedSignals);
+            using ProcessTerminationHandler terminationHandler = new(blockedSignals);
+            return await parseResult.InvokeAsync(
+                configuration: new InvocationConfiguration
+                {
+                    // System.CommandLine should not interfere with Ctrl+C
+                    ProcessTerminationTimeout = null,
+                },
+                cancellationToken: terminationHandler.GetToken).ConfigureAwait(false);
         }
 
         private ProcessTerminationHandler(string blockedSignals)

--- a/src/Tools/dotnet-counters/Program.cs
+++ b/src/Tools/dotnet-counters/Program.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
 
             monitorCommand.TreatUnmatchedTokensAsErrors = false; // see the logic in Main
 
-            monitorCommand.SetAction(static (parseResult, ct) => new CounterMonitor(parseResult.Configuration.Output, parseResult.Configuration.Error).Monitor(
+            monitorCommand.SetAction(static (parseResult, ct) => new CounterMonitor(parseResult.InvocationConfiguration.Output, parseResult.InvocationConfiguration.Error).Monitor(
                 ct,
                 counters: parseResult.GetValue(CounterOption),
                 processId: parseResult.GetValue(ProcessIdOption),
@@ -77,7 +77,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
 
             collectCommand.TreatUnmatchedTokensAsErrors = false; // see the logic in Main
 
-            collectCommand.SetAction((parseResult, ct) => new CounterMonitor(parseResult.Configuration.Output, parseResult.Configuration.Error).Collect(
+            collectCommand.SetAction((parseResult, ct) => new CounterMonitor(parseResult.InvocationConfiguration.Output, parseResult.InvocationConfiguration.Error).Collect(
                 ct,
                 counters: parseResult.GetValue(CounterOption),
                 processId: parseResult.GetValue(ProcessIdOption),

--- a/src/Tools/dotnet-dump/Program.cs
+++ b/src/Tools/dotnet-dump/Program.cs
@@ -32,8 +32,8 @@ namespace Microsoft.Diagnostics.Tools.Dump
             };
 
             command.SetAction((parseResult) => new Dumper().Collect(
-                stdOutput: parseResult.Configuration.Output,
-                stdError: parseResult.Configuration.Error,
+                stdOutput: parseResult.InvocationConfiguration.Output,
+                stdError: parseResult.InvocationConfiguration.Error,
                 processId: parseResult.GetValue(ProcessIdOption),
                 output: parseResult.GetValue(OutputOption),
                 diag: parseResult.GetValue(DiagnosticLoggingOption),
@@ -60,7 +60,7 @@ namespace Microsoft.Diagnostics.Tools.Dump
         private static readonly Option<string> OutputOption =
             new("--output", "-o")
             {
-                Description = @"The path where collected dumps should be written. Defaults to '.\dump_YYYYMMDD_HHMMSS.dmp' on Windows and './core_YYYYMMDD_HHMMSS' 
+                Description = @"The path where collected dumps should be written. Defaults to '.\dump_YYYYMMDD_HHMMSS.dmp' on Windows and './core_YYYYMMDD_HHMMSS'
 on Linux where YYYYMMDD is Year/Month/Day and HHMMSS is Hour/Minute/Second. Otherwise, it is the full path and file name of the dump."
             };
 

--- a/src/Tools/dotnet-sos/Program.cs
+++ b/src/Tools/dotnet-sos/Program.cs
@@ -32,8 +32,8 @@ namespace Microsoft.Diagnostics.Tools.SOS
             };
 
             installCommand.SetAction(parseResult => Invoke(
-                parseResult.Configuration.Output,
-                parseResult.Configuration.Error,
+                parseResult.InvocationConfiguration.Output,
+                parseResult.InvocationConfiguration.Error,
                 architecture: parseResult.GetValue(ArchitectureOption),
                 install: true));
 
@@ -53,8 +53,8 @@ namespace Microsoft.Diagnostics.Tools.SOS
                 description: "Uninstalls SOS and reverts any configuration changes to LLDB.");
 
             uninstallCommand.SetAction(parseResult => Invoke(
-                parseResult.Configuration.Output,
-                parseResult.Configuration.Error,
+                parseResult.InvocationConfiguration.Output,
+                parseResult.InvocationConfiguration.Error,
                 architecture: null,
                 install: false));
 

--- a/src/Tools/dotnet-stack/ReportCommand.cs
+++ b/src/Tools/dotnet-stack/ReportCommand.cs
@@ -193,8 +193,8 @@ namespace Microsoft.Diagnostics.Tools.Stack
             };
 
             reportCommand.SetAction((parseResult, ct) => Report(ct,
-                stdOutput: parseResult.Configuration.Output,
-                stdError: parseResult.Configuration.Error,
+                stdOutput: parseResult.InvocationConfiguration.Output,
+                stdError: parseResult.InvocationConfiguration.Error,
                 processId: parseResult.GetValue(ProcessIdOption),
                 name: parseResult.GetValue(NameOption),
                 duration: parseResult.GetValue(DurationOption)));

--- a/src/Tools/dotnet-stack/Symbolicate.cs
+++ b/src/Tools/dotnet-stack/Symbolicate.cs
@@ -306,8 +306,8 @@ namespace Microsoft.Diagnostics.Tools.Stack
             };
 
             symbolicateCommand.SetAction((parseResult, ct) => Task.FromResult(Symbolicate(
-                stdOutput: parseResult.Configuration.Output,
-                stdError: parseResult.Configuration.Error,
+                stdOutput: parseResult.InvocationConfiguration.Output,
+                stdError: parseResult.InvocationConfiguration.Error,
                 inputPath: parseResult.GetValue(InputFileArgument),
                 searchDir: parseResult.GetValue(SearchDirectoryOption),
                 output: parseResult.GetValue(OutputFileOption),

--- a/src/Tools/dotnet-trace/CommandLine/Commands/ConvertCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/ConvertCommand.cs
@@ -103,8 +103,8 @@ namespace Microsoft.Diagnostics.Tools.Trace
             };
 
             convertCommand.SetAction((parseResult, ct) => Task.FromResult(ConvertFile(
-                stdOut: parseResult.Configuration.Output,
-                stdError: parseResult.Configuration.Error,
+                stdOut: parseResult.InvocationConfiguration.Output,
+                stdError: parseResult.InvocationConfiguration.Error,
                 inputFilename: parseResult.GetValue(InputFileArgument),
                 format: parseResult.GetValue(CommonOptions.ConvertFormatOption),
                 output: parseResult.GetValue(OutputOption


### PR DESCRIPTION
Context: https://github.com/dotnet/command-line-api/pull/2563