### PR TITLE
Update the list of handle types in the !gchandles help

### DIFF
--- a/src/SOS/Strike/sosdocs.txt
+++ b/src/SOS/Strike/sosdocs.txt
@@ -1649,6 +1649,9 @@ Paremeters:
            Variable
            AsyncPinned
            SizedRef
+           Dependent
+           WeakWinRT
+           WeakInteriorPointer
 
 Sometimes the  source of a memory leak is a GCHandle leak. For example, code
 might keep a 50 Megabyte array alive because a strong GCHandle points to it,

--- a/src/SOS/Strike/sosdocsunix.txt
+++ b/src/SOS/Strike/sosdocsunix.txt
@@ -1433,6 +1433,9 @@ Paremeters:
            Variable
            AsyncPinned
            SizedRef
+           Dependent
+           WeakWinRT
+           WeakInteriorPointer
 
 Sometimes the  source of a memory leak is a GCHandle leak. For example, code
 might keep a 50 Megabyte array alive because a strong GCHandle points to it,


### PR DESCRIPTION
The documentation of `!gchandles` is outdated, the command supports more handle types than what is listed (I found out while trying to list dependent handles in a memory dump)