### PR TITLE
[DiagnosticsClient] Add cross-container support

### DIFF
--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
@@ -417,7 +417,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
                 discoveredPids.Add(pid);
             }
 
-            foreach (int pid in GetCrossNamespacePublishedProcesses())
+            foreach (int pid in GetProcPublishedProcesses())
             {
                 discoveredPids.Add(pid);
             }
@@ -462,11 +462,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
                     continue;
                 }
 
-                try
-                {
-                    Process.GetProcessById(processId);
-                }
-                catch (ArgumentException)
+                if (!PidIpcEndpoint.CheckProcessExists(processId))
                 {
                     continue;
                 }
@@ -478,10 +474,11 @@ namespace Microsoft.Diagnostics.NETCore.Client
         }
 
         /// <summary>
-        /// Discovers .NET processes with diagnostic sockets in different PID namespaces
-        /// by scanning /proc for cross-namespace entries. Linux-only; returns empty on other platforms.
+        /// Discovers .NET processes via /proc that aren't found by the local IPC root scan.
+        /// Finds cross-namespace processes and same-namespace processes with different TMPDIR.
+        /// Linux-only; returns empty on other platforms.
         /// </summary>
-        private static IEnumerable<int> GetCrossNamespacePublishedProcesses()
+        private static IEnumerable<int> GetProcPublishedProcesses()
         {
             List<int> discoveredPids = new();
 
@@ -490,12 +487,12 @@ namespace Microsoft.Diagnostics.NETCore.Client
                 return discoveredPids;
             }
 
-            string[] procEntries;
+            IEnumerable<string> procEntries;
             try
             {
-                procEntries = Directory.GetDirectories(PidIpcEndpoint.ProcPath);
+                procEntries = Directory.EnumerateDirectories(PidIpcEndpoint.ProcPath);
             }
-            catch
+            catch (UnauthorizedAccessException)
             {
                 return discoveredPids;
             }
@@ -507,23 +504,30 @@ namespace Microsoft.Diagnostics.NETCore.Client
                     continue;
                 }
 
-                if (!PidIpcEndpoint.TryGetNamespacePid(hostPid, out int nsPid))
+                if (!PidIpcEndpoint.CheckProcessExists(hostPid))
                 {
                     continue;
                 }
 
-                try
+                string targetTmpDir = PidIpcEndpoint.GetProcessTmpDir(hostPid, out _);
+
+                if (PidIpcEndpoint.TryGetNamespacePid(hostPid, out int nsPid))
                 {
-                    PidIpcEndpoint.TryGetProcessTmpDir(hostPid, out string targetTmpDir);
-                    string crossNsPath = Path.Combine(PidIpcEndpoint.GetProcessRootPath(hostPid), targetTmpDir.TrimStart(Path.DirectorySeparatorChar));
-                    string[] files = Directory.GetFiles(crossNsPath, PidIpcEndpoint.GetDiagnosticSocketSearchPattern(nsPid));
-                    if (files.Length > 0)
+                    // Cross-namespace: search via /proc/{pid}/root/
+                    string crossNsDir = Path.Combine(PidIpcEndpoint.GetProcessRootPath(hostPid), targetTmpDir.TrimStart(Path.DirectorySeparatorChar));
+                    if (PidIpcEndpoint.TryResolveAddress(crossNsDir, nsPid, out _))
                     {
-                        Process.GetProcessById(hostPid);
                         discoveredPids.Add(hostPid);
                     }
                 }
-                catch { }
+                else if (!string.Equals(targetTmpDir, PidIpcEndpoint.IpcRootPath, StringComparison.Ordinal))
+                {
+                    // Same namespace but different TMPDIR
+                    if (PidIpcEndpoint.TryResolveAddress(targetTmpDir, hostPid, out _))
+                    {
+                        discoveredPids.Add(hostPid);
+                    }
+                }
             }
 
             return discoveredPids;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
