### PR TITLE
[ProcessLauncher] Explicitly set diagnostic port configs

### DIFF
--- a/src/Tools/Common/ReversedServerHelpers/ReversedServerHelpers.cs
+++ b/src/Tools/Common/ReversedServerHelpers/ReversedServerHelpers.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Internal.Common.Utils
             _childProc.StartInfo.RedirectStandardOutput = !showChildIO;
             _childProc.StartInfo.RedirectStandardError = !showChildIO;
             _childProc.StartInfo.RedirectStandardInput = !showChildIO;
-            _childProc.StartInfo.Environment.Add("DOTNET_DiagnosticPorts", $"{diagnosticTransportName}");
+            _childProc.StartInfo.Environment.Add("DOTNET_DiagnosticPorts", $"{diagnosticTransportName},suspend,connect");
             try
             {
                 if (printLaunchCommand && !showChildIO)


### PR DESCRIPTION
Partly addresses https://github.com/dotnet/diagnostics/issues/5501

Child processes started by diagnostic tooling set a `DOTNET_DiagnosticPort` environment variable, specifying only the path.
The runtime [defaults to a connect type port in suspend mode](https://github.com/dotnet/runtime/blob/22ccb0563cbb79e950b8d8e2d8bed306b125e7d8/src/native/eventpipe/ds-ipc.c#L628-L637), which isn't clear from the end user's viewpoint, as [logging will only reveal the DiagnosticPort value](https://github.com/dotnet/runtime/blob/22ccb0563cbb79e950b8d8e2d8bed306b125e7d8/src/coreclr/vm/eventing/eventpipe/ds-rt-coreclr.h#L390-L412). Instead, we can mitigate confusion by explicitly setting the config from the tooling side.

### Before
```
The runtime has been configured to pause during startup and is awaiting a Diagnostics IPC ResumeStartup command from a Diagnostic Port.
DOTNET_DiagnosticPorts="dotnet-trace-48696-20250614_161420.socket"
DOTNET_DefaultDiagnosticPortSuspend=0
```

### Now
```
The runtime has been configured to pause during startup and is awaiting a Diagnostics IPC ResumeStartup command from a Diagnostic Port.
DOTNET_DiagnosticPorts="dotnet-trace-29004-20250616_134924.socket,suspend,connect"
DOTNET_DefaultDiagnosticPortSuspend=0
```