### PR TITLE
[CollectLinux] Fix no-tty crash with console capability aware ProgressWriter

### DIFF
--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectLinuxCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectLinuxCommand.cs
@@ -589,7 +589,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
 
                 _nextUpdateTimestamp = now + Stopwatch.Frequency;
                 _console.Out.WriteLine($"[{_stopwatch.Elapsed:dd\\:hh\\:mm\\:ss}]\tRecording trace.");
-                _console.Out.WriteLine("Press <Enter> or <Ctrl-C> to exit...");
+                _console.Out.WriteLine("Press <Enter> or <Ctrl+C> to exit...");
             }
 
             private void Initialize()
@@ -606,7 +606,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 LineRewriter rewriter = new(_console);
                 rewriter.LineToClear = _console.CursorTop - 1;
 
-                if (rewriter.IsRewriteConsoleLineSupported)
+                if (rewriter.LineToClear >= 0 && rewriter.IsRewriteConsoleLineSupported)
                 {
                     _rewriter = rewriter;
                 }

--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectLinuxCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectLinuxCommand.cs
@@ -20,11 +20,9 @@ namespace Microsoft.Diagnostics.Tools.Trace
     {
         private bool stopTracing;
         private Stopwatch stopwatch = new();
-        private LineRewriter rewriter;
-        private long statusUpdateTimestamp;
+        private ProgressWriter progressWriter;
         private Version minRuntimeSupportingUserEventsIPCCommand = new(10, 0, 0);
         private readonly bool cancelOnEnter;
-        private readonly bool printStatusOverTime;
 
         internal sealed record CollectLinuxArgs(
             CancellationToken Ct,
@@ -42,9 +40,8 @@ namespace Microsoft.Diagnostics.Tools.Trace
         public CollectLinuxCommandHandler(IConsole console = null)
         {
             Console = console ?? new DefaultConsole();
-            rewriter = new LineRewriter(Console);
             cancelOnEnter = !Console.IsInputRedirected;
-            printStatusOverTime = !Console.IsOutputRedirected;
+            progressWriter = new ProgressWriter(Console, stopwatch);
         }
 
         internal static bool IsSupported()
@@ -495,26 +492,9 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 stopTracing = true;
             }
 
-            if (printStatusOverTime && ot == OutputType.Progress)
+            if (ot == OutputType.Progress)
             {
-                long currentTimestamp = Stopwatch.GetTimestamp();
-                if (statusUpdateTimestamp != 0 && currentTimestamp < statusUpdateTimestamp)
-                {
-                    return stopTracing ? 1 : 0;
-                }
-
-                if (statusUpdateTimestamp == 0)
-                {
-                    rewriter.LineToClear = Console.CursorTop - 1;
-                }
-                else
-                {
-                    rewriter.RewriteConsoleLine();
-                }
-
-                statusUpdateTimestamp = currentTimestamp + Stopwatch.Frequency;
-                Console.Out.WriteLine($"[{stopwatch.Elapsed:dd\\:hh\\:mm\\:ss}]\tRecording trace.");
-                Console.Out.WriteLine("Press <Enter> or <Ctrl-C> to exit...");
+                progressWriter.Update();
             }
 
             return stopTracing ? 1 : 0;
@@ -558,6 +538,84 @@ namespace Microsoft.Diagnostics.Tools.Trace
             byte[] command,
             UIntPtr commandLen,
             recordTraceCallback callback);
