### PR TITLE
[Tests][CollectLinux] Reduce redundant unsupported validation

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -30,6 +30,7 @@
     <MicrosoftBclAsyncInterfacesVersion>9.0.8</MicrosoftBclAsyncInterfacesVersion>
     <MicrosoftDiaSymReaderNativeVersion>17.10.0-beta1.24272.1</MicrosoftDiaSymReaderNativeVersion>
     <MicrosoftDiagnosticsTracingTraceEventVersion>3.1.23</MicrosoftDiagnosticsTracingTraceEventVersion>
+    <MicrosoftDotNetXUnitExtensionsVersion>11.0.0-beta.25528.108</MicrosoftDotNetXUnitExtensionsVersion>
     <MicrosoftExtensionsLoggingVersion>8.0.1</MicrosoftExtensionsLoggingVersion>
     <MicrosoftExtensionsLoggingAbstractionsVersion>8.0.3</MicrosoftExtensionsLoggingAbstractionsVersion>
     <MicrosoftExtensionsLoggingConsoleVersion>8.0.1</MicrosoftExtensionsLoggingConsoleVersion>

--- a/src/tests/dotnet-trace/CollectLinuxCommandFunctionalTests.cs
+++ b/src/tests/dotnet-trace/CollectLinuxCommandFunctionalTests.cs
@@ -5,12 +5,13 @@ using System;
 using System.Collections.Generic;
 using System.CommandLine;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Linq;
 using Microsoft.Diagnostics.Tests.Common;
 using Microsoft.Diagnostics.Tools.Trace;
+using Microsoft.DotNet.XUnitExtensions;
 using Microsoft.Internal.Common.Utils;
 using Xunit;
 
@@ -18,6 +19,8 @@ namespace Microsoft.Diagnostics.Tools.Trace
 {
     public class CollectLinuxCommandFunctionalTests
     {
+        public static bool IsCollectLinuxSupported => CollectLinuxCommandHandler.IsSupported();
+        public static bool IsCollectLinuxNotSupported => !CollectLinuxCommandHandler.IsSupported();
         private static CollectLinuxCommandHandler.CollectLinuxArgs TestArgs(
             CancellationToken ct = default,
             string[] providers = null,
@@ -42,46 +45,36 @@ namespace Microsoft.Diagnostics.Tools.Trace
                                                                    processId);
         }
 
-        [Theory]
+        [ConditionalTheory(nameof(IsCollectLinuxSupported))]
         [MemberData(nameof(BasicCases))]
         public void CollectLinuxCommandProviderConfigurationConsolidation(object testArgs, string[] expectedLines)
         {
             MockConsole console = new(200, 30);
             int exitCode = Run(testArgs, console);
-            if (CollectLinuxCommandHandler.IsSupported())
-            {
-                Assert.Equal((int)ReturnCode.Ok, exitCode);
-                console.AssertSanitizedLinesEqual(CollectLinuxSanitizer, expectedLines);
-            }
-            else
-            {
-                Assert.Equal((int)ReturnCode.PlatformNotSupportedError, exitCode);
-                console.AssertSanitizedLinesEqual(null, new string[] {
-                    $"The collect-linux command is not supported on this platform.",
-                    $"For requirements, please visit https://learn.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-trace."
-                });
-            }
+            Assert.Equal((int)ReturnCode.Ok, exitCode);
+            console.AssertSanitizedLinesEqual(CollectLinuxSanitizer, expectedLines);
         }
 
-        [Theory]
+        [ConditionalTheory(nameof(IsCollectLinuxSupported))]
         [MemberData(nameof(InvalidProviders))]
         public void CollectLinuxCommandProviderConfigurationConsolidation_Throws(object testArgs, string[] expectedException)
         {
             MockConsole console = new(200, 30);
             int exitCode = Run(testArgs, console);
-            if (CollectLinuxCommandHandler.IsSupported())
-            {
-                Assert.Equal((int)ReturnCode.ArgumentError, exitCode);
-                console.AssertSanitizedLinesEqual(null, expectedException);
-            }
-            else
-            {
-                Assert.Equal((int)ReturnCode.PlatformNotSupportedError, exitCode);
-                console.AssertSanitizedLinesEqual(null, new string[] {
-                    $"The collect-linux command is not supported on this platform.",
-                    $"For requirements, please visit https://learn.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-trace."
-                });
-            }
+            Assert.Equal((int)ReturnCode.ArgumentError, exitCode);
+            console.AssertSanitizedLinesEqual(null, expectedException);
+        }
+
+        [ConditionalFact(nameof(IsCollectLinuxNotSupported))]
+        public void CollectLinuxCommand_NotSupported_OnNonLinux()
+        {
+            MockConsole console = new(200, 30);
+            int exitCode = Run(TestArgs(), console);
+            Assert.Equal((int)ReturnCode.PlatformNotSupportedError, exitCode);
+            console.AssertSanitizedLinesEqual(null, new string[] {
+                "The collect-linux command is not supported on this platform.",
+                "For requirements, please visit https://learn.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-trace."
+            });
         }
 
         private static int Run(object args, MockConsole console)

--- a/src/tests/dotnet-trace/DotnetTrace.UnitTests.csproj
+++ b/src/tests/dotnet-trace/DotnetTrace.UnitTests.csproj
@@ -5,6 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.XUnitExtensions" Version="$(MicrosoftDotNetXUnitExtensionsVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\Tools\dotnet-trace\dotnet-trace.csproj" />
     <ProjectReference Include="..\CommonTestRunner\CommonTestRunner.csproj" />
   </ItemGroup>


### PR DESCRIPTION
As functional test cases increase, validating unsupported behavior becomes more redundant. Instead, leverage ConditionalFact and ConditionalTheory attributes from Microsoft.DotNet.XUnitExtensions https://github.com/dotnet/arcade/tree/main/src/Microsoft.DotNet.XUnitExtensions.Shared/Attributes to simplify test logic.