### PR TITLE
Improve Ctrl+C support in dotnet-trace tool

### DIFF
--- a/src/Tools/Common/Commands/Utils.cs
+++ b/src/Tools/Common/Commands/Utils.cs
@@ -42,9 +42,9 @@ namespace Microsoft.Internal.Common.Utils
         // <summary>
         // Returns processId that matches the given dsrouter.
         // </summary>
-        // <param name="dsrouter">dsroutercommand</param>
+        // <param name="dsrouter">dsrouterCommand</param>
         // <returns>processId</returns>
-        public static int LaunchDSRouterProcess(string dsroutercommand)
+        public static int LaunchDSRouterProcess(string dsrouterCommand)
         {
             ConsoleColor currentColor = Console.ForegroundColor;
             Console.ForegroundColor = ConsoleColor.Yellow;
@@ -52,7 +52,7 @@ namespace Microsoft.Internal.Common.Utils
             Console.ForegroundColor = currentColor;
             Console.WriteLine("For finer control over the dotnet-dsrouter options, run it separately and connect to it using -p" + Environment.NewLine);
 
-            return DsRouterProcessLauncher.Launcher.Start(dsroutercommand, default);
+            return DsRouterProcessLauncher.Launcher.Start(dsrouterCommand, default);
         }
 
 

--- a/src/Tools/Common/DsRouterProcessLauncher.cs
+++ b/src/Tools/Common/DsRouterProcessLauncher.cs
@@ -85,6 +85,12 @@ namespace Microsoft.Internal.Common.Utils
                     _childProc.StandardInput.Flush();
 
                     _childProc.WaitForExit(1000);
+                }
+                // if process exited while we were trying to write to stdin, it can throw IOException
+                catch (IOException) { }
+
+                try
+                {
                     if (!_childProc.HasExited)
                     {
                         _childProc.Kill();
@@ -92,8 +98,20 @@ namespace Microsoft.Internal.Common.Utils
                 }
                 // if process exited while we were trying to kill it, it can throw IOE
                 catch (InvalidOperationException) { }
-                _stdOutTask.Wait();
-                _stdErrTask.Wait();
+
+                try
+                {
+                    _stdOutTask.Wait();
+                }
+                // Ignore any fault/cancel state of task.
+                catch (AggregateException) { }
+
+                try
+                {
+                    _stdErrTask.Wait();
+                }
+                // Ignore any fault/cancel state of task.
+                catch (AggregateException) { }
             }
         }
     }

