### PR TITLE
Pass remaining arguments to arcade build.ps1 in test step

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -125,7 +125,8 @@ if ($test) {
           /p:RuntimeSourceFeed="$runtimesourcefeed" `
           /p:RuntimeSourceFeedKey="$runtimesourcefeedkey" `
           /p:LiveRuntimeDir="$liveRuntimeDir" `
-          $testFilterArg
+          $testFilterArg `
+          $remainingargs
 
         if ($lastExitCode -ne 0) {
             exit $lastExitCode


### PR DESCRIPTION
## Summary

Pass `$remainingargs` through to arcade's `build.ps1` in the test step of `eng/build.ps1`.

Currently remaining arguments (like `-projects`) are forwarded for the managed build step (line 73) but not for the test step. This prevents callers from passing arcade parameters like `-projects` to scope which test projects are run.

### Change

Add `$remainingargs` to the test invocation of arcade's `build.ps1`.

This enables the `runtime-diagnostics` pipeline in dotnet/runtime to pass `-projects` to run only specific test projects (e.g. `SOS.UnitTests.csproj`), avoiding unrelated flaky test failures from `EventPipe.UnitTests`.

> [!NOTE]
> This PR was generated with the assistance of GitHub Copilot.