### PR TITLE
Poll for environment available in test process startup in GetProcessTmpDir tests

### DIFF
--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcTransport.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcTransport.cs
@@ -416,6 +416,9 @@ namespace Microsoft.Diagnostics.NETCore.Client
         /// <summary>
         /// Gets the TMPDIR for a target process by reading /proc/{pid}/environ.
         /// Falls back to the platform temp directory if TMPDIR is not set or environ cannot be read.
+        /// This API is a best-effort helper - it can return the default value for processes that set
+        /// TMPDIR if it's called too early during startup as the environment can change several times
+        /// and there's no clear marker that such intermmediate states are over.
         /// The environReadable output indicates whether /proc/{pid}/environ was successfully read.
         /// </summary>
         internal static string GetProcessTmpDir(int hostPid, out bool environReadable)

--- a/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcTransport.cs
+++ b/src/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcTransport.cs
@@ -445,6 +445,14 @@ namespace Microsoft.Diagnostics.NETCore.Client
             }
 
             environReadable = true;
+
+            if (environData.Length == 0)
+            {
+                // Empty environ can mean the process has no environment variables, or that we read
+                // between fork() and execve() before the kernel populates the environment.
+                return tmpDirPath;
+            }
+
             tmpDirPath = ParseTmpDir(environData);
             return tmpDirPath;
         }

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/PidIpcEndpointTests.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/PidIpcEndpointTests.cs
@@ -163,7 +163,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
                 // Wait for /proc/{pid}/environ to be populated.
                 // Between fork() and execve(), the environ file may be empty (0 bytes).
                 bool environPopulated = false;
-                const long MAX_TRIES = 20;
+                const int MAX_TRIES = 20;
                 const int DELAY_MS = 50;
                 for (int attempt = 0; attempt < MAX_TRIES && !environPopulated; attempt++)
                 {

--- a/src/tests/Microsoft.Diagnostics.NETCore.Client/PidIpcEndpointTests.cs
+++ b/src/tests/Microsoft.Diagnostics.NETCore.Client/PidIpcEndpointTests.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Threading;
 using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
 
@@ -157,8 +158,31 @@ namespace Microsoft.Diagnostics.NETCore.Client
             using Process child = Process.Start(psi);
             try
             {
-                // Read the child's environ directly for diagnostics
                 string environPath = $"/proc/{child.Id}/environ";
+
+                // Wait for /proc/{pid}/environ to be populated.
+                // Between fork() and execve(), the environ file may be empty (0 bytes).
+                bool environPopulated = false;
+                const long MAX_TRIES = 20;
+                const int DELAY_MS = 50;
+                for (int attempt = 0; attempt < MAX_TRIES && !environPopulated; attempt++)
+                {
+                    try
+                    {
+                        environPopulated = File.ReadAllBytes(environPath).Length > 0;
+                    }
+                    catch (IOException)
+                    {
+                        // File may be temporarily unavailable.
+                    }
+
+                    if (!environPopulated)
+                    {
+                        Thread.Sleep(DELAY_MS);
+                    }
+                }
+
+                // Read the child's environ directly for diagnostics
                 string environPerms = "unknown";
                 try
                 {
@@ -192,7 +216,8 @@ namespace Microsoft.Diagnostics.NETCore.Client
                     + $"environ permissions: {environPerms}, "
                     + $"parent TMPDIR: '{Environment.GetEnvironmentVariable("TMPDIR") ?? "(not set)"}', "
                     + $"psi.Environment TMPDIR: '{psi.Environment["TMPDIR"]}', "
-                    + $"current user: {Environment.UserName}, ";
+                    + $"current user: {Environment.UserName}, "
+                    + $"environ populated after poll: {environPopulated}, ";
 
                 if (environReadError != null)
                 {


### PR DESCRIPTION
There's a short period of time between `Process.Start` returning, and the pinvokes into fork and exec. During this period, the target might not have a populated environ procfs file. Loop with a sleep and try again.