### PR TITLE
Add /usr/lib/dotnet and /usr/lib64/dotnet to UnixInstallPaths for improved Linux distro compatibility

### DIFF
--- a/src/SOS/extensions/hostcoreclr.cpp
+++ b/src/SOS/extensions/hostcoreclr.cpp
@@ -131,6 +131,10 @@ namespace RuntimeHostingConstants
         "/rh-dotnet60/root/usr/bin/dotnet",
         "/rh-dotnet100/root/usr/bin/dotnet",
         "/usr/share/dotnet",
+        "/usr/lib/dotnet",
+#if defined(HOST_AMD64)
+        "/usr/lib64/dotnet",
+#endif
 #endif
     };
 #endif


### PR DESCRIPTION
### Summary

This PR expands the set of probed install paths for .NET runtimes on Unix systems by adding:

- `/usr/lib/dotnet` (always)
- `/usr/lib64/dotnet` (when `HOST_AMD64` is defined)

to the `UnixInstallPaths` array in `hostcoreclr.cpp`.

### Rationale

Many Linux distributions follow the Filesystem Hierarchy Standard (FHS) or their own policies, installing multi-arch runtime files in `/usr/lib/dotnet` or `/usr/lib64/dotnet` instead of `/usr/share/dotnet` or `/usr/local/share/dotnet`.

Adding this upstream reduces maintenance burden and compatibility issues and would be much appreciated.