### PR TITLE
Fix sign extension bug in clrstack -l for ushort values (issue #5218)

### DIFF
--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -11400,7 +11400,7 @@ private:
                     switch(tmp)
                     {
                         case 1: outVar = *((BYTE *)pByte.GetPtr()); break;
-                        case 2: outVar = *((short *)pByte.GetPtr()); break;
+                        case 2: outVar = *((unsigned short *)pByte.GetPtr()); break;
                         case 4: outVar = *((DWORD *)pByte.GetPtr()); break;
                         case 8: outVar = *((ULONG64 *)pByte.GetPtr()); break;
                         default: outVar = 0;
@@ -11492,7 +11492,7 @@ private:
                     switch(dwSize)
                     {
                         case 1: outVar = *((BYTE *) pByte.GetPtr()); break;
-                        case 2: outVar = *((short *) pByte.GetPtr()); break;
+                        case 2: outVar = *((unsigned short *) pByte.GetPtr()); break;
                         case 4: outVar = *((DWORD *) pByte.GetPtr()); break;
                         case 8: outVar = *((ULONG64 *) pByte.GetPtr()); break;
                         default: outVar = 0;


### PR DESCRIPTION
Both ShowLocals switch statements in strike.cpp cast 2-byte values to signed 'short' before assigning to ULONG64, causing sign extension for values >= 0x8000. Change both to 'unsigned short' to match the unsigned types used in cases 1, 4, 8.

Fixes #5218.