### PR TITLE
[dsrouter] improve log message when launched as a subprocess

### DIFF
--- a/src/Tools/Common/DsRouterProcessLauncher.cs
+++ b/src/Tools/Common/DsRouterProcessLauncher.cs
@@ -18,7 +18,6 @@ namespace Microsoft.Internal.Common.Utils
 {
     internal sealed partial class DsRouterProcessLauncher
     {
-        private const string DiagnosticSubprocessEnvVar = "DOTNET_DIAGNOSTIC_SUBPROCESS";
         private Process _childProc;
         private Task _stdOutTask = Task.CompletedTask;
         private Task _stdErrTask = Task.CompletedTask;
@@ -118,9 +117,6 @@ namespace Microsoft.Internal.Common.Utils
 
         private Process ChildProc => _childProc;
 
-        public static bool IsLaunchedByDotnetTrace() =>
-            Environment.GetEnvironmentVariable(DiagnosticSubprocessEnvVar) == "1";
-
         public int Start(string dsrouterCommand, CancellationToken ct)
         {
             string toolsRoot = System.IO.Path.GetDirectoryName(System.Environment.ProcessPath);
@@ -132,7 +128,7 @@ namespace Microsoft.Internal.Common.Utils
             }
 
             // Block SIGINT and SIGQUIT in child process.
-            dsrouterCommand += " --block-signals SIGINT;SIGQUIT";
+            dsrouterCommand += " --block-signals SIGINT;SIGQUIT --subprocess";
 
             _childProc = new Process();
 
@@ -142,7 +138,6 @@ namespace Microsoft.Internal.Common.Utils
             _childProc.StartInfo.RedirectStandardOutput = true;
             _childProc.StartInfo.RedirectStandardError = true;
             _childProc.StartInfo.RedirectStandardInput = true;
-            _childProc.StartInfo.EnvironmentVariables.Add(DiagnosticSubprocessEnvVar, "1");
             try
             {
                 _childProc.Start();

--- a/src/Tools/Common/DsRouterProcessLauncher.cs
+++ b/src/Tools/Common/DsRouterProcessLauncher.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Internal.Common.Utils
 {
     internal sealed partial class DsRouterProcessLauncher
     {
+        private const string DiagnosticSubprocessEnvVar = "DOTNET_DIAGNOSTIC_SUBPROCESS";
         private Process _childProc;
         private Task _stdOutTask = Task.CompletedTask;
         private Task _stdErrTask = Task.CompletedTask;
@@ -117,6 +118,9 @@ namespace Microsoft.Internal.Common.Utils
 
         private Process ChildProc => _childProc;
 
+        public static bool IsLaunchedByDotnetTrace() =>
+            Environment.GetEnvironmentVariable(DiagnosticSubprocessEnvVar) == "1";
+
         public int Start(string dsrouterCommand, CancellationToken ct)
         {
             string toolsRoot = System.IO.Path.GetDirectoryName(System.Environment.ProcessPath);
@@ -138,6 +142,7 @@ namespace Microsoft.Internal.Common.Utils
             _childProc.StartInfo.RedirectStandardOutput = true;
             _childProc.StartInfo.RedirectStandardError = true;
             _childProc.StartInfo.RedirectStandardInput = true;
+            _childProc.StartInfo.EnvironmentVariables.Add(DiagnosticSubprocessEnvVar, "1");
             try
             {
                 _childProc.Start();

--- a/src/Tools/Common/DsRouterProcessLauncher.cs
+++ b/src/Tools/Common/DsRouterProcessLauncher.cs
@@ -127,8 +127,10 @@ namespace Microsoft.Internal.Common.Utils
                 dotnetDsrouterTool = Path.Combine(toolsRoot, dotnetDsrouterTool);
             }
 
+            using Process currentProcess = Process.GetCurrentProcess();
+
             // Block SIGINT and SIGQUIT in child process.
-            dsrouterCommand += " --block-signals SIGINT;SIGQUIT --subprocess";
+            dsrouterCommand += $" --block-signals SIGINT;SIGQUIT --parentprocess \"{currentProcess.Id}:{currentProcess.ProcessName}\"";
 
             _childProc = new Process();
 

--- a/src/Tools/dotnet-dsrouter/DiagnosticsServerRouterCommands.cs
+++ b/src/Tools/dotnet-dsrouter/DiagnosticsServerRouterCommands.cs
@@ -514,8 +514,11 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
             message.AppendLine($"DOTNET_DiagnosticPorts={deviceTcpIpAddress},nosuspend,{listenMode}");
             message.AppendLine("[Startup Tracing]");
             message.AppendLine($"DOTNET_DiagnosticPorts={deviceTcpIpAddress},suspend,{listenMode}");
-            message.AppendLine($"Run diagnotic tool connecting application on {deviceName} through dotnet-dsrouter pid={pid}:");
-            message.AppendLine($"dotnet-trace collect -p {pid}");
+            if (!DsRouterProcessLauncher.IsLaunchedByDotnetTrace())
+            {
+                message.AppendLine($"Run diagnotic tool connecting application on {deviceName} through dotnet-dsrouter pid={pid}:");
+                message.AppendLine($"dotnet-trace collect -p {pid}");
+            }
             message.AppendLine($"See https://learn.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-dsrouter for additional details and examples.");
 
             ConsoleColor currentColor = Console.ForegroundColor;

--- a/src/Tools/dotnet-dsrouter/DiagnosticsServerRouterCommands.cs
+++ b/src/Tools/dotnet-dsrouter/DiagnosticsServerRouterCommands.cs
@@ -357,41 +357,41 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
             }
         }
 
-        public async Task<int> RunIpcServerIOSSimulatorRouter(CancellationToken token, int runtimeTimeout, string verbose, bool info, bool subprocess)
+        public async Task<int> RunIpcServerIOSSimulatorRouter(CancellationToken token, int runtimeTimeout, string verbose, bool info, string parentProcess)
         {
             if (info || ParseLogLevel(verbose) <= LogLevel.Information)
             {
-                logRouterUsageInfo("ios simulator", "127.0.0.1:9000", true, subprocess);
+                logRouterUsageInfo("ios simulator", "127.0.0.1:9000", true, parentProcess);
             }
 
             return await RunIpcServerTcpClientRouter(token, "", "127.0.0.1:9000", runtimeTimeout, verbose, "").ConfigureAwait(false);
         }
 
-        public async Task<int> RunIpcServerIOSRouter(CancellationToken token, int runtimeTimeout, string verbose, bool info, bool subprocess)
+        public async Task<int> RunIpcServerIOSRouter(CancellationToken token, int runtimeTimeout, string verbose, bool info, string parentProcess)
         {
             if (info || ParseLogLevel(verbose) <= LogLevel.Information)
             {
-                logRouterUsageInfo("ios device", "127.0.0.1:9000", true, subprocess);
+                logRouterUsageInfo("ios device", "127.0.0.1:9000", true, parentProcess);
             }
 
             return await RunIpcServerTcpClientRouter(token, "", "127.0.0.1:9000", runtimeTimeout, verbose, "iOS").ConfigureAwait(false);
         }
 
-        public async Task<int> RunIpcServerAndroidEmulatorRouter(CancellationToken token, int runtimeTimeout, string verbose, bool info, bool subprocess)
+        public async Task<int> RunIpcServerAndroidEmulatorRouter(CancellationToken token, int runtimeTimeout, string verbose, bool info, string parentProcess)
         {
             if (info || ParseLogLevel(verbose) <= LogLevel.Information)
             {
-                logRouterUsageInfo("android emulator", "10.0.2.2:9000", false, subprocess);
+                logRouterUsageInfo("android emulator", "10.0.2.2:9000", false, parentProcess);
             }
 
             return await RunIpcServerTcpServerRouter(token, "", "127.0.0.1:9000", runtimeTimeout, verbose, "").ConfigureAwait(false);
         }
 
-        public async Task<int> RunIpcServerAndroidRouter(CancellationToken token, int runtimeTimeout, string verbose, bool info, bool subprocess)
+        public async Task<int> RunIpcServerAndroidRouter(CancellationToken token, int runtimeTimeout, string verbose, bool info, string parentProcess)
         {
             if (info || ParseLogLevel(verbose) <= LogLevel.Information)
             {
-                logRouterUsageInfo("android device", "127.0.0.1:9000", false, subprocess);
+                logRouterUsageInfo("android device", "127.0.0.1:9000", false, parentProcess);
             }
 
             return await RunIpcServerTcpServerRouter(token, "", "127.0.0.1:9001", runtimeTimeout, verbose, "Android").ConfigureAwait(false);
@@ -501,7 +501,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
             return logLevel;
         }
 
-        private static void logRouterUsageInfo(string deviceName, string deviceTcpIpAddress, bool deviceListenMode, bool subprocess)
+        private static void logRouterUsageInfo(string deviceName, string deviceTcpIpAddress, bool deviceListenMode, string parentProcess)
         {
             StringBuilder message = new();
 
@@ -514,7 +514,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
             message.AppendLine($"DOTNET_DiagnosticPorts={deviceTcpIpAddress},nosuspend,{listenMode}");
             message.AppendLine("[Startup Tracing]");
             message.AppendLine($"DOTNET_DiagnosticPorts={deviceTcpIpAddress},suspend,{listenMode}");
-            if (!subprocess)
+            if (string.IsNullOrEmpty(parentProcess))
             {
                 message.AppendLine($"Run diagnotic tool connecting application on {deviceName} through dotnet-dsrouter pid={pid}:");
                 message.AppendLine($"dotnet-trace collect -p {pid}");

--- a/src/Tools/dotnet-dsrouter/DiagnosticsServerRouterCommands.cs
+++ b/src/Tools/dotnet-dsrouter/DiagnosticsServerRouterCommands.cs
@@ -357,41 +357,41 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
             }
         }
 
-        public async Task<int> RunIpcServerIOSSimulatorRouter(CancellationToken token, int runtimeTimeout, string verbose, bool info)
+        public async Task<int> RunIpcServerIOSSimulatorRouter(CancellationToken token, int runtimeTimeout, string verbose, bool info, bool subprocess)
         {
             if (info || ParseLogLevel(verbose) <= LogLevel.Information)
             {
-                logRouterUsageInfo("ios simulator", "127.0.0.1:9000", true);
+                logRouterUsageInfo("ios simulator", "127.0.0.1:9000", true, subprocess);
             }
 
             return await RunIpcServerTcpClientRouter(token, "", "127.0.0.1:9000", runtimeTimeout, verbose, "").ConfigureAwait(false);
         }
 
-        public async Task<int> RunIpcServerIOSRouter(CancellationToken token, int runtimeTimeout, string verbose, bool info)
+        public async Task<int> RunIpcServerIOSRouter(CancellationToken token, int runtimeTimeout, string verbose, bool info, bool subprocess)
         {
             if (info || ParseLogLevel(verbose) <= LogLevel.Information)
             {
-                logRouterUsageInfo("ios device", "127.0.0.1:9000", true);
+                logRouterUsageInfo("ios device", "127.0.0.1:9000", true, subprocess);
             }
 
             return await RunIpcServerTcpClientRouter(token, "", "127.0.0.1:9000", runtimeTimeout, verbose, "iOS").ConfigureAwait(false);
         }
 
-        public async Task<int> RunIpcServerAndroidEmulatorRouter(CancellationToken token, int runtimeTimeout, string verbose, bool info)
+        public async Task<int> RunIpcServerAndroidEmulatorRouter(CancellationToken token, int runtimeTimeout, string verbose, bool info, bool subprocess)
         {
             if (info || ParseLogLevel(verbose) <= LogLevel.Information)
             {
-                logRouterUsageInfo("android emulator", "10.0.2.2:9000", false);
+                logRouterUsageInfo("android emulator", "10.0.2.2:9000", false, subprocess);
             }
 
             return await RunIpcServerTcpServerRouter(token, "", "127.0.0.1:9000", runtimeTimeout, verbose, "").ConfigureAwait(false);
         }
 
-        public async Task<int> RunIpcServerAndroidRouter(CancellationToken token, int runtimeTimeout, string verbose, bool info)
+        public async Task<int> RunIpcServerAndroidRouter(CancellationToken token, int runtimeTimeout, string verbose, bool info, bool subprocess)
         {
             if (info || ParseLogLevel(verbose) <= LogLevel.Information)
             {
-                logRouterUsageInfo("android device", "127.0.0.1:9000", false);
+                logRouterUsageInfo("android device", "127.0.0.1:9000", false, subprocess);
             }
 
             return await RunIpcServerTcpServerRouter(token, "", "127.0.0.1:9001", runtimeTimeout, verbose, "Android").ConfigureAwait(false);
@@ -501,7 +501,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
             return logLevel;
         }
 
-        private static void logRouterUsageInfo(string deviceName, string deviceTcpIpAddress, bool deviceListenMode)
+        private static void logRouterUsageInfo(string deviceName, string deviceTcpIpAddress, bool deviceListenMode, bool subprocess)
         {
             StringBuilder message = new();
 
@@ -514,7 +514,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
             message.AppendLine($"DOTNET_DiagnosticPorts={deviceTcpIpAddress},nosuspend,{listenMode}");
             message.AppendLine("[Startup Tracing]");
             message.AppendLine($"DOTNET_DiagnosticPorts={deviceTcpIpAddress},suspend,{listenMode}");
-            if (!DsRouterProcessLauncher.IsLaunchedByDotnetTrace())
+            if (!subprocess)
             {
                 message.AppendLine($"Run diagnotic tool connecting application on {deviceName} through dotnet-dsrouter pid={pid}:");
                 message.AppendLine($"dotnet-trace collect -p {pid}");

--- a/src/Tools/dotnet-dsrouter/Program.cs
+++ b/src/Tools/dotnet-dsrouter/Program.cs
@@ -156,7 +156,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
                                 "Router is configured using an IPC server (connecting to by diagnostic tools) " +
                                 "and a TCP/IP server (accepting runtime TCP client).")
             {
-                RuntimeTimeoutOption, VerboseOption, InfoOption, BlockedSignalsOption, SubprocessOption
+                RuntimeTimeoutOption, VerboseOption, InfoOption, BlockedSignalsOption, ParentProcessOption
             };
 
             command.SetAction((parseResult, ct) => new DiagnosticsServerRouterCommands().RunIpcServerIOSSimulatorRouter(
@@ -164,7 +164,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
                 runtimeTimeout: parseResult.GetValue(RuntimeTimeoutOption),
                 verbose: parseResult.GetValue(VerboseOption),
                 info: parseResult.GetValue(InfoOption),
-                subprocess: parseResult.GetValue(SubprocessOption)
+                parentProcess: parseResult.GetValue(ParentProcessOption)
             ));
 
             return command;
@@ -178,7 +178,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
                                 "Router is configured using an IPC server (connecting to by diagnostic tools) " +
                                 "and a TCP/IP client (connecting runtime TCP server over usbmux).")
             {
-                RuntimeTimeoutOption, VerboseOption, InfoOption, BlockedSignalsOption, SubprocessOption
+                RuntimeTimeoutOption, VerboseOption, InfoOption, BlockedSignalsOption, ParentProcessOption
             };
 
             command.SetAction((parseResult, ct) => new DiagnosticsServerRouterCommands().RunIpcServerIOSRouter(
@@ -186,7 +186,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
                 runtimeTimeout: parseResult.GetValue(RuntimeTimeoutOption),
                 verbose: parseResult.GetValue(VerboseOption),
                 info: parseResult.GetValue(InfoOption),
-                subprocess: parseResult.GetValue(SubprocessOption)
+                parentProcess: parseResult.GetValue(ParentProcessOption)
             ));
 
             return command;
@@ -200,7 +200,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
                                 "Router is configured using an IPC server (connecting to by diagnostic tools) " +
                                 "and a TCP/IP server (accepting runtime TCP client).")
             {
-                RuntimeTimeoutOption, VerboseOption, InfoOption, BlockedSignalsOption, SubprocessOption
+                RuntimeTimeoutOption, VerboseOption, InfoOption, BlockedSignalsOption, ParentProcessOption
             };
 
             command.SetAction((parseResult, ct) => new DiagnosticsServerRouterCommands().RunIpcServerAndroidEmulatorRouter(
@@ -208,7 +208,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
                 runtimeTimeout: parseResult.GetValue(RuntimeTimeoutOption),
                 verbose: parseResult.GetValue(VerboseOption),
                 info: parseResult.GetValue(InfoOption),
-                subprocess: parseResult.GetValue(SubprocessOption)
+                parentProcess: parseResult.GetValue(ParentProcessOption)
             ));
 
             return command;
@@ -222,7 +222,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
                                 "Router is configured using an IPC server (connecting to by diagnostic tools) " +
                                 "and a TCP/IP server (accepting runtime TCP client).")
             {
-                RuntimeTimeoutOption, VerboseOption, InfoOption, BlockedSignalsOption, SubprocessOption
+                RuntimeTimeoutOption, VerboseOption, InfoOption, BlockedSignalsOption, ParentProcessOption
             };
 
             command.SetAction((parseResult, ct) => new DiagnosticsServerRouterCommands().RunIpcServerAndroidRouter(
@@ -230,7 +230,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
                 runtimeTimeout: parseResult.GetValue(RuntimeTimeoutOption),
                 verbose: parseResult.GetValue(VerboseOption),
                 info: parseResult.GetValue(InfoOption),
-                subprocess: parseResult.GetValue(SubprocessOption)
+                parentProcess: parseResult.GetValue(ParentProcessOption)
             ));
 
             return command;
@@ -310,11 +310,11 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
                 Description = "Print info on how to use current dotnet-dsrouter instance with application and diagnostic tooling."
             };
 
-        private static readonly Option<bool> SubprocessOption =
-            new("--subprocess")
+        private static readonly Option<string> ParentProcessOption =
+            new("--parentprocess")
             {
-                Description = "Indicates if dsrouter was launched from dotnet-trace or another .NET diagnostic tool",
-                DefaultValueFactory = _ => false,
+                Description = "If dsrouter was launched from dotnet-trace or another .NET diagnostic tool, contains the parent process ID and name: --parentprocess pid:name",
+                DefaultValueFactory = _ => "",
                 Hidden = true
             };
 

--- a/src/Tools/dotnet-dsrouter/Program.cs
+++ b/src/Tools/dotnet-dsrouter/Program.cs
@@ -156,14 +156,15 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
                                 "Router is configured using an IPC server (connecting to by diagnostic tools) " +
                                 "and a TCP/IP server (accepting runtime TCP client).")
             {
-                RuntimeTimeoutOption, VerboseOption, InfoOption, BlockedSignalsOption
+                RuntimeTimeoutOption, VerboseOption, InfoOption, BlockedSignalsOption, SubprocessOption
             };
 
             command.SetAction((parseResult, ct) => new DiagnosticsServerRouterCommands().RunIpcServerIOSSimulatorRouter(
                 ct,
                 runtimeTimeout: parseResult.GetValue(RuntimeTimeoutOption),
                 verbose: parseResult.GetValue(VerboseOption),
-                info: parseResult.GetValue(InfoOption)
+                info: parseResult.GetValue(InfoOption),
+                subprocess: parseResult.GetValue(SubprocessOption)
             ));
 
             return command;
