### PR TITLE
Add tool version lookup for correlating commits to daily builds

### DIFF
--- a/eng/tool-version-lookup.cmd
+++ b/eng/tool-version-lookup.cmd
@@ -1,0 +1,3 @@
+@echo off
+powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0tool-version-lookup.ps1""" %*"
+exit /b %ErrorLevel%

--- a/eng/tool-version-lookup.ps1
+++ b/eng/tool-version-lookup.ps1
@@ -30,6 +30,11 @@
     Finds the earliest daily build version published after a given commit.
 
 .EXAMPLE
+    eng\tool-version-lookup.ps1 verify 10.0.711601
+
+    Checks whether a specific version exists on the dotnet-tools feed.
+
+.EXAMPLE
     eng\tool-version-lookup.ps1 list -Last 5
 
     Lists the 5 most recent daily build versions on the feed.
@@ -38,7 +43,7 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory=$true, Position=0)]
-    [ValidateSet("decode", "before", "after", "list")]
+    [ValidateSet("decode", "before", "after", "verify", "list")]
     [string]$Command,
 
     [Parameter(Position=1)]
@@ -328,9 +333,54 @@ function Invoke-List {
     }
 }
 
+function Invoke-Verify {
+    if (-not $Ref) {
+        Write-Error "Usage: tool-version-lookup.ps1 verify <version>"
+        exit 1
+    }
+    $versions = Get-FeedVersions $Tool
+
+    if ($versions -contains $Ref) {
+        $parsed = Parse-ToolVersion $Ref
+        if ($parsed) {
+            Write-Host "[OK] $Tool $Ref exists on the feed"
+            Write-Host "  Built: $(Format-BuildDate $parsed.Patch)"
+        }
+        else {
+            Write-Host "[OK] $Tool $Ref exists on the feed"
+        }
+    }
+    else {
+        Write-Host "[NOT FOUND] $Tool $Ref NOT found on the feed" -ForegroundColor Red
+
+        $parsed = Parse-ToolVersion $Ref
+        if ($parsed) {
+            $nearby = @()
+            foreach ($v in $versions) {
+                $vp = Parse-ToolVersion $v
+                if ($vp -and $vp.Major -eq $parsed.Major -and $vp.Minor -eq $parsed.Minor) {
+                    if ([math]::Abs($vp.Patch - $parsed.Patch) -lt 500) {
+                        $nearby += $v
+                    }
+                }
+            }
+            if ($nearby.Length -gt 0) {
+                Write-Host ""
+                Write-Host "  Nearby versions:"
+                $nearby | Select-Object -Last 5 | ForEach-Object {
+                    $vp = Parse-ToolVersion $_
+                    Write-Host ("    {0,-20}  built {1}" -f $_, (Format-BuildDate $vp.Patch))
+                }
+            }
+        }
+        exit 1
+    }
+}
+
 switch ($Command) {
     "decode"  { Invoke-Decode }
     "before"  { Invoke-BeforeOrAfter -IsBefore $true }
     "after"   { Invoke-BeforeOrAfter -IsBefore $false }
+    "verify"  { Invoke-Verify }
     "list"    { Invoke-List }
 }

--- a/eng/tool-version-lookup.sh
+++ b/eng/tool-version-lookup.sh
@@ -5,6 +5,7 @@
 #   eng/tool-version-lookup.sh decode 10.0.715501
 #   eng/tool-version-lookup.sh before <commit-sha> [--tool dotnet-trace]
 #   eng/tool-version-lookup.sh after <commit-sha> [--tool dotnet-trace]
+#   eng/tool-version-lookup.sh verify 10.0.711601 [--tool dotnet-trace]
 #   eng/tool-version-lookup.sh list [--tool dotnet-trace] [--last 10]
 
 set -euo pipefail
@@ -283,6 +284,46 @@ cmd_before_or_after() {
     fi
 }
 
+cmd_verify() {
+    local version="$1"
+    local versions
+    versions=$(get_feed_versions "$TOOL")
+
+    if echo "$versions" | grep -qxF "$version"; then
+        parse_version "$version"
+        echo "[OK] $TOOL $version exists on the feed"
+        echo "  Built: $(format_build_date "$VER_PATCH")"
+    else
+        echo "[NOT FOUND] $TOOL $version NOT found on the feed" >&2
+
+        if parse_version "$version"; then
+            local target_major=$VER_MAJOR target_minor=$VER_MINOR target_patch=$VER_PATCH
+            local nearby=()
+            while IFS= read -r v; do
+                if parse_version "$v"; then
+                    if [ "$VER_MAJOR" -eq "$target_major" ] && [ "$VER_MINOR" -eq "$target_minor" ]; then
+                        local diff=$(( VER_PATCH - target_patch ))
+                        [ "$diff" -lt 0 ] && diff=$(( -diff ))
+                        if [ "$diff" -lt 500 ]; then
+                            nearby+=("$v")
+                        fi
+                    fi
+                fi
+            done <<< "$versions"
+
+            if [ ${#nearby[@]} -gt 0 ]; then
+                echo "" >&2
+                echo "  Nearby versions:" >&2
+                printf '%s\n' "${nearby[@]}" | tail -5 | while IFS= read -r v; do
+                    parse_version "$v"
+                    printf "    %-20s  built %s\n" "$v" "$(format_build_date "$VER_PATCH")" >&2
+                done
+            fi
+        fi
+        exit 1
+    fi
+}
+
 cmd_list() {
     local versions
     versions=$(get_feed_versions "$TOOL")
@@ -326,6 +367,7 @@ while [[ $# -gt 0 ]]; do
             echo "  decode <version>     Decode a tool version to its build date"
             echo "  before <commit>      Find latest feed version built before a commit/date"
             echo "  after <commit>       Find earliest feed version built after a commit/date"
+            echo "  verify <version>     Check if a version exists on the feed"
             echo "  list                 List recent versions on the feed"
             echo ""
             echo "Options:"
@@ -352,6 +394,10 @@ case "$COMMAND" in
         ;;
     after)
         cmd_before_or_after "false" "$REF_ARG"
+        ;;
+    verify)
+        [ -n "$REF_ARG" ] || die "Usage: tool-version-lookup.sh verify <version>"
+        cmd_verify "$REF_ARG"
         ;;
     list)
         cmd_list


### PR DESCRIPTION
When users encounter problematic daily builds of our tools (e.g., #5752), it would be helpful to quickly provide them with either a version before the problematic commit to downgrade to, or a version after the fix commit to upgrade to. Today this requires manually decoding the Arcade SDK version encoding and searching the NuGet feed.
   
   This PR adds `eng/tool-version-lookup.{ps1,sh,cmd}` with five commands:
   
   - **`decode <version>`** — Decode a tool version to its build date, OfficialBuildId, and commit SHA
   - **`before <commit>`** — Find the latest feed version built before a commit (downgrade past a regression)
   - **`after <commit>`** — Find the earliest feed version built after a commit (upgrade to include a fix)
   - **`verify <version>`** — Check whether a version exists on the dotnet-tools feed
   - **`list`** — List recent daily build versions with decoded build dates
   
   ### Example: triaging #5752
   
   ```
   # User reported version 10.0.715501+86150ac0... — what commit is that?
   eng/tool-version-lookup.ps1 decode "10.0.715501+86150ac0275658c5efc6035269499a86dee68e54"
   
   # Find a version before the problematic commit to downgrade to
   eng/tool-version-lookup.ps1 before bda9ea7b
   
   # Find the first version after the fix to upgrade to
   eng/tool-version-lookup.ps1 after 18cf9d1
   ```
   
   ### Design notes
   
   - Version math mirrors the Arcade SDK's `Version.BeforeCommonTargets.targets` (`PATCH = (YY*1000 + MM*50 + DD - 19000) * 100 + revision`)
   - Queries the dotnet-tools NuGet flat container API (read-only, no credentials)
   - Commit refs validated as hex-only to prevent argument injection
   - PowerShell (`.ps1`) and Bash (`.sh`) are independent native implementations; `.cmd` is a thin wrapper following repo convention