### PR TITLE
Re-enable ConcurrentDictionaries test on Linux for .NET 10

### DIFF
--- a/src/tests/SOS.UnitTests/SOS.cs
+++ b/src/tests/SOS.UnitTests/SOS.cs
@@ -648,11 +648,6 @@ public class SOS
     [SkippableTheory, MemberData(nameof(Configurations))]
     public async Task ConcurrentDictionaries(TestConfiguration config)
     {
-        if (OS.Kind != OSKind.Windows && config.RuntimeFrameworkVersionMajor == 10)
-        {
-            throw new SkipTestException("Dumping concurrent dict objects in dumps hits unavailable memory on linux dumps. Tracking: dotnet/diagnostics#5491");
-        }
-
         await SOSTestHelpers.RunTest(
             scriptName: "ConcurrentDictionaries.script",
             new SOSRunner.TestInformation


### PR DESCRIPTION
The CoreLibBinder::EnumMemoryRegions regression that caused missing memory in Linux dumps has been fixed in the .NET 10.0.0 GA runtime.  I'm getting some odd test failures unrelated to this that I'm investigating locally, but I believe I got a clean run of this test earlier.  Using CI to see if these pass now to confirm local results while I fight the test system.

Fixes #5491