### PR TITLE
Disable desktop CLR and single-file DAC tests blocked by CDB SecureLoadDotNetExtensions

### DIFF
--- a/src/tests/SOS.UnitTests/SOS.cs
+++ b/src/tests/SOS.UnitTests/SOS.cs
@@ -251,7 +251,11 @@ public class SOS
 
     private ITestOutputHelper Output { get; set; }
 
-    public static IEnumerable<object[]> Configurations => SOSTestHelpers.GetConfigurations("TestName", value: null);
+    // Desktop CLR configurations are temporarily excluded because CDB SecureLoadDotNetExtensions
+    // and dotnet-dump DacSignatureVerification reject desktop CLR DAC DLLs.
+    // Tracking: https://github.com/dotnet/diagnostics/issues/5757
+    public static IEnumerable<object[]> Configurations => SOSTestHelpers.GetConfigurations("TestName", value: null)
+        .Where(args => !((TestConfiguration)args[0]).IsDesktop);
 
     [SkippableTheory, MemberData(nameof(SOSTestHelpers.GetNetCoreConfigurations), MemberType = typeof(SOSTestHelpers))]
     public async Task MiniDumpLocalVarLookup(TestConfiguration config)
@@ -546,6 +550,12 @@ public class SOS
     [SkippableTheory, MemberData(nameof(SOSTestHelpers.GetConfigurations), "TestName", "SOS.StackAndOtherTests", MemberType = typeof(SOSTestHelpers))]
     public async Task StackAndOtherTests(TestConfiguration config)
     {
+        // Single-file .NET 8 servicing DAC signature verification fails with CDB SecureLoadDotNetExtensions.
+        // Tracking: https://github.com/dotnet/diagnostics/issues/5757
+        if (OS.Kind == OSKind.Windows && config.PublishSingleFile)
+        {
+            throw new SkipTestException("Single-file DAC signature verification failure with CDB (https://github.com/dotnet/diagnostics/issues/5757)");
+        }
         if (config.RuntimeFrameworkVersionMajor == 10)
         {
             // The clrstack -i -a command regressed on .NET 10 win-x86, so skip this test for now.
@@ -623,6 +633,13 @@ public class SOS
         if (config.PublishSingleFile)
         {
             throw new SkipTestException("Single file not supported");
+        }
+        // Desktop CLR DAC signature verification fails with CDB SecureLoadDotNetExtensions
+        // and dotnet-dump DacSignatureVerification.
+        // Tracking: https://github.com/dotnet/diagnostics/issues/5757
+        if (OS.Kind == OSKind.Windows)
+        {
+            throw new SkipTestException("Desktop CLR DAC signature verification failure (https://github.com/dotnet/diagnostics/issues/5757)");
         }
         // The assembly path, class and function name of the desktop test code to load/run
         string desktopTestParameters = TestConfiguration.MakeCanonicalPath(config.GetValue("DesktopTestParameters"));

--- a/src/tests/SOS.UnitTests/SOSRunner.cs
+++ b/src/tests/SOS.UnitTests/SOSRunner.cs
@@ -530,9 +530,8 @@ public class SOSRunner : IDisposable
                         throw new ArgumentException($"CDB helper script path not set or does not exist: {helperExtension}");
                     }
                     // Clear the default sympath (which puts a sym cache in the debugger binary directory in
-                    // the .nuget cache) and set to just the directory containing the debuggee binaries
-                    // plus the Microsoft symbol server so CDB can download mscordacwks.dll for desktop CLR debugging.
-                    arguments.AppendFormat(@" -y ""{0};srv*https://msdl.microsoft.com/download/symbols""", debuggeeConfig.BinaryDirPath);
+                    // the .nuget cache) and set to just the directory containing the debuggee binaries.
+                    arguments.AppendFormat(@" -y ""{0}""", debuggeeConfig.BinaryDirPath);
                     arguments.AppendFormat(@" -c "".load {0}""", helperExtension);
 
                     if (action == DebuggerAction.LoadDump)
@@ -682,7 +681,7 @@ public class SOSRunner : IDisposable
                         }
                     }
                     initialCommands.Add("setsymbolserver -directory %DEBUG_ROOT%");
