### PR TITLE
Refine compiler options for signed overflow and aliasing

### DIFF
--- a/eng/native/configurecompiler.cmake
+++ b/eng/native/configurecompiler.cmake
@@ -526,9 +526,14 @@ if (CLR_CMAKE_HOST_UNIX)
   # Disable frame pointer optimizations so profilers can get better call stacks
   add_compile_options(-fno-omit-frame-pointer)
 
-  # Make signed arithmetic overflow of addition, subtraction, and multiplication wrap around
+  # Make signed overflow well-defined. Implies the following flags in clang-20 and above.
+  # -fwrapv - Make signed arithmetic overflow of addition, subtraction, and multiplication wrap around
   # using twos-complement representation (this is normally undefined according to the C++ spec).
-  add_compile_options(-fwrapv)
+  # -fwrapv-pointer - The same as -fwrapv but for pointers.
+  add_compile_options(-fno-strict-overflow)
+
+  # Suppress C++ strict aliasing rules. This matches our use of MSVC.
+  add_compile_options(-fno-strict-aliasing)
 
   if(CLR_CMAKE_HOST_APPLE)
     # Clang will by default emit objc_msgSend stubs in Xcode 14, which ld from earlier Xcodes doesn't understand.


### PR DESCRIPTION
Updated comments and compile options for signed overflow and strict aliasing.

See related code for dotnet/runtime - https://github.com/dotnet/runtime/pull/120775