### PR TITLE
Add uncompressed windbg manifest generation to SOS build

### DIFF
--- a/src/SOS/SOS.Package/GenerateManifest/GenerateManifest.cs
+++ b/src/SOS/SOS.Package/GenerateManifest/GenerateManifest.cs
@@ -1,0 +1,67 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System.Xml.Linq;
+using System.Xml.XPath;
+
+const string ExpectedParameters = "<GalleryManifestBaseTemplate> <GalleryManifestPath> <CompressedManifestPath> <ExtensionVersion>";
+
+const string FilesXpathInPackageElement = "Components/BinaryComponent/Files";
+const string CompressedGalleryManifestTemplate = """
+<?xml version="1.0" encoding="utf-8"?>
+<ExtensionPackages Version="1.0.0.0" Compression="none">
+</ExtensionPackages>
+""";
+
+if (args is null || args.Length != 4)
+{
+    Console.Error.WriteLine("Expected parameters: {0}", ExpectedParameters);
+    return -1;
+}
+
+string galleryManifestBaseTemplate = args[0];
+string galleryManifestPath = args[1];
+string uncompressedManifestPath = args[2];
+string extensionVersion = args[3];
+
+// Compressed and uncompressed manifests are the same for SOS except for two main differences:
+// - The compressed manifest has the ExtensionPackage as a top level element, while the uncompressed manifest has ExtensionPackages as the top level element
+//   with Compression="none" attribute. The uncompressed manifest contains a single ExtensionPackage element with the ExtensionPackage that would appear in
+//   the compressed manifest as a child element.
+// - The uncompressed manifest's ExtensionPackage contains a single File element pointing to the architecture-specific extension installed by the win SDK installer.
+//   The compressed manifest's ExtensionPackage contains a File element per architecture as the extension gallery ships all of them in one.
+Console.WriteLine("Generating manifests for SOS version {0}", extensionVersion);
+
+XDocument galleryManifest = XDocument.Load(galleryManifestBaseTemplate);
+XElement extensionPackageElement = galleryManifest.Root!;
+extensionPackageElement.XPathSelectElement("Version")!.Value = extensionVersion;
+
+// Create uncompressed manifest with the updated version.
+XDocument uncompressedGalleryManifest = XDocument.Parse(CompressedGalleryManifestTemplate);
+XElement extensionPackageInCompressedManifest = new(extensionPackageElement);
+uncompressedGalleryManifest.Root!.Add(extensionPackageInCompressedManifest);
+
+Console.WriteLine("Generating extension gallery manifest.");
+// Update compressed/regular manifest to have a File element per RID since the gallery ships all architectures in one package.
+XElement files = extensionPackageElement.XPathSelectElement(FilesXpathInPackageElement)!;
+files.RemoveNodes();
+files.Add(
+    new XElement("File", new XAttribute("Architecture", "amd64"), new XAttribute("Module", "win-x64\\sos.dll")),
+    new XElement("File", new XAttribute("Architecture", "x86"), new XAttribute("Module", "win-x86\\sos.dll")),
+    new XElement("File", new XAttribute("Architecture", "arm64"), new XAttribute("Module", "win-arm64\\sos.dll")));
+
+// Create folder if it doesn't exist and save the gallery manifest.
+Directory.CreateDirectory(Path.GetDirectoryName(galleryManifestPath)!);
+galleryManifest.Save(galleryManifestPath);
+
+Console.WriteLine("Generating debugger layout (uncompressed) manifest.");
+// Update uncompressed manifest to have a single File element pointing to the winext\sos\sos.dll path.
+// The installer is responsible for installing the correct architecture-specific DLL.
+XElement uncompressedFiles = extensionPackageInCompressedManifest.XPathSelectElement(FilesXpathInPackageElement)!;
+uncompressedFiles.RemoveNodes();
+uncompressedFiles.Add(
+    new XElement("File", new XAttribute("Architecture", "Any"), new XAttribute("Module", "winext\\sos\\sos.dll"), new XAttribute("FilePathKind", "RepositoryRelative")));
+Directory.CreateDirectory(Path.GetDirectoryName(uncompressedManifestPath)!);
+uncompressedGalleryManifest.Save(uncompressedManifestPath);
+
+Console.WriteLine("Done.");
+return 0;

--- a/src/SOS/SOS.Package/ManifestBase.xml
+++ b/src/SOS/SOS.Package/ManifestBase.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ExtensionPackage>
+  <Name>SOS</Name>
+  <Version />
+  <Description>Debugging aid for .NET Core programs and runtimes</Description>
+  <Components>
+    <BinaryComponent Name="sos" Type="Engine">
+      <Files />
+      <LoadTriggers>
+        <TriggerSet>
+          <ModuleTrigger Name="coreclr.dll" />
+        </TriggerSet>
+        <TriggerSet>
+          <ModuleTrigger Name="libcoreclr.so" />
+        </TriggerSet>
+        <TriggerSet>
+          <ExceptionTrigger ExceptionCode="0xC0000409">
+            <Parameters>
+              <Parameter Index="0" Value="0x48" />
+            </Parameters>
+          </ExceptionTrigger>
+        </TriggerSet>
+        <TriggerSet>
+          <ExceptionTrigger ExceptionCode="0xC000027B" />
+        </TriggerSet>
+        <TriggerSet>
+          <ExceptionTrigger ExceptionCode="0xC000027C" />
+        </TriggerSet>
+      </LoadTriggers>
+      <EngineCommands>
+        <EngineCommand Name="soshelp">
+          <EngineCommandItem>
+            <Syntax>!soshelp</Syntax>
+            <Description>Displays all available SOS commands or details about the command</Description>
+          </EngineCommandItem>
+        </EngineCommand>
+      </EngineCommands>
+    </BinaryComponent>
+  </Components>
+</ExtensionPackage>

