### PR TITLE
[dotnet-trace][collect-linux] Handle incompatible glibc

### DIFF
--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectLinuxCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectLinuxCommand.cs
@@ -95,9 +95,10 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 Console.Error.WriteLine($"[ERROR] {e.Message}");
                 ret = (int)ReturnCode.TracingError;
             }
-            catch (DllNotFoundException)
+            catch (DllNotFoundException dnfe)
             {
                 Console.Error.WriteLine($"[ERROR] Could not find or load dependencies for collect-linux. For requirements, please visit https://learn.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-trace");
+                Console.Error.WriteLine($"[ERROR] {dnfe.Message}");
                 ret = (int)ReturnCode.PlatformNotSupportedError;
             }
             catch (Exception ex)


### PR DESCRIPTION
Not all supported RIDs will be compatible with RecordTrace, which currently has a minimum requirement of glibc 2.34. So users running `dotnet-trace collect-linux` in older distros will be unable to p/invoke `librecordtrace.so` even though they are running on Linux x64/arm64.