### PR TITLE
Allow crashinfo to work correctly on dotnet-dump and hide on live attach

### DIFF
--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/ModuleServiceFromDataReader.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/ModuleServiceFromDataReader.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
+using System.Runtime.InteropServices;
 using Microsoft.Diagnostics.Runtime;
 
 namespace Microsoft.Diagnostics.DebugServices.Implementation
@@ -160,6 +161,30 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
                 }
             }
             return modules;
+        }
+
+        public override IModule EntryPointModule
+        {
+            get
+            {
+                foreach (IModule module in ((IModuleService)this).EnumerateModules())
+                {
+                    if (Target.OperatingSystem == OSPlatform.Windows)
+                    {
+                        // The entry point module is not necessarily the first module in the sorted list of modules.
+                        if (module.FileName?.EndsWith(".exe", StringComparison.OrdinalIgnoreCase) == true)
+                        {
+                            return module;
+                        }
+                    }
+                    else
+                    {
+                        // On non-Windows, assume the entry point module is the first module.
+                        return module;
+                    }
+                }
+                return null;
+            }
         }
     }
 }

--- a/src/Microsoft.Diagnostics.ExtensionCommands/CrashInfoCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/CrashInfoCommand.cs
@@ -22,9 +22,12 @@ namespace Microsoft.Diagnostics.ExtensionCommands
         [Option(Name = "--moduleEnumerationScheme", Aliases = new string[] { "-e" }, Help = "Enables searching modules for the NativeAOT crashinfo data.  Default is None")]
         public ModuleEnumerationScheme ModuleEnumerationScheme { get; set; } = ModuleEnumerationScheme.None;
 
+        [FilterInvoke(Message = "This command is only supported with dumps.")]
+        public static bool FilterInvoke([ServiceImport(Optional = true)] ICrashInfoModuleService crashInfoFactory) => crashInfoFactory != null;
+
         public override void Invoke()
         {
-            ICrashInfoService crashInfo = CrashInfo ?? CrashInfoFactory.Create(ModuleEnumerationScheme);
+            ICrashInfoService crashInfo = CrashInfo ?? CrashInfoFactory?.Create(ModuleEnumerationScheme);
             if (crashInfo == null)
             {
                 throw new DiagnosticsException("No crash info to display");


### PR DESCRIPTION
This modifies the `crashinfo` command to only load if the ICrashInfoModuleService loads, which means that the data target is a dump either hosted by a debugger or dotnet-dump.  The EntryPoint module on windows might not be the first module loaded, so it will locate the first module that has an EXE file extension.