--- a/src/Tools/Common/ProcessTerminationHandler.cs
+++ b/src/Tools/Common/ProcessTerminationHandler.cs
@@ -1,0 +1,110 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.CommandLine;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Internal.Common.Utils
+{
+    internal sealed class ProcessTerminationHandler : IDisposable
+    {
+        private bool _isDisposed;
+        private CancellationTokenSource _cancellationTokenSource;
+        private readonly PosixSignalRegistration _sigIntRegistration;
+        private readonly PosixSignalRegistration _sigQuitRegistration;
+        private readonly PosixSignalRegistration _sigTermRegistration;
+        private bool _blockSIGINT;
+        private bool _blockSIGTERM;
+        private bool _blockSIGQUIT;
+
+        internal CancellationToken GetToken => _cancellationTokenSource.Token;
+
+        internal static async Task<int> InvokeAsync(ParseResult parseResult, string blockedSignals = "")
+        {
+            using ProcessTerminationHandler terminationHandler = ConfigureTerminationHandler(parseResult, blockedSignals);
+            return await parseResult.InvokeAsync(terminationHandler.GetToken).ConfigureAwait(false);
+        }
+
+        private static ProcessTerminationHandler ConfigureTerminationHandler(ParseResult parseResult, string blockedSignals)
+        {
+            // Use custom process terminate handler for the command line tool parse result.
+            parseResult.Configuration.ProcessTerminationTimeout = null;
+            return new ProcessTerminationHandler(blockedSignals);
+        }
+
+        private ProcessTerminationHandler(string blockedSignals)
+        {
+            _cancellationTokenSource = new();
+
+            if (!string.IsNullOrEmpty(blockedSignals))
+            {
+                foreach (string signal in blockedSignals.Split(';'))
+                {
+                    if (signal.Equals("SIGINT", StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        _blockSIGINT = true;
+                    }
+                    else if (signal.Equals("SIGQUIT", StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        _blockSIGQUIT = true;
+                    }
+                    else if (signal.Equals("SIGTERM", StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        _blockSIGTERM = true;
+                    }
+                }
+            }
+
+            _sigIntRegistration = PosixSignalRegistration.Create(PosixSignal.SIGINT, OnPosixSignal);
+            _sigQuitRegistration = PosixSignalRegistration.Create(PosixSignal.SIGQUIT, OnPosixSignal);
+            _sigTermRegistration = PosixSignalRegistration.Create(PosixSignal.SIGTERM, OnPosixSignal);
+        }
+
+        public void Dispose()
+        {
+            if (!_isDisposed)
+            {
+                _sigIntRegistration?.Dispose();
+                _sigQuitRegistration?.Dispose();
+                _sigTermRegistration?.Dispose();
+
+                GC.SuppressFinalize(this);
+            }
+
+            _isDisposed = true;
+        }
+
+        private void OnPosixSignal(PosixSignalContext context)
+        {
+            context.Cancel = true;
+
+            if (_blockSIGINT && context.Signal == PosixSignal.SIGINT)
+            {
+                return;
+            }
+            else if (_blockSIGQUIT && context.Signal == PosixSignal.SIGQUIT)
+            {
+                return;
+            }
+            else if (_blockSIGTERM && context.Signal == PosixSignal.SIGTERM)
+            {
+                return;
+            }
+
+            Cancel();
+        }
+
+        private void Cancel()
+        {
+            if (_cancellationTokenSource.IsCancellationRequested)
+            {
+                return;
+            }
+
+            _cancellationTokenSource.Cancel();
+        }
+    }
+}

--- a/src/Tools/Common/ReversedServerHelpers/ReversedServerHelpers.cs
+++ b/src/Tools/Common/ReversedServerHelpers/ReversedServerHelpers.cs
@@ -128,8 +128,20 @@ namespace Microsoft.Internal.Common.Utils
                 }
                 // if process exited while we were trying to kill it, it can throw IOE
                 catch (InvalidOperationException) { }
-                _stdOutTask.Wait();
-                _stdErrTask.Wait();
+
+                try
+                {
+                    _stdOutTask.Wait();
+                }
+                // Ignore any fault/cancel state of task.
+                catch (AggregateException) { }
+
+                try
+                {
+                    _stdErrTask.Wait();
+                }
+                // Ignore any fault/cancel state of task.
+                catch (AggregateException) { }
             }
         }
     }

--- a/src/Tools/dotnet-dsrouter/ADBTcpRouterFactory.cs
+++ b/src/Tools/dotnet-dsrouter/ADBTcpRouterFactory.cs
@@ -194,8 +194,11 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
 
             try
             {
-                _portReverseTaskCancelToken.Cancel();
-                await _portReverseTask.ConfigureAwait(false);
+                if (_portReverseTaskCancelToken is not null && _portReverseTask is not null)
+                {
+                    _portReverseTaskCancelToken.Cancel();
+                    await _portReverseTask.ConfigureAwait(false);
+                }
             }
             catch { }
 
