### PR TITLE
Fix COM ref counting in SOSMethodEnum

### DIFF
--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -1317,7 +1317,7 @@ DECLARE_API(DumpMT)
 
         table.WriteRow("Entry", "MethodDesc", "JIT", "Slot", "Name");
 
-        ISOSMethodEnum *pMethodEnumerator;
+        ToRelease<ISOSMethodEnum> pMethodEnumerator;
         if (SUCCEEDED(g_sos15->GetMethodTableSlotEnumerator(dwStartAddr, &pMethodEnumerator)))
         {
             SOSMethodData entry;

--- a/src/SOS/Strike/util.cpp
+++ b/src/SOS/Strike/util.cpp
@@ -3644,7 +3644,7 @@ class SOSDacInterface15Simulator : public ISOSDacInterface15
         unsigned int slotCount;
         ULONG refCount;
     public:
-        SOSMethodEnum(CLRDATA_ADDRESS mt) : pMT(mt), refCount(1)
+        SOSMethodEnum(CLRDATA_ADDRESS mt) : pMT(mt), refCount(0)
         {
         }
 
@@ -3769,16 +3769,18 @@ public:
             ISOSMethodEnum **enumerator)
     {
         SOSMethodEnum *simulator = new(std::nothrow) SOSMethodEnum(mt);
-        *enumerator = simulator;
         if (simulator == NULL)
         {
             return E_OUTOFMEMORY;
         }
         HRESULT hr = simulator->Reset();
+
+        if (SUCCEEDED(hr))
+            hr = simulator->QueryInterface(__uuidof(ISOSMethodEnum), (void**)enumerator);
+
         if (FAILED(hr))
-        {
-            simulator->Release();
-        }
+            delete simulator;
+
         return hr;
     }
 } SOSDacInterface15Simulator_Instance;


### PR DESCRIPTION
## Summary

Matching PR for dotnet/runtime#125231, which fixes `DefaultCOMImpl::Release()` reference counting bugs in the DAC.

### Changes

**1. Fix `SOSMethodEnum` simulator COM ref counting** (`util.cpp`)

The `SOSDacInterface15` simulator's `GetMethodTableSlotEnumerator` had the same bug pattern fixed in the runtime PR — raw pointer assignment without `QueryInterface`, and the null check occurred after the dereference. Fixed to:
- Initialize `refCount` to 0 (matching `DefaultCOMImpl` convention)
- Use `QueryInterface` to return the interface, properly calling `AddRef`
- Check for null before dereferencing the out parameter
- Use `delete` on failure (since `QueryInterface` wasn't called at refCount 0)

**2. Fix `ISOSMethodEnum` leak in `strike.cpp`**

Changed raw `ISOSMethodEnum*` to `ToRelease<ISOSMethodEnum>` so `Release()` is called when the pointer goes out of scope, matching the pattern used everywhere else (e.g., `ToRelease<ISOSHandleEnum>`).