### PR TITLE
Log pid of remote executed process.

### DIFF
--- a/src/Microsoft.Diagnostics.TestHelpers/RemoteExecutorHelper.cs
+++ b/src/Microsoft.Diagnostics.TestHelpers/RemoteExecutorHelper.cs
@@ -29,6 +29,9 @@ namespace Microsoft.Diagnostics.TestHelpers
             // When RemoteExecutor is fixed the "using" can be added and the GC.SuppressFinalize be removed.
             RemoteInvokeHandle remoteInvokeHandle = RemoteExecutor.Invoke(method, config.Serialize(), options);
             GC.SuppressFinalize(remoteInvokeHandle);
+
+            output.WriteLine($"RemoteExecutorHelper.RemoteInvoke: starting process {remoteInvokeHandle.Process.Id}");
+
             try
             {
                 Task stdOutputTask = WriteStreamToOutput(remoteInvokeHandle.Process.StandardOutput, output);


### PR DESCRIPTION
When debugging different parts of the test pipeline it is good to see the different pids of launched processes in case there is need to attach debugger to it. For the debuggee we output the pid, but for the debugger executed through remote executor we didn't. This PR adds logging to output pid of started process.