### PR TITLE
Fix restore cursor for collect-linux

### DIFF
--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectLinuxCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectLinuxCommand.cs
@@ -82,8 +82,6 @@ namespace Microsoft.Diagnostics.Tools.Trace
 
             int ret = (int)ReturnCode.TracingError;
             string scriptPath = null;
-            bool cursorVisibilityChanged = false;
-            bool originalCursorVisible = false;
             try
             {
                 if (args.Probe)
@@ -104,12 +102,9 @@ namespace Microsoft.Diagnostics.Tools.Trace
 
                 args.Ct.Register(() => stopTracing = true);
 
-                // Only hide cursor if output is not redirected
                 if (!Console.IsOutputRedirected)
                 {
-                    originalCursorVisible = Console.CursorVisible;
                     Console.CursorVisible = false;
-                    cursorVisibilityChanged = true;
                 }
 
                 byte[] command = BuildRecordTraceArgs(args, out scriptPath);
@@ -145,10 +140,9 @@ namespace Microsoft.Diagnostics.Tools.Trace
             }
             finally
             {
-                // Restore cursor visibility to its original state if we changed it
-                if (cursorVisibilityChanged)
+                if (!Console.IsOutputRedirected)
                 {
-                    Console.CursorVisible = originalCursorVisible;
+                    Console.CursorVisible = true;
                 }
 
                 if (!string.IsNullOrEmpty(scriptPath))

--- a/src/tests/dotnet-trace/CollectLinuxCommandFunctionalTests.cs
+++ b/src/tests/dotnet-trace/CollectLinuxCommandFunctionalTests.cs
@@ -225,20 +225,24 @@ namespace Microsoft.Diagnostics.Tools.Trace
         [ConditionalFact(nameof(IsCollectLinuxSupported))]
         public void CollectLinuxCommand_RestoresCursorVisibility_OnSuccess()
         {
-            MockConsole console = new(200, 30, _outputHelper);
-            console.CursorVisible = true;
+            MockConsole console = new(200, 30, _outputHelper)
+            {
+                CursorVisible = false
+            };
 
             int exitCode = Run(TestArgs(), console);
 
-            // Cursor should be restored to visible after command completes
+            // Cursor visibility should always be restored to visible after command completes
             Assert.True(console.CursorVisible, "Cursor should be visible after command completes");
         }
 
         [ConditionalFact(nameof(IsCollectLinuxSupported))]
         public void CollectLinuxCommand_RestoresCursorVisibility_OnError()
         {
-            MockConsole console = new(200, 30, _outputHelper);
-            console.CursorVisible = true;
+            MockConsole console = new(200, 30, _outputHelper)
+            {
+                CursorVisible = false
+            };
 
             var handler = new CollectLinuxCommandHandler(console);
             // Simulate an error by throwing an exception in the RecordTraceInvoker
@@ -248,7 +252,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
 
             int exitCode = handler.CollectLinux(TestArgs());
 
-            // Cursor should be restored to visible even when an error occurs
+            // Cursor visibility should always be restored to visible even when an error occurs
             Assert.True(console.CursorVisible, "Cursor should be visible after error");
             Assert.Equal((int)ReturnCode.TracingError, exitCode);
         }
@@ -258,9 +262,11 @@ namespace Microsoft.Diagnostics.Tools.Trace
         [InlineData(false)]
         public void CollectLinuxCommand_DoesNotChangeCursorVisibility_WhenOutputIsRedirected(bool initialCursorVisible)
         {
-            MockConsole console = new(200, 30, _outputHelper);
-            console.CursorVisible = initialCursorVisible;
-            console.IsOutputRedirected = true;
+            MockConsole console = new(200, 30, _outputHelper)
+            {
+                CursorVisible = initialCursorVisible,
+                IsOutputRedirected = true
+            };
 
             int exitCode = Run(TestArgs(), console);
 


### PR DESCRIPTION
On Linux, the in-framework Console.CursorVisible getter always throws PlatformNotSupportedException while the setter works via ANSI escape codes. The collect-linux command was reading Console.CursorVisible to save and restore cursor state, which caused an unhandled exception on every invocation. Since the tests were mocking console, nothing got caught.

The getter is unsupported on Linux (the only platform collect-linux runs on) - the most sensible thing was to remove the read entirely and always restore cursor visibility to true on exit.
