### PR TITLE
[DotnetTrace][CollectLinux] Enable callstack capture for .NET runtime events in collect-linux

### DIFF
--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectLinuxCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectLinuxCommand.cs
@@ -381,6 +381,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 }
 
                 scriptBuilder.Append($"let {providerNameSanitized}_flags = new_dotnet_provider_flags();\n");
+                scriptBuilder.Append($"{providerNameSanitized}_flags.with_callstacks();\n");
                 scriptBuilder.Append($"record_dotnet_provider(\"{providerName}\", 0x{keywords:X}, {eventLevel}, {providerNameSanitized}_flags);\n\n");
             }
 


### PR DESCRIPTION
`dotnet-trace collect-linux` creates provider flags with `new_dotnet_provider_flags()` which defaults callstacks to false. This causes `perf_event` to skip callchain capture for .NET runtime events (exceptions, GC, etc.), resulting in stacks that only show the kernel's `user_events_write_core` frame with no user-space context.

This adds `with_callstacks()` to the provider flags so `perf_event` captures callchains for runtime events. Without this fix, the exception stacks view in PerfView shows:
```
Name
 ROOT
+ Process32 dotnet-sample (2672) Args: dotnet-sample
 + Thread (2683)
  + BROKEN
   + vmlinux!user_events_write_core.isra.0
    + Throw() 
```

With this fix, the physical call stack is captured including resolved runtime frames:
```
Name
 ROOT
+ Process32 dotnet-sample (9808) Args: dotnet-sample
 + Thread (9819)
  + BROKEN
   + libcoreclr.so!DispatchManagedException(Object*, _CONTEXT*, _EXCEPTION_RECORD*)
    + libcoreclr.so!DispatchCallSimple(unsigned long*, unsigned int, unsigned long, unsigned int)
     + libcoreclr.so!CallDescrWorkerInternal
      + ManagedModule!EH.DispatchEx
      |+ libcoreclr.so!SfiInit
      | + libcoreclr.so!SfiInitWorker(StackFrameIterator*, _CONTEXT*, bool, bool*)
      |  + libcoreclr.so!ETW::ExceptionLog::ExceptionThrown(CrawlFrame*, int, int)
      |   + libcoreclr.so!EventPipeWriteEventExceptionThrown_V1
      |    + libcoreclr.so!ep_write_event(_EventPipeEvent*, unsigned char*, unsigned int, unsigned char const*, unsigned char const*)
      |     + libcoreclr.so!write_event_2(Thread*, _EventPipeEvent*, _EventPipeEventPayload*, unsigned char const*, unsigned char const*, Thread*, _EventPipeStackContents*)
      |      + libcoreclr.so!ep_session_write_event(_EventPipeSession*, Thread*, _EventPipeEvent*, _EventPipeEventPayload*, unsigned char const*, unsigned char const*, Thread*, _EventPipeStackContents*)
      |       + libc.so.6!writev
      |        + vmlinux!entry_SYSCALL_64_after_hwframe
      |         + vmlinux!do_syscall_64
      |          + vmlinux!x64_sys_call
      |           + vmlinux!__x64_sys_writev
      |            + vmlinux!do_writev
      |             + vmlinux!vfs_writev
      |              + vmlinux!do_iter_write
      |               + vmlinux!do_iter_readv_writev
      |                + vmlinux!user_events_write_iter
      |                 + vmlinux!user_events_write_core.isra.0
      |                  + Throw() 

```
Note: collect-linux captures the physical CPU call stack at the tracepoint fire site, which includes runtime internals. The clean managed-only stacks shown by dotnet-trace collect (e.g., `ExceptionWorker` -> `ThrowNested` -> `Throw`) require the runtime's internal managed stack walker, which is not yet included in user_events tracepoint data.