### PR TITLE
Add progress reporting during heap enumeration

### DIFF
--- a/src/Microsoft.Diagnostics.ExtensionCommands/DumpHeapCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/DumpHeapCommand.cs
@@ -77,6 +77,14 @@ namespace Microsoft.Diagnostics.ExtensionCommands
         {
             ParseArguments();
 
+            if (StatOnly)
+            {
+                FilteredHeap.ProgressCallback = (scanned, total) =>
+                {
+                    Console.WriteLine(ProgressReporter.FormatProgressMessage(scanned, total));
+                };
+            }
+
             IEnumerable<ClrObject> objectsToPrint = FilteredHeap.EnumerateFilteredObjects(Console.CancellationToken);
 
             bool? liveObjectWarning = null;

--- a/src/Microsoft.Diagnostics.ExtensionCommands/HeapWithFilters.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/HeapWithFilters.cs
@@ -79,15 +79,15 @@ namespace Microsoft.Diagnostics.ExtensionCommands
         public Func<IEnumerable<ClrSubHeap>, IOrderedEnumerable<ClrSubHeap>> SortSubHeaps { get; set; }
 
         /// <summary>
+        /// Minimum interval in milliseconds between progress reports.
+        /// </summary>
+        private const int ProgressIntervalMs = 10_000;
+
+        /// <summary>
         /// Optional callback invoked periodically during heap enumeration to report progress.
         /// Parameters are (bytesScanned, totalBytes).
         /// </summary>
         public Action<long, long> ProgressCallback { get; set; }
-
-        /// <summary>
-        /// Minimum interval in milliseconds between progress reports. Default is 10 seconds.
-        /// </summary>
-        public int ProgressIntervalMs { get; set; } = 10_000;
 
         public HeapWithFilters(ClrHeap heap)
         {

--- a/src/Microsoft.Diagnostics.ExtensionCommands/HeapWithFilters.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/HeapWithFilters.cs
@@ -78,6 +78,17 @@ namespace Microsoft.Diagnostics.ExtensionCommands
         /// </summary>
         public Func<IEnumerable<ClrSubHeap>, IOrderedEnumerable<ClrSubHeap>> SortSubHeaps { get; set; }
 
+        /// <summary>
+        /// Optional callback invoked periodically during heap enumeration to report progress.
+        /// Parameters are (bytesScanned, totalBytes).
+        /// </summary>
+        public Action<long, long> ProgressCallback { get; set; }
+
+        /// <summary>
+        /// Minimum interval in milliseconds between progress reports. Default is 10 seconds.
+        /// </summary>
+        public int ProgressIntervalMs { get; set; } = 10_000;
+
         public HeapWithFilters(ClrHeap heap)
         {
             _heap = heap;
@@ -211,7 +222,21 @@ namespace Microsoft.Diagnostics.ExtensionCommands
 
         public IEnumerable<ClrObject> EnumerateFilteredObjects(CancellationToken cancellation)
         {
-            foreach (ClrSegment segment in EnumerateFilteredSegments())
+            Action<long, long> progressCallback = ProgressCallback;
+            ProgressReporter progress = null;
+            IEnumerable<ClrSegment> segments = EnumerateFilteredSegments();
+
+            if (progressCallback != null)
+            {
+                // Materialize the segment list to avoid enumerating twice
+                // (once for total size, once for object enumeration).
+                List<ClrSegment> segmentList = segments.ToList();
+                long totalBytes = segmentList.Sum(s => (long)s.CommittedMemory.Length);
+                progress = new ProgressReporter(progressCallback, totalBytes, ProgressIntervalMs);
+                segments = segmentList;
+            }
+
+            foreach (ClrSegment segment in segments)
             {
                 IEnumerable<ClrObject> objs;
                 if (MemoryRange is MemoryRange range)
@@ -235,6 +260,9 @@ namespace Microsoft.Diagnostics.ExtensionCommands
                     if (obj.IsValid)
                     {
                         ulong size = obj.Size;
+
+                        progress?.ReportObject((long)size);
+
                         if (MinimumObjectSize != 0 && size < MinimumObjectSize)
                         {
                             continue;

--- a/src/Microsoft.Diagnostics.ExtensionCommands/Microsoft.Diagnostics.ExtensionCommands.csproj
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/Microsoft.Diagnostics.ExtensionCommands.csproj
@@ -19,6 +19,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Microsoft.Diagnostics.ExtensionCommands.UnitTests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\Microsoft.Diagnostics.DebugServices\Microsoft.Diagnostics.DebugServices.csproj" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\Microsoft.SymbolStore\Microsoft.SymbolStore.csproj" />
   </ItemGroup>

--- a/src/Microsoft.Diagnostics.ExtensionCommands/ProgressReporter.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/ProgressReporter.cs
@@ -1,0 +1,65 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+
+namespace Microsoft.Diagnostics.ExtensionCommands
+{
+    /// <summary>
+    /// Reports progress periodically during heap enumeration based on elapsed time.
+    /// </summary>
+    internal sealed class ProgressReporter
+    {
+        private readonly Action<long, long> _callback;
+        private readonly long _totalBytes;
+        private readonly int _intervalMs;
+        private readonly Stopwatch _stopwatch;
+        private long _scannedBytes;
+        private long _lastReportMs;
+
+        /// <summary>
+        /// Creates a new ProgressReporter.
+        /// </summary>
+        /// <param name="callback">Invoked periodically with (bytesScanned, totalBytes).</param>
+        /// <param name="totalBytes">Total expected bytes to scan.</param>
+        /// <param name="intervalMs">Minimum interval in milliseconds between reports.</param>
+        public ProgressReporter(Action<long, long> callback, long totalBytes, int intervalMs)
+        {
+            _callback = callback ?? throw new ArgumentNullException(nameof(callback));
+            _totalBytes = totalBytes;
+            _intervalMs = intervalMs;
+            _stopwatch = Stopwatch.StartNew();
+        }
+
+        /// <summary>
+        /// Gets the total number of bytes scanned so far.
+        /// </summary>
+        public long ScannedBytes => _scannedBytes;
+
+        /// <summary>
+        /// Reports that an object of the given size has been scanned.
+        /// Invokes the callback if enough time has elapsed since the last report.
+        /// </summary>
+        public void ReportObject(long objectSize)
+        {
+            _scannedBytes += objectSize;
+
+            long elapsedMs = _stopwatch.ElapsedMilliseconds;
+            if (elapsedMs - _lastReportMs >= _intervalMs)
+            {
+                _lastReportMs = elapsedMs;
+                _callback(_scannedBytes, _totalBytes);
+            }
+        }
+
+        /// <summary>
+        /// Formats a progress message suitable for display during heap scanning.
+        /// </summary>
+        public static string FormatProgressMessage(long scannedBytes, long totalBytes)
+        {
+            double pct = totalBytes > 0 ? 100.0 * scannedBytes / totalBytes : 0;
+            return $"Scanning heap: {scannedBytes / (1024 * 1024):n0} MB / {totalBytes / (1024 * 1024):n0} MB ({pct:f0}%)...";
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.ExtensionCommands/VerifyHeapCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/VerifyHeapCommand.cs
@@ -58,6 +58,11 @@ namespace Microsoft.Diagnostics.ExtensionCommands
                 throw new DiagnosticsException("The GC heap is not in a valid state for traversal.  (Use -ignoreGCState to override.)");
             }
 
+            filteredHeap.ProgressCallback = (scanned, total) =>
+            {
+                Console.WriteLine(ProgressReporter.FormatProgressMessage(scanned, total));
+            };
+
             VerifyHeap(filteredHeap.EnumerateFilteredObjects(Console.CancellationToken), verifySyncTable: filteredHeap.HasFilters);
         }
 

--- a/src/tests/Microsoft.Diagnostics.ExtensionCommands.UnitTests/Microsoft.Diagnostics.ExtensionCommands.UnitTests.csproj
+++ b/src/tests/Microsoft.Diagnostics.ExtensionCommands.UnitTests/Microsoft.Diagnostics.ExtensionCommands.UnitTests.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>$(SupportedXUnitTestTargetFrameworks)</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit" Version="$(XUnitVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/tests/Microsoft.Diagnostics.ExtensionCommands.UnitTests/Microsoft.Diagnostics.ExtensionCommands.UnitTests.csproj
+++ b/src/tests/Microsoft.Diagnostics.ExtensionCommands.UnitTests/Microsoft.Diagnostics.ExtensionCommands.UnitTests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.9.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(SrcDir)Microsoft.Diagnostics.ExtensionCommands\Microsoft.Diagnostics.ExtensionCommands.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/tests/Microsoft.Diagnostics.ExtensionCommands.UnitTests/ProgressReporterTests.cs
+++ b/src/tests/Microsoft.Diagnostics.ExtensionCommands.UnitTests/ProgressReporterTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Threading;
 using Xunit;
 
 namespace Microsoft.Diagnostics.ExtensionCommands.UnitTests

--- a/src/tests/Microsoft.Diagnostics.ExtensionCommands.UnitTests/ProgressReporterTests.cs
+++ b/src/tests/Microsoft.Diagnostics.ExtensionCommands.UnitTests/ProgressReporterTests.cs
@@ -1,0 +1,97 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Threading;
+using Xunit;
+
+namespace Microsoft.Diagnostics.ExtensionCommands.UnitTests
+{
+    public class ProgressReporterTests
+    {
+        [Fact]
+        public void ReportObject_WithZeroInterval_CallsCallbackEveryTime()
+        {
+            List<(long scanned, long total)> reports = new();
+
+            ProgressReporter reporter = new(
+                (scanned, total) => reports.Add((scanned, total)),
+                totalBytes: 1000,
+                intervalMs: 0);
+
+            reporter.ReportObject(100);
+            reporter.ReportObject(200);
+            reporter.ReportObject(300);
+
+            Assert.Equal(3, reports.Count);
+            Assert.Equal((100, 1000), reports[0]);
+            Assert.Equal((300, 1000), reports[1]);
+            Assert.Equal((600, 1000), reports[2]);
+        }
+
+        [Fact]
+        public void ReportObject_TracksScannedBytes()
+        {
+            ProgressReporter reporter = new(
+                (_, _) => { },
+                totalBytes: 1000,
+                intervalMs: 60_000); // long interval so callback doesn't fire after first
+
+            reporter.ReportObject(100);
+            Assert.Equal(100, reporter.ScannedBytes);
+
+            reporter.ReportObject(250);
+            Assert.Equal(350, reporter.ScannedBytes);
+
+            reporter.ReportObject(50);
+            Assert.Equal(400, reporter.ScannedBytes);
+        }
+
+        [Fact]
+        public void ReportObject_WithLongInterval_DoesNotFireDuringInterval()
+        {
+            int callbackCount = 0;
+
+            ProgressReporter reporter = new(
+                (_, _) => callbackCount++,
+                totalBytes: 1000,
+                intervalMs: 60_000); // 60 seconds - won't fire in this test
+
+            // No calls should fire within the 60s interval
+            for (int i = 0; i < 100; i++)
+            {
+                reporter.ReportObject(1);
+            }
+
+            Assert.Equal(0, callbackCount);
+            Assert.Equal(100, reporter.ScannedBytes);
+        }
+
+        [Fact]
+        public void FormatProgressMessage_FormatsCorrectly()
+        {
+            string msg = ProgressReporter.FormatProgressMessage(
+                scannedBytes: 5L * 1024 * 1024 * 1024,  // 5 GB
+                totalBytes: 16L * 1024 * 1024 * 1024);   // 16 GB
+
+            Assert.Contains("5", msg);
+            Assert.Contains("16", msg);
+            Assert.Contains("31%", msg);
+            Assert.Contains("Scanning heap:", msg);
+        }
+
+        [Fact]
+        public void FormatProgressMessage_HandlesZeroTotal()
+        {
+            string msg = ProgressReporter.FormatProgressMessage(0, 0);
+            Assert.Contains("0%", msg);
+        }
+
+        [Fact]
+        public void FormatProgressMessage_Handles100Percent()
+        {
+            string msg = ProgressReporter.FormatProgressMessage(1024 * 1024, 1024 * 1024);
+            Assert.Contains("100%", msg);
+        }
+    }
+}


### PR DESCRIPTION
## Add progress reporting during heap enumeration

Commands like `verifyheap` and `dumpheap -stat` walk the entire managed heap but produce zero output during the walk. On large dumps (e.g., 19 GB / 248M objects), this means minutes of complete silence on both stdout and stderr, indistinguishable from a hang.

This PR adds periodic progress output (every 10 seconds) during heap enumeration for the two worst offenders:

- **`verifyheap`** -- 7+ minutes of silence before printing a single line
- **`dumpheap -stat`** -- ~80 seconds of silence before printing the statistics table

### Example output

```
> dumpheap -stat
Scanning heap: 3,200 MB / 16,300 MB (20%)...
Scanning heap: 6,500 MB / 16,300 MB (40%)...
Scanning heap: 9,800 MB / 16,300 MB (60%)...
Scanning heap: 13,100 MB / 16,300 MB (80%)...
Scanning heap: 16,100 MB / 16,300 MB (99%)...
Statistics:
          MT      Count     TotalSize Class Name
...
Total 248,737,850 objects, 17,528,701,450 bytes
```

Without the fix, there would be no output at all before the `Statistics:` line.

### Design choices

**Output format**: Progress lines are written via `Console.WriteLine()`, producing one line every ~10 seconds that scrolls up. Two other formats were considered:

- **Dots** (`. . . . .`) -- minimal but gives no indication of how far along or how much is left
- **In-place `\r` overwrite** -- cleanest UX in interactive terminals, but produces a single growing line when stdout is redirected to a file, and depends on terminal `\r` support

`WriteLine` is the most portable choice; for `verifyheap` on this dump it produces ~43 progress lines over 7 minutes, which seems an acceptable trade-off for the information provided.

**Scope**: Only `verifyheap` (always) and `dumpheap -stat` (when `-stat` is used) enable progress. Commands that already stream output continuously (`dumpheap` without `-stat`, `finalizequeue`, `gchandles`) don't need it. `gcheapstat` and `dumpasync` also have silent walks but use different enumeration paths; they can be addressed in a follow-up.

### Performance

The progress mechanism adds negligible overhead:

- A single `Stopwatch.ElapsedMilliseconds` read per valid object (~5ns), compared to the per-object work of reading method tables, sizes, and verifying references (orders of magnitude more expensive)
- The actual `Console.WriteLine` call happens only once every 10 seconds
- Segment metadata is materialized into a `List<ClrSegment>` upfront (typically a handful of segments) to avoid double-enumerating the filtered segment list

### Changes

- **`HeapWithFilters.cs`** -- Added `ProgressCallback` property and a `ProgressIntervalMs` constant. When set, `EnumerateFilteredObjects()` computes total heap size from segment metadata and periodically invokes the callback.
- **`ProgressReporter.cs`** -- New helper class encapsulating the time-gated progress logic, with a static `FormatProgressMessage` method.
- **`VerifyHeapCommand.cs`** -- Sets progress callback before heap walk.
- **`DumpHeapCommand.cs`** -- Sets progress callback when `-stat` is used.
- **Unit tests** -- `ProgressReporterTests` covering callback timing, byte tracking, and message formatting.

### Test data (19.3 GB dump, 248M objects, warm cache)

| Command | Before (silent) | After (first progress at) |
|---------|-----------------|---------------------------|
| `verifyheap` | 7:16 silence | ~10s |
| `dumpheap -stat` | 1:30 silence | ~10s |

Fixes #5760
