### PR TITLE
Remove check from SOS test

### DIFF
--- a/src/SOS/SOS.UnitTests/Scripts/StackTraceSoftwareExceptionFrame.script
+++ b/src/SOS/SOS.UnitTests/Scripts/StackTraceSoftwareExceptionFrame.script
@@ -36,7 +36,6 @@ VERIFY:\s+<DECVAL>\s+<DECVAL>\s+<HEXVAL>\s+<HEXVAL>.*\s+
 SOSCOMMAND:ClrStack
 VERIFY:.*OS Thread Id:\s+0x<HEXVAL>\s+.*
 VERIFY:\s+Child\s+SP\s+IP\s+Call Site\s+
-VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+\[InlinedCallFrame: <HEXVAL>\]\s+
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+\[SoftwareExceptionFrame: <HEXVAL>\]\s+
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+UserObject\.UseObject(\(.*\))?\s+
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+Simple\.Main(\(.*\))?\s+


### PR DESCRIPTION
Runtime frames changed and this ICF is no longer present at execution point.


runtime-diagnostics on head of runtime with fix: https://dev.azure.com/dnceng-public/public/_build/results?buildId=1163752&view=results

https://github.com/dotnet/runtime/pull/119863
runtime-diagnostics on head of diagnostics before runtime change above: https://dev.azure.com/dnceng-public/public/_build/results?buildId=1163755&view=results