+
+        /// <summary>
+        /// Encapsulates progress display for the native record-trace callback.
+        /// Probes console capability on the first Update() call, then handles throttled
+        /// in-place rewrites (interactive), a single static message (non-interactive),
+        /// or silent no-op (output redirected).
+        /// </summary>
+        private sealed class ProgressWriter
+        {
+            private readonly IConsole _console;
+            private readonly Stopwatch _stopwatch;
+            private bool _initialized;
+            // Non-null after initialization only when in-place rewriting is supported.
+            private LineRewriter _rewriter;
+            private long _nextUpdateTimestamp;
+
+            public ProgressWriter(IConsole console, Stopwatch stopwatch)
+            {
+                _console = console;
+                _stopwatch = stopwatch;
+            }
+
+            /// <summary>
+            /// Called on each Progress callback from native record-trace.
+            /// No-ops if output is redirected, non-interactive, or within the 1-second throttle window.
+            /// </summary>
+            public void Update()
+            {
+                if (!_initialized)
+                {
+                    Initialize();
+                }
+
+                if (_rewriter == null)
+                {
+                    return;
+                }
+
+                long now = Stopwatch.GetTimestamp();
+                if (_nextUpdateTimestamp != 0 && now < _nextUpdateTimestamp)
+                {
+                    return;
+                }
+
+                if (_nextUpdateTimestamp != 0)
+                {
+                    _rewriter.RewriteConsoleLine();
+                }
+
+                _nextUpdateTimestamp = now + Stopwatch.Frequency;
+                _console.Out.WriteLine($"[{_stopwatch.Elapsed:dd\\:hh\\:mm\\:ss}]\tRecording trace.");
+                _console.Out.WriteLine("Press <Enter> or <Ctrl-C> to exit...");
+            }
+
+            private void Initialize()
+            {
+                _initialized = true;
+
+                if (_console.IsOutputRedirected)
+                {
+                    return;
+                }
+
+                // Only capture the cursor position to rewrite once we've committed to writing progress output,
+                // otherwise the position becomes stale the moment any other console output occurs.
+                LineRewriter rewriter = new(_console);
+                rewriter.LineToClear = _console.CursorTop - 1;
+
+                if (rewriter.IsRewriteConsoleLineSupported)
+                {
+                    _rewriter = rewriter;
+                }
+                else
+                {
+                    _console.Out.WriteLine("Recording trace in progress. Press <Enter> or <Ctrl+C> to exit...");
+                }
+            }
+        }
 
 #region testing seams
         internal Func<byte[], UIntPtr, recordTraceCallback, int> RecordTraceInvoker { get; set; } = RunRecordTrace;

