### PR TITLE
FindRootsOlderGeneration refactor

### DIFF
--- a/src/SOS/SOS.UnitTests/Debuggees/FindRootsOlderGeneration/Program.cs
+++ b/src/SOS/SOS.UnitTests/Debuggees/FindRootsOlderGeneration/Program.cs
@@ -24,6 +24,11 @@ internal class Program
         Debugger.Break();
 
         Console.WriteLine("Forcing GC...");
+
+        // On CI runs, in server GC mode, these collects have sometimes triggered
+        // a gen 2 collection that is not expected and causes the test to fail.
+        // Adding "SustainedLowLatency" mode to try to prevent that.
+        GCSettings.LatencyMode = GCLatencyMode.SustainedLowLatency;
         GC.Collect(0, GCCollectionMode.Forced, true);
         GC.Collect(0, GCCollectionMode.Forced, true);
         Console.WriteLine("GC complete.");

--- a/src/SOS/SOS.UnitTests/Scripts/FindRootsOlderGeneration.script
+++ b/src/SOS/SOS.UnitTests/Scripts/FindRootsOlderGeneration.script
@@ -21,9 +21,6 @@ COMMAND:sxe CLRN
 # Should break on a GCNotification
 CONTINUE
 
-# Verify that we triggered a gen 0 or gen 1 collection
-VERIFY:Performing\s+a\s+gen\s+[01]\s+collection
-
 # Print list of threads with their stacks
 SOSCOMMAND:clrstack -all
 

--- a/src/SOS/SOS.UnitTests/Scripts/FindRootsOlderGeneration.script
+++ b/src/SOS/SOS.UnitTests/Scripts/FindRootsOlderGeneration.script
@@ -21,8 +21,10 @@ COMMAND:sxe CLRN
 # Should break on a GCNotification
 CONTINUE
 
-# Print list of threads with their stacks
+# Verify that we triggered a gen 0 or gen 1 collection
+VERIFY:Performing\s+a\s+gen\s+[01]\s+collection
 
+# Print list of threads with their stacks
 SOSCOMMAND:clrstack -all
 
 # Switch to main runtime thread


### PR DESCRIPTION
This test is still being flaky due to server GC attempting to collect the gen2 heap. I modified the test to force the entire LOH array to be alive which should prevent the GC from doing a gen2 collection.

Distinct invocations of `runtime-diagnostics` to test flakiness:
* https://dev.azure.com/dnceng-public/public/_build/results?buildId=1164893
* https://dev.azure.com/dnceng-public/public/_build/results?buildId=1164894
* https://dev.azure.com/dnceng-public/public/_build/results?buildId=1164895