### PR TITLE
[dotnet-trace] Improve supported platform messages for musl.

### DIFF
--- a/src/Tools/Common/Commands/Utils.cs
+++ b/src/Tools/Common/Commands/Utils.cs
@@ -4,8 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
-using System.Runtime.InteropServices;
 using Microsoft.Diagnostics.NETCore.Client;
 using Microsoft.Diagnostics.Tools.Common;
 
@@ -194,37 +192,6 @@ namespace Microsoft.Internal.Common.Utils
             }
             resolvedProcessId = processId;
             return true;
-        }
-
-        public static string GetRid()
-        {
-            string os = null;
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                os = "win";
-            }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                os = "osx";
-            }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                os = "linux";
-                try
-                {
-                    string ostype = File.ReadAllText("/etc/os-release");
-                    if (ostype.Contains("ID=alpine"))
-                    {
-                        os = "linux-musl";
-                    }
-                }
-                catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException or IOException)
-                {
-                }
-            }
-            os ??= "unknown";
-            string architectureString = RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant();
-            return $"{os}-{architectureString}";
         }
     }
 

--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectLinuxCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectLinuxCommand.cs
@@ -23,12 +23,6 @@ namespace Microsoft.Diagnostics.Tools.Trace
         private LineRewriter rewriter;
         private long statusUpdateTimestamp;
 
-        public static readonly string[] SupportedRids = new[]
-        {
-            "linux-x64",
-            "linux-arm64"
-        };
-
         internal sealed record CollectLinuxArgs(
             CancellationToken Ct,
             string[] Providers,
@@ -47,17 +41,33 @@ namespace Microsoft.Diagnostics.Tools.Trace
             rewriter = new LineRewriter(Console);
         }
 
+        internal static bool IsSupported()
+        {
+            bool isSupportedLinuxPlatform = false;
+            if (OperatingSystem.IsLinux())
+            {
+                isSupportedLinuxPlatform = true;
+                try
+                {
+                    string ostype = File.ReadAllText("/etc/os-release");
+                    isSupportedLinuxPlatform = !ostype.Contains("ID=alpine");
+                }
+                catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException or IOException) {}
+            }
+
+            return isSupportedLinuxPlatform;
+        }
+
         /// <summary>
         /// Collects diagnostic traces using perf_events, a Linux OS technology. collect-linux requires admin privileges to capture kernel- and user-mode events, and by default, captures events from all processes.
         /// This Linux-only command includes the same .NET events as dotnet-trace collect, and it uses the kernel’s user_events mechanism to emit .NET events as perf events, enabling unification of user-space .NET events with kernel-space system events.
         /// </summary>
         internal int CollectLinux(CollectLinuxArgs args)
         {
-            string rid = CommandUtils.GetRid();
-            if (!SupportedRids.Contains(rid))
+            if (!IsSupported())
             {
-                Console.Error.WriteLine($"The collect-linux command is not supported on the current platform '{rid}'.");
-                Console.Error.WriteLine($"Supported platforms are: {string.Join(", ", SupportedRids)}.");
+                Console.Error.WriteLine("The collect-linux command is not supported on this platform.");
+                Console.Error.WriteLine("For requirements, please visit https://learn.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-trace.");
                 return (int)ReturnCode.PlatformNotSupportedError;
             }
 

--- a/src/tests/dotnet-trace/CollectLinuxCommandFunctionalTests.cs
+++ b/src/tests/dotnet-trace/CollectLinuxCommandFunctionalTests.cs
@@ -18,7 +18,6 @@ namespace Microsoft.Diagnostics.Tools.Trace
 {
     public class CollectLinuxCommandFunctionalTests
     {
-        private string _testRid = CommandUtils.GetRid();
         private static CollectLinuxCommandHandler.CollectLinuxArgs TestArgs(
             CancellationToken ct = default,
             string[] providers = null,
@@ -49,7 +48,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
         {
             MockConsole console = new(200, 30);
             int exitCode = Run(testArgs, console);
-            if (CollectLinuxCommandHandler.SupportedRids.Contains(_testRid))
+            if (CollectLinuxCommandHandler.IsSupported())
             {
                 Assert.Equal((int)ReturnCode.Ok, exitCode);
                 console.AssertSanitizedLinesEqual(CollectLinuxSanitizer, expectedLines);
@@ -58,8 +57,8 @@ namespace Microsoft.Diagnostics.Tools.Trace
             {
                 Assert.Equal((int)ReturnCode.PlatformNotSupportedError, exitCode);
                 console.AssertSanitizedLinesEqual(null, new string[] {
-                    $"The collect-linux command is not supported on the current platform '{_testRid}'.",
-                    $"Supported platforms are: {string.Join(", ", CollectLinuxCommandHandler.SupportedRids)}."
+                    $"The collect-linux command is not supported on this platform.",
+                    $"For requirements, please visit https://learn.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-trace."
                 });
             }
         }
@@ -70,7 +69,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
         {
             MockConsole console = new(200, 30);
             int exitCode = Run(testArgs, console);
-            if (CollectLinuxCommandHandler.SupportedRids.Contains(_testRid))
+            if (CollectLinuxCommandHandler.IsSupported())
             {
                 Assert.Equal((int)ReturnCode.TracingError, exitCode);
                 console.AssertSanitizedLinesEqual(null, expectedException);
@@ -79,8 +78,8 @@ namespace Microsoft.Diagnostics.Tools.Trace
             {
                 Assert.Equal((int)ReturnCode.PlatformNotSupportedError, exitCode);
                 console.AssertSanitizedLinesEqual(null, new string[] {
-                    $"The collect-linux command is not supported on the current platform '{_testRid}'.",
-                    $"Supported platforms are: {string.Join(", ", CollectLinuxCommandHandler.SupportedRids)}."
+                    $"The collect-linux command is not supported on this platform.",
+                    $"For requirements, please visit https://learn.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-trace."
                 });
             }
         }


### PR DESCRIPTION
RecordTrace does not build for musl platforms at this time.