### PR TITLE
Fix native to IL line number mappings in SOS test scripts

### DIFF
--- a/src/SOS/Strike/util.cpp
+++ b/src/SOS/Strike/util.cpp
@@ -4652,6 +4652,88 @@ GetClrMethodInstance(
 }
 
 //
+// Searches the IL address map for the entry containing the given native offset.
+// Fallback for older runtimes where GetILOffsetsByAddress is buggy or unsupported.
+HRESULT
+GetILOffsetFromAddressMap(
+    ___in IXCLRDataMethodInstance* Method,
+    ___in ULONG64 nativeOffset,
+    ___out PULONG32 MethodOffs)
+{
+    HRESULT Status;
+    CLRDATA_IL_ADDRESS_MAP MapLocal[16];
+    CLRDATA_IL_ADDRESS_MAP* Map = MapLocal;
+    ULONG32 MapCount = ARRAY_SIZE(MapLocal);
+    ULONG32 MapNeeded;
+
+    for (;;)
+    {
+        if ((Status = Method->GetILAddressMap(MapCount, &MapNeeded, Map)) != S_OK)
+        {
+            if (Map != MapLocal)
+            {
+                delete[] Map;
+            }
+            return Status;
+        }
+
+        if (MapNeeded <= MapCount)
+        {
+            break;
+        }
+
+        // Need more map entries.
+        if (Map != MapLocal)
+        {
+            delete[] Map;
+            return E_UNEXPECTED;
+        }
+
+        Map = new NOTHROW CLRDATA_IL_ADDRESS_MAP[MapNeeded];
+        if (!Map)
+        {
+            return E_OUTOFMEMORY;
+        }
+
+        MapCount = MapNeeded;
+    }
+
+    // Search for the entry whose native address range contains nativeOffset.
+    // The last map entry sometimes has a bogus endAddress (e.g., wrapping back to
+    // the method start). Handle this by treating any entry where endAddress <=
+    // startAddress as extending to infinity (the end of the method code).
+    Status = E_FAIL;
+    for (size_t i = 0; i < MapNeeded; i++)
+    {
+        bool inRange;
+        if (Map[i].endAddress > Map[i].startAddress)
+        {
+            // Normal range.
+            inRange = (Map[i].startAddress <= nativeOffset && nativeOffset < Map[i].endAddress);
+        }
+        else
+        {
+            // Malformed/last entry: endAddress <= startAddress. Treat as open-ended.
+            inRange = (Map[i].startAddress <= nativeOffset);
+        }
+
+        if (inRange)
+        {
+            *MethodOffs = Map[i].ilOffset;
+            Status = S_OK;
+            break;
+        }
+    }
+
+    if (Map != MapLocal)
+    {
+        delete[] Map;
+    }
+
+    return Status;
+}
+
+//
 // Enumerates over the IL address map associated with the passed in
 // managed method, and returns the highest non-epilog offset.
 HRESULT
@@ -4687,7 +4769,7 @@ GetLastMethodIlOffset(
             return E_UNEXPECTED;
         }
 
-        Map = new CLRDATA_IL_ADDRESS_MAP[MapNeeded];
+        Map = new NOTHROW CLRDATA_IL_ADDRESS_MAP[MapNeeded];
         if (!Map)
         {
             return E_OUTOFMEMORY;
@@ -4751,33 +4833,49 @@ ConvertNativeToIlOffset(
         }
     }
 
-    if ((Status = pMethodInst->GetILOffsetsByAddress(nativeOffset, 1, NULL, methodOffs)) != S_OK)
+    // For runtimes prior to .NET 5.0, GetILOffsetsByAddress can return S_OK with incorrect IL
+    // offsets (the bug we're working around for issue #794). For those runtimes, walk the IL
+    // address map ourselves. On .NET 5.0+ GetILOffsetsByAddress is correct and is preferred,
+    // because the raw map can ambiguously place an IP at the previous statement when an IP
+    // sits exactly on a sequence-point boundary.
+    if (!IsRuntimeVersionAtLeast(5))
+    {
+        Status = GetILOffsetFromAddressMap(pMethodInst, nativeOffset, methodOffs);
+        if (Status != S_OK)
+        {
+            // Map unavailable -- fall back to the runtime API even though it may be wrong.
+            if ((Status = pMethodInst->GetILOffsetsByAddress(nativeOffset, 1, NULL, methodOffs)) != S_OK)
+            {
+                ExtDbgOut("ConvertNativeToIlOffset(%p): GetILOffsetsByAddress FAILED %08x\n", nativeOffset, Status);
+                *methodOffs = 0;
+            }
+        }
+    }
+    else if ((Status = pMethodInst->GetILOffsetsByAddress(nativeOffset, 1, NULL, methodOffs)) != S_OK)
     {
         ExtDbgOut("ConvertNativeToIlOffset(%p): GetILOffsetsByAddress FAILED %08x\n", nativeOffset, Status);
         *methodOffs = 0;
     }
