### PR TITLE
Try to reduce variance in FindRootsOlderGeneration SOS test

### DIFF
--- a/src/SOS/SOS.UnitTests/Debuggees/FindRootsOlderGeneration/Program.cs
+++ b/src/SOS/SOS.UnitTests/Debuggees/FindRootsOlderGeneration/Program.cs
@@ -24,6 +24,11 @@ internal class Program
         Debugger.Break();
 
         Console.WriteLine("Forcing GC...");
+
+        // On CI runs, in server GC mode, these collects have sometimes triggered
+        // a gen 2 collection that is not expected and causes the test to fail.
+        // Adding "SustainedLowLatency" mode to try to prevent that.
+        GCSettings.LatencyMode = GCLatencyMode.SustainedLowLatency;
         GC.Collect(0, GCCollectionMode.Forced, true);
         GC.Collect(0, GCCollectionMode.Forced, true);
         Console.WriteLine("GC complete.");


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/120317

See runs linked in issue. Sometimes on CI and server GC mode, the debuggee will have a gen 2 collection rather than a gen 0 collection. This invalidates the assumptions of the test and causes it to fail. It appears setting `GCSettings.LatencyMode = GCLatencyMode.SustainedLowLatency` should prevent gen 2 collections.