### PR TITLE
skip build dependencies when running tests

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -72,6 +72,9 @@
     <SupportedSubProcessTargetFrameworks>net8.0;net9.0;net10.0</SupportedSubProcessTargetFrameworks>
     <!-- This is the list of TFMs we build our unit tests as. -->
     <SupportedXUnitTestTargetFrameworks>net8.0</SupportedXUnitTestTargetFrameworks>
+    <!-- Arcade wants to be opinionated and use embedded PDBs for CI/local builds.
+      We want to test the detached case in general. -->
+    <DebugType>portable</DebugType>
   </PropertyGroup>
 
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,6 +22,9 @@
   </PropertyGroup>
 
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
+  <PropertyGroup>
+    <CustomAfterTraversalTargets>$(RepoRoot)eng/traversalFixups.targets</CustomAfterTraversalTargets>
+  </PropertyGroup>
 
   <!--
     $(TargetOS) - target operating system (win, linux, osx). Defaults to host OS.

--- a/build.proj
+++ b/build.proj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.Build.Traversal">
 
+  <PropertyGroup>
+    <CustomAfterTraversalTargets>eng/traversalFixups.targets</CustomAfterTraversalTargets>
+  </PropertyGroup>
+
   <ItemGroup >
     <ProjectReference Include="src/dirs.proj" />
     <ProjectReference Include="src/tests/dirs.proj" Condition="'$(SkipTests)' != 'true'" />

--- a/build.proj
+++ b/build.proj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.Build.Traversal">
 
-  <PropertyGroup>
-    <CustomAfterTraversalTargets>eng/traversalFixups.targets</CustomAfterTraversalTargets>
-  </PropertyGroup>
-
   <ItemGroup >
     <ProjectReference Include="src/dirs.proj" />
     <ProjectReference Include="src/tests/dirs.proj" Condition="'$(SkipTests)' != 'true'" />

--- a/eng/traversalFixups.targets
+++ b/eng/traversalFixups.targets
@@ -1,0 +1,14 @@
+<Project>
+  <!-- The traversal project SDK has a test depends on build model. While this is great
+   to get us closer to the way SDK logic works for vanilla projects, it regresses the official
+   build in a few ways. It causes a full rebuild making it slow and it surfaces a bug in the SDK where
+   some settings are not considered as inputs to :
+   - dotnet test build.proj doesn't work due to dotnet/sdk#51316
+   - dotnet build /t:Test would work, but we need to fix the build scripts so that build and test are called with the
+    same properties, otherwise we trigger rebuilds that hit the bug.
+    This doesn't preclude people from doing `dotnet test` on a specific test project for inner loop.
+    -->
+  <PropertyGroup>
+    <TestDependsOn />
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
- **Avoid using embedded symbols and don't build on test run target**
- **Avoid using embedded symbols and don't build on test run target**
- **Move to dbprops**