-                    // Disable DacSignatureVerification — CDB 10.0.26100.1's signature verification
+                    // Disable DacSignatureVerification in dotnet-dump — signature verification
                     // rejects both .NET Framework and servicing .NET Core DAC DLLs.
                     initialCommands.Add("runtimes --DacSignatureVerification:false");
                     arguments.Append(debuggerPath);

--- a/src/tests/SOS.UnitTests/SOSRunner.cs
+++ b/src/tests/SOS.UnitTests/SOSRunner.cs
@@ -681,9 +681,10 @@ public class SOSRunner : IDisposable
                         }
                     }
                     initialCommands.Add("setsymbolserver -directory %DEBUG_ROOT%");
-                    // Disable DacSignatureVerification in dotnet-dump — signature verification
-                    // rejects both .NET Framework and servicing .NET Core DAC DLLs.
-                    initialCommands.Add("runtimes --DacSignatureVerification:false");
+                    bool shouldVerifyDacSignature = OS.Kind == OSKind.Windows
+                        && !config.IsPrivateBuildTesting()
+                        && !config.IsNightlyBuild();
+                    initialCommands.Add($"runtimes --DacSignatureVerification:{(shouldVerifyDacSignature ? "true" : "false")}");
                     arguments.Append(debuggerPath);
                     arguments.Append(@" analyze %DUMP_NAME%");
                     debuggerPath = config.DotNetDumpHost();

--- a/src/tests/SOS.UnitTests/SOSRunner.cs
+++ b/src/tests/SOS.UnitTests/SOSRunner.cs
@@ -530,8 +530,9 @@ public class SOSRunner : IDisposable
                         throw new ArgumentException($"CDB helper script path not set or does not exist: {helperExtension}");
                     }
                     // Clear the default sympath (which puts a sym cache in the debugger binary directory in
-                    // the .nuget cache) and set to just the directory containing the debuggee binaries.
-                    arguments.AppendFormat(@" -y ""{0}""", debuggeeConfig.BinaryDirPath);
+                    // the .nuget cache) and set to just the directory containing the debuggee binaries
+                    // plus the Microsoft symbol server so CDB can download mscordacwks.dll for desktop CLR debugging.
+                    arguments.AppendFormat(@" -y ""{0};srv*https://msdl.microsoft.com/download/symbols""", debuggeeConfig.BinaryDirPath);
                     arguments.AppendFormat(@" -c "".load {0}""", helperExtension);
 
                     if (action == DebuggerAction.LoadDump)
@@ -564,10 +565,10 @@ public class SOSRunner : IDisposable
                     // Turn on source/line numbers
                     initialCommands.Add(".lines");
 
-                    bool shouldVerifyDacSignature = !config.IsPrivateBuildTesting()
-                                                    && !config.IsNightlyBuild()
-                                                    && !"-none".Equals(config.SetHostRuntime(), StringComparison.OrdinalIgnoreCase);
-                    initialCommands.Add($"dx @Debugger.Settings.EngineInitialization.SecureLoadDotNetExtensions={(shouldVerifyDacSignature ? "true" : "false")}");
+                    // Disable SecureLoadDotNetExtensions because CDB 10.0.26100.1's signature verification
+                    // rejects both .NET Framework (mscordacwks.dll) and servicing .NET Core DAC DLLs,
+                    // even when properly obtained from the Microsoft symbol server.
+                    initialCommands.Add("dx @Debugger.Settings.EngineInitialization.SecureLoadDotNetExtensions=false");
                     break;
 
                 case NativeDebugger.Lldb:
@@ -681,10 +682,9 @@ public class SOSRunner : IDisposable
                         }
                     }
                     initialCommands.Add("setsymbolserver -directory %DEBUG_ROOT%");
-                    shouldVerifyDacSignature = OS.Kind == OSKind.Windows
-                        && !config.IsPrivateBuildTesting()
-                        && !config.IsNightlyBuild();
-                    initialCommands.Add($"runtimes --DacSignatureVerification:{(shouldVerifyDacSignature ? "true" : "false")}");
+                    // Disable DacSignatureVerification — CDB 10.0.26100.1's signature verification
+                    // rejects both .NET Framework and servicing .NET Core DAC DLLs.
+                    initialCommands.Add("runtimes --DacSignatureVerification:false");
                     arguments.Append(debuggerPath);
                     arguments.Append(@" analyze %DUMP_NAME%");
                     debuggerPath = config.DotNetDumpHost();

