### PR TITLE
[dsrouter] cache Android SDK path

### DIFF
--- a/src/Tools/dotnet-dsrouter/ADBTcpRouterFactory.cs
+++ b/src/Tools/dotnet-dsrouter/ADBTcpRouterFactory.cs
@@ -66,27 +66,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
 
         public static bool RunAdbCommandInternal(string command, string expectedOutput, int expectedExitCode, bool rethrow, ILogger logger)
         {
-            void sdklogger(TraceLevel level, string message)
-            {
-                switch (level)
-                {
-                    case TraceLevel.Error:
-                        logger?.LogError(message);
-                        break;
-                    case TraceLevel.Warning:
-                        logger?.LogWarning(message);
-                        break;
-                    case TraceLevel.Info:
-                        logger?.LogInformation(message);
-                        break;
-                    case TraceLevel.Verbose:
-                        logger?.LogDebug(message);
-                        break;
-                }
-            };
-
-            // AndroidSdkInfo checks $ANDROID_SDK_ROOT, $ANDROID_HOME, and default locations.
-            string sdkRoot = new AndroidSdkInfo(logger: sdklogger).AndroidSdkPath;
+            string sdkRoot = GetAndroidSdkPath(logger);
             string adbTool = "adb";
 
             if (!string.IsNullOrEmpty(sdkRoot))
@@ -147,6 +127,38 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
             }
 
             return processStartedResult && expectedOutputResult && expectedExitCodeResult;
+        }
+
+        private static string AndroidSdkPath;
+
+        private static string GetAndroidSdkPath(ILogger logger)
+        {
+            if (AndroidSdkPath is not null)
+            {
+                return AndroidSdkPath;
+            }
+
+            void sdklogger(TraceLevel level, string message)
+            {
+                switch (level)
+                {
+                    case TraceLevel.Error:
+                        logger?.LogError(message);
+                        break;
+                    case TraceLevel.Warning:
+                        logger?.LogWarning(message);
+                        break;
+                    case TraceLevel.Info:
+                        logger?.LogInformation(message);
+                        break;
+                    case TraceLevel.Verbose:
+                        logger?.LogDebug(message);
+                        break;
+                }
+            }
+
+            // AndroidSdkInfo checks $ANDROID_SDK_ROOT, $ANDROID_HOME, and default locations.
+            return AndroidSdkPath = new AndroidSdkInfo(logger: sdklogger).AndroidSdkPath;
         }
     }
 


### PR DESCRIPTION
This improves upon d7d85009 by caching the Android SDK path in a `static` field.

I was testing `dsrouter` and noticed it logging duplicate messages:

    > dotnet-trace collect --dsrouter android
    For finer control over the dotnet-dsrouter options, run it separately and connect to it using -p

    WARNING: dotnet-dsrouter is a development tool not intended for production environments.

    How to connect current dotnet-dsrouter pid=45036 with android device and diagnostics tooling.
    Start an application on android device with ONE of the following environment variables set:
    [Default Tracing]
    DOTNET_DiagnosticPorts=127.0.0.1:9000,nosuspend,connect
    [Startup Tracing]
    DOTNET_DiagnosticPorts=127.0.0.1:9000,suspend,connect
    Run diagnotic tool connecting application on android device through dotnet-dsrouter pid=45036:
    dotnet-trace collect -p 45036
    See https://learn.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-dsrouter for additional details and examples.

    info: dotnet-dsrouter-45036[0]
          Starting dotnet-dsrouter using pid=45036
    info: dotnet-dsrouter-45036[0]
          Looking for Android NDK...
    info: dotnet-dsrouter-45036[0]
          Looking for Android SDK...
    info: dotnet-dsrouter-45036[0]
          Looking for Android NDK...
    info: dotnet-dsrouter-45036[0]
          Looking for Android SDK...
    info: dotnet-dsrouter-45036[0]

With the changes in d7d85009, it is running the code to "find" the Android SDK multiple times. The operation itself isn't very fast if called repeatedly, and it also clutters the logs with duplicate messages.

With these changes, I only see the log message once now:

    info: dotnet-dsrouter-48616[0]
          Starting dotnet-dsrouter using pid=48616
    info: dotnet-dsrouter-48616[0]
          Looking for Android NDK...
    info: dotnet-dsrouter-48616[0]
          Looking for Android SDK...