### PR TITLE
Fix build break with clang-21 on linux-x64

### DIFF
--- a/src/shared/gcinfo/gcinfodumper.cpp
+++ b/src/shared/gcinfo/gcinfodumper.cpp
@@ -617,7 +617,7 @@ GcInfoDumper::EnumerateStateChangesResults GcInfoDumper::EnumerateStateChanges (
 
     REGDISPLAY regdisp;
 
-    ZeroMemory(&regdisp, sizeof(regdisp));
+    ZeroMemory(static_cast<void*>(&regdisp), sizeof(regdisp));
 
     regdisp.pContext = &regdisp.ctxOne;
     regdisp.IsCallerContextValid = TRUE;

--- a/src/shared/inc/regdisp.h
+++ b/src/shared/inc/regdisp.h
@@ -258,7 +258,7 @@ struct REGDISPLAY : public REGDISPLAY_BASE {
     REGDISPLAY()
     {
         // Initialize
-        memset(this, 0, sizeof(REGDISPLAY));
+        memset(static_cast<void*>(this), 0, sizeof(REGDISPLAY));
     }
 };
 


### PR DESCRIPTION
linux-x64 build with clang-21 fails with below error. 

```
[  248s] In file included from /home/abuild/rpmbuild/BUILD/coreclr-diagnostics-8.0.547301/src/SOS/Strike/disasm.cpp:57:
[  248s] In file included from /home/abuild/rpmbuild/BUILD/coreclr-diagnostics-8.0.547301/src/shared/gcdump/gcdumpnonx86.cpp:13:
[  248s] In file included from /home/abuild/rpmbuild/BUILD/coreclr-diagnostics-8.0.547301/src/shared/inc/gcinfodecoder.h:170:
[  248s] /home/abuild/rpmbuild/BUILD/coreclr-diagnostics-8.0.547301/src/shared/inc/regdisp.h:261:16: error: first argument in call to 'memset' is a pointer to non-trivially copyable type 'REGDISPLAY' [-Werror,-Wnontrivial-memcall]
[  248s]   261 |         memset(this, 0, sizeof(REGDISPLAY));
[  248s]       |                ^
[  248s] /home/abuild/rpmbuild/BUILD/coreclr-diagnostics-8.0.547301/src/shared/inc/regdisp.h:261:16: note: explicitly cast the pointer to silence this warning
[  248s]   261 |         memset(this, 0, sizeof(REGDISPLAY));
[  248s]       |                ^
[  248s]       |                (void*)
[  248s] In file included from /home/abuild/rpmbuild/BUILD/coreclr-diagnostics-8.0.547301/src/SOS/Strike/disasm.cpp:57:
[  248s] In file included from /home/abuild/rpmbuild/BUILD/coreclr-diagnostics-8.0.547301/src/shared/gcdump/gcdumpnonx86.cpp:591:
[  248s] /home/abuild/rpmbuild/BUILD/coreclr-diagnostics-8.0.547301/src/shared/gcdump/../gcinfo/gcinfodumper.cpp:620:16: error: first argument in call to 'memset' is a pointer to non-trivially copyable type 'REGDISPLAY' [-Werror,-Wnontrivial-memcall]
[  248s]   620 |     ZeroMemory(&regdisp, sizeof(regdisp));
[  248s]       |                ^
[  248s] /home/abuild/rpmbuild/BUILD/coreclr-diagnostics-8.0.547301/src/shared/gcdump/../gcinfo/gcinfodumper.cpp:620:16: note: explicitly cast the pointer to silence this warning
[  248s] 2 errors generated.
[  248s] make[2]: *** [src/SOS/Strike/CMakeFiles/sos.dir/build.make:79: src/SOS/Strike/CMakeFiles/sos.dir/disasm.cpp.o] Error 1
[  248s] make[2]: *** Waiting for unfinished jobs....
[  248s] [ 99%] Linking CXX shared library libdbgshim.so
[  248s] [ 99%] Built target dbgshim
[  249s] [ 99%] Linking CXX shared library libsosplugin.so
[  249s] [ 99%] Built target sosplugin
[  250s] make[1]: *** [CMakeFiles/Makefile2:742: src/SOS/Strike/CMakeFiles/sos.dir/all] Error 2
[  250s] make: *** [Makefile:136: all] Error 2
[  250s] Failed to build.
```

refer to https://github.com/dotnet/diagnostics/commit/6b1e6c531cb5167f9157d68d21724d42d2ad6537