### PR TITLE
[counters] add `--dsrouter` switch

### DIFF
--- a/src/Tools/dotnet-counters/Program.cs
+++ b/src/Tools/dotnet-counters/Program.cs
@@ -33,7 +33,8 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 MaxHistogramOption,
                 MaxTimeSeriesOption,
                 DurationOption,
-                ShowDeltasOption
+                ShowDeltasOption,
+                DSRouterOption
             };
 
             monitorCommand.TreatUnmatchedTokensAsErrors = false; // see the logic in Main
@@ -50,7 +51,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 maxTimeSeries: parseResult.GetValue(MaxTimeSeriesOption),
                 duration: parseResult.GetValue(DurationOption),
                 showDeltas: parseResult.GetValue(ShowDeltasOption),
-                dsrouter: string.Empty
+                dsrouter: parseResult.GetValue(DSRouterOption)
             ));
 
             return monitorCommand;
@@ -72,7 +73,8 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 ResumeRuntimeOption,
                 MaxHistogramOption,
                 MaxTimeSeriesOption,
-                DurationOption
+                DurationOption,
+                DSRouterOption
             };
 
             collectCommand.TreatUnmatchedTokensAsErrors = false; // see the logic in Main
@@ -90,7 +92,7 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 maxHistograms: parseResult.GetValue(MaxHistogramOption),
                 maxTimeSeries: parseResult.GetValue(MaxTimeSeriesOption),
                 duration: parseResult.GetValue(DurationOption),
-                dsrouter: string.Empty));
+                dsrouter: parseResult.GetValue(DSRouterOption)));
 
             return collectCommand;
         }
@@ -137,6 +139,12 @@ namespace Microsoft.Diagnostics.Tools.Counters
                 " names can either refer to the name of a Meter for the System.Diagnostics.Metrics API or the name of an EventSource for the EventCounters API. If the monitored application has both" +
                 " a Meter and an EventSource with the same name, the Meter is automatically preferred. Use the prefix \'EventCounters\\\' in front of a provider name to only show the EventCounters." +
                 " To discover well-known provider and counter names, please visit https://learn.microsoft.com/dotnet/core/diagnostics/built-in-metrics."
+            };
+
+        private static readonly Option<string> DSRouterOption =
+            new("--dsrouter")
+            {
+                Description = @"The dsrouter command to start. Value should be one of ios, ios-sim, android, android-emu. Run `dotnet-dsrouter -h` for more information."
             };
 
         private static Command ListCommand()


### PR DESCRIPTION
We added this to `dotnet-gcdump` in fcaeae33 and `dotnet-trace` in a29f26dd.

This allows `dsrouter` to be launched, such as:

    > dotnet-counters collect --dsrouter android
    For finer control over the dotnet-dsrouter options, run it separately and connect to it using -p

    WARNING: dotnet-dsrouter is a development tool not intended for production environments.

    How to connect current dotnet-dsrouter pid=40432 with android device and diagnostics tooling.
    Start an application on android device with ONE of the following environment variables set:
    [Default Tracing]
    DOTNET_DiagnosticPorts=127.0.0.1:9000,nosuspend,connect
    [Startup Tracing]
    DOTNET_DiagnosticPorts=127.0.0.1:9000,suspend,connect
    See https://learn.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-dsrouter for additional details and examples.

    info: dotnet-dsrouter-40432[0]
        Starting dotnet-dsrouter using pid=40432
    info: dotnet-dsrouter-40432[0]
        Looking for Android NDK...
    info: dotnet-dsrouter-40432[0]
        Looking for Android SDK...
    info: dotnet-dsrouter-40432[0]
        Starting IPC server (dotnet-diagnostic-dsrouter-40432) <--> TCP server (127.0.0.1:9001) router.
    --counters is unspecified. Monitoring System.Runtime counters by default.

Opening a PR for documentation shortly.