@@ -514,7 +514,8 @@ namespace Microsoft.Diagnostics.NETCore.Client
 
                 try
                 {
-                    string crossNsPath = $"{PidIpcEndpoint.GetProcessRootPath(hostPid)}{PidIpcEndpoint.GetProcessTmpDir(hostPid)}";
+                    PidIpcEndpoint.TryGetProcessTmpDir(hostPid, out string targetTmpDir);
+                    string crossNsPath = Path.Combine(PidIpcEndpoint.GetProcessRootPath(hostPid), targetTmpDir.TrimStart(Path.DirectorySeparatorChar));
                     string[] files = Directory.GetFiles(crossNsPath, PidIpcEndpoint.GetDiagnosticSocketSearchPattern(nsPid));
                     if (files.Length > 0)
                     {

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcTransport.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcTransport.cs
@@ -3,12 +3,14 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.IO.Pipes;
 using System.Linq;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using System.Security.Principal;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -244,6 +246,17 @@ namespace Microsoft.Diagnostics.NETCore.Client
         private const string _dsrouterAddressFormatWindows = "dotnet-diagnostic-dsrouter-{0}";
         private const string _defaultAddressFormatNonWindows = "dotnet-diagnostic-{0}-{1}-socket";
         private const string _dsrouterAddressFormatNonWindows = "dotnet-diagnostic-dsrouter-{0}-{1}-socket";
+        private const string _procStatusPathFormat = "/proc/{0}/status";
+        private const string _procEnvironPathFormat = "/proc/{0}/environ";
+        private const string _procRootPathFormat = "/proc/{0}/root";
+
+        /// <summary>
+        /// Returns the path to a process's root filesystem via /proc/{pid}/root.
+        /// Linux-only; returns null on other platforms.
+        /// </summary>
+        internal static string GetProcessRootPath(int pid) =>
+            RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? string.Format(_procRootPathFormat, pid) : null;
+
         private int _pid;
         private IpcEndpointConfig _config;
         /// <summary>
@@ -286,20 +299,24 @@ namespace Microsoft.Diagnostics.NETCore.Client
             return GetDefaultAddress(_pid);
         }
 
-        private static bool TryGetDefaultAddress(int pid, out string defaultAddress)
+        /// <summary>
+        /// Searches a base path for a diagnostic endpoint matching the given PID.
+        /// On Windows, resolves named pipes. On other platforms, searches for Unix domain sockets.
+        /// </summary>
+        private static bool TryResolveAddress(string basePath, int pid, out string address)
         {
-            defaultAddress = null;
+            address = null;
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                defaultAddress = string.Format(_defaultAddressFormatWindows, pid);
+                address = string.Format(_defaultAddressFormatWindows, pid);
 
                 try
                 {
-                    string dsrouterAddress = Directory.GetFiles(IpcRootPath, string.Format(_dsrouterAddressFormatWindows, pid)).FirstOrDefault();
+                    string dsrouterAddress = Directory.GetFiles(basePath, string.Format(_dsrouterAddressFormatWindows, pid)).FirstOrDefault();
                     if (!string.IsNullOrEmpty(dsrouterAddress))
                     {
-                        defaultAddress = dsrouterAddress;
+                        address = dsrouterAddress;
                     }
                 }
                 catch { }
@@ -308,29 +325,100 @@ namespace Microsoft.Diagnostics.NETCore.Client
             {
                 try
                 {
-                    defaultAddress = Directory.GetFiles(IpcRootPath, string.Format(_defaultAddressFormatNonWindows, pid, "*")) // Try best match.
+                    address = Directory.GetFiles(basePath, string.Format(_defaultAddressFormatNonWindows, pid, "*"))
                         .OrderByDescending(f => new FileInfo(f).LastWriteTime)
                         .FirstOrDefault();
 
-                    string dsrouterAddress = Directory.GetFiles(IpcRootPath, string.Format(_dsrouterAddressFormatNonWindows, pid, "*")) // Try best match.
+                    string dsrouterAddress = Directory.GetFiles(basePath, string.Format(_dsrouterAddressFormatNonWindows, pid, "*"))
                         .OrderByDescending(f => new FileInfo(f).LastWriteTime)
                         .FirstOrDefault();
 
-                    if (!string.IsNullOrEmpty(dsrouterAddress) && !string.IsNullOrEmpty(defaultAddress))
+                    if (!string.IsNullOrEmpty(dsrouterAddress) && !string.IsNullOrEmpty(address))
                     {
-                        FileInfo defaultFile = new(defaultAddress);
+                        FileInfo defaultFile = new(address);
                         FileInfo dsrouterFile = new(dsrouterAddress);
 
                         if (dsrouterFile.LastWriteTime >= defaultFile.LastWriteTime)
                         {
-                            defaultAddress = dsrouterAddress;
+                            address = dsrouterAddress;
                         }
                     }
                 }
-                catch { }
+                catch
+                {
+                    return false;
+                }
             }
 
-            return !string.IsNullOrEmpty(defaultAddress);
+            return !string.IsNullOrEmpty(address);
+        }
+
+        /// <summary>
+        /// On Linux, reads /proc/{pid}/status to determine if the process is in a different PID namespace.
+        /// Returns true and outputs the namespace PID if cross-namespace, false otherwise.
+        /// Returns false on non-Linux platforms.
+        /// </summary>
+        /// <remarks>
+        /// The NSpid line contains the PID as seen in each namespace, with the last value being
+        /// the innermost (target process's own view). For nested containers, there may be multiple values.
+        /// Example: "NSpid:  680     50      1" means host PID 680, intermediate namespace PID 50, container PID 1.
+        /// </remarks>
+        internal static bool TryGetNamespacePid(int hostPid, out int nsPid)
+        {
+            nsPid = hostPid;
+
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return false;
+            }
+
+            try
+            {
+                foreach (string line in File.ReadLines(string.Format(_procStatusPathFormat, hostPid)))
+                {
+                    if (line.StartsWith("NSpid:\t", StringComparison.Ordinal))
+                    {
+                        string[] parts = line.Substring(7).Split(new[] { '\t' }, StringSplitOptions.RemoveEmptyEntries);
+                        if (parts.Length > 1 && int.TryParse(parts[parts.Length - 1], NumberStyles.Integer, CultureInfo.InvariantCulture, out int parsedPid))
+                        {
+                            nsPid = parsedPid;
+                            return true;
+                        }
+                        return false;
+                    }
+                }
+            }
+            catch { }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Gets the TMPDIR environment variable for a process by reading /proc/{pid}/environ.
+        /// Falls back to the platform temp directory if TMPDIR is not set or cannot be read.
+        /// </summary>
+        internal static string GetProcessTmpDir(int hostPid)
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return Path.GetTempPath();
+            }
+
+            try
+            {
+                // environ file uses null-separated KEY=VALUE pairs
+                string environ = Encoding.UTF8.GetString(File.ReadAllBytes(string.Format(_procEnvironPathFormat, hostPid)));
+                foreach (string envVar in environ.Split(new[] { '\0' }, StringSplitOptions.RemoveEmptyEntries))
+                {
+                    if (envVar.StartsWith("TMPDIR=", StringComparison.Ordinal))
+                    {
+                        return envVar.Substring(7);
+                    }
+                }
+            }
+            catch { }
+
+            return Path.GetTempPath();
         }
 
         public static string GetDefaultAddress(int pid)