--- a/src/tests/Common/MockConsole.cs
+++ b/src/tests/Common/MockConsole.cs
@@ -71,6 +71,12 @@ namespace Microsoft.Diagnostics.Tests.Common
         }
         public void SetCursorPosition(int col, int row)
         {
+            if (col < 0 || col >= BufferWidth)
+            {
+                throw new ArgumentOutOfRangeException(nameof(col),
+                    col,
+                    "The value must be greater than or equal to zero and less than the console's buffer size in that dimension.");
+            }
             if (row < 0 || row >= WindowHeight)
             {
                 throw new ArgumentOutOfRangeException(nameof(row),

--- a/src/tests/Common/MockConsole.cs
+++ b/src/tests/Common/MockConsole.cs
@@ -71,6 +71,12 @@ namespace Microsoft.Diagnostics.Tests.Common
         }
         public void SetCursorPosition(int col, int row)
         {
+            if (row < 0 || row >= WindowHeight)
+            {
+                throw new ArgumentOutOfRangeException(nameof(row),
+                    row,
+                    "The value must be greater than or equal to zero and less than the console's buffer size in that dimension.");
+            }
             CursorTop = row;
             _cursorLeft = col;
         }

--- a/src/tests/dotnet-trace/CollectLinuxCommandFunctionalTests.cs
+++ b/src/tests/dotnet-trace/CollectLinuxCommandFunctionalTests.cs
@@ -326,6 +326,50 @@ namespace Microsoft.Diagnostics.Tools.Trace
             Assert.True(callbackInvoked);
         }
 
+        [ConditionalFact(nameof(IsCollectLinuxSupported))]
+        public void CollectLinuxCommand_DoesNotCrash_WhenCursorTopIsZero()
+        {
+            // Regression test: when CursorTop is 0 (e.g., no TTY), LineToClear = CursorTop - 1 = -1,
+            // which caused SetCursorPosition to throw ArgumentOutOfRangeException on the second
+            // progress callback when RewriteConsoleLine was called with the negative LineToClear.
+            MockConsole console = new(200, 30, _outputHelper);
+
+            var handler = new CollectLinuxCommandHandler(console);
+            handler.RecordTraceInvoker = (cmd, len, cb) => {
+                // Must send multiple callbacks — the crash occurred on the second one.
+                cb(3, IntPtr.Zero, UIntPtr.Zero);
+                cb(3, IntPtr.Zero, UIntPtr.Zero);
+                return 0;
+            };
+
+            int exitCode = handler.CollectLinux(TestArgs());
+            Assert.Equal((int)ReturnCode.Ok, exitCode);
+        }
+
+        [ConditionalFact(nameof(IsCollectLinuxSupported))]
+        public void CollectLinuxCommand_PrintsStatusOnce_WhenCursorRepositioningUnsupported()
+        {
+            // When cursor repositioning isn't supported, the status line should be
+            // printed exactly once — not spammed every second.
+            MockConsole console = new(200, 30, _outputHelper);
+
+            var handler = new CollectLinuxCommandHandler(console);
+            handler.RecordTraceInvoker = (cmd, len, cb) => {
+                for (int i = 0; i < 5; i++)
+                {
+                    cb(3, IntPtr.Zero, UIntPtr.Zero);
+                }
+                return 0;
+            };
+
+            int exitCode = handler.CollectLinux(TestArgs());
+            Assert.Equal((int)ReturnCode.Ok, exitCode);
+
+            string[] lines = console.Lines;
+            int statusLineCount = lines.Count(l => l.Contains("Recording trace", StringComparison.OrdinalIgnoreCase));
+            Assert.Equal(1, statusLineCount);
+        }
+
         private static int Run(object args, MockConsole console)
         {
             var handler = new CollectLinuxCommandHandler(console);

--- a/src/tests/dotnet-trace/CollectLinuxCommandFunctionalTests.cs
+++ b/src/tests/dotnet-trace/CollectLinuxCommandFunctionalTests.cs
@@ -327,38 +327,18 @@ namespace Microsoft.Diagnostics.Tools.Trace
         }
 
         [ConditionalFact(nameof(IsCollectLinuxSupported))]
-        public void CollectLinuxCommand_DoesNotCrash_WhenCursorTopIsZero()
-        {
-            // Regression test: when CursorTop is 0 (e.g., no TTY), LineToClear = CursorTop - 1 = -1,
-            // which caused SetCursorPosition to throw ArgumentOutOfRangeException on the second
-            // progress callback when RewriteConsoleLine was called with the negative LineToClear.
-            MockConsole console = new(200, 30, _outputHelper);
-
-            var handler = new CollectLinuxCommandHandler(console);
-            handler.RecordTraceInvoker = (cmd, len, cb) => {
-                // Must send multiple callbacks — the crash occurred on the second one.
-                cb(3, IntPtr.Zero, UIntPtr.Zero);
-                cb(3, IntPtr.Zero, UIntPtr.Zero);
-                return 0;
-            };
-
-            int exitCode = handler.CollectLinux(TestArgs());
-            Assert.Equal((int)ReturnCode.Ok, exitCode);
-        }
-
-        [ConditionalFact(nameof(IsCollectLinuxSupported))]
         public void CollectLinuxCommand_PrintsStatusOnce_WhenCursorRepositioningUnsupported()
         {
-            // When cursor repositioning isn't supported, the status line should be
-            // printed exactly once — not spammed every second.
             MockConsole console = new(200, 30, _outputHelper);
 
             var handler = new CollectLinuxCommandHandler(console);
             handler.RecordTraceInvoker = (cmd, len, cb) => {
-                for (int i = 0; i < 5; i++)
-                {
-                    cb(3, IntPtr.Zero, UIntPtr.Zero);
-                }
+                // Simulate cursor repositioning unsupported by resetting the cursor
+                // during the callback, undoing any cursor advancement from the tool's
+                // earlier console output (banner, provider table, etc.).
+                console.Clear();
+                cb(3, IntPtr.Zero, UIntPtr.Zero);
+                cb(3, IntPtr.Zero, UIntPtr.Zero);
                 return 0;
             };
 
@@ -576,7 +556,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
             DefaultOutputFile,
             "",
             "[dd:hh:mm:ss]\tRecording trace.",
-            "Press <Enter> or <Ctrl-C> to exit...",
+            "Press <Enter> or <Ctrl+C> to exit...",
         ];
         private static string[] PreviewMessages = [
             "==========================================================================================",


### PR DESCRIPTION
﻿When CursorTop is 0 (e.g., in environments where cursor positioning isn't available), LineToClear was set to -1, causing SetCursorPosition to throw ArgumentOutOfRangeException on progress callbacks.

 Extract the progress display concern from OutputHandler into a nested ProgressWriter class that:
  - Probes console capability on first Update() call
  - Interactive: rewrites status line in-place with 1s throttle
  - Non-interactive: prints a static message once, silently no-ops after
  - Owns LineRewriter and LineToClear internally

 OutputHandler's status block reduces to progressWriter.Update(), fully decoupling it from LineRewriter. Matches CollectCommand's pattern of probing capability upfront and gating on it.

 Also adds bounds validation to MockConsole.SetCursorPosition and a regression test for the CursorTop=0 case.