### PR TITLE
docs(ipc-protocol): document SetEnvironmentVariable

### DIFF
--- a/documentation/design-docs/ipc-protocol.md
+++ b/documentation/design-docs/ipc-protocol.md
@@ -1325,6 +1325,8 @@ struct Payload
 }
 ```
 
+> Available since .NET 6.0
+
 ### `SetEnvironmentVariable`
 
 Command Code: `0x0403`


### PR DESCRIPTION
Adds the missing Process `SetEnvironmentVariable` command section (0x0403) to `documentation/design-docs/ipc-protocol.md`.

Fixes dotnet/diagnostics#5664.