@@ -348,26 +436,38 @@ namespace Microsoft.Diagnostics.NETCore.Client
                 throw new ServerNotAvailableException($"Process {pid} seems to be elevated.");
             }
 
-            if (!TryGetDefaultAddress(pid, out string defaultAddress))
+            if (TryGetNamespacePid(pid, out int nsPid))
             {
-                string msg = $"Unable to connect to Process {pid}.";
-                if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                if (TryResolveAddress($"{GetProcessRootPath(pid)}{GetProcessTmpDir(pid)}", nsPid, out string crossNsAddress))
                 {
-                    int total_length = IpcRootPath.Length + string.Format(_defaultAddressFormatNonWindows, pid, "##########").Length;
-                    if (total_length > 108) // This isn't perfect as we don't know the disambiguation key length. However it should catch most cases.
-                    {
-                        msg += "The total length of the diagnostic socket path may exceed 108 characters. " +
-                            "Try setting the TMPDIR environment variable to a shorter path";
-                    }
-                    msg += $" Please verify that {IpcRootPath} is writable by the current user. "
-                        + "If the target process has environment variable TMPDIR set, please set TMPDIR to the same directory. "
-                        + "Please also ensure that the target process has {TMPDIR}/dotnet-diagnostic-{pid}-{disambiguation_key}-socket shorter than 108 characters. "
-                        + "Please see https://aka.ms/dotnet-diagnostics-port for more information";
+                    return crossNsAddress;
                 }
-                throw new ServerNotAvailableException(msg);
             }
 
-            return defaultAddress;
+            if (TryResolveAddress(IpcRootPath, pid, out string localAddress))
+            {
+                return localAddress;
+            }
+
+            string msg = $"Unable to connect to Process {pid}.";
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                int total_length = IpcRootPath.Length + string.Format(_defaultAddressFormatNonWindows, pid, "##########").Length;
+                if (total_length > 108)
+                {
+                    msg += " The diagnostic socket path may exceed the 108-character limit."
+                        + " Try setting TMPDIR to a shorter path.";
+                }
+                msg += $" Ensure {IpcRootPath} is writable by the current user."
+                    + " If the target process sets TMPDIR, set it to the same directory.";
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                {
+                    msg += " If the target process is in a different container, ensure this process runs with 'pid: host'"
+                        + " and has access to /proc/{pid}/root/ (requires CAP_SYS_PTRACE or privileged mode).";
+                }
+                msg += " See https://aka.ms/dotnet-diagnostics-port for more information.";
+            }
+            throw new ServerNotAvailableException(msg);
         }
 
         public static bool IsDefaultAddressDSRouter(int pid, string address)

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcTransport.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcTransport.cs
@@ -246,6 +246,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
         private const string _dsrouterAddressFormatWindows = "dotnet-diagnostic-dsrouter-{0}";
         private const string _defaultAddressFormatNonWindows = "dotnet-diagnostic-{0}-{1}-socket";
         private const string _dsrouterAddressFormatNonWindows = "dotnet-diagnostic-dsrouter-{0}-{1}-socket";
+        internal const string ProcPath = "/proc";
         private const string _procStatusPathFormat = "/proc/{0}/status";
         private const string _procEnvironPathFormat = "/proc/{0}/environ";
         private const string _procRootPathFormat = "/proc/{0}/root";
@@ -256,6 +257,12 @@ namespace Microsoft.Diagnostics.NETCore.Client
         /// </summary>
         internal static string GetProcessRootPath(int pid) =>
             RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? string.Format(_procRootPathFormat, pid) : null;
+
+        /// <summary>
+        /// Returns a file search pattern for diagnostic sockets matching the given PID.
+        /// </summary>
+        internal static string GetDiagnosticSocketSearchPattern(int pid) =>
+            string.Format(_defaultAddressFormatNonWindows, pid, "*");
 
         private int _pid;
         private IpcEndpointConfig _config;

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcTransport.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcTransport.cs
@@ -259,12 +259,6 @@ namespace Microsoft.Diagnostics.NETCore.Client
         internal static string GetProcessRootPath(int pid) =>
             RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? string.Format(_procRootPathFormat, pid) : null;
 