@@ -265,8 +268,11 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
         {
             try
             {
-                _portForwardTaskCancelToken.Cancel();
-                _portForwardTask.Wait();
+                if (_portForwardTaskCancelToken is not null && _portForwardTask is not null)
+                {
+                    _portForwardTaskCancelToken.Cancel();
+                    _portForwardTask.Wait();
+                }
             }
             catch { }
 

--- a/src/Tools/dotnet-dsrouter/Program.cs
+++ b/src/Tools/dotnet-dsrouter/Program.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
                                 "Router is configured using an IPC client (connecting diagnostic tool IPC server) " +
                                 "and a TCP/IP server (accepting runtime TCP client).")
             {
-                IpcClientAddressOption, TcpServerAddressOption, RuntimeTimeoutOption, VerboseOption, ForwardPortOption
+                IpcClientAddressOption, TcpServerAddressOption, RuntimeTimeoutOption, VerboseOption, ForwardPortOption, BlockedSignalsOption
             };
 
             command.SetAction((parseResult, ct) => new DiagnosticsServerRouterCommands().RunIpcClientTcpServerRouter(
@@ -43,7 +43,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
                                 "Router is configured using an IPC server (connecting to by diagnostic tools) " +
                                 "and a TCP/IP server (accepting runtime TCP client).")
             {
-                IpcServerAddressOption, TcpServerAddressOption, RuntimeTimeoutOption, VerboseOption, ForwardPortOption
+                IpcServerAddressOption, TcpServerAddressOption, RuntimeTimeoutOption, VerboseOption, ForwardPortOption, BlockedSignalsOption
             };
 
             command.SetAction((parseResult, ct) => new DiagnosticsServerRouterCommands().RunIpcServerTcpServerRouter(
@@ -66,7 +66,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
                                 "Router is configured using an IPC server (connecting to by diagnostic tools) " +
                                 "and a TCP/IP client (connecting runtime TCP server).")
             {
-                IpcServerAddressOption, TcpClientAddressOption, RuntimeTimeoutOption, VerboseOption, ForwardPortOption
+                IpcServerAddressOption, TcpClientAddressOption, RuntimeTimeoutOption, VerboseOption, ForwardPortOption, BlockedSignalsOption
             };
 
             command.SetAction((parseResult, ct) => new DiagnosticsServerRouterCommands().RunIpcServerTcpClientRouter(
@@ -89,7 +89,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
                                     "Router is configured using an IPC server (connecting to by diagnostic tools) " +
                                     "and a WebSocket server (accepting runtime WebSocket client).")
             {
-                IpcServerAddressOption, WebSocketURLAddressOption, RuntimeTimeoutOption, VerboseOption
+                IpcServerAddressOption, WebSocketURLAddressOption, RuntimeTimeoutOption, VerboseOption, BlockedSignalsOption
             };
 
             command.SetAction((parseResult, ct) => new DiagnosticsServerRouterCommands().RunIpcServerWebSocketServerRouter(
@@ -111,7 +111,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
                                     "Router is configured using an IPC client (connecting diagnostic tool IPC server) " +
                                     "and a WebSocket server (accepting runtime WebSocket client).")
             {
-                IpcClientAddressOption, WebSocketURLAddressOption, RuntimeTimeoutOption, VerboseOption
+                IpcClientAddressOption, WebSocketURLAddressOption, RuntimeTimeoutOption, VerboseOption, BlockedSignalsOption
             };
 
             command.SetAction((parseResult, ct) => new DiagnosticsServerRouterCommands().RunIpcClientWebSocketServerRouter(
@@ -133,7 +133,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
                                 "Router is configured using an IPC client (connecting diagnostic tool IPC server) " +
                                 "and a TCP/IP client (connecting runtime TCP server).")
             {
-                IpcClientAddressOption, TcpClientAddressOption, RuntimeTimeoutOption, VerboseOption, ForwardPortOption
+                IpcClientAddressOption, TcpClientAddressOption, RuntimeTimeoutOption, VerboseOption, ForwardPortOption, BlockedSignalsOption
             };
 
             command.SetAction((parseResult, ct) => new DiagnosticsServerRouterCommands().RunIpcClientTcpClientRouter(
@@ -156,7 +156,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
                                 "Router is configured using an IPC server (connecting to by diagnostic tools) " +
                                 "and a TCP/IP server (accepting runtime TCP client).")
             {
-                RuntimeTimeoutOption, VerboseOption, InfoOption
+                RuntimeTimeoutOption, VerboseOption, InfoOption, BlockedSignalsOption
             };
 
             command.SetAction((parseResult, ct) => new DiagnosticsServerRouterCommands().RunIpcServerIOSSimulatorRouter(
@@ -177,7 +177,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
                                 "Router is configured using an IPC server (connecting to by diagnostic tools) " +
                                 "and a TCP/IP client (connecting runtime TCP server over usbmux).")
             {
-                RuntimeTimeoutOption, VerboseOption, InfoOption
+                RuntimeTimeoutOption, VerboseOption, InfoOption, BlockedSignalsOption
             };
 
             command.SetAction((parseResult, ct) => new DiagnosticsServerRouterCommands().RunIpcServerIOSRouter(
@@ -198,7 +198,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
                                 "Router is configured using an IPC server (connecting to by diagnostic tools) " +
                                 "and a TCP/IP server (accepting runtime TCP client).")
             {
-                RuntimeTimeoutOption, VerboseOption, InfoOption
+                RuntimeTimeoutOption, VerboseOption, InfoOption, BlockedSignalsOption
             };
 
             command.SetAction((parseResult, ct) => new DiagnosticsServerRouterCommands().RunIpcServerAndroidEmulatorRouter(
@@ -218,7 +218,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
                                 "Router is configured using an IPC server (connecting to by diagnostic tools) " +
                                 "and a TCP/IP server (accepting runtime TCP client).")
             {
-                RuntimeTimeoutOption, VerboseOption, InfoOption
+                RuntimeTimeoutOption, VerboseOption, InfoOption, BlockedSignalsOption
             };
 
             command.SetAction((parseResult, ct) => new DiagnosticsServerRouterCommands().RunIpcServerAndroidRouter(
@@ -291,6 +291,12 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
                 Description = "Enable port forwarding, values Android|iOS for TcpClient and only Android for TcpServer. Make sure to set ANDROID_SDK_ROOT before using this option on Android."
             };
 
+        private static readonly Option<string> BlockedSignalsOption =
+            new("--block-signals", "-bsig")
+            {
+                Description = "Blocks specified signals, currently SIGINT and SIGQUIT can be disabled, each signal is separated with ;"
+            };
+
         private static readonly Option<bool> InfoOption =
             new("--info", "-i")
             {
@@ -329,7 +335,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
                 Console.ForegroundColor = currentColor;
             }
 
-            return parseResult.InvokeAsync();
+            return ProcessTerminationHandler.InvokeAsync(parseResult, parseResult.GetValue(BlockedSignalsOption));
         }
     }
 }

--- a/src/Tools/dotnet-dsrouter/dotnet-dsrouter.csproj
+++ b/src/Tools/dotnet-dsrouter/dotnet-dsrouter.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <Compile Include="..\Common\ReversedServerHelpers\ReversedServerHelpers.cs" Link="ReversedServerHelpers.cs" />
     <Compile Include="..\Common\CommandLineErrorException.cs" Link="CommandLineErrorException.cs" />
+    <Compile Include="..\Common\ProcessTerminationHandler.cs" Link="ProcessTerminationHandler.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
@@ -280,7 +280,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                         try
                         {
                             EventPipeSessionConfiguration config = new(providerCollection, (int)buffersize, rundownKeyword: rundownKeyword, requestStackwalk: true);
-                            session = diagnosticsClient.StartEventPipeSession(config);
+                            session = await diagnosticsClient.StartEventPipeSessionAsync(config, ct).ConfigureAwait(false);
                         }
                         catch (UnsupportedCommandException e)
                         {
@@ -298,7 +298,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                                 // Debug.Assert(rundownKeyword != EventPipeSession.DefaultRundownKeyword);
                                 //
                                 EventPipeSessionConfiguration config = new(providerCollection, (int)buffersize, rundownKeyword: EventPipeSession.DefaultRundownKeyword, requestStackwalk: true);
-                                session = diagnosticsClient.StartEventPipeSession(config);
+                                session = await diagnosticsClient.StartEventPipeSessionAsync(config, ct).ConfigureAwait(false);
                             }
                             else if (retryStrategy == RetryStrategy.DropKeywordDropRundown)
                             {
@@ -314,7 +314,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                                 // Debug.Assert(rundownKeyword != EventPipeSession.DefaultRundownKeyword);
                                 //
                                 EventPipeSessionConfiguration config = new(providerCollection, (int)buffersize, rundownKeyword: 0, requestStackwalk: true);
-                                session = diagnosticsClient.StartEventPipeSession(config);
+                                session = await diagnosticsClient.StartEventPipeSessionAsync(config, ct).ConfigureAwait(false);
                             }
                             else
                             {
@@ -331,7 +331,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                         {
                             try
                             {
-                                diagnosticsClient.ResumeRuntime();
+                                await diagnosticsClient.ResumeRuntimeAsync(ct).ConfigureAwait(false);
                             }
                             catch (UnsupportedCommandException)
                             {
@@ -490,6 +490,13 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 Console.Error.WriteLine($"[ERROR] {e.Message}");
                 collectionStopped = true;
                 ret = (int)ReturnCode.TracingError;
+            }
+            catch (OperationCanceledException)
+            {
+                if (printStatusOverTime)
+                {
+                    ConsoleWriteLine("\nTrace collection canceled.");
+                }
             }
             catch (Exception ex)
             {

--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
@@ -493,10 +493,9 @@ namespace Microsoft.Diagnostics.Tools.Trace
             }
             catch (OperationCanceledException)
             {
-                if (printStatusOverTime)
-                {
-                    ConsoleWriteLine("\nTrace collection canceled.");
-                }
+                ConsoleWriteLine("\nTrace collection canceled.");
+                collectionStopped = true;
+                ret = (int)ReturnCode.TracingError;
             }
             catch (Exception ex)
             {

--- a/src/Tools/dotnet-trace/Program.cs
+++ b/src/Tools/dotnet-trace/Program.cs
@@ -24,13 +24,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 ReportCommandHandler.ReportCommand()
             };
 
-            CommandLineConfiguration configuration = new(rootCommand)
-            {
-                // System.CommandLine should not interfere with Ctrl+C
-                ProcessTerminationTimeout = null
-            };
-
-            ParseResult parseResult = rootCommand.Parse(args, configuration);
+            ParseResult parseResult = rootCommand.Parse(args);
             string parsedCommandName = parseResult.CommandResult.Command.Name;
             if (parsedCommandName == "collect")
             {
@@ -41,7 +35,8 @@ namespace Microsoft.Diagnostics.Tools.Trace
                     ProcessLauncher.Launcher.PrepareChildProcess(args);
                 }
             }
-            return parseResult.InvokeAsync();
+
+            return ProcessTerminationHandler.InvokeAsync(parseResult);
         }
     }
 }


### PR DESCRIPTION
Changing the cmd line tooling implementation in the following commit:

https://github.com/dotnet/diagnostics/commit/6837b8f319b08a458142605bcac76aff4e5af00a#diff-d33d6d23aba37ebcfc05462b2fa260136a11df1b03f129f1912a856c36a8d7f3

broke Ctrl+C handling in dotnet-trace, since it disabled the process termination handler leading to process termination without
 being able to close the session, creating a corrupt file.

dotnet-trace and dotnet-dsrouter tooling needs better control of its Ctrl+C shutdown, so this commit implements a custom process termination handler and disable the default handler implemented by the cmd line tools. This handler makes sure to signal a cancelation token if one of the configured signals hits the process.

This commit also fix an issue with the integrated execution of dsrouter from other tools. Since Ctrl+C gets passed to child processes, integrated dsrouter could stop before dotnet-trace was able to close the session causing corrupt trace file and exception being logged in dotnet-trace.

To mitigate this, dsrouter implements a way to block signals only accepting shutdown sequence on redirected stdin and dotnet-trace will launch dsrouter in this mode. This makes the shutdown sequence deterministic making sure dsrouter won't stop before dotnet-trace completed any outstanding trace sessions.