### PR TITLE
[dsrouter] improved instructions/log messages

### DIFF
--- a/src/Tools/dotnet-dsrouter/DiagnosticsServerRouterCommands.cs
+++ b/src/Tools/dotnet-dsrouter/DiagnosticsServerRouterCommands.cs
@@ -361,7 +361,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
         {
             if (info || ParseLogLevel(verbose) <= LogLevel.Information)
             {
-                logRouterUsageInfo("ios simulator", "127.0.0.1:9000", true, parentProcess);
+                logRouterUsageInfo("ios simulator", "127.0.0.1", "9000", true, parentProcess);
             }
 
             return await RunIpcServerTcpClientRouter(token, "", "127.0.0.1:9000", runtimeTimeout, verbose, "").ConfigureAwait(false);
@@ -371,7 +371,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
         {
             if (info || ParseLogLevel(verbose) <= LogLevel.Information)
             {
-                logRouterUsageInfo("ios device", "127.0.0.1:9000", true, parentProcess);
+                logRouterUsageInfo("ios device", "127.0.0.1", "9000", true, parentProcess);
             }
 
             return await RunIpcServerTcpClientRouter(token, "", "127.0.0.1:9000", runtimeTimeout, verbose, "iOS").ConfigureAwait(false);
@@ -381,7 +381,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
         {
             if (info || ParseLogLevel(verbose) <= LogLevel.Information)
             {
-                logRouterUsageInfo("android emulator", "10.0.2.2:9000", false, parentProcess);
+                logRouterUsageInfo("android emulator", "10.0.2.2", "9000", false, parentProcess);
             }
 
             return await RunIpcServerTcpServerRouter(token, "", "127.0.0.1:9000", runtimeTimeout, verbose, "").ConfigureAwait(false);
@@ -391,7 +391,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
         {
             if (info || ParseLogLevel(verbose) <= LogLevel.Information)
             {
-                logRouterUsageInfo("android device", "127.0.0.1:9000", false, parentProcess);
+                logRouterUsageInfo("android device", "127.0.0.1", "9000", false, parentProcess);
             }
 
             return await RunIpcServerTcpServerRouter(token, "", "127.0.0.1:9001", runtimeTimeout, verbose, "Android").ConfigureAwait(false);
@@ -501,7 +501,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
             return logLevel;
         }
 
-        private static void logRouterUsageInfo(string deviceName, string deviceTcpIpAddress, bool deviceListenMode, string parentProcess)
+        private static void logRouterUsageInfo(string deviceName, string deviceTcpIpAddress, string deviceTcpIpPort, bool deviceListenMode, string parentProcess)
         {
             StringBuilder message = new();
 
@@ -509,11 +509,11 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
             int pid = Process.GetCurrentProcess().Id;
 
             message.AppendLine($"How to connect current dotnet-dsrouter pid={pid} with {deviceName} and diagnostics tooling.");
-            message.AppendLine($"Start an application on {deviceName} with ONE of the following environment variables set:");
+            message.AppendLine($"Build and run your application on {deviceName} such as:");
             message.AppendLine("[Default Tracing]");
-            message.AppendLine($"DOTNET_DiagnosticPorts={deviceTcpIpAddress},nosuspend,{listenMode}");
+            message.AppendLine($"dotnet build -t:Run -c Release -p:DiagnosticAddress={deviceTcpIpAddress} -p:DiagnosticPort={deviceTcpIpPort} -p:DiagnosticSuspend=false -p:DiagnosticListenMode={listenMode}");
             message.AppendLine("[Startup Tracing]");
-            message.AppendLine($"DOTNET_DiagnosticPorts={deviceTcpIpAddress},suspend,{listenMode}");
+            message.AppendLine($"dotnet build -t:Run -c Release -p:DiagnosticAddress={deviceTcpIpAddress} -p:DiagnosticPort={deviceTcpIpPort} -p:DiagnosticSuspend=true -p:DiagnosticListenMode={listenMode}");
             if (string.IsNullOrEmpty(parentProcess))
             {
                 message.AppendLine($"Run diagnotic tool connecting application on {deviceName} through dotnet-dsrouter pid={pid}:");


### PR DESCRIPTION
Context: https://github.com/dotnet/android/pull/10351
Context: https://github.com/dotnet/macios/pull/23429

We are adding new MSBuild properties to simplify setting `$DOTNET_DiagnosticPorts` on mobile:

* `$(DiagnosticAddress)`
* `$(DiagnosticPort)`
* `$(DiagnosticSuspend)`
* `$(DiagnosticListenMode)`
* `$(DiagnosticConfiguration)` if you want to specify the full value yourself, escape `,` with `%2c`, etc.

We will ship these properties in future releases of .NET 9 and 10.

To improve `dsrouter` the current log message:

    Start an application on android device with ONE of the following environment variables set:
    [Default Tracing]
    DOTNET_DiagnosticPorts=127.0.0.1:9000,nosuspend,connect
    [Startup Tracing]
    DOTNET_DiagnosticPorts=127.0.0.1:9000,suspend,connect

Will change to:

    Build and run an Android application such as:
    [Default Tracing]
    dotnet build -t:Run -c Release -p:DiagnosticAddress=127.0.0.1 -p:DiagnosticPort=9000 -p:DiagnosticSuspend=false -p:DiagnosticListenMode=connect
    [Startup Tracing]
    dotnet build -t:Run -c Release -p:DiagnosticAddress=127.0.0.1 -p:DiagnosticPort=9000 -p:DiagnosticSuspend=true -p:DiagnosticListenMode=connect

Note that `dotnet run` *does work*, but it doesn't show good progress on the build & deploy steps as compared to `dotnet build -t:Run` and MSBuild's terminal logger. It can take several seconds to run a `Release` build. I think it's better to recommend `-t:Run` until we improve `dotnet run`.