### PR TITLE
[dotnet-trace] Pack librecordtrace

### DIFF
--- a/src/Tools/dotnet-trace/dotnet-trace.csproj
+++ b/src/Tools/dotnet-trace/dotnet-trace.csproj
@@ -32,7 +32,11 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetRid)' != '' and $([System.String]::Copy('$(TargetRid)').StartsWith('linux'))">
-    <None Include="$(PkgMicrosoft_OneCollect_RecordTrace)/runtimes/$(TargetRid)/native/librecordtrace.so" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest"
+    <None Include="$(PkgMicrosoft_OneCollect_RecordTrace)/runtimes/$(TargetRid)/native/librecordtrace.so"
+          Pack="true"
+          Visible="false"
+          CopyToOutputDirectory="PreserveNewest"
+          CopyToPublishDirectory="PreserveNewest"
           Condition="Exists('$(PkgMicrosoft_OneCollect_RecordTrace)/runtimes/$(TargetRid)/native/librecordtrace.so')" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes librecordtrace.so not being packed into the official build of dotnet-trace.