-        /// <summary>
-        /// Returns a file search pattern for diagnostic sockets matching the given PID.
-        /// </summary>
-        internal static string GetDiagnosticSocketSearchPattern(int pid) =>
-            string.Format(_defaultAddressFormatNonWindows, pid, "*");
-
         private int _pid;
         private IpcEndpointConfig _config;
         /// <summary>
@@ -308,10 +302,10 @@ namespace Microsoft.Diagnostics.NETCore.Client
         }
 
         /// <summary>
-        /// Searches a base path for a diagnostic endpoint matching the given PID.
+        /// Searches files in a directory for a diagnostic endpoint matching the given PID.
         /// On Windows, resolves named pipes. On other platforms, searches for Unix domain sockets.
         /// </summary>
-        private static bool TryResolveAddress(string basePath, int pid, out string address)
+        internal static bool TryResolveAddress(string searchDirectory, int pid, out string address)
         {
             address = null;
 
@@ -321,7 +315,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
 
                 try
                 {
-                    string dsrouterAddress = Directory.GetFiles(basePath, string.Format(_dsrouterAddressFormatWindows, pid)).FirstOrDefault();
+                    string dsrouterAddress = Directory.GetFiles(searchDirectory, string.Format(_dsrouterAddressFormatWindows, pid)).FirstOrDefault();
                     if (!string.IsNullOrEmpty(dsrouterAddress))
                     {
                         address = dsrouterAddress;
@@ -333,11 +327,11 @@ namespace Microsoft.Diagnostics.NETCore.Client
             {
                 try
                 {
-                    address = Directory.GetFiles(basePath, string.Format(_defaultAddressFormatNonWindows, pid, "*"))
+                    address = Directory.GetFiles(searchDirectory, string.Format(_defaultAddressFormatNonWindows, pid, "*"))
                         .OrderByDescending(f => new FileInfo(f).LastWriteTime)
                         .FirstOrDefault();
 
-                    string dsrouterAddress = Directory.GetFiles(basePath, string.Format(_dsrouterAddressFormatNonWindows, pid, "*"))
+                    string dsrouterAddress = Directory.GetFiles(searchDirectory, string.Format(_dsrouterAddressFormatNonWindows, pid, "*"))
                         .OrderByDescending(f => new FileInfo(f).LastWriteTime)
                         .FirstOrDefault();
 
@@ -380,13 +374,18 @@ namespace Microsoft.Diagnostics.NETCore.Client
                 return false;
             }
 
+            string[] lines;
             try
             {
-                return TryParseNamespacePid(File.ReadLines(string.Format(_procStatusPathFormat, hostPid)), hostPid, out nsPid);
+                lines = File.ReadAllLines(string.Format(_procStatusPathFormat, hostPid));
             }
-            catch { }
+            catch (DirectoryNotFoundException)
+            {
+                // The process may have exited between discovery and reading its status file.
+                return false;
+            }
 
-            return false;
+            return TryParseNamespacePid(lines, hostPid, out nsPid);
         }
 
         /// <summary>
@@ -415,23 +414,39 @@ namespace Microsoft.Diagnostics.NETCore.Client
         }
 
         /// <summary>
-        /// Gets the TMPDIR environment variable for a process by reading /proc/{pid}/environ.
-        /// Falls back to the platform temp directory if TMPDIR is not set or cannot be read.
+        /// Gets the TMPDIR for a target process by reading /proc/{pid}/environ.
+        /// Falls back to the platform temp directory if TMPDIR is not set or environ cannot be read.
+        /// The environReadable output indicates whether /proc/{pid}/environ was successfully read.
         /// </summary>
-        internal static string GetProcessTmpDir(int hostPid)
+        internal static string GetProcessTmpDir(int hostPid, out bool environReadable)
         {
+            environReadable = false;
+            string tmpDirPath = Path.GetTempPath();
+
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                return Path.GetTempPath();
+                return tmpDirPath;
             }
 
+            byte[] environData;
             try
             {
-                return ParseTmpDir(File.ReadAllBytes(string.Format(_procEnvironPathFormat, hostPid)));
+                environData = File.ReadAllBytes(string.Format(_procEnvironPathFormat, hostPid));
             }
-            catch { }
+            catch (DirectoryNotFoundException)
+            {
+                // The process may have exited between discovery and reading its environ file.
+                return tmpDirPath;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                // /proc/{pid}/environ is owner-readable only (0400); other users' environ is inaccessible.
+                return tmpDirPath;
+            }
 
-            return Path.GetTempPath();
+            environReadable = true;
+            tmpDirPath = ParseTmpDir(environData);
+            return tmpDirPath;
         }
 
         /// <summary>
@@ -452,51 +467,74 @@ namespace Microsoft.Diagnostics.NETCore.Client
             return Path.GetTempPath();
         }
 
