### PR TITLE
Indenting tag set value rows by one more indent

### DIFF
--- a/src/Tools/dotnet-counters/Exporters/ConsoleWriter.cs
+++ b/src/Tools/dotnet-counters/Exporters/ConsoleWriter.cs
@@ -233,7 +233,7 @@ namespace Microsoft.Diagnostics.Tools.Counters.Exporters
                     tagWithSpaces += " ";
                     tagRow += tagWithSpaces;
                 }
-                if (!RenderCounterValueRow(ref row, indentLevel: 2, tagRow, tagSet.LastValue, 0))
+                if (!RenderCounterValueRow(ref row, indentLevel: 3, tagRow, tagSet.LastValue, 0))
                 {
                     return false;
                 }


### PR DESCRIPTION
This PR is intended to indent tag sets such as those under gc.heap.generation by one extra indent. This makes it clearer that the label gc.heap.generation is a header and not a data value.

Before:
<img width="3818" height="1145" alt="image" src="https://github.com/user-attachments/assets/226f5bfe-7635-4581-a91d-203f3fd51579" />

After:
<img width="3819" height="1127" alt="image" src="https://github.com/user-attachments/assets/1b1b756d-064f-4b43-be1e-cdcfeb629300" />

closes #4935

