### PR TITLE
Update build.sh to error on native build failures

### DIFF
--- a/eng/build.sh
+++ b/eng/build.sh
@@ -217,7 +217,7 @@ fi
 if [[ "$__NativeBuild" == 1 ]]; then
     build_native "$__TargetOS" "$__TargetArch" "$__RepoRootDir" "$__IntermediatesDir" "install" "$__ExtraCmakeArgs" "diagnostic component" | tee "$__LogsDir"/make.log
 
-    if [ "$?" != 0 ]; then
+    if [ "${PIPESTATUS[0]}" != 0 ]; then
         echo "Native build FAILED"
         exit 1
     fi


### PR DESCRIPTION
Build.sh looked at the exit code of the tee command for the native build. Check the 0th exit code for the native build.

Co-authored-by:  Steve Pfister <steveisok@users.noreply.github.com>