-    else
+
+    switch((LONG)*methodOffs)
     {
-        switch((LONG)*methodOffs)
+    case CLRDATA_IL_OFFSET_NO_MAPPING:
+        return E_NOINTERFACE;
+
+    case CLRDATA_IL_OFFSET_PROLOG:
+        // Treat all of the prologue as part of
+        // the first source line.
+        *methodOffs = 0;
+        break;
+
+    case CLRDATA_IL_OFFSET_EPILOG:
+        // Back up until we find the last real
+        // IL offset.
+        if ((Status = GetLastMethodIlOffset(pMethodInst, methodOffs)) != S_OK)
         {
-        case CLRDATA_IL_OFFSET_NO_MAPPING:
-            return E_NOINTERFACE;
-
-        case CLRDATA_IL_OFFSET_PROLOG:
-            // Treat all of the prologue as part of
-            // the first source line.
-            *methodOffs = 0;
-            break;
-
-        case CLRDATA_IL_OFFSET_EPILOG:
-            // Back up until we find the last real
-            // IL offset.
-            if ((Status = GetLastMethodIlOffset(pMethodInst, methodOffs)) != S_OK)
-            {
-                return Status;
-            }
-            break;
+            return Status;
         }
+        break;
     }
 
     return pMethodInst->GetTokenAndScope(methodToken, ppModule);

--- a/src/tests/SOS.UnitTests/Scripts/DivZero.script
+++ b/src/tests/SOS.UnitTests/Scripts/DivZero.script
@@ -37,7 +37,7 @@ VERIFY:\[.*[\\|/]Debuggees[\\|/].*DivZero[\\|/]DivZero\.cs @ 24\s*\]\s*
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+[Dd]iv[Zz]ero.*!C\.F2(\(.*\))?\+0x<HEXVAL>\s+
 VERIFY:\[.*[\\|/]Debuggees[\\|/].*DivZero[\\|/]DivZero\.cs @ 36\s*\]\s*
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+[Dd]iv[Zz]ero.*!C\.Main(\(.*\))?\+0x<HEXVAL>\s+
-VERIFY:\[.*[\\|/]Debuggees[\\|/].*DivZero[\\|/]DivZero\.cs @ (57|56)\s*\]\s*
+VERIFY:\[.*[\\|/]Debuggees[\\|/].*DivZero[\\|/]DivZero\.cs @ 57\s*\]\s*
 
 # Verify that Threads (clrthreads) works
 SOSCOMMAND:clrthreads
@@ -57,4 +57,4 @@ VERIFY:\s+Child\s+SP\s+IP\s+Call Site\s+
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+(\*\*\* WARNING: Unable to verify checksum for DivZero.exe\s*)?C\.DivideByZero(\(.*\))?\s+\[(?i:.*[\\|/]DivZero\.cs) @ 15\s*\]\s+
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+C\.F3(\(.*\))?\s+\[(?i:.*[\\|/]DivZero\.cs) @ 24\s*\]\s+
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+C\.F2(\(.*\))?\s+\[(?i:.*[\\|/]DivZero\.cs) @ 36\s*\]\s+
-VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+C\.Main(\(.*\))?\s+\[(?i:.*[\\|/]DivZero\.cs) @ (57|56)\s*\]\s+
+VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+C\.Main(\(.*\))?\s+\[(?i:.*[\\|/]DivZero\.cs) @ 57\s*\]\s+

--- a/src/tests/SOS.UnitTests/Scripts/NestedExceptionTest.script
+++ b/src/tests/SOS.UnitTests/Scripts/NestedExceptionTest.script
@@ -93,7 +93,12 @@ VERIFY:InnerException:\s+System\.FormatException, Use !?printexception <HEXVAL> 
 VERIFY:StackTrace \(generated\):
 VERIFY:\s+SP\s+IP\s+Function\s+
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+[Nn]ested[Ee]xception[Tt]est.*!NestedExceptionTest\.Program\.Main(\(.*\))?\+0x<HEXVAL>\s*
+IFDEF:DESKTOP
 VERIFY:\[.*[\\|/]Debuggees[\\|/].*[Nn]ested[Ee]xception[Tt]est[\\|/][Nn]ested[Ee]xception[Tt]est\.cs @ (11|20)\s*\]\s*
