### PR TITLE
Loosening line numbers on three SOS tests

### DIFF
--- a/src/tests/SOS.UnitTests/Scripts/NestedExceptionTest.script
+++ b/src/tests/SOS.UnitTests/Scripts/NestedExceptionTest.script
@@ -28,7 +28,7 @@ ENDIF:DESKTOP
 
 SOSCOMMAND:ClrStack
 VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+NestedExceptionTest\.Program\.Main(\(.*\))?\s*
-VERIFY:\[.*[\\|/]Debuggees[\\|/].*[Nn]ested[Ee]xception[Tt]est[\\|/][Nn]ested[Ee]xception[Tt]est\.cs @ 11\s*\]\s*
+VERIFY:\[.*[\\|/]Debuggees[\\|/].*[Nn]ested[Ee]xception[Tt]est[\\|/][Nn]ested[Ee]xception[Tt]est\.cs @ (11|16)\s*\]\s*
 
 ENDIF:UNIX_SINGLE_FILE_APP
 ENDIF:ALPINE

--- a/src/tests/SOS.UnitTests/Scripts/OtherCommands.script
+++ b/src/tests/SOS.UnitTests/Scripts/OtherCommands.script
@@ -26,7 +26,7 @@ LOADSOS
 ENDIF:DESKTOP
 
 SOSCOMMAND:ClrStack
-VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.Program\.Main\(.*\)\s+\[(?i:.*[\\|/]SymbolTestApp\.cs) @ 19\]\s*
+VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.Program\.Main\(.*\)\s+\[(?i:.*[\\|/]SymbolTestApp\.cs) @ (19|22)\]\s*
 SOSCOMMAND:bpmd -clearall
 
 SOSCOMMAND:bpmd SymbolTestApp.cs:32

--- a/src/tests/SOS.UnitTests/Scripts/StackAndOtherTests.script
+++ b/src/tests/SOS.UnitTests/Scripts/StackAndOtherTests.script
@@ -27,7 +27,7 @@ LOADSOS
 ENDIF:DESKTOP
 
 SOSCOMMAND:ClrStack
-VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.Program\.Main\(.*\)\s+\[(?i:.*[\\|/]SymbolTestApp\.cs) @ 19\]\s*
+VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.Program\.Main\(.*\)\s+\[(?i:.*[\\|/]SymbolTestApp\.cs) @ (19|22)\]\s*
 SOSCOMMAND:bpmd -clearall
 
 SOSCOMMAND:bpmd SymbolTestApp.cs:32


### PR DESCRIPTION
https://dev.azure.com/dnceng-public/public/_build/results?buildId=1348854
For an unknown reason, the cDAC SOS test runs have better !clrstack output than that of the DAC in these three tests - the DAC output resolves the bottom of the stack to the start of the method, whereas the cDAC is able to resolve the exact line. The tests currently expect the start of the method, so they fail on the cDAC. This just loosens the tests to accept either the exact line or the start of the method.