### PR TITLE
Remove `FreeLibrary` invocations in managed SOS host

### DIFF
--- a/src/SOS/SOS.Hosting/RuntimeWrapper.cs
+++ b/src/SOS/SOS.Hosting/RuntimeWrapper.cs
@@ -158,10 +158,13 @@ namespace SOS.Hosting
             }
             if (_dacHandle != IntPtr.Zero)
             {
+                // Previously, the DAC was freed here, but as we transition to the cDAC which uses NativeAOT,
+                // it is no longer possible to free the DAC library when it is using the shimmed cDAC.
                 _dacHandle = IntPtr.Zero;
             }
             if (_cdacHandle != IntPtr.Zero)
             {
+                // cDAC can not be freed because it is a NativeAOT dll.
                 _cdacHandle = IntPtr.Zero;
             }
             if (_dbiHandle != IntPtr.Zero)


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/117785, the `runtime-diagnostics` pipeline has had intermittent failures due to SOS freeing the DAC/cDAC library and causing a double free race condition. 

[NativeAOT binaries do not support being unloaded](https://github.com/dotnet/runtime/issues/103028#issuecomment-2147709895), therefore this will be required for future cDAC use. 

This change doesn't impact the native host, but in most scenarios the managed host is favored.