### PR TITLE
Fix correlation field parsing for Microsoft-Extensions-Logging TraceLogging events

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/TraceEventExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/TraceEventExtensions.cs
@@ -26,21 +26,22 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
             string argsJson = (string)traceEvent.PayloadValue(6);
             string formattedMessage = (string)traceEvent.PayloadValue(7);
 
-            string? activityTraceId;
-            string? activitySpanId;
-            string? activityTraceFlags;
-            if (traceEvent.Version >= 2)
+            string? activityTraceId = null;
+            string? activitySpanId = null;
+            string? activityTraceFlags = null;
+
+            int idxTraceId = traceEvent.PayloadIndex("ActivityTraceId");
+            int idxSpanId = traceEvent.PayloadIndex("ActivitySpanId");
+            if (idxTraceId >= 0 && idxSpanId >= 0)
             {
-                // Note: Trace correlation fields added in .NET 9
-                activityTraceId = (string)traceEvent.PayloadValue(8);
-                activitySpanId = (string)traceEvent.PayloadValue(9);
-                activityTraceFlags = (string)traceEvent.PayloadValue(10);
+                activityTraceId = (string)traceEvent.PayloadValue(idxTraceId);
+                activitySpanId = (string)traceEvent.PayloadValue(idxSpanId);
             }
-            else
+
+            int idxFlags = traceEvent.PayloadIndex("ActivityTraceFlags");
+            if (idxFlags >= 0)
             {
-                activityTraceId = null;
-                activitySpanId = null;
-                activityTraceFlags = null;
+                activityTraceFlags = (string)traceEvent.PayloadValue(idxFlags);
             }
 
             eventData = new(

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/TraceEventExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/TraceEventExtensions.cs
@@ -31,17 +31,17 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
             string? activityTraceFlags = null;
 
             int idxTraceId = traceEvent.PayloadIndex("ActivityTraceId");
-            int idxSpanId = traceEvent.PayloadIndex("ActivitySpanId");
-            if (idxTraceId >= 0 && idxSpanId >= 0)
+            if (idxTraceId >= 0)
             {
-                activityTraceId = (string)traceEvent.PayloadValue(idxTraceId);
-                activitySpanId = (string)traceEvent.PayloadValue(idxSpanId);
-            }
+                int idxSpanId = traceEvent.PayloadIndex("ActivitySpanId");
+                int idxFlags = traceEvent.PayloadIndex("ActivityTraceFlags");
 
-            int idxFlags = traceEvent.PayloadIndex("ActivityTraceFlags");
-            if (idxFlags >= 0)
-            {
-                activityTraceFlags = (string)traceEvent.PayloadValue(idxFlags);
+                if (idxSpanId >= 0 && idxFlags >= 0)
+                {
+                    activityTraceId = (string)traceEvent.PayloadValue(idxTraceId);
+                    activitySpanId = (string)traceEvent.PayloadValue(idxSpanId);
+                    activityTraceFlags = (string)traceEvent.PayloadValue(idxFlags);
+                }
             }
 
             eventData = new(

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/TraceEventExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/TraceEventExtensions.cs
@@ -26,10 +26,6 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
             string argsJson = (string)traceEvent.PayloadValue(6);
             string formattedMessage = (string)traceEvent.PayloadValue(7);
 
-            string? activityTraceId = null;
-            string? activitySpanId = null;
-            string? activityTraceFlags = null;
-
             // NOTE: The Microsoft-Extensions-Logging EventSource is created with
             // EventSourceSettings.EtwSelfDescribingEventFormat (TraceLogging). In TraceLogging,
             // the ETW event header Version is always 0 even if the [Event] attribute declares
@@ -37,19 +33,9 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
             // ActivityTraceFlags) were added in .NET 9, and with TraceLogging their presence
             // is discoverable only via payload schema (field names), not header Version.
             // Therefore we detect by payload name instead of checking traceEvent.Version.
-            int idxTraceId = traceEvent.PayloadIndex("ActivityTraceId");
-            if (idxTraceId >= 0)
-            {
-                int idxSpanId = traceEvent.PayloadIndex("ActivitySpanId");
-                int idxFlags = traceEvent.PayloadIndex("ActivityTraceFlags");
-
-                if (idxSpanId >= 0 && idxFlags >= 0)
-                {
-                    activityTraceId = (string)traceEvent.PayloadValue(idxTraceId);
-                    activitySpanId = (string)traceEvent.PayloadValue(idxSpanId);
-                    activityTraceFlags = (string)traceEvent.PayloadValue(idxFlags);
-                }
-            }
+            string? activityTraceId = (string)traceEvent.PayloadByName("ActivityTraceId");
+            string? activitySpanId = (string)traceEvent.PayloadByName("ActivitySpanId");
+            string? activityTraceFlags = (string)traceEvent.PayloadByName("ActivityTraceFlags");
 
             eventData = new(
                 traceEvent.TimeStamp,

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/TraceEventExtensions.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/Logs/TraceEventExtensions.cs
@@ -30,6 +30,13 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
             string? activitySpanId = null;
             string? activityTraceFlags = null;
 
+            // NOTE: The Microsoft-Extensions-Logging EventSource is created with
+            // EventSourceSettings.EtwSelfDescribingEventFormat (TraceLogging). In TraceLogging,
+            // the ETW event header Version is always 0 even if the [Event] attribute declares
+            // Version=2. The three correlation fields (ActivityTraceId, ActivitySpanId,
+            // ActivityTraceFlags) were added in .NET 9, and with TraceLogging their presence
+            // is discoverable only via payload schema (field names), not header Version.
+            // Therefore we detect by payload name instead of checking traceEvent.Version.
             int idxTraceId = traceEvent.PayloadIndex("ActivityTraceId");
             if (idxTraceId >= 0)
             {


### PR DESCRIPTION
Fixes #5557

**Description:**
This PR fixes a bug in `TraceEventExtensions.GetLogMessageJsonEventData` where `ActivityTraceId`, `ActivitySpanId`, and `ActivityTraceFlags` were never read because the method gated on `traceEvent.Version >= 2`.

Since `Microsoft-Extensions-Logging.LoggingEventSource` uses TraceLogging (`EtwSelfDescribingEventFormat`), the ETW event header always reports `Version=0`. As a result, the correlation fields introduced in .NET 9 were silently ignored.

**Changes:**

- Replace `traceEvent.Version >= 2` check with a payload name lookup for `"ActivityTraceId"`, `"ActivitySpanId"`, and `"ActivityTraceFlags"`.

- This ensures:
  - On runtimes where the fields don’t exist (<= .NET 8): values remain `null`.
  - On .NET 9+: fields are parsed correctly.

**Result**:
Out-of-process auto-instrumentation (dotnet-monitor) now receives full trace correlation data for logs emitted via `Microsoft-Extensions-Logging`.

<img width="3693" height="351" alt="image" src="https://github.com/user-attachments/assets/42395320-1691-4751-99d1-074a33e0fbdc" />

