### PR TITLE
[Test] Fix collect command test race condition with status printer

### DIFF
--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
@@ -385,7 +385,6 @@ namespace Microsoft.Diagnostics.Tools.Trace
                                 }
                             }
 
-                            FileInfo fileInfo = new(output.FullName);
                             bool wroteStatus = false;
                             Action printStatus = () => {
                                 if (printStatusOverTime && rewriter.IsRewriteConsoleLineSupported)
@@ -399,8 +398,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                                         // First time writing status, so don't rewrite console yet.
                                         wroteStatus = true;
                                     }
-                                    fileInfo.Refresh();
-                                    ConsoleWriteLine($"[{stopwatch.Elapsed:dd\\:hh\\:mm\\:ss}]\tRecording trace {GetSize(fileInfo.Length)}");
+                                    ConsoleWriteLine($"[{stopwatch.Elapsed:dd\\:hh\\:mm\\:ss}]\tRecording trace {GetSize(eventStream.Length)}");
                                     ConsoleWriteLine("Press <Enter> or <Ctrl+C> to exit...");
                                 }
 

--- a/src/tests/dotnet-trace/CollectCommandFunctionalTests.cs
+++ b/src/tests/dotnet-trace/CollectCommandFunctionalTests.cs
@@ -91,6 +91,12 @@ namespace Microsoft.Diagnostics.Tools.Trace
 
         private static async Task<int> RunAsync(CollectArgs config, MockConsole console, bool hasChildProcess = false)
         {
+            // Disable the interactive status-printing path. It is currently non-deterministic in these tests because the
+            // MemoryStream-backed session completes near-instantly, and whether the status line fires before the loop exits
+            // depends on thread scheduling. The MemoryStream substitution also means no trace file exists on disk, so
+            // FileInfo.Length in the status printer would throw.
+            console.IsOutputRedirected = true;
+
             var handler = new CollectCommandHandler(console);
             handler.StartTraceSessionAsync = (client, cfg, ct) => Task.FromResult<CollectCommandHandler.ICollectSession>(new TestCollectSession());
             handler.ResumeRuntimeAsync = (client, ct) => Task.CompletedTask;


### PR DESCRIPTION
The CollectCommandFunctionalTests substitute a MemoryStream for the output file stream, so the trace file is never created on disk. The interactive status-printing path is non-deterministic in these tests because the MemoryStream-backed session completes near-instantly, and whether the status line fires before the loop exits depends on thread scheduling. When it does fire, FileInfo.Length throws because the file does not exist.

Set IsOutputRedirected=true on MockConsole to disable the status path.