### PR TITLE
Fix COM ref counting in SOSMethodEnum simulator

### DIFF
--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -1317,7 +1317,7 @@ DECLARE_API(DumpMT)
 
         table.WriteRow("Entry", "MethodDesc", "JIT", "Slot", "Name");
 
-        ISOSMethodEnum *pMethodEnumerator;
+        ToRelease<ISOSMethodEnum> pMethodEnumerator;
         if (SUCCEEDED(g_sos15->GetMethodTableSlotEnumerator(dwStartAddr, &pMethodEnumerator)))
         {
             SOSMethodData entry;

--- a/src/SOS/Strike/util.cpp
+++ b/src/SOS/Strike/util.cpp
@@ -3644,7 +3644,7 @@ class SOSDacInterface15Simulator : public ISOSDacInterface15
         unsigned int slotCount;
         ULONG refCount;
     public:
-        SOSMethodEnum(CLRDATA_ADDRESS mt) : pMT(mt), refCount(1)
+        SOSMethodEnum(CLRDATA_ADDRESS mt) : pMT(mt), refCount(0)
         {
         }
 
@@ -3769,16 +3769,18 @@ public:
             ISOSMethodEnum **enumerator)
     {
         SOSMethodEnum *simulator = new(std::nothrow) SOSMethodEnum(mt);
-        *enumerator = simulator;
         if (simulator == NULL)
         {
             return E_OUTOFMEMORY;
         }
         HRESULT hr = simulator->Reset();
+
+        if (SUCCEEDED(hr))
+            hr = simulator->QueryInterface(__uuidof(ISOSMethodEnum), (void**)enumerator);
+
         if (FAILED(hr))
-        {
-            simulator->Release();
-        }
+            delete simulator;
+
         return hr;
     }
 } SOSDacInterface15Simulator_Instance;

--- a/src/shared/inc/sospriv.idl
+++ b/src/shared/inc/sospriv.idl
@@ -444,7 +444,7 @@ interface ISOSDacInterface8 : IUnknown
 // Increment anytime there is a change in the data structures that SOS depends on like
 // stress log structs (StressMsg, StressLogChunck, ThreadStressLog, etc), exception
 // stack traces (StackTraceElement), the PredefinedTlsSlots enums, etc.
-cpp_quote("#define SOS_BREAKING_CHANGE_VERSION 5")
+cpp_quote("#define SOS_BREAKING_CHANGE_VERSION 6")
 
 [
     object,

--- a/src/shared/pal/prebuilt/inc/sospriv.h
+++ b/src/shared/pal/prebuilt/inc/sospriv.h
@@ -2802,7 +2802,7 @@ EXTERN_C const IID IID_ISOSDacInterface8;
 /* interface __MIDL_itf_sospriv_0000_0012 */
 /* [local] */
 
-#define SOS_BREAKING_CHANGE_VERSION 5
+#define SOS_BREAKING_CHANGE_VERSION 6
 
 
 extern RPC_IF_HANDLE __MIDL_itf_sospriv_0000_0012_v0_0_c_ifspec;


### PR DESCRIPTION
## Summary

Matching PR for dotnet/runtime#125231, which fixes `DefaultCOMImpl::Release()` reference counting bugs in the DAC.

### Changes

**1. Fix `SOSMethodEnum` simulator COM ref counting** (`util.cpp`)

The `SOSDacInterface15` simulator's `GetMethodTableSlotEnumerator` had the same bug pattern fixed in the runtime PR — raw pointer assignment without `QueryInterface`, and the null check occurred after the dereference. Fixed to:
- Initialize `refCount` to 0 (matching `DefaultCOMImpl` convention)
- Use `QueryInterface` to return the interface, properly calling `AddRef`
- Check for null before dereferencing the out parameter
- Use `delete` on failure (since `QueryInterface` wasn't called at refCount 0)

**2. Fix `ISOSMethodEnum` leak in `strike.cpp`**

Changed raw `ISOSMethodEnum*` to `ToRelease<ISOSMethodEnum>` so `Release()` is called when the pointer goes out of scope, matching the pattern used everywhere else (e.g., `ToRelease<ISOSHandleEnum>`).