### PR TITLE
ELF binary parsing: Accept two valid e_type value ranges

### DIFF
--- a/src/Microsoft.FileFormats/ELF/ELFStructures.cs
+++ b/src/Microsoft.FileFormats/ELF/ELFStructures.cs
@@ -110,7 +110,9 @@ namespace Microsoft.FileFormats.ELF
         Relocatable = 1,
         Executable = 2,
         Shared = 3,
-        Core = 4
+        Core = 4,
+        LowOS = 0xFE00,
+        HighOS = 0xFEFF
     }
 
     public class ELFHeader : ELFHeaderIdent

--- a/src/Microsoft.SymbolStore/KeyGenerators/ELFFileKeyGenerator.cs
+++ b/src/Microsoft.SymbolStore/KeyGenerators/ELFFileKeyGenerator.cs
@@ -50,7 +50,10 @@ namespace Microsoft.SymbolStore.KeyGenerators
         public override bool IsValid()
         {
             return _elfFile.IsValid() &&
-                (_elfFile.Header.Type == ELFHeaderType.Executable || _elfFile.Header.Type == ELFHeaderType.Shared || _elfFile.Header.Type == ELFHeaderType.Relocatable);
+                (_elfFile.Header.Type == ELFHeaderType.Executable ||
+                 _elfFile.Header.Type == ELFHeaderType.Shared ||
+                 _elfFile.Header.Type == ELFHeaderType.Relocatable ||
+                 ((ushort)_elfFile.Header.Type >= (ushort)ELFHeaderType.LowOS && (ushort)_elfFile.Header.Type <= (ushort)ELFHeaderType.HighOS));
         }
 
         public override IEnumerable<SymbolStoreKey> GetKeys(KeyTypeFlags flags)


### PR DESCRIPTION
Customer requested allowing some e_type values (0xFE00-0xFEFF) in the symbol server key generated.  This allows key generation for ELF binaries produced by custom toolchains that use the ET_LOOS..ET_HIOS range defined in the ELF spec.

There's no way for us to test this, but it's a completely reasonable request and easy/low risk of regression.  I suggest we fix it for his internal symbol server.  Otherwise close the original bug as won't fix.  That's fine by me too.

Fixes #5089