-        public static string GetDefaultAddress(int pid)
+        /// <summary>
+        /// Checks whether a process with the given PID exists and is accessible.
+        /// </summary>
+        internal static bool CheckProcessExists(int pid)
         {
             try
             {
-                Process process = Process.GetProcessById(pid);
+                Process.GetProcessById(pid);
+                return true;
             }
             catch (ArgumentException)
             {
+                return false;
+            }
+        }
+
+        public static string GetDefaultAddress(int pid)
+        {
+            if (!CheckProcessExists(pid))
+            {
                 throw new ServerNotAvailableException($"Process {pid} is not running.");
             }
-            catch (InvalidOperationException)
-            {
-                throw new ServerNotAvailableException($"Process {pid} seems to be elevated.");
-            }
 
-            if (TryGetNamespacePid(pid, out int nsPid))
+            string searchDirectory = IpcRootPath;
+            int searchPid = pid;
+            bool environReadable = false;
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                if (TryResolveAddress($"{GetProcessRootPath(pid)}{GetProcessTmpDir(pid)}", nsPid, out string crossNsAddress))
+                string targetTmpDir = GetProcessTmpDir(pid, out environReadable);
+
+                if (TryGetNamespacePid(pid, out int nsPid))
                 {
-                    return crossNsAddress;
+                    searchDirectory = Path.Combine(GetProcessRootPath(pid), targetTmpDir.TrimStart(Path.DirectorySeparatorChar));
+                    searchPid = nsPid;
+                }
+                else
+                {
+                    searchDirectory = targetTmpDir;
                 }
             }
 
-            if (TryResolveAddress(IpcRootPath, pid, out string localAddress))
+            if (TryResolveAddress(searchDirectory, searchPid, out string address))
             {
-                return localAddress;
+                return address;
             }
 
             string msg = $"Unable to connect to Process {pid}.";
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                int total_length = IpcRootPath.Length + string.Format(_defaultAddressFormatNonWindows, pid, "##########").Length;
-                if (total_length > 108)
+                int total_length = searchDirectory.Length + string.Format(_defaultAddressFormatNonWindows, pid, "##########").Length;
+                if (total_length > 108) // This isn't perfect as we don't know the disambiguation key length. However it should catch most cases.
                 {
-                    msg += " The diagnostic socket path may exceed the 108-character limit."
-                        + " Try setting TMPDIR to a shorter path.";
+                    msg += " The total length of the diagnostic socket path may exceed 108 characters."
+                        + " Try setting the TMPDIR environment variable to a shorter path.";
                 }
-                msg += $" Ensure {IpcRootPath} is writable by the current user."
-                    + " If the target process sets TMPDIR, set it to the same directory.";
+                msg += $" Please verify that {searchDirectory} is writable by the current user.";
+                if (!environReadable)
+                {
+                    msg += " If the target process has environment variable TMPDIR set, please set TMPDIR to the same directory."
+                        + " Please also ensure that the target process has {TMPDIR}/dotnet-diagnostic-{pid}-{disambiguation_key}-socket shorter than 108 characters.";
+                }
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 {
                     msg += " If the target process is in a different container, ensure this process runs with 'pid: host'"
                         + " and has access to /proc/{pid}/root/ (requires CAP_SYS_PTRACE or privileged mode).";
                 }