+ENDIF:DESKTOP
+!IFDEF:DESKTOP
+VERIFY:\[.*[\\|/]Debuggees[\\|/].*[Nn]ested[Ee]xception[Tt]est[\\|/][Nn]ested[Ee]xception[Tt]est\.cs @ 20\s*\]\s*
+ENDIF:DESKTOP
 VERIFY:(StackTraceString: <none>\s+)?
 VERIFY:HResult:\s+80131509\s+
 VERIFY:There are nested exceptions on this thread. Run with -nested for details
@@ -114,4 +119,9 @@ SOSCOMMAND:ClrStack
 VERIFY:.*OS Thread Id:\s+0x<HEXVAL>\s+.*
 VERIFY:\s+Child\s+SP\s+IP\s+Call Site\s+
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+NestedExceptionTest\.Program\.Main(\(.*\))?\s*
+IFDEF:DESKTOP
 VERIFY:\[.*[\\|/]Debuggees[\\|/].*[Nn]ested[Ee]xception[Tt]est[\\|/][Nn]ested[Ee]xception[Tt]est\.cs @ (11|20)\s*\]\s*
+ENDIF:DESKTOP
+!IFDEF:DESKTOP
+VERIFY:\[.*[\\|/]Debuggees[\\|/].*[Nn]ested[Ee]xception[Tt]est[\\|/][Nn]ested[Ee]xception[Tt]est\.cs @ 20\s*\]\s*
+ENDIF:DESKTOP

