### PR TITLE
[ProcessLauncher] Fix Child Proc Arg Validation

### DIFF
--- a/src/Tools/Common/Commands/Utils.cs
+++ b/src/Tools/Common/Commands/Utils.cs
@@ -99,9 +99,11 @@ namespace Microsoft.Internal.Common.Utils
                 Console.WriteLine($"{processId} is not a valid process ID");
                 return false;
             }
-            else if ( processId != 0 && (!string.IsNullOrEmpty(name) || !string.IsNullOrEmpty(port) || !string.IsNullOrEmpty(dsrouter))
-                    || !string.IsNullOrEmpty(name) && (!string.IsNullOrEmpty(port) || !string.IsNullOrEmpty(dsrouter))
-                    || !string.IsNullOrEmpty(port) && !string.IsNullOrEmpty(dsrouter))
+            else if ((processId != 0 ? 1 : 0) +
+                     (!string.IsNullOrEmpty(name) ? 1 : 0) +
+                     (!string.IsNullOrEmpty(port) ? 1 : 0) +
+                     (!string.IsNullOrEmpty(dsrouter) ? 1 : 0)
+                     != 1)
             {
                 Console.WriteLine("Only one of the --name, --process-id, --diagnostic-port, or --dsrouter options may be specified.");
                 return false;

--- a/src/Tools/Common/Commands/Utils.cs
+++ b/src/Tools/Common/Commands/Utils.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Internal.Common.Utils
         /// <returns></returns>
         public static bool ValidateArgumentsForChildProcess(int processId, string name, string port)
         {
-            if (processId != 0 && name != null && !string.IsNullOrEmpty(port))
+            if (processId != 0 || name != null || !string.IsNullOrEmpty(port))
             {
                 Console.WriteLine("None of the --name, --process-id, or --diagnostic-port options may be specified when launching a child process.");
                 return false;


### PR DESCRIPTION
It's stated that none of the `process-id`, `name`, or `diagnostic-port` options should be configured when launching a child process with `dotnet-trace collect ... -- <child process to launch>`, yet the check only errors when all are configured.

Additionally makes the exclusive check on `process-id`, `name`, `diagnosic-port`, and `dsrouter` more readable.

### Before
```
SUCCESS
PS C:\Users\mihw\source\repos\mdh1418\diagnostics\latest> .\artifacts\bin\dotnet-trace\Debug\net8.0\dotnet-trace.exe collect -p 1418 --show-child-io  -- dotnet package search json
The runtime has been configured to pause during startup and is awaiting a Diagnostics IPC ResumeStartup command from a Diagnostic Port.
DOTNET_DiagnosticPorts="dotnet-trace-26020-20250616_135956.socket,suspend,connect"
DOTNET_DefaultDiagnosticPortSuspend=0

FAIL
PS C:\Users\mihw\source\repos\mdh1418\diagnostics\latest> .\artifacts\bin\dotnet-trace\Debug\net8.0\dotnet-trace.exe collect -p 1418 --show-child-io -n mihw --dport whim  -- dotnet package search json
None of the --name, --process-id, or --diagnostic-port options may be specified when launching a child process.

SUCCESS
PS C:\Users\mihw\source\repos\mdh1418\diagnostics\latest> .\artifacts\bin\dotnet-trace\Debug\net8.0\dotnet-trace.exe collect -p 1418 --show-child-io -n mihw  -- dotnet package search json             
The runtime has been configured to pause during startup and is awaiting a Diagnostics IPC ResumeStartup command from a Diagnostic Port.
DOTNET_DiagnosticPorts="dotnet-trace-27244-20250616_140018.socket,suspend,connect"
DOTNET_DefaultDiagnosticPortSuspend=0
```

### After
```
FAIL
PS C:\Users\mihw\source\repos\mdh1418\diagnostics\latest> .\artifacts\bin\dotnet-trace\Debug\net8.0\dotnet-trace.exe collect -p 1418 --show-child-io  -- dotnet package search json                 
None of the --name, --process-id, or --diagnostic-port options may be specified when launching a child process.

FAIL
PS C:\Users\mihw\source\repos\mdh1418\diagnostics\latest> .\artifacts\bin\dotnet-trace\Debug\net8.0\dotnet-trace.exe collect -p 1418 --show-child-io -n mihw --dport whim  -- dotnet package search json
None of the --name, --process-id, or --diagnostic-port options may be specified when launching a child process.

FAIL
PS C:\Users\mihw\source\repos\mdh1418\diagnostics\latest> .\artifacts\bin\dotnet-trace\Debug\net8.0\dotnet-trace.exe collect -p 1418 --show-child-io -n mihw  -- dotnet package search json         
None of the --name, --process-id, or --diagnostic-port options may be specified when launching a child process.
```