@@ -177,14 +178,15 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
                                 "Router is configured using an IPC server (connecting to by diagnostic tools) " +
                                 "and a TCP/IP client (connecting runtime TCP server over usbmux).")
             {
-                RuntimeTimeoutOption, VerboseOption, InfoOption, BlockedSignalsOption
+                RuntimeTimeoutOption, VerboseOption, InfoOption, BlockedSignalsOption, SubprocessOption
             };
 
             command.SetAction((parseResult, ct) => new DiagnosticsServerRouterCommands().RunIpcServerIOSRouter(
                 ct,
                 runtimeTimeout: parseResult.GetValue(RuntimeTimeoutOption),
                 verbose: parseResult.GetValue(VerboseOption),
-                info: parseResult.GetValue(InfoOption)
+                info: parseResult.GetValue(InfoOption),
+                subprocess: parseResult.GetValue(SubprocessOption)
             ));
 
             return command;
@@ -198,14 +200,16 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
                                 "Router is configured using an IPC server (connecting to by diagnostic tools) " +
                                 "and a TCP/IP server (accepting runtime TCP client).")
             {
-                RuntimeTimeoutOption, VerboseOption, InfoOption, BlockedSignalsOption
+                RuntimeTimeoutOption, VerboseOption, InfoOption, BlockedSignalsOption, SubprocessOption
             };
 
             command.SetAction((parseResult, ct) => new DiagnosticsServerRouterCommands().RunIpcServerAndroidEmulatorRouter(
                 ct,
                 runtimeTimeout: parseResult.GetValue(RuntimeTimeoutOption),
                 verbose: parseResult.GetValue(VerboseOption),
-                info: parseResult.GetValue(InfoOption)));
+                info: parseResult.GetValue(InfoOption),
+                subprocess: parseResult.GetValue(SubprocessOption)
+            ));
 
             return command;
         }