-                msg += " See https://aka.ms/dotnet-diagnostics-port for more information.";
+                msg += " Please see https://aka.ms/dotnet-diagnostics-port for more information.";
             }
             throw new ServerNotAvailableException(msg);
         }

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.UnitTests.csproj
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.UnitTests.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="$(MicrosoftDiagnosticsTracingTraceEventVersion)" />
+    <PackageReference Include="Microsoft.DotNet.XUnitExtensions" Version="$(MicrosoftDotNetXUnitExtensionsVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/PidIpcEndpointTests.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/PidIpcEndpointTests.cs
@@ -1,0 +1,194 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+using Microsoft.DotNet.XUnitExtensions;
+using Xunit;
+
+namespace Microsoft.Diagnostics.NETCore.Client
+{
+    public class PidIpcEndpointTests
+    {
+        public static bool IsLinux => RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+        public static bool IsNotLinux => !IsLinux;
+
+        #region Parsing tests (platform-independent, synthetic data)
+
+        // Realistic /proc/{pid}/status content based on Docker cross-container testing.
+        // The NSpid line shows host PID 2209 mapped to container PID 1.
+        private static readonly string[] CrossNamespaceStatus = new[]
+        {
+            "Name:\tdotnet",
+            "Umask:\t0022",
+            "State:\tS (sleeping)",
+            "Tgid:\t2209",
+            "Ngid:\t0",
+            "Pid:\t2209",
+            "PPid:\t2189",
+            "NSpid:\t2209\t1",
+            "Threads:\t15",
+        };
+
+        private static readonly string[] SameNamespaceStatus = new[]
+        {
+            "Name:\tdotnet",
+            "State:\tS (sleeping)",
+            "Pid:\t500",
+            "NSpid:\t500",
+            "Threads:\t10",
+        };
+
+        private static readonly string[] NestedContainerStatus = new[]
+        {
+            "Name:\tdotnet",
+            "Pid:\t680",
+            "NSpid:\t680\t50\t1",
+        };
+
+        [Fact]
+        public void TryParseNamespacePid_CrossNamespace_ReturnsTrueWithContainerPid()
+        {
+            bool result = PidIpcEndpoint.TryParseNamespacePid(CrossNamespaceStatus, 2209, out int nsPid);
+            Assert.True(result);
+            Assert.Equal(1, nsPid);
+        }
+
+        [Fact]
+        public void TryParseNamespacePid_SameNamespace_ReturnsFalse()
+        {
+            bool result = PidIpcEndpoint.TryParseNamespacePid(SameNamespaceStatus, 500, out int nsPid);
+            Assert.False(result);
+            Assert.Equal(500, nsPid);
+        }
+
+        [Fact]
+        public void TryParseNamespacePid_NestedContainers_ReturnsInnermostPid()
+        {
+            bool result = PidIpcEndpoint.TryParseNamespacePid(NestedContainerStatus, 680, out int nsPid);
+            Assert.True(result);
+            Assert.Equal(1, nsPid);
+        }
+
+        [Fact]
+        public void TryParseNamespacePid_NoNSpidLine_ReturnsFalse()
+        {
+            string[] status = new[] { "Name:\tdotnet", "Pid:\t100", "Threads:\t5" };
+            bool result = PidIpcEndpoint.TryParseNamespacePid(status, 100, out int nsPid);
+            Assert.False(result);
+            Assert.Equal(100, nsPid);
+        }
+
+        [Fact]
+        public void TryParseNamespacePid_EmptyInput_ReturnsFalse()
+        {
+            bool result = PidIpcEndpoint.TryParseNamespacePid(new string[0], 100, out int nsPid);
+            Assert.False(result);
+            Assert.Equal(100, nsPid);
+        }
+
+        [Fact]
+        public void TryParseNamespacePid_MalformedNSpid_ReturnsFalse()
+        {
+            string[] status = new[] { "NSpid:\tabc\txyz" };
+            bool result = PidIpcEndpoint.TryParseNamespacePid(status, 100, out int nsPid);
+            Assert.False(result);
+            Assert.Equal(100, nsPid);
+        }
+
+        [Fact]
+        public void ParseTmpDir_TmpdirSet_ReturnsValue()
+        {
+            byte[] environ = Encoding.UTF8.GetBytes("PATH=/usr/bin\0TMPDIR=/custom/tmp\0HOME=/root\0");
+            string result = PidIpcEndpoint.ParseTmpDir(environ);
+            Assert.Equal("/custom/tmp", result);
+        }
+
+        [Fact]
+        public void ParseTmpDir_TmpdirNotSet_ReturnsFallback()
+        {
+            byte[] environ = Encoding.UTF8.GetBytes("PATH=/usr/bin\0HOME=/root\0");
+            string result = PidIpcEndpoint.ParseTmpDir(environ);
+            Assert.Equal(Path.GetTempPath(), result);
+        }
+
+        [Fact]
+        public void ParseTmpDir_EmptyEnviron_ReturnsFallback()
+        {
+            byte[] environ = new byte[0];
+            string result = PidIpcEndpoint.ParseTmpDir(environ);
+            Assert.Equal(Path.GetTempPath(), result);
+        }
+
+        [Fact]
+        public void GetDiagnosticSocketSearchPattern_ReturnsExpectedFormat()
+        {
+            string pattern = PidIpcEndpoint.GetDiagnosticSocketSearchPattern(1);
+            Assert.Equal("dotnet-diagnostic-1-*-socket", pattern);
+        }
+
+        [Fact]
+        public void GetDiagnosticSocketSearchPattern_LargePid()
+        {
+            string pattern = PidIpcEndpoint.GetDiagnosticSocketSearchPattern(32768);
+            Assert.Equal("dotnet-diagnostic-32768-*-socket", pattern);
+        }
+
+        #endregion
+
+        #region Behavioral tests (platform-specific, real system calls)
+
+        [ConditionalFact(nameof(IsLinux))]
+        public void TryGetNamespacePid_CurrentProcess_SameNamespace_ReturnsFalse()
+        {
+            int currentPid = Process.GetCurrentProcess().Id;
+            bool result = PidIpcEndpoint.TryGetNamespacePid(currentPid, out int nsPid);
+            Assert.False(result);
+            Assert.Equal(currentPid, nsPid);
+        }
+
+        [ConditionalFact(nameof(IsNotLinux))]
+        public void TryGetNamespacePid_NonLinux_ReturnsFalse()
+        {
+            bool result = PidIpcEndpoint.TryGetNamespacePid(1, out int nsPid);
+            Assert.False(result);
+            Assert.Equal(1, nsPid);
+        }
+
+        [ConditionalFact(nameof(IsLinux))]
+        public void GetProcessTmpDir_ChildProcess_ReadsTmpdir()
+        {
+            string customTmpDir = "/custom/tmp/test";
+            ProcessStartInfo psi = new("sleep", "30")
+            {
+                Environment = { ["TMPDIR"] = customTmpDir },
+                UseShellExecute = false,
+            };
+
+            using Process child = Process.Start(psi);
+            try
+            {
+                string result = PidIpcEndpoint.GetProcessTmpDir(child.Id);
+                Assert.Equal(customTmpDir, result);
+            }
+            finally
+            {
+                child.Kill();
+                child.WaitForExit();
+            }
+        }
+
+        [Fact]
+        public void GetDefaultAddress_NonExistentPid_ThrowsServerNotAvailable()
+        {
+            ServerNotAvailableException ex = Assert.Throws<ServerNotAvailableException>(
+                () => PidIpcEndpoint.GetDefaultAddress(int.MaxValue));
+            Assert.Contains("is not running", ex.Message);
+        }
+
+        #endregion
+    }
+}

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/PidIpcEndpointTests.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/PidIpcEndpointTests.cs
@@ -123,20 +123,6 @@ namespace Microsoft.Diagnostics.NETCore.Client
             Assert.Equal(Path.GetTempPath(), result);
         }
 