--- a/src/SOS/SOS.Package/SOS.Package.csproj
+++ b/src/SOS/SOS.Package/SOS.Package.csproj
@@ -9,7 +9,9 @@
     <IsPackable>true</IsPackable>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <SOSPackagePathPrefix>tools</SOSPackagePathPrefix>
-    <GalleryManifestName>$(ArtifactsPackagesDir)\GalleryManifest.xml</GalleryManifestName>
+    <GalleryManifestBase>$(MSBuildThisFileDirectory)ManifestBase.xml</GalleryManifestBase>
+    <ExtensionGalleryManifestOutputFile>$(IntermediateOutputPath)sos_GalleryManifest.xml</ExtensionGalleryManifestOutputFile>
+    <UncompressedGalleryManifestOutputFile>$(IntermediateOutputPath)GalleryManifest.xml</UncompressedGalleryManifestOutputFile>
     <BeforePack>GenerateGalleryManifest</BeforePack>
     <IsShipping>true</IsShipping>
     <IsShippingPackage>false</IsShippingPackage>
@@ -22,7 +24,11 @@
   <Target Name="Build" />
 
   <ItemGroup>
-    <None Include="$(GalleryManifestName)" Pack="true" Visible="false">
+    <Compile Remove="**/*.cs" />
+    <None Include="$(ExtensionGalleryManifestOutputFile)" Pack="true" Visible="false">
+      <PackagePath>$(SOSPackagePathPrefix)</PackagePath>
+    </None>
+    <None Include="$(UncompressedGalleryManifestOutputFile)" Pack="true" Visible="false">
       <PackagePath>$(SOSPackagePathPrefix)</PackagePath>
     </None>
     <None Include="$(SOSExtensionsBinaries)" Pack="true" Visible="false">
@@ -30,64 +36,18 @@
     </None>
   </ItemGroup>
 
+  <!-- This target generates the gallery manifest files, both the extension gallery format and
+   the uncompressed one used by the SDK installer. -->
   <Target Name="GenerateGalleryManifest"
     DependsOnTargets="GetAssemblyVersion;AddSourceRevisionToInformationalVersion">
-    <PropertyGroup>
-      <GalleryManifestLines>
-<![CDATA[
-<?xml version="1.0" encoding="utf-8"?>
-<ExtensionPackage>
-  <Name>SOS</Name>
-  <Version>$(FileVersion)</Version>
-  <Description>Debugging aid for .NET Core programs and runtimes</Description>
-  <Components>
-    <BinaryComponent Name="sos" Type="Engine">
-      <Files>
-        <File Architecture="amd64" Module="win-x64\sos.dll" />
-        <File Architecture="x86" Module="win-x86\sos.dll" />
-        <File Architecture="arm64" Module="win-arm64\sos.dll" />
-      </Files>
-      <LoadTriggers>
-        <TriggerSet>
-          <ModuleTrigger Name="coreclr.dll" />
-        </TriggerSet>
-        <TriggerSet>
-          <ModuleTrigger Name="libcoreclr.so" />
-        </TriggerSet>
-        <TriggerSet>
-          <ExceptionTrigger ExceptionCode="0xC0000409">
-            <Parameters>
-              <Parameter Index="0" Value="0x48" />
-            </Parameters>
-          </ExceptionTrigger>
-        </TriggerSet>
-        <TriggerSet>
-          <ExceptionTrigger ExceptionCode="0xC000027B" />
-        </TriggerSet>
-        <TriggerSet>
-          <ExceptionTrigger ExceptionCode="0xC000027C" />
-        </TriggerSet>
-      </LoadTriggers>
-      <EngineCommands>
-        <EngineCommand Name="soshelp">
-          <EngineCommandItem>
-            <Syntax>!soshelp</Syntax>
-            <Description>Displays all available SOS commands or details about the command</Description>
-          </EngineCommandItem>
-        </EngineCommand>
-      </EngineCommands>
-    </BinaryComponent>
-  </Components>
-</ExtensionPackage>
-]]>
-      </GalleryManifestLines>
-    </PropertyGroup>
 
-    <WriteLinesToFile File="$(GalleryManifestName)" Lines="$(GalleryManifestLines)" Overwrite="true" />
+    <Exec Command="$(DotNetTool) run --file $(MSBuildThisFileDirectory)GenerateManifest\GenerateManifest.cs &quot;$(GalleryManifestBase)&quot; &quot;$(ExtensionGalleryManifestOutputFile)&quot; &quot;$(UncompressedGalleryManifestOutputFile)&quot; &quot;$(FileVersion)&quot;" />
 
     <ItemGroup>
-      <FileWrites Include="$(GalleryManifestName)" />
+      <FileWrites Include="$(ExtensionGalleryManifestOutputFile)" />
+      <FileWrites Include="$(UncompressedGalleryManifestOutputFile)" />
     </ItemGroup>
+
   </Target>
 
 </Project>

--- a/src/SOS/SOS.Package/SOS.Symbol.Package.csproj
+++ b/src/SOS/SOS.Package/SOS.Symbol.Package.csproj
@@ -14,6 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="**/*.cs" />
     <None Include="$(ArtifactsBinDir)\SOS.Extensions\$(Configuration)\netstandard2.0\publish\*.pdb" Pack="true" Visible="false">
       <PackagePath>$(SOSPackagePathPrefix)/lib</PackagePath>
     </None>


### PR DESCRIPTION
- Use file-based app to generate manifests for SOS packages
- Generate both regular and uncompressed manifest formats