@@ -218,14 +222,16 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
                                 "Router is configured using an IPC server (connecting to by diagnostic tools) " +
                                 "and a TCP/IP server (accepting runtime TCP client).")
             {
-                RuntimeTimeoutOption, VerboseOption, InfoOption, BlockedSignalsOption
+                RuntimeTimeoutOption, VerboseOption, InfoOption, BlockedSignalsOption, SubprocessOption
             };
 
             command.SetAction((parseResult, ct) => new DiagnosticsServerRouterCommands().RunIpcServerAndroidRouter(
                 ct,
                 runtimeTimeout: parseResult.GetValue(RuntimeTimeoutOption),
                 verbose: parseResult.GetValue(VerboseOption),
-                info: parseResult.GetValue(InfoOption)));
+                info: parseResult.GetValue(InfoOption),
+                subprocess: parseResult.GetValue(SubprocessOption)
+            ));
 
             return command;
         }
@@ -302,6 +308,14 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
             new("--info", "-i")
             {
                 Description = "Print info on how to use current dotnet-dsrouter instance with application and diagnostic tooling."
+            };
+
+        private static readonly Option<bool> SubprocessOption =
+            new("--subprocess")
+            {
+                Description = "Indicates if dsrouter was launched from dotnet-trace or another .NET diagnostic tool",
+                DefaultValueFactory = _ => false,
+                Hidden = true
             };
 
         private static Task<int> Main(string[] args)