--- a/src/tests/SOS.UnitTests/Scripts/OtherCommands.script
+++ b/src/tests/SOS.UnitTests/Scripts/OtherCommands.script
@@ -43,7 +43,7 @@ VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.Program\.Foo2\(.*\)\s+\[(?i:.*[\\
 
 CONTINUE
 SOSCOMMAND:ClrStack
-VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.Program\.Foo4\(.*\)\s+\[(?i:.*[\\|/]SymbolTestApp\.cs) @ (37|57)\]\s*
+VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.Program\.Foo4\(.*\)\s+\[(?i:.*[\\|/]SymbolTestApp\.cs) @ 37\]\s*
 
 ENDIF:UNIX_SINGLE_FILE_APP
 ENDIF:ALPINE

--- a/src/tests/SOS.UnitTests/Scripts/StackAndOtherTests.script
+++ b/src/tests/SOS.UnitTests/Scripts/StackAndOtherTests.script
@@ -67,7 +67,7 @@ SOSCOMMAND:SOSStatus
 SOSCOMMAND:ClrStack
 VERIFY:.*OS Thread Id:\s+0x<HEXVAL>\s+.*
 VERIFY:\s+Child\s+SP\s+IP\s+Call Site\s+
-VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>.*\s+SymbolTestApp\.Program\.Foo4\(System\.String\)\s+\[(?i:.*[\\|/]SymbolTestApp\.cs) @ (53|57)\]\s*
+VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>.*\s+SymbolTestApp\.Program\.Foo4\(System\.String\)\s+\[(?i:.*[\\|/]SymbolTestApp\.cs) @ 57\]\s*
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.Program\.Foo2\(.*\)\s+\[(?i:.*[\\|/]SymbolTestApp\.cs) @ 32\]\s*
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.Program\.Foo1\(.*\)\s+\[(?i:.*[\\|/]SymbolTestApp\.cs) @ 27\]\s*
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.Program\.Main\(.*\)\s+\[(?i:.*[\\|/]SymbolTestApp\.cs) @ 22\]\s*
@@ -93,7 +93,7 @@ ENDIF:MAJOR_RUNTIME_VERSION_GE_7
 SOSCOMMAND:ClrStack -f
 VERIFY:.*OS Thread Id:\s+0x<HEXVAL>\s+.*
 VERIFY:\s+Child\s+SP\s+IP\s+Call Site\s+
-VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.(dll|exe)!SymbolTestApp\.Program\.Foo4\(System\.String\)\s+\+\s+<DECVAL>\s+\[(?i:.*[\\|/]SymbolTestApp\.cs) @ (53|57)\]\s*
+VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.(dll|exe)!SymbolTestApp\.Program\.Foo4\(System\.String\)\s+\+\s+<DECVAL>\s+\[(?i:.*[\\|/]SymbolTestApp\.cs) @ 57\]\s*
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.(dll|exe)!SymbolTestApp\.Program\.Foo2\(.*\)\s+\+\s+<DECVAL>\s+\[(?i:.*[\\|/]SymbolTestApp\.cs) @ 32\]\s*
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.(dll|exe)!SymbolTestApp\.Program\.Foo1\(.*\)\s+\+\s+<DECVAL>\s+\[(?i:.*[\\|/]SymbolTestApp\.cs) @ 27\]\s*
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.(dll|exe)!SymbolTestApp\.Program\.Main\(.*\)\s+\+\s+<DECVAL>\s+\[(?i:.*[\\|/]SymbolTestApp\.cs) @ 22\]\s*
@@ -102,7 +102,7 @@ VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.(dll|exe)!SymbolTestApp\.Program\
 SOSCOMMAND:ClrStack -a
 VERIFY:.*OS Thread Id:\s+0x<HEXVAL>\s+.*
 VERIFY:\s+Child\s+SP\s+IP\s+Call Site\s+
-VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.Program\.Foo4\(System\.String\)\s+\[(?i:.*[\\|/]SymbolTestApp\.cs) @ (53|57)\]\s*
+VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.Program\.Foo4\(System\.String\)\s+\[(?i:.*[\\|/]SymbolTestApp\.cs) @ 57\]\s*
 VERIFY:\s+PARAMETERS:\s+
 VERIFY:\s+dllPath \(0x<HEXVAL>\) = 0x<HEXVAL>\s+
 VERIFY:.*\s+LOCALS:\s+
@@ -116,7 +116,7 @@ SOSCOMMAND:ClrStack -r
 VERIFY:.*OS Thread Id:\s+0x<HEXVAL>\s+.*
 VERIFY:\s+Child\s+SP\s+IP\s+Call Site\s+
 
-VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.Program\.Foo4\(System\.String\)\s+\[(?i:.*[\\|/]SymbolTestApp\.cs) @ (53|57)\]\s*
+VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.Program\.Foo4\(System\.String\)\s+\[(?i:.*[\\|/]SymbolTestApp\.cs) @ 57\]\s*
 IFDEF:ARM
 VERIFY:\s+r0=<HEXVAL>\s+r1=<HEXVAL>\s+r2=<HEXVAL>\s+
 ENDIF:ARM
@@ -236,7 +236,7 @@ ENDIF:DOTNETDUMP
 SOSCOMMAND:ClrStack
 SOSCOMMAND:IP2MD <POUT>.*\s+(<HEXVAL>)\s+SymbolTestApp\.Program\.Foo4.*\s+<POUT>
 VERIFY:.*\s+Method Name:\s+SymbolTestApp\.Program\.Foo4\(System\.String\)\s+
-VERIFY:.*\s+Source file:\s+(?i:.*[\\|/]SymbolTestApp\.cs) @ (53|57)\s+
+VERIFY:.*\s+Source file:\s+(?i:.*[\\|/]SymbolTestApp\.cs) @ 57\s+
 
 # Verify that DumpIL works (depends on the IP2MD right above)
 SOSCOMMAND:DumpIL <POUT>\s*MethodDesc:\s+(<HEXVAL>)\s*<POUT>
@@ -256,7 +256,7 @@ SOSCOMMAND:clru <POUT>\s*MethodDesc:\s+(<HEXVAL>)\s*<POUT>
 VERIFY:\s*Normal JIT generated code\s+
 VERIFY:\s+SymbolTestApp\.Program\.Foo4\(System\.String\)\s+
 VERIFY:\s+Begin\s+<HEXVAL>,\s+size\s+<HEXVAL>\s+
-VERIFY:\s+(?i:.*[\\|/]SymbolTestApp\.cs) @ (53|57):\s+
+VERIFY:\s+(?i:.*[\\|/]SymbolTestApp\.cs) @ 57:\s+
 
 # Verify that "u" with no line info works
 SOSCOMMAND:clru -n <PREVPOUT>
@@ -269,7 +269,7 @@ SOSCOMMAND:clru -o <PREVPOUT>
 VERIFY:\s*Normal JIT generated code\s+
 VERIFY:\s+SymbolTestApp\.Program\.Foo4\(System\.String\)\s+
 VERIFY:\s+Begin\s+<HEXVAL>,\s+size\s+<HEXVAL>\s+
-VERIFY:\s+(?i:.*[\\|/]SymbolTestApp\.cs) @ (53|57):\s+
+VERIFY:\s+(?i:.*[\\|/]SymbolTestApp\.cs) @ 57:\s+
 
 ENDIF:DOTNETDUMP
 

--- a/src/tests/SOS.UnitTests/Scripts/StackTests.script
+++ b/src/tests/SOS.UnitTests/Scripts/StackTests.script
@@ -20,7 +20,12 @@ ENDIF:ALPINE
 SOSCOMMAND:ClrStack
 VERIFY:.*OS Thread Id:\s+0x<HEXVAL>\s+.*
 VERIFY:\s+Child\s+SP\s+IP\s+Call Site\s+
+IFDEF:DESKTOP
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>.*\s+NestedExceptionTest\.Program\.Main\(.*\)\s+\[(?i:.*[\\|/]NestedExceptionTest\.cs) @ (11|20)\s*\]\s+
+ENDIF:DESKTOP
+!IFDEF:DESKTOP
+VERIFY:\s+<HEXVAL>\s+<HEXVAL>.*\s+NestedExceptionTest\.Program\.Main\(.*\)\s+\[(?i:.*[\\|/]NestedExceptionTest\.cs) @ 20\s*\]\s+
+ENDIF:DESKTOP
 IFDEF:64BIT
 VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+NestedExceptionTest\.Program\.Main\(.*\)\s+\[(?i:.*[\\|/]NestedExceptionTest\.cs) @ 16\s*\]\s+
 ENDIF:64BIT
@@ -42,7 +47,12 @@ ENDIF:DOTNETDUMP
 SOSCOMMAND:ClrStack -f
 VERIFY:.*OS Thread Id:\s+0x<HEXVAL>\s+.*
 VERIFY:\s+Child\s+SP\s+IP\s+Call Site\s+
+IFDEF:DESKTOP
 VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+(?i:NestedExceptionTest.*)!NestedExceptionTest\.Program\.Main\(.*\)\s+\+\s+<DECVAL>\s+\[(?i:.*[\\|/]NestedExceptionTest\.cs) @ (11|20)\s*\]\s+
+ENDIF:DESKTOP
+!IFDEF:DESKTOP
+VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+(?i:NestedExceptionTest.*)!NestedExceptionTest\.Program\.Main\(.*\)\s+\+\s+<DECVAL>\s+\[(?i:.*[\\|/]NestedExceptionTest\.cs) @ 20\s*\]\s+
+ENDIF:DESKTOP
 IFDEF:64BIT
 VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+(?i:NestedExceptionTest.*)!NestedExceptionTest\.Program\.Main\(.*\)\s+\+\s+<DECVAL>\s+\[(?i:.*[\\|/]NestedExceptionTest\.cs) @ 16\s*\]\s+
 ENDIF:64BIT
@@ -51,7 +61,12 @@ ENDIF:64BIT
 SOSCOMMAND:ClrStack -a
 VERIFY:.*OS Thread Id:\s+0x<HEXVAL>\s+.*
 VERIFY:\s+Child\s+SP\s+IP\s+Call Site\s+
+IFDEF:DESKTOP
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+NestedExceptionTest\.Program\.Main\(.*\)\s+\[(?i:.*[\\|/]NestedExceptionTest\.cs) @ (11|20)\s*\]\s+
+ENDIF:DESKTOP
+!IFDEF:DESKTOP
+VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+NestedExceptionTest\.Program\.Main\(.*\)\s+\[(?i:.*[\\|/]NestedExceptionTest\.cs) @ 20\s*\]\s+
+ENDIF:DESKTOP
 VERIFY:\s+PARAMETERS:\s+
 VERIFY:\s+args \(0x<HEXVAL>\) = 0x<HEXVAL>\s+
 VERIFY:\s+LOCALS:\s+
@@ -69,7 +84,12 @@ SOSCOMMAND:ClrStack -r
 VERIFY:.*OS Thread Id:\s+0x<HEXVAL>\s+.*
 VERIFY:\s+Child\s+SP\s+IP\s+Call Site\s+
 
+IFDEF:DESKTOP
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+NestedExceptionTest\.Program\.Main\(.*\)\s+\[(?i:.*[\\|/]NestedExceptionTest\.cs) @ (11|20)\s*\]\s+
+ENDIF:DESKTOP
+!IFDEF:DESKTOP
+VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+NestedExceptionTest\.Program\.Main\(.*\)\s+\[(?i:.*[\\|/]NestedExceptionTest\.cs) @ 20\s*\]\s+
+ENDIF:DESKTOP
 IFDEF:ARM
 VERIFY:\s+r0=<HEXVAL>\s+r1=<HEXVAL>\s+r2=<HEXVAL>\s+
 ENDIF:ARM

--- a/src/tests/SOS.UnitTests/Scripts/TaskNestedException.script
+++ b/src/tests/SOS.UnitTests/Scripts/TaskNestedException.script
@@ -30,7 +30,7 @@ VERIFY:\s+SP\s+IP\s+Function\s+
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>.+RandomTest(::|\.)RandomUserTask\.<\.ctor>.+\+0x<HEXVAL>\s*
 !IFDEF:DESKTOP
 !IFDEF:TRIAGE_DUMP
-VERIFY:[.+[\\|/]Debuggees[\\|/].*[Tt]ask[Nn]ested[Ee]xception[\\|/][Rr]andom[Uu]ser[Ll]ibrary[\\|/][Rr]andom[Uu]ser[Tt]ask\.cs @ (19|26)\]
+VERIFY:[.+[\\|/]Debuggees[\\|/].*[Tt]ask[Nn]ested[Ee]xception[\\|/][Rr]andom[Uu]ser[Ll]ibrary[\\|/][Rr]andom[Uu]ser[Tt]ask\.cs @ 26\]
 ENDIF:TRIAGE_DUMP
 ENDIF:DESKTOP
 
@@ -44,7 +44,7 @@ VERIFY:\s+SP\s+IP\s+Function\s+
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>.+RandomTest(::|\.)RandomUserTask\.InnerException(\(\))?\+0x<HEXVAL>\s*
 !IFDEF:DESKTOP
 !IFDEF:TRIAGE_DUMP
-VERIFY:[.+[\\|/]Debuggees[\\|/].*[Tt]ask[Nn]ested[Ee]xception[\\|/][Rr]andom[Uu]ser[Ll]ibrary[\\|/][Rr]andom[Uu]ser[Tt]ask\.cs @ (37|38)\]
+VERIFY:[.+[\\|/]Debuggees[\\|/].*[Tt]ask[Nn]ested[Ee]xception[\\|/][Rr]andom[Uu]ser[Ll]ibrary[\\|/][Rr]andom[Uu]ser[Tt]ask\.cs @ 38\]
 ENDIF:TRIAGE_DUMP
 ENDIF:DESKTOP
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>.+RandomTest(::|\.)RandomUserTask\.<\.ctor>.+\+0x<HEXVAL>\s*


### PR DESCRIPTION
Fixes dotnet/diagnostics#794

## Product code change (`src/SOS/Strike/util.cpp`)

Adds a runtime-version-dependent fallback path in `ConvertNativeToIlOffset`:

- **.NET 5.0 and newer:** continue calling `IXCLRDataMethodInstance::GetILOffsetsByAddress` (the runtime-side fix landed in .NET 5, so this returns the correct IL offset for a given native address).
- **Pre-.NET 5.0 (incl. Desktop CLR):** walk the IL-to-native address map ourselves via the new helper `GetILOffsetFromAddressMap` and pick the entry whose native range contains the queried offset. The old DAC method on those runtimes returns `S_OK` with the wrong IL offset, so SOS line numbers were off-by-one-statement on .NET Framework / pre-5.0 Core. Falls back to `GetILOffsetsByAddress` if the map is unavailable.

## Test script changes

Now that the .NET 5+ path returns correct IL offsets, the test scripts can expect a single line number on Core configs and only keep the dual-match `(a|b)` patterns guarded by `IFDEF:DESKTOP` where Desktop CLR still maps to the previous statement:

- `DivZero.script` — Main expects `@ 57` (was `(57|56)`).
- `StackAndOtherTests.script` — Foo2/Foo4 expect single line numbers across the multiple `ClrStack` checks.
- `OtherCommands.script` — Foo2/Foo4 line numbers tightened.
- `NestedExceptionTest.script` / `StackTests.script` — Core path now expects `@ 20` only; Desktop branches still allow `(11|20)`.
- `TaskNestedException.script` — RandomUserTask constructor and InnerException line numbers updated to match the corrected offsets.