-        [Fact]
-        public void GetDiagnosticSocketSearchPattern_ReturnsExpectedFormat()
-        {
-            string pattern = PidIpcEndpoint.GetDiagnosticSocketSearchPattern(1);
-            Assert.Equal("dotnet-diagnostic-1-*-socket", pattern);
-        }
-
-        [Fact]
-        public void GetDiagnosticSocketSearchPattern_LargePid()
-        {
-            string pattern = PidIpcEndpoint.GetDiagnosticSocketSearchPattern(32768);
-            Assert.Equal("dotnet-diagnostic-32768-*-socket", pattern);
-        }
-
         #endregion
 
         #region Behavioral tests (platform-specific, real system calls)
@@ -159,7 +145,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
         }
 
         [ConditionalFact(nameof(IsLinux))]
-        public void TryGetProcessTmpDir_ChildProcess_ReadsTmpdir()
+        public void GetProcessTmpDir_ChildProcess_ReadsTmpdir()
         {
             string customTmpDir = "/custom/tmp/test";
             ProcessStartInfo psi = new("sleep", "30")
@@ -171,9 +157,17 @@ namespace Microsoft.Diagnostics.NETCore.Client
             using Process child = Process.Start(psi);
             try
             {
-                bool readable = PidIpcEndpoint.TryGetProcessTmpDir(child.Id, out string result);
-                Assert.True(readable);
-                Assert.Equal(customTmpDir, result);
+                string result = PidIpcEndpoint.GetProcessTmpDir(child.Id, out bool environReadable);
+                if (environReadable)
+                {
+                    // environ was readable — expect the custom TMPDIR
+                    Assert.Equal(customTmpDir, result);
+                }
+                else
+                {
+                    // Systems with hidepid or restricted /proc permissions fall back to default
+                    Assert.Equal(Path.GetTempPath(), result);
+                }
             }
             finally
             {

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/PidIpcEndpointTests.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/PidIpcEndpointTests.cs
@@ -159,7 +159,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
         }
 
         [ConditionalFact(nameof(IsLinux))]
-        public void GetProcessTmpDir_ChildProcess_ReadsTmpdir()
+        public void TryGetProcessTmpDir_ChildProcess_ReadsTmpdir()
         {
             string customTmpDir = "/custom/tmp/test";
             ProcessStartInfo psi = new("sleep", "30")
@@ -171,7 +171,8 @@ namespace Microsoft.Diagnostics.NETCore.Client
             using Process child = Process.Start(psi);
             try
             {
-                string result = PidIpcEndpoint.GetProcessTmpDir(child.Id);
+                bool readable = PidIpcEndpoint.TryGetProcessTmpDir(child.Id, out string result);
+                Assert.True(readable);
                 Assert.Equal(customTmpDir, result);
             }
             finally


### PR DESCRIPTION
## Summary

When diagnostic tools (dotnet-trace, dotnet-counters, dotnet-stack, dotnet-dump) run in a sidecar container with `pid: host`, they cannot find the target process's diagnostic IPC socket. The socket is named using the container-internal PID (NSpid) and located under `/proc/{hostPid}/root/{tmpdir}/`, but the tools only look in local `/tmp/`.

This PR adds cross-namespace IPC resolution to `Microsoft.Diagnostics.NETCore.Client` so all diagnostic tools work transparently across PID namespaces. It also adds TMPDIR-aware resolution for same-namespace processes with a non-default TMPDIR.

Fixes #5694

## Changes

### Commit 1: Core IPC transport support
- Add `TryGetNamespacePid()` — reads `/proc/{pid}/status` NSpid to detect cross-namespace processes
- Add `GetProcessTmpDir()` — reads `/proc/{pid}/environ` for TMPDIR (returns `out bool environReadable` for error messaging)
- Parameterize `TryResolveAddress()` — handles both Windows named pipes and Unix sockets from any search directory
- Simplify `GetDefaultAddress()` flow: resolve one (searchDirectory, searchPid) pair, single `TryResolveAddress` call
- All Linux-specific methods self-guard, returning safe defaults on other platforms

### Commit 2: Process enumeration
- Add `GetCrossNamespacePublishedProcesses()` — scans `/proc` for processes in different namespaces with diagnostic sockets
- Refactor `GetLocalPublishedProcesses()` to be self-contained (handles its own file listing and exceptions)
- `GetPublishedProcesses()` is a clean union of both methods
- Introduce `ProcPath` constant to avoid hardcoding

### Commit 3: Unit tests
- Extract `TryParseNamespacePid()` and `ParseTmpDir()` for testable parsing logic
- 9 parsing tests with synthetic data (NSpid variants, TMPDIR parsing)
- 4 behavioral tests with `[ConditionalFact]` (same-namespace detection, child process TMPDIR reading, platform guards, error paths)

### Commit 4: Address IPC transport review feedback
- Rename `basePath` → `searchDirectory` in `TryResolveAddress`, update doc comment
- Make `TryResolveAddress` internal for reuse in enumeration
- Change `GetProcessTmpDir` to return `out bool environReadable` for conditional error messaging
- Narrow try/catch: `DirectoryNotFoundException` for process-exit races, `UnauthorizedAccessException` for `/proc/{pid}/environ` (owner-only 0400)
- Add `CheckProcessExists` helper (catches `ArgumentException` from `Process.GetProcessById`)
- Use `Path.Combine` for cross-namespace path construction to handle relative TMPDIR
- Simplify `GetDefaultAddress` to single `TryResolveAddress` call with Linux-guarded path resolution
- Add same-namespace different-TMPDIR support: on Linux, use target's TMPDIR instead of `IpcRootPath`
- Fix error message: reference target's search directory, conditional TMPDIR hint when environ is unreadable, restore original 108-char socket path guidance

### Commit 5: Address enumeration review feedback
- Rename `GetCrossNamespacePublishedProcesses` → `GetProcPublishedProcesses` (now discovers both cross-namespace AND same-namespace different-TMPDIR)
- Use `TryResolveAddress` instead of `Directory.GetFiles` for robust socket discovery (handles stale sockets, dsrouter)
- Use `Directory.EnumerateDirectories` for streaming `/proc` iteration
- Use `CheckProcessExists` helper in both enumeration methods

### Commit 6: Update tests for feedback changes
- Handle `hidepid` fallback in child process TMPDIR test (accept default when environ unreadable)
- Remove `GetDiagnosticSocketSearchPattern` tests (method removed — `TryResolveAddress` used instead)

## How it works

```
GetDefaultAddress(pid):
  1. CheckProcessExists(pid) or throw
  2. On Linux:
     a. GetProcessTmpDir(pid) → target's TMPDIR (falls back to Path.GetTempPath())
     b. TryGetNamespacePid(pid) → cross-namespace?
        If yes: searchDirectory = /proc/{pid}/root/{targetTmpDir}, searchPid = nsPid
        If no:  searchDirectory = targetTmpDir, searchPid = pid
     On other platforms:
        searchDirectory = IpcRootPath, searchPid = pid
  3. TryResolveAddress(searchDirectory, searchPid)
  4. Error with platform-specific guidance
```

## Docker Validation

Tested with two containers: target-app (PID 1 inside, host PID 2209) and tracer (`privileged: true`, `pid: host`).

**Baseline (stock tools v9.0.661903):** All tools fail with `ServerNotAvailableException`.

| Tool | Command | Result |
|------|---------|--------|
| dotnet-trace | `ps` | ❌ No processes found |
| dotnet-trace | `collect -p 2209` | ❌ ServerNotAvailableException |
| dotnet-trace | `collect-linux --probe -p 2209` | ❌ ServerNotAvailableException |
| dotnet-trace | `collect-linux -p 2209` | ❌ ServerNotAvailableException |
| dotnet-counters | `ps` | ❌ No processes found |
| dotnet-counters | `monitor -p 2209` | ❌ ServerNotAvailableException |
| dotnet-stack | `report -p 2209` | ❌ ServerNotAvailableException |
| dotnet-dump | `collect -p 2209` | ❌ ServerNotAvailableException |

**Fix (this branch):** All tools work.

| Tool | Command | Result |
|------|---------|--------|
| dotnet-trace | `ps` | ✅ Discovers process |
| dotnet-trace | `collect -p 2209 --duration 5s` | ✅ Trace completed (404KB nettrace) |
| dotnet-trace | `collect-linux --probe -p 2209` | ✅ Connected successfully (runtime version check) |
| dotnet-trace | `collect-linux -p 2209 --duration 5s` | ✅ Connected successfully (runtime version check) |
| dotnet-counters | `ps` | ✅ Discovers process |
| dotnet-counters | `monitor -p 2209 --duration 5` | ✅ Collected counters |
| dotnet-stack | `report -p 2209` | ✅ Thread stacks printed |
| dotnet-dump | `collect -p 2209` | ✅ Dump written |

> **Note on collect-linux:** The `collect-linux` tests connect successfully (proving cross-namespace IPC works) but report a runtime version mismatch because the target runs .NET 10.0.0-preview.7 and `collect-linux` requires 10.0.0 RTM. This is expected — the baseline fails with `ServerNotAvailableException` (can't connect at all), while the fix gets past the connection to the version check.