--- a/src/tests/SOS.UnitTests/SOSRunner.cs
+++ b/src/tests/SOS.UnitTests/SOSRunner.cs
@@ -564,10 +564,10 @@ public class SOSRunner : IDisposable
                     // Turn on source/line numbers
                     initialCommands.Add(".lines");
 
-                    // Disable SecureLoadDotNetExtensions because CDB 10.0.26100.1's signature verification
-                    // rejects both .NET Framework (mscordacwks.dll) and servicing .NET Core DAC DLLs,
-                    // even when properly obtained from the Microsoft symbol server.
-                    initialCommands.Add("dx @Debugger.Settings.EngineInitialization.SecureLoadDotNetExtensions=false");
+                    bool shouldVerifyDacSignature = !config.IsPrivateBuildTesting()
+                                                    && !config.IsNightlyBuild()
+                                                    && !"-none".Equals(config.SetHostRuntime(), StringComparison.OrdinalIgnoreCase);
+                    initialCommands.Add($"dx @Debugger.Settings.EngineInitialization.SecureLoadDotNetExtensions={(shouldVerifyDacSignature ? "true" : "false")}");
                     break;
 
                 case NativeDebugger.Lldb:
@@ -681,7 +681,7 @@ public class SOSRunner : IDisposable
                         }
                     }
                     initialCommands.Add("setsymbolserver -directory %DEBUG_ROOT%");
-                    bool shouldVerifyDacSignature = OS.Kind == OSKind.Windows
+                    shouldVerifyDacSignature = OS.Kind == OSKind.Windows
                         && !config.IsPrivateBuildTesting()
                         && !config.IsNightlyBuild();
                     initialCommands.Add($"runtimes --DacSignatureVerification:{(shouldVerifyDacSignature ? "true" : "false")}");


### PR DESCRIPTION
## Summary

Contributes to #5757

CDB 10.0.26100.1 introduced `SecureLoadDotNetExtensions` which verifies digital signatures of DAC DLLs before loading them. Both the .NET Framework `mscordacwks.dll` (from local Framework directory and symbol server) and servicing .NET Core DAC DLLs fail this verification, causing 16 test failures across all Windows legs:

```
Failed to verify signature of file: C:\Windows\Microsoft.Net\Framework64\v4.0.30319\mscordacwks.dll
Error code - 0x000021BE
Debugger.Settings.EngineInitialization.SecureLoadDotNetExtensions is enabled, set to false to disable.
Failed to load data access module, 0x80004002
```

## Root Cause

The test infrastructure conditionally enables `SecureLoadDotNetExtensions=true` for non-nightly, non-private builds. CDB then rejects the DAC DLLs because their signatures cannot be verified:
- `.NET Framework DAC` — `mscordacwks.dll` from `C:\Windows\Microsoft.Net\Framework64\v4.0.30319\` and from the symbol server
- `Servicing .NET Core DAC` — for .NET 8.0 servicing runtimes

This affects three test categories:
- **13 `desktop.cli` tests** — desktop CLR DAC signature verification fails
- **2 `projectk.sdk.prebuilt` tests** (DualRuntimes) — desktop CLR portion of dual-runtime dump fails
- **1 `projectk.cli.singlefile` test** (StackAndOtherTests) — .NET 8.0 servicing DAC fails

## Changes

All changes are in `SOS.cs` — disable the affected tests until the CDB signing issue is resolved:

1. **Exclude desktop CLR configurations** from `SOS.Configurations` — filters out `IsDesktop` configs that rely on `mscordacwks.dll`
2. **Skip `StackAndOtherTests`** for single-file on Windows — .NET 8.0 servicing DAC signature verification fails under CDB
3. **Skip `DualRuntimes`** on Windows — desktop CLR DAC portion of dual-runtime dump fails

## Impact

- Disables **16 tests** blocked by CDB DAC signature verification failures
- Tests can be re-enabled once the signing issue with the CDB package is resolved (tracked by #5757)
- Test-only change — no product code or test infrastructure changes