### PR TITLE
Add product arguments to release tool and clean up calls to tool

### DIFF
--- a/diagnostics.yml
+++ b/diagnostics.yml
@@ -32,6 +32,12 @@ pr:
     - LICENSE.TXT
 
 variables:
+- ${{ if and(notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.DefinitionName'], 'dotnet-diagnostics')) }}:
+  - name: isOfficialBuild
+    value: true
+- ${{ else }}:
+  - name: isOfficialBuild
+    value: false
 - template : /eng/pipelines/global-variables.yml
   parameters:
     runtimeFeed: ${{ parameters.runtimeFeed }}
@@ -354,3 +360,7 @@ extends:
 
     # This sets up the bits to do a Release.
     - template: /eng/pipelines/prepare-release.yml
+      parameters:
+        isOfficialBuild: ${{ variables['isOfficialBuild'] }}
+        repoAllowList: https://github.com/dotnet/diagnostics https://dev.azure.com/dnceng/internal/_git/dotnet-diagnostics
+        productAllowList: diagnostics dotnet-diagnostics

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -38,9 +38,9 @@
   <PropertyGroup>
     <!-- Opt-in/out repo features -->
     <UsingToolXliff>false</UsingToolXliff>
-    <AzureIdentityVersion>1.12.0</AzureIdentityVersion>
-    <AzureCoreVersion>1.43.0</AzureCoreVersion>
-    <AzureStorageBlobsVersion>12.22.0</AzureStorageBlobsVersion>
+    <AzureIdentityVersion>1.13.1</AzureIdentityVersion>
+    <AzureCoreVersion>1.45.0</AzureCoreVersion>
+    <AzureStorageBlobsVersion>12.23.0</AzureStorageBlobsVersion>
     <!-- Uncomment this line to use the custom version of roslyn as needed. -->
     <!-- <UsingToolMicrosoftNetCompilers Condition="'$(DotNetBuildSourceOnly)' != 'true'">true</UsingToolMicrosoftNetCompilers> -->
     <!-- CoreFX -->
@@ -48,12 +48,15 @@
     <SystemCollectionsImmutableVersion>8.0.0</SystemCollectionsImmutableVersion>
     <!-- Other libs -->
     <MicrosoftBclAsyncInterfacesVersion>6.0.0</MicrosoftBclAsyncInterfacesVersion>
-    <MicrosoftDiagnosticsRuntimeVersion>4.0.0-beta.25381.2</MicrosoftDiagnosticsRuntimeVersion>
+    <MicrosoftDiagnosticsRuntimeVersion>4.0.0-beta.25359.1</MicrosoftDiagnosticsRuntimeVersion>
     <MicrosoftDiaSymReaderNativeVersion>17.10.0-beta1.24272.1</MicrosoftDiaSymReaderNativeVersion>
     <MicrosoftDiagnosticsTracingTraceEventVersion>3.1.23</MicrosoftDiagnosticsTracingTraceEventVersion>
-    <MicrosoftExtensionsLoggingVersion>6.0.0</MicrosoftExtensionsLoggingVersion>
-    <MicrosoftExtensionsLoggingAbstractionsVersion>6.0.4</MicrosoftExtensionsLoggingAbstractionsVersion>
-    <MicrosoftExtensionsLoggingConsoleVersion>6.0.0</MicrosoftExtensionsLoggingConsoleVersion>
+    <MicrosoftExtensionsLoggingVersion>9.0.8</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftExtensionsLoggingAbstractionsVersion>9.0.8</MicrosoftExtensionsLoggingAbstractionsVersion>
+    <MicrosoftExtensionsLoggingConsoleVersion>9.0.8</MicrosoftExtensionsLoggingConsoleVersion>
+    <MicrosoftExtensionsConfigurationVersion>9.0.8</MicrosoftExtensionsConfigurationVersion>
+    <MicrosoftExtensionsConfigurationJsonVersion>9.0.8</MicrosoftExtensionsConfigurationJsonVersion>
+    <MicrosoftExtensionsLoggingConfigurationVersion>9.0.8</MicrosoftExtensionsLoggingConfigurationVersion>
     <!-- Need version that understands UseAppFilters sentinel. -->
     <MicrosoftExtensionsLoggingEventSourceVersion>5.0.1</MicrosoftExtensionsLoggingEventSourceVersion>
     <SystemCommandLineVersion>2.0.0-beta5.25210.1</SystemCommandLineVersion>

--- a/eng/pipelines/global-variables.yml
+++ b/eng/pipelines/global-variables.yml
@@ -1,7 +1,6 @@
 parameters:
   runtimeFeed: default
   runtimeFeedToken: default
-  isCodeQLRun: false
 
 variables:
 - name: _TeamName
@@ -17,26 +16,15 @@ variables:
   - name: BuildPool
     value: $(DncEngInternalBuildPool)
   - name: WindowsImage
-    value: 1es-windows-2022
+    value: windows.vs2022.amd64
   - name: LinuxImage
-    value: 1es-ubuntu-2204
+    value: Build.Ubuntu.2204.Amd64
   - name: macOSImage
     value: macOS-latest
   - name: sourceBuildTemplate
     value: /eng/common/templates-official/job/source-build.yml@self
   - name: jobTemplate
     value: /eng/common/templates-official/job/job.yml@self
-  - ${{ if eq(parameters.isCodeQLRun, 'true') }}:
-    - name: Codeql.Enabled
-      value: True
-    - name: Codeql.Cadence
-      value: 0
-    - name: Codeql.TSAEnabled
-      value: True
-    - name: Codeql.BuildIdentifier
-      value: $(System.JobDisplayName)
-    - name: Codeql.Language
-      value: csharp,cpp
   - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
     - name: _SignType
       value: real
@@ -69,4 +57,3 @@ variables:
 - ${{ if eq(parameters.runtimeFeedToken, 'dotnetclimsrc-sas-token-base64') }}:
   - name: RuntimeFeedBase64SasToken
     value: $(dotnetclimsrc-read-sas-token-base64)
-

--- a/eng/pipelines/prepare-release.yml
+++ b/eng/pipelines/prepare-release.yml
@@ -1,6 +1,21 @@
+parameters:
+- name: isOfficialBuild
+  type: boolean
+  default: false
+- name: repoAllowList
+  type: string
+  default: ''
+- name: productAllowList
+  type: string
+  default: ''
+- name: dependsOn
+  type: object
+  default: [ publish_using_darc ]
+
 stages:
 - stage: PrepareReleaseStage
   displayName: Release Preparation
+  dependsOn: ${{ parameters.dependsOn }}
   jobs:
   - job: PrepareReleaseJob
     displayName: Prepare Release
@@ -8,7 +23,7 @@ stages:
       name: $(BuildPool)
       demands: ImageOverride -equals $(WindowsImage)
       os: windows
-    ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), or(startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'))) }}:
+    ${{ if and(eq(parameters.isOfficialBuild, true), or(startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'))) }}:
       templateContext:
         outputs:
         - output: pipelineArtifact
@@ -17,25 +32,24 @@ stages:
           displayName: 'Publish Release Drop'
           condition: succeeded()
     variables:
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), or(startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'))) }}:
+    - ${{ if and(eq(parameters.isOfficialBuild, true), or(startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'))) }}:
+
       - group: DotNet-Diagnostics-Storage
       - group: Release-Pipeline
     steps:
-    - ${{ if or(in(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
+    - ${{ if or(eq(parameters.isOfficialBuild, false), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
       - script: '$(Build.Repository.LocalPath)\dotnet.cmd build $(Build.Repository.LocalPath)\eng\release\DiagnosticsReleaseTool\DiagnosticsReleaseTool.csproj -c Release /bl'
         workingDirectory: '$(System.ArtifactsDirectory)'
         displayName: 'Build Manifest generation and asset publishing tool'
-    - ${{ elseif and(ne(variables['System.TeamProject'], 'public'), or(startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'))) }}:
+    - ${{ elseif and(eq(parameters.isOfficialBuild, true), or(startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'))) }}:
       - task: UseDotNet@2
         displayName: 'Use .NET Core runtime 8.x'
         inputs:
           packageType: runtime
           version: 8.x
           installationPath: '$(Build.Repository.LocalPath)\.dotnet'
-      - template: /eng/common/templates/post-build/setup-maestro-vars.yml
-
+      - template: /eng/common/templates/post-build/setup-maestro-vars.yml@self
       - task: NuGetAuthenticate@1
-
       - task: AzureCLI@2
         displayName: 'DARC Gather build'
         inputs:
@@ -44,7 +58,7 @@ stages:
           scriptPath: '$(Build.Repository.LocalPath)/eng/release/Scripts/AcquireBuild.ps1'
           arguments: >-
             -BarBuildId "$(BARBuildId)"
-            -ReleaseVersion "$(Build.BuildNumber)"
+            -ReleaseVersion "$(Build.Repository.Name)_$(Build.BuildNumber)"
             -DownloadTargetPath "$(System.ArtifactsDirectory)\ReleaseTarget"
             -AzdoToken "$(dn-bot-all-drop-rw-code-rw-release-all)"
           workingDirectory: '$(Build.Repository.LocalPath)'
@@ -64,7 +78,9 @@ stages:
                 --input-drop-path "$(System.ArtifactsDirectory)\ReleaseTarget" `
                 --tool-manifest "$(Build.Repository.LocalPath)\eng\release\tool-list.json" `
                 --staging-directory "$(System.ArtifactsDirectory)\ReleaseStaging" `
-                --release-name "$(Build.BuildNumber)" `
+                --release-name "$(Build.Repository.Name)_$(Build.BuildNumber)" `
+                --product-allow-list ${{ parameters.productAllowList }} `
+                --repo-allow-list ${{ parameters.repoAllowList }} `
                 --account-name "$(dotnet-diagnostics-storage-accountname)" `
                 --client-id "$env:servicePrincipalId" `
                 --container-name "$(dotnet-diagnostics-container-name)" `

--- a/eng/release/DiagnosticsReleaseTool/Config.cs
+++ b/eng/release/DiagnosticsReleaseTool/Config.cs
@@ -15,6 +15,8 @@ namespace DiagnosticsReleaseTool.Impl
         public string AccountName { get; }
         public string ClientId { get; }
         public string ContainerName { get; }
+        public string[] ReleaseProductAllowList { get; }
+        public string[] ReleaseRepoAllowList { get; }
 
         public Config(
             FileInfo toolManifest,
@@ -22,6 +24,8 @@ namespace DiagnosticsReleaseTool.Impl
             DirectoryInfo inputDropPath,
             DirectoryInfo stagingDirectory,
             string releaseName,
+            string[] releaseProductAllowList,
+            string[] releaseRepoAllowList,
             string accountName,
             string clientId,
             string containerName)
@@ -34,6 +38,8 @@ namespace DiagnosticsReleaseTool.Impl
             AccountName = accountName;
             ClientId = clientId;
             ContainerName = containerName;
+            ReleaseProductAllowList = releaseProductAllowList;
+            ReleaseRepoAllowList = releaseRepoAllowList;
         }
     }
 }

--- a/eng/release/DiagnosticsReleaseTool/Core/Release.cs
+++ b/eng/release/DiagnosticsReleaseTool/Core/Release.cs
@@ -188,7 +188,7 @@ namespace ReleaseTool.Core
 
             using IDisposable scope = _logger.BeginScope("Laying out files");
 
-            _logger.LogInformation("Laying out files from {_productBuildPath}", _productBuildPath.Name);
+            _logger.LogInformation("Laying out files from {_productBuildPath}", _productBuildPath.FullName);
 
             // TODO: Make this parallel using Task.Run + semaphore to batch process files. Need to make collections concurrent or have single
             //       queue to aggregate results.

--- a/eng/release/DiagnosticsReleaseTool/DarcHelpers.cs
+++ b/eng/release/DiagnosticsReleaseTool/DarcHelpers.cs
@@ -58,7 +58,7 @@ namespace DiagnosticsReleaseTool.Util
                 if (repoBuilds.Count() != 1)
                 {
                     throw new InvalidOperationException(
-                        $"There's either no build for requested repos or more than one. Can't retrieve metadata.");
+                        $"There's {repoBuilds.Count()} builds that come from requested repos in the release manifest. Expected 1.");
                 }
 
                 JsonElement build = repoBuilds.First();
@@ -92,7 +92,7 @@ namespace DiagnosticsReleaseTool.Util
                 if (matchingProducts.Count() != 1)
                 {
                     throw new InvalidOperationException(
-                        $"There's either no product under the provided names or more than one in the drop.");
+                        $"There's {matchingProducts.Count()} products that could be released in the release manifest. Expected 1");
                 }
 
                 return new DirectoryInfo(matchingProducts.First().GetProperty("fileshare").GetString());

--- a/eng/release/DiagnosticsReleaseTool/DiagnosticsManifestGenerator.cs
+++ b/eng/release/DiagnosticsReleaseTool/DiagnosticsManifestGenerator.cs
@@ -24,8 +24,12 @@ namespace DiagnosticsReleaseTool.Impl
         public DiagnosticsManifestGenerator(ReleaseMetadata productReleaseMetadata, FileInfo toolManifest, ILogger logger)
         {
             _productReleaseMetadata = productReleaseMetadata;
-            string manifestContent = File.ReadAllText(toolManifest.FullName);
-            _assetManifestManifestDom = JsonDocument.Parse(manifestContent);
+            using Stream manifestStream = File.OpenRead(toolManifest.FullName);
+            _assetManifestManifestDom = JsonDocument.Parse(manifestStream, new JsonDocumentOptions
+            {
+                AllowTrailingCommas = true,
+                CommentHandling = JsonCommentHandling.Skip
+            });
             _logger = logger;
         }
 

--- a/eng/release/DiagnosticsReleaseTool/DiagnosticsReleaseCommandLine.cs
+++ b/eng/release/DiagnosticsReleaseTool/DiagnosticsReleaseCommandLine.cs
@@ -29,7 +29,7 @@ namespace DiagnosticsReleaseTool.CommandLine
                 description: "Given a darc drop, generates validated manifests and layouts to initiate a tool release.")
             {
                 // Inputs
-                InputDropPathOption, ToolManifestPathOption, ReleaseNameOption,
+                InputDropPathOption, ToolManifestPathOption, ReleaseNameOption, ReleaseProductAllowListOption, ReleaseRepoAllowListOption,
                 // Toggles
                 ToolManifestVerificationOption, DiagnosticLoggingOption,
                 // Outputs
@@ -45,6 +45,8 @@ namespace DiagnosticsReleaseTool.CommandLine
                     inputDropPath: parseResult.GetValue(InputDropPathOption),
                     stagingDirectory: parseResult.GetValue(StagingPathOption),
                     releaseName: parseResult.GetValue(ReleaseNameOption),
+                    releaseProductAllowList: parseResult.GetValue(ReleaseProductAllowListOption),
+                    releaseRepoAllowList: parseResult.GetValue(ReleaseRepoAllowListOption),
                     accountName: parseResult.GetValue(AzureStorageAccountNameOption),
                     clientId: parseResult.GetValue(AzureStorageAccountKeyOption),
                     containerName: parseResult.GetValue(AzureStorageContainerNameOption)
@@ -92,6 +94,21 @@ namespace DiagnosticsReleaseTool.CommandLine
                 Required = true
             };
 
+        private static Option<string[]> ReleaseProductAllowListOption =
+            new("--product-allow-list")
+            {
+                AllowMultipleArgumentsPerToken = true,
+                Description = "List of allowed product names for this release.",
+                Required = true
+            };
+
+        private static Option<string[]> ReleaseRepoAllowListOption =
+            new("--repo-allow-list")
+            {
+                AllowMultipleArgumentsPerToken = true,
+                Description = "List of allowed repository urls for this release.",
+                Required = true
+            };
 
         private static readonly Option<DirectoryInfo> StagingPathOption = InitStagingPath();
 

--- a/eng/release/DiagnosticsReleaseTool/DiagnosticsReleaseRunner.cs
+++ b/eng/release/DiagnosticsReleaseTool/DiagnosticsReleaseRunner.cs
@@ -47,8 +47,8 @@ namespace DiagnosticsReleaseTool.Impl
             }
 
             // TODO: Probably should use BAR ID instead as an identifier for the metadata to gather.
-            ReleaseMetadata releaseMetadata = darcLayoutHelper.GetDropMetadataForSingleRepoVariants(DiagnosticsRepoHelpers.RepositoryUrls);
-            DirectoryInfo basePublishDirectory = darcLayoutHelper.GetShippingDirectoryForSingleProjectVariants(DiagnosticsRepoHelpers.ProductNames);
+            ReleaseMetadata releaseMetadata = darcLayoutHelper.GetDropMetadataForSingleRepoVariants(releaseConfig.ReleaseRepoAllowList);
+            DirectoryInfo basePublishDirectory = darcLayoutHelper.GetShippingDirectoryForSingleProjectVariants(releaseConfig.ReleaseProductAllowList);
             string publishManifestPath = Path.Combine(releaseConfig.StagingDirectory.FullName, ManifestName);
 
             IPublisher releasePublisher = new AzureBlobBublisher(releaseConfig.AccountName, releaseConfig.ClientId, releaseConfig.ContainerName, releaseConfig.ReleaseName, logger);

--- a/eng/release/DiagnosticsReleaseTool/DiagnosticsReleaseTool.csproj
+++ b/eng/release/DiagnosticsReleaseTool/DiagnosticsReleaseTool.csproj
@@ -1,6 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Condition="'$(DotNetBuildSourceOnly)' != 'true'" Project="$(RepositoryEngineeringDir)Analyzers.props" />
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>$(NetCoreAppMinTargetFramework)</TargetFramework>
@@ -14,12 +12,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="9.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsConfigurationVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsConfigurationJsonVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractionsVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="$(MicrosoftExtensionsLoggingConfigurationVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingConsoleVersion)" />
 
     <PackageReference Include="Azure.Core" Version="$(AzureCoreVersion)" />
     <PackageReference Include="Azure.Identity" Version="$(AzureIdentityVersion)" />

--- a/eng/release/DiagnosticsReleaseTool/DiagnosticsRepoHelpers.cs
+++ b/eng/release/DiagnosticsReleaseTool/DiagnosticsRepoHelpers.cs
@@ -10,9 +10,8 @@ namespace DiagnosticsReleaseTool.Util
 {
     public static partial class DiagnosticsRepoHelpers
     {
-        public static readonly string[] ProductNames = ["diagnostics", "dotnet-diagnostics"];
-        public static readonly string[] RepositoryUrls = ["https://github.com/dotnet/diagnostics", "https://dev.azure.com/dnceng/internal/_git/dotnet-diagnostics"];
-        public static string BundleToolsPathInDrop => System.IO.Path.Combine("diagnostics", "bundledtools");
+        public static readonly string PublicBundleToolsPathInDrop = System.IO.Path.Combine("diagnostics", "bundledtools");
+        public static readonly string InternalBundleToolsPathInDrop = System.IO.Path.Combine("diagnostics-internal", "bundledtools");
         public const string BundledToolsPrefix = "diagnostic-tools-";
         public const string BundledToolsCategory = "ToolBundleAssets";
         public const string PdbCategory = "PdbAssets";
@@ -68,7 +67,7 @@ namespace DiagnosticsReleaseTool.Util
         public static bool IsBundledToolArchive(FileInfo file)
         {
             return file.Exists && file.Extension == ".zip"
-                && file.DirectoryName.Contains(BundleToolsPathInDrop)
+                && (file.DirectoryName.Contains(InternalBundleToolsPathInDrop) || file.DirectoryName.Contains(PublicBundleToolsPathInDrop))
                 && file.Name.StartsWith(BundledToolsPrefix);
         }
 

--- a/src/singlefile-tools.proj
+++ b/src/singlefile-tools.proj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(NetCoreAppMinTargetFramework)</TargetFramework>
-    <SupportedRids>win-x64;win-x86;win-arm64;linux-x64;linux-musl-arm64;linux-arm64;linux-musl-x64;linux-arm</SupportedRids>
+    <SupportedRids>win-x64;win-x86;win-arm64;linux-x64;linux-musl-x64;linux-musl-arm64;linux-arm64;linux-arm;linux-musl-arm</SupportedRids>
     <ArcadeSdkMSBuildProjectDir>$([System.IO.Path]::GetDirectoryName('$(ArcadeSdkBuildTasksAssembly)'))\..\</ArcadeSdkMSBuildProjectDir>
     <ArcadeSdkSignProject>$(ArcadeSdkMSBuildProjectDir)Sign.proj</ArcadeSdkSignProject>
     <BundledToolsZipDirectory>$(BundledToolsPath)$(Configuration)/zips/</BundledToolsZipDirectory>
@@ -22,14 +22,15 @@
       </ProjectToBundle>
     </ItemGroup>
 
-    <!-- First pass: restore and build all the different  -->
+    <!-- First pass: restore the different tools -->
     <MSBuild Projects="@(ProjectToBundle)"
         BuildInParallel="true"
         SkipNonexistentProjects="false"
         SkipNonexistentTargets="false"
         StopOnFirstFailure="true"
-        Targets="Restore;Build"
-        ContinueOnError="false" />
+        Targets="Restore"
+        ContinueOnError="false"
+        Properties="MSBuildRestoreSessionId=$([System.Guid]::NewGuid())"/>
 
     <!-- Second: Get the files that we'll bundle for every rid and project combination. -->
     <!--        and need signing. -->
@@ -39,7 +40,7 @@
         SkipNonexistentProjects="false"
         SkipNonexistentTargets="false"
         StopOnFirstFailure="true"
-        Targets="CollectBundleFilesToSign"
+        Targets="Build;CollectBundleFilesToSign"
         ContinueOnError="false">
         <Output TaskParameter="TargetOutputs" ItemName="ItemsNeedingSigning" />
     </MSBuild>


### PR DESCRIPTION
This change largely:

- Cleans up conditions to call the release tool.
- Fixes up pools to the ones we should be using.
- Fixes an issue with building singlefile tools.
- Pipes down product names and new release names to the release tool to allow it to be used elsewhere.