### PR TITLE
Fix DumpIL error message for IL stubs

### DIFF
--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -790,10 +790,16 @@ DECLARE_API(DumpIL)
         }
         else
         {
+            if (IsNilToken(MethodDescData.MDToken))
+            {
+                ExtOut("This method has no IL body (e.g. IL stubs generated for P/Invoke or Reverse P/Invoke marshaling).\n");
+                return S_OK;
+            }
+
             GetILAddressResult result = GetILAddress(MethodDescData);
             if (std::get<0>(result) == (TADDR)0)
             {
-                ExtOut("ilAddr is %p\n", SOS_PTR(std::get<0>(result)));
+                ExtOut("Unable to retrieve IL for this method (ilAddr is %p).\n", SOS_PTR(std::get<0>(result)));
                 return E_FAIL;
             }
             ExtOut("ilAddr is %p pImport is %p\n", SOS_PTR(std::get<0>(result)), SOS_PTR(std::get<1>(result)));


### PR DESCRIPTION
IL stubs (P/Invoke and Reverse P/Invoke marshaling stubs) have a nil metadata token (0x06000000) and no IL body. The DumpIL command now detects this case early via IsNilToken and prints a clear message instead of the cryptic 'error decoding IL' / 'ilAddr is 0'.  Also improved the fallback error message when GetILAddress fails for non-nil tokens.

This is the right fix, as IL for stubs is freed after JIT'ing in FreeCompileTimeState.  Sometimes they persist if the IL was put on the loader heap for a couple of specific stubs, but it's not worth building a big feature to display these in SOS, so we'll improve the message and be done.

Fixes dotnet/diagnostics#3005