### PR TITLE
[Dotnet-Trace] Bump Record-Trace version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -37,7 +37,7 @@
     <MicrosoftExtensionsConfigurationVersion>8.0.0</MicrosoftExtensionsConfigurationVersion>
     <MicrosoftExtensionsConfigurationJsonVersion>8.0.1</MicrosoftExtensionsConfigurationJsonVersion>
     <MicrosoftExtensionsLoggingConfigurationVersion>8.0.1</MicrosoftExtensionsLoggingConfigurationVersion>
-    <MicrosoftOneCollectRecordTraceVersions>0.1.33551</MicrosoftOneCollectRecordTraceVersions>
+    <MicrosoftOneCollectRecordTraceVersions>0.1.33621</MicrosoftOneCollectRecordTraceVersions>
     <!-- Need version that understands UseAppFilters sentinel. -->
     <MicrosoftExtensionsLoggingEventSourceVersion>5.0.1</MicrosoftExtensionsLoggingEventSourceVersion>
     <SystemComponentModelAnnotationsVersion>5.0.0</SystemComponentModelAnnotationsVersion>


### PR DESCRIPTION
OneCollect has some fixes that will improve `dotnet-trace collect-linux`'s tracing experience.
- https://github.com/microsoft/one-collect/pull/239
- https://github.com/microsoft/one-collect/pull/240