--- a/src/Tools/dotnet-dsrouter/dotnet-dsrouter.csproj
+++ b/src/Tools/dotnet-dsrouter/dotnet-dsrouter.csproj
@@ -15,7 +15,6 @@
     <Compile Include="..\Common\ReversedServerHelpers\ReversedServerHelpers.cs" Link="ReversedServerHelpers.cs" />
     <Compile Include="..\Common\CommandLineErrorException.cs" Link="CommandLineErrorException.cs" />
     <Compile Include="..\Common\ProcessTerminationHandler.cs" Link="ProcessTerminationHandler.cs" />
-    <Compile Include="..\Common\DsRouterProcessLauncher.cs" Link="DsRouterProcessLauncher.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tools/dotnet-dsrouter/dotnet-dsrouter.csproj
+++ b/src/Tools/dotnet-dsrouter/dotnet-dsrouter.csproj
@@ -15,6 +15,7 @@
     <Compile Include="..\Common\ReversedServerHelpers\ReversedServerHelpers.cs" Link="ReversedServerHelpers.cs" />
     <Compile Include="..\Common\CommandLineErrorException.cs" Link="CommandLineErrorException.cs" />
     <Compile Include="..\Common\ProcessTerminationHandler.cs" Link="ProcessTerminationHandler.cs" />
+    <Compile Include="..\Common\DsRouterProcessLauncher.cs" Link="DsRouterProcessLauncher.cs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
`dotnet-trace collect --dsrouter android` logs an unnecessary message currently:

    Run diagnotic tool connecting application on android device through dotnet-dsrouter pid=38004:
    dotnet-trace collect -p 38004

`dotnet-trace` is launching and controlling `dotnet-dsrouter`, and so you would not need to run `dotnet-trace collect -p 38004`.

To solve this:

* Pass `--parentprocess pid:name` when launching `dotnet-dsrouter` from `dotnet-trace`

* `dotnet-dsrouter` checks `--parentprocess` switch to tell if it is running as a subprocess

* Only log this message when *not* a subprocess