### PR TITLE
[dotnet-trace/dsrouter] simplify mobile tracing to a one-liner!

### DIFF
--- a/src/Tools/Common/Commands/Utils.cs
+++ b/src/Tools/Common/Commands/Utils.cs
@@ -44,11 +44,11 @@ namespace Microsoft.Internal.Common.Utils
         // </summary>
         // <param name="dsrouter">dsrouterCommand</param>
         // <returns>processId</returns>
-        public static int LaunchDSRouterProcess(string dsrouterCommand)
+        public static int LaunchDSRouterProcess(string dsrouterCommand, IReadOnlyList<string> unmatchedTokens)
         {
             Console.WriteLine("For finer control over the dotnet-dsrouter options, run it separately and connect to it using -p" + Environment.NewLine);
 
-            return DsRouterProcessLauncher.Launcher.Start(dsrouterCommand, default);
+            return DsRouterProcessLauncher.Launcher.Start(dsrouterCommand, unmatchedTokens, default);
         }
 
 
@@ -80,9 +80,10 @@ namespace Microsoft.Internal.Common.Utils
         /// <param name="name">name</param>
         /// <param name="port">port</param>
         /// <param name="dsrouter">dsrouter</param>
+        /// <param name="unmatchedTokens">unmatchedTokens</param>
         /// <param name="resolvedProcessId">resolvedProcessId</param>
         /// <returns></returns>
-        public static bool ResolveProcessForAttach(int processId, string name, string port, string dsrouter, out int resolvedProcessId)
+        public static bool ResolveProcessForAttach(int processId, string name, string port, string dsrouter, IReadOnlyList<string> unmatchedTokens, out int resolvedProcessId)
         {
             resolvedProcessId = -1;
             if (processId == 0 && string.IsNullOrEmpty(name) && string.IsNullOrEmpty(port) && string.IsNullOrEmpty(dsrouter))
@@ -124,7 +125,7 @@ namespace Microsoft.Internal.Common.Utils
                     Console.WriteLine("Invalid value for --dsrouter. Valid values are 'ios', 'ios-sim', 'android' and 'android-emu'.");
                     return false;
                 }
-                if ((processId = LaunchDSRouterProcess(dsrouter)) < 0)
+                if ((processId = LaunchDSRouterProcess(dsrouter, unmatchedTokens)) < 0)
                 {
                     if (processId == -2)
                     {

--- a/src/Tools/Common/DsRouterProcessLauncher.cs
+++ b/src/Tools/Common/DsRouterProcessLauncher.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Binding;
 using System.Diagnostics;
@@ -117,7 +118,7 @@ namespace Microsoft.Internal.Common.Utils
 
         private Process ChildProc => _childProc;
 
-        public int Start(string dsrouterCommand, CancellationToken ct)
+        public int Start(string dsrouterCommand, IReadOnlyList<string> unmatchedTokens, CancellationToken ct)
         {
             string toolsRoot = System.IO.Path.GetDirectoryName(System.Environment.ProcessPath);
             string dotnetDsrouterTool = "dotnet-dsrouter";
@@ -131,6 +132,11 @@ namespace Microsoft.Internal.Common.Utils
 
             // Block SIGINT and SIGQUIT in child process.
             dsrouterCommand += $" --block-signals SIGINT;SIGQUIT --parentprocess \"{currentProcess.Id}:{currentProcess.ProcessName}\"";
+
+            if (unmatchedTokens.Count > 0)
+            {
+                dsrouterCommand += $" -- {string.Join(" ", unmatchedTokens)}";
+            }
 
             _childProc = new Process();
 

--- a/src/Tools/Common/ReversedServerHelpers/ReversedServerHelpers.cs
+++ b/src/Tools/Common/ReversedServerHelpers/ReversedServerHelpers.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -32,6 +33,16 @@ namespace Microsoft.Internal.Common.Utils
                 return;
             }
 
+            PrepareChildProcess(args, unparsedTokenIdx);
+        }
+
+        public void PrepareChildProcess(IEnumerable<string> unmatchedTokens)
+        {
+            PrepareChildProcess([.. unmatchedTokens], 0);
+        }
+
+        private void PrepareChildProcess(string[] args, int unparsedTokenIdx)
+        {
             _childProc = new Process();
             _childProc.StartInfo.FileName = args[unparsedTokenIdx];
             string arguments = "";

--- a/src/Tools/dotnet-counters/CounterMonitor.cs
+++ b/src/Tools/dotnet-counters/CounterMonitor.cs
@@ -176,7 +176,8 @@ namespace Microsoft.Diagnostics.Tools.Counters
             int maxTimeSeries,
             TimeSpan duration,
             bool showDeltas,
-            string dsrouter)
+            string dsrouter,
+            IReadOnlyList<string> unmatchedTokens)
         {
             try
             {
@@ -186,7 +187,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 // to it.
                 ValidateNonNegative(maxHistograms, nameof(maxHistograms));
                 ValidateNonNegative(maxTimeSeries, nameof(maxTimeSeries));
-                if (!ProcessLauncher.Launcher.HasChildProc && !CommandUtils.ResolveProcessForAttach(processId, name, diagnosticPort, dsrouter, out _processId))
+                if (!ProcessLauncher.Launcher.HasChildProc && !CommandUtils.ResolveProcessForAttach(processId, name, diagnosticPort, dsrouter, unmatchedTokens, out _processId))
                 {
                     return ReturnCode.ArgumentError;
                 }
@@ -261,7 +262,8 @@ namespace Microsoft.Diagnostics.Tools.Counters
             int maxHistograms,
             int maxTimeSeries,
             TimeSpan duration,
-            string dsrouter)
+            string dsrouter,
+            IReadOnlyList<string> unmatchedTokens)
         {
             try
             {
@@ -271,7 +273,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 // to it.
                 ValidateNonNegative(maxHistograms, nameof(maxHistograms));
                 ValidateNonNegative(maxTimeSeries, nameof(maxTimeSeries));
-                if (!ProcessLauncher.Launcher.HasChildProc && !CommandUtils.ResolveProcessForAttach(processId, name, diagnosticPort, dsrouter, out _processId))
+                if (!ProcessLauncher.Launcher.HasChildProc && !CommandUtils.ResolveProcessForAttach(processId, name, diagnosticPort, dsrouter, unmatchedTokens, out _processId))
                 {
                     return ReturnCode.ArgumentError;
                 }

--- a/src/Tools/dotnet-counters/Program.cs
+++ b/src/Tools/dotnet-counters/Program.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 maxTimeSeries: parseResult.GetValue(MaxTimeSeriesOption),
                 duration: parseResult.GetValue(DurationOption),
                 showDeltas: parseResult.GetValue(ShowDeltasOption),
-                dsrouter: string.Empty
+                dsrouter: string.Empty,
+                unmatchedTokens: parseResult.UnmatchedTokens
             ));
 
             return monitorCommand;
@@ -90,7 +91,9 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 maxHistograms: parseResult.GetValue(MaxHistogramOption),
                 maxTimeSeries: parseResult.GetValue(MaxTimeSeriesOption),
                 duration: parseResult.GetValue(DurationOption),
-                dsrouter: string.Empty));
+                dsrouter: string.Empty,
+                unmatchedTokens: parseResult.UnmatchedTokens
+            ));
 
             return collectCommand;
         }

--- a/src/Tools/dotnet-dsrouter/DiagnosticsServerRouterCommands.cs
+++ b/src/Tools/dotnet-dsrouter/DiagnosticsServerRouterCommands.cs
@@ -361,7 +361,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
         {
             if (info || ParseLogLevel(verbose) <= LogLevel.Information)
             {
-                logRouterUsageInfo("ios simulator", "127.0.0.1:9000", true, parentProcess);
+                logRouterUsageInfo("ios simulator", "127.0.0.1", "9000", true, parentProcess);
             }
 
             return await RunIpcServerTcpClientRouter(token, "", "127.0.0.1:9000", runtimeTimeout, verbose, "").ConfigureAwait(false);
@@ -371,7 +371,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
         {
             if (info || ParseLogLevel(verbose) <= LogLevel.Information)
             {
-                logRouterUsageInfo("ios device", "127.0.0.1:9000", true, parentProcess);
+                logRouterUsageInfo("ios device", "127.0.0.1", "9000", true, parentProcess);
             }
 
             return await RunIpcServerTcpClientRouter(token, "", "127.0.0.1:9000", runtimeTimeout, verbose, "iOS").ConfigureAwait(false);
@@ -381,7 +381,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
         {
             if (info || ParseLogLevel(verbose) <= LogLevel.Information)
             {
-                logRouterUsageInfo("android emulator", "10.0.2.2:9000", false, parentProcess);
+                logRouterUsageInfo("android emulator", "10.0.2.2", "9000", false, parentProcess);
             }
 
             return await RunIpcServerTcpServerRouter(token, "", "127.0.0.1:9000", runtimeTimeout, verbose, "").ConfigureAwait(false);
@@ -391,7 +391,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
         {
             if (info || ParseLogLevel(verbose) <= LogLevel.Information)
             {
-                logRouterUsageInfo("android device", "127.0.0.1:9000", false, parentProcess);
+                logRouterUsageInfo("android device", "127.0.0.1", "9000", false, parentProcess);
             }
 
             return await RunIpcServerTcpServerRouter(token, "", "127.0.0.1:9001", runtimeTimeout, verbose, "Android").ConfigureAwait(false);
@@ -501,7 +501,7 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
             return logLevel;
         }
 
-        private static void logRouterUsageInfo(string deviceName, string deviceTcpIpAddress, bool deviceListenMode, string parentProcess)
+        private static void logRouterUsageInfo(string deviceName, string deviceTcpIpAddress, string deviceTcpIpPort, bool deviceListenMode, string parentProcess)
         {
             StringBuilder message = new();
 
@@ -509,11 +509,11 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
             int pid = Process.GetCurrentProcess().Id;
 
             message.AppendLine($"How to connect current dotnet-dsrouter pid={pid} with {deviceName} and diagnostics tooling.");
-            message.AppendLine($"Start an application on {deviceName} with ONE of the following environment variables set:");
+            message.AppendLine($"Build and run your application on {deviceName} such as:");
             message.AppendLine("[Default Tracing]");
-            message.AppendLine($"DOTNET_DiagnosticPorts={deviceTcpIpAddress},nosuspend,{listenMode}");
+            message.AppendLine($"dotnet build -t:Run -c Release -p:DiagnosticAddress={deviceTcpIpAddress} -p:DiagnosticPort={deviceTcpIpPort} -p:DiagnosticSuspend=false -p:DiagnosticListenMode={listenMode}");
             message.AppendLine("[Startup Tracing]");
-            message.AppendLine($"DOTNET_DiagnosticPorts={deviceTcpIpAddress},suspend,{listenMode}");
+            message.AppendLine($"dotnet build -t:Run -c Release -p:DiagnosticAddress={deviceTcpIpAddress} -p:DiagnosticPort={deviceTcpIpPort} -p:DiagnosticSuspend=true -p:DiagnosticListenMode={listenMode}");
             if (string.IsNullOrEmpty(parentProcess))
             {
                 message.AppendLine($"Run diagnotic tool connecting application on {deviceName} through dotnet-dsrouter pid={pid}:");

--- a/src/Tools/dotnet-dsrouter/Program.cs
+++ b/src/Tools/dotnet-dsrouter/Program.cs
@@ -158,13 +158,15 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
             {
                 RuntimeTimeoutOption, VerboseOption, InfoOption, BlockedSignalsOption, ParentProcessOption
             };
+            command.TreatUnmatchedTokensAsErrors = false;
 
             command.SetAction((parseResult, ct) => new DiagnosticsServerRouterCommands().RunIpcServerIOSSimulatorRouter(
                 ct,
                 runtimeTimeout: parseResult.GetValue(RuntimeTimeoutOption),
                 verbose: parseResult.GetValue(VerboseOption),
                 info: parseResult.GetValue(InfoOption),
-                parentProcess: parseResult.GetValue(ParentProcessOption)
+                parentProcess: parseResult.GetValue(ParentProcessOption),
+                unmatchedTokens: parseResult.UnmatchedTokens
             ));
 
             return command;
@@ -180,13 +182,15 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
             {
                 RuntimeTimeoutOption, VerboseOption, InfoOption, BlockedSignalsOption, ParentProcessOption
             };
+            command.TreatUnmatchedTokensAsErrors = false;
 
             command.SetAction((parseResult, ct) => new DiagnosticsServerRouterCommands().RunIpcServerIOSRouter(
                 ct,
                 runtimeTimeout: parseResult.GetValue(RuntimeTimeoutOption),
                 verbose: parseResult.GetValue(VerboseOption),
                 info: parseResult.GetValue(InfoOption),
-                parentProcess: parseResult.GetValue(ParentProcessOption)
+                parentProcess: parseResult.GetValue(ParentProcessOption),
+                unmatchedTokens: parseResult.UnmatchedTokens
             ));
 
             return command;
@@ -202,13 +206,15 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
             {
                 RuntimeTimeoutOption, VerboseOption, InfoOption, BlockedSignalsOption, ParentProcessOption
             };
+            command.TreatUnmatchedTokensAsErrors = false;
 
             command.SetAction((parseResult, ct) => new DiagnosticsServerRouterCommands().RunIpcServerAndroidEmulatorRouter(
                 ct,
                 runtimeTimeout: parseResult.GetValue(RuntimeTimeoutOption),
                 verbose: parseResult.GetValue(VerboseOption),
                 info: parseResult.GetValue(InfoOption),
-                parentProcess: parseResult.GetValue(ParentProcessOption)
+                parentProcess: parseResult.GetValue(ParentProcessOption),
+                unmatchedTokens: parseResult.UnmatchedTokens
             ));
 
             return command;
@@ -224,13 +230,15 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
             {
                 RuntimeTimeoutOption, VerboseOption, InfoOption, BlockedSignalsOption, ParentProcessOption
             };
+            command.TreatUnmatchedTokensAsErrors = false;
 
             command.SetAction((parseResult, ct) => new DiagnosticsServerRouterCommands().RunIpcServerAndroidRouter(
                 ct,
                 runtimeTimeout: parseResult.GetValue(RuntimeTimeoutOption),
                 verbose: parseResult.GetValue(VerboseOption),
                 info: parseResult.GetValue(InfoOption),
-                parentProcess: parseResult.GetValue(ParentProcessOption)
+                parentProcess: parseResult.GetValue(ParentProcessOption),
+                unmatchedTokens: parseResult.UnmatchedTokens
             ));
 
             return command;
@@ -320,6 +328,11 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
 
         private static Task<int> Main(string[] args)
         {
+            Command iosCommand = IOSRouterCommand();
+            Command iosSimulatorCommand = IOSSimulatorRouterCommand();
+            Command androidCommand = AndroidRouterCommand();
+            Command androidEmulatorCommand = AndroidEmulatorRouterCommand();
+
             RootCommand rootCommand = new()
             {
                 IpcClientTcpServerRouterCommand(),
@@ -328,15 +341,20 @@ namespace Microsoft.Diagnostics.Tools.DiagnosticsServerRouter
                 IpcClientTcpClientRouterCommand(),
                 IpcServerWebSocketServerRouterCommand(),
                 IpcClientWebSocketServerRouterCommand(),
-                IOSSimulatorRouterCommand(),
-                IOSRouterCommand(),
-                AndroidEmulatorRouterCommand(),
-                AndroidRouterCommand()
+                iosSimulatorCommand,
+                iosCommand,
+                androidEmulatorCommand,
+                androidCommand
             };
 
             ParseResult parseResult = rootCommand.Parse(args);
 
-            if (parseResult.UnmatchedTokens.Count > 0)
+            string parsedCommandName = parseResult.CommandResult.Command.Name;
+            if (parseResult.UnmatchedTokens.Count > 0 &&
+                parsedCommandName != iosCommand.Name &&
+                parsedCommandName != iosSimulatorCommand.Name &&
+                parsedCommandName != androidCommand.Name &&
+                parsedCommandName != androidEmulatorCommand.Name)
             {
                 ProcessLauncher.Launcher.PrepareChildProcess(args);
             }

--- a/src/Tools/dotnet-dump/Dumper.cs
+++ b/src/Tools/dotnet-dump/Dumper.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Diagnostics.Tools.Dump
         {
             try
             {
-                if (CommandUtils.ResolveProcessForAttach(processId, name, diagnosticPort, string.Empty, out int resolvedProcessId))
+                if (CommandUtils.ResolveProcessForAttach(processId, name, diagnosticPort, string.Empty, [], out int resolvedProcessId))
                 {
                     processId = resolvedProcessId;
                 }

--- a/src/Tools/dotnet-gcdump/CommandLine/CollectCommandHandler.cs
+++ b/src/Tools/dotnet-gcdump/CommandLine/CollectCommandHandler.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using System.CommandLine;
 using System.IO;
 using System.Threading;
@@ -27,10 +28,11 @@ namespace Microsoft.Diagnostics.Tools.GCDump
         /// <param name="name">The process name to collect the gcdump from.</param>
         /// <param name="diagnosticPort">The diagnostic IPC channel to collect the gcdump from.</param>
         /// <param name="dsrouter">The dsrouter command to use for collecting the gcdump.</param>
+        /// <param name="unmatchedTokens">Unmatched tokens from the command line.</param>
         /// <returns></returns>
-        private static async Task<int> Collect(CancellationToken ct, int processId, string output, int timeout, bool verbose, string name, string diagnosticPort, string dsrouter)
+        private static async Task<int> Collect(CancellationToken ct, int processId, string output, int timeout, bool verbose, string name, string diagnosticPort, string dsrouter, IReadOnlyList<string> unmatchedTokens)
         {
-            if (!CommandUtils.ResolveProcessForAttach(processId, name, diagnosticPort, dsrouter, out int resolvedProcessId))
+            if (!CommandUtils.ResolveProcessForAttach(processId, name, diagnosticPort, dsrouter, unmatchedTokens, out int resolvedProcessId))
             {
                 return -1;
             }
@@ -155,7 +157,9 @@ namespace Microsoft.Diagnostics.Tools.GCDump
                     verbose: parseResult.GetValue(VerboseOption),
                     name: parseResult.GetValue(NameOption),
                     diagnosticPort: parseResult.GetValue(DiagnosticPortOption) ?? string.Empty,
-                    dsrouter: parseResult.GetValue(DsRouterOption) ?? string.Empty));
+                    dsrouter: parseResult.GetValue(DsRouterOption) ?? string.Empty,
+                    unmatchedTokens: parseResult.UnmatchedTokens
+            ));
 
             return collectCommand;
         }

--- a/src/Tools/dotnet-gcdump/CommandLine/ReportCommandHandler.cs
+++ b/src/Tools/dotnet-gcdump/CommandLine/ReportCommandHandler.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Binding;
 using System.IO;
@@ -91,7 +92,7 @@ namespace Microsoft.Diagnostics.Tools.GCDump
 
         private static Task<int> ReportFromProcess(int processId, string diagnosticPort, string dsrouter, CancellationToken ct)
         {
-            if (!CommandUtils.ResolveProcessForAttach(processId, string.Empty, diagnosticPort, dsrouter, out int resolvedProcessId))
+            if (!CommandUtils.ResolveProcessForAttach(processId, string.Empty, diagnosticPort, dsrouter, [], out int resolvedProcessId))
             {
                 return Task.FromResult(-1);
             }

--- a/src/Tools/dotnet-trace/Program.cs
+++ b/src/Tools/dotnet-trace/Program.cs
@@ -29,8 +29,9 @@ namespace Microsoft.Diagnostics.Tools.Trace
             if (parsedCommandName == "collect")
             {
                 IReadOnlyCollection<string> unparsedTokens = parseResult.UnmatchedTokens;
+                string dsrouter = CollectCommandHandler.GetDSRouterOption(parseResult);
                 // If we notice there are unparsed tokens, user might want to attach on startup.
-                if (unparsedTokens.Count > 0)
+                if (string.IsNullOrEmpty(dsrouter) && unparsedTokens.Count > 0)
                 {
                     ProcessLauncher.Launcher.PrepareChildProcess(args);
                 }

--- a/src/tests/dotnet-counters/CounterMonitorPayloadTests.cs
+++ b/src/tests/dotnet-counters/CounterMonitorPayloadTests.cs
@@ -217,7 +217,9 @@ namespace DotnetCounters.UnitTests
                             maxHistograms: 10,
                             maxTimeSeries: 1000,
                             duration: TimeSpan.FromSeconds(10),
-                            dsrouter: null));
+                            dsrouter: null,
+                            unmatchedTokens: []
+                        ));
                 }, testRunner, source.Token);
 
                 return CreateMetricComponents();


### PR DESCRIPTION
This is WIP, I have a TODO list at the bottom.

This enables you to do:

    dotnet-trace collect --dsrouter android -- dotnet build MyApp.csproj -t:Run -c Release -p:DiagnosticSuspend=false

Where `-p:DiagnosticSuspend=false` is optional.

What this does:

* `dotnet-trace` starts

* `dotnet-trace` launches `dotnet-dsrouter` passing the `--` unmatched
  args along.

* `dotnet-dsrouter` appends additional MSBuild properties if it
  detects the unmatched args are a `dotnet build` or `dotnet run`
  commands

* `dotnet-dsrouter` launches the command for the unmatched args.

## TODO ##

- [ ] Merge this one first: https://github.com/dotnet/diagnostics/pull/5535

- [ ] Figure out how we show progress. `dotnet build -t:Run` can take
  30 seconds+, so it seems like we somehow need to let the terminal
  logger show progress? Not sure how that can work.

- [ ] Switches after the `--` must be quoted in some cases: `'-t:Run'`
  for example. This is also a problem with plain `dotnet-trace`. This
  could maybe be addressed in a separate PR.