### PR TITLE
Look up TEB from OS thread ID instead of DacpThreadData.teb

### DIFF
--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -4408,10 +4408,9 @@ HRESULT PrintThreadsFromThreadStore(BOOL bMiniDump, BOOL bPrintLiveThreadsOnly)
         }
 
         BOOL bSwitchedOutFiber = Thread.osThreadId == SWITCHED_OUT_FIBER_OSID;
+        ULONG id = 0;
         if (!IsKernelDebugger())
         {
-            ULONG id = 0;
-
             if (bSwitchedOutFiber)
             {
                 table.WriteColumn(0, "<<<< ");
@@ -4457,10 +4456,17 @@ HRESULT PrintThreadsFromThreadStore(BOOL bMiniDump, BOOL bPrintLiveThreadsOnly)
 #ifndef FEATURE_PAL
         DWORD_PTR OleTlsDataAddr;
         ULONG64 teb = 0;
-        IDebuggerServices* debuggerServices = GetDebuggerServices();
-        if (IsWindowsTarget() && !bSwitchedOutFiber
-                && debuggerServices != nullptr
-                && SUCCEEDED(debuggerServices->GetThreadTeb(Thread.osThreadId, &teb)) && teb != 0
+        if (IsWindowsTarget() && !bSwitchedOutFiber && id != 0)
+        {
+            ULONG curId;
+            if (SUCCEEDED(g_ExtSystem->GetCurrentThreadId(&curId)) &&
+                SUCCEEDED(g_ExtSystem->SetCurrentThreadId(id)))
+            {
+                g_ExtSystem->GetCurrentThreadTeb(&teb);
+                g_ExtSystem->SetCurrentThreadId(curId);
+            }
+        }
+        if (teb != 0
                 && SafeReadMemory(TO_TADDR(teb + offsetof(TEB, ReservedForOle)),
                             &OleTlsDataAddr,
                             sizeof(OleTlsDataAddr), NULL) && OleTlsDataAddr != 0)

--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -4456,8 +4456,12 @@ HRESULT PrintThreadsFromThreadStore(BOOL bMiniDump, BOOL bPrintLiveThreadsOnly)
         // Apartment state
 #ifndef FEATURE_PAL
         DWORD_PTR OleTlsDataAddr;
+        ULONG64 teb = 0;
+        IDebuggerServices* debuggerServices = GetDebuggerServices();
         if (IsWindowsTarget() && !bSwitchedOutFiber
-                && SafeReadMemory(TO_TADDR(Thread.teb + offsetof(TEB, ReservedForOle)),
+                && debuggerServices != nullptr
+                && SUCCEEDED(debuggerServices->GetThreadTeb(Thread.osThreadId, &teb)) && teb != 0
+                && SafeReadMemory(TO_TADDR(teb + offsetof(TEB, ReservedForOle)),
                             &OleTlsDataAddr,
                             sizeof(OleTlsDataAddr), NULL) && OleTlsDataAddr != 0)
         {

--- a/src/tests/SOS.UnitTests/Debuggees/ThreadApartment/ThreadApartment.cs
+++ b/src/tests/SOS.UnitTests/Debuggees/ThreadApartment/ThreadApartment.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+
+internal sealed class ThreadApartment
+{
+    private static readonly ManualResetEventSlim s_staReady = new();
+    private static readonly ManualResetEventSlim s_mtaReady = new();
+
+    private static void Main()
+    {
+        // Create an STA thread using SetApartmentState before Start.
+        // The runtime will call CoInitializeEx(COINIT_APARTMENTTHREADED) when the thread starts.
+        Thread staThread = new Thread(() =>
+        {
+            s_staReady.Set();
+            Thread.Sleep(Timeout.Infinite);
+        });
+        staThread.SetApartmentState(ApartmentState.STA);
+        staThread.IsBackground = true;
+        staThread.Start();
+
+        // Create an MTA thread using SetApartmentState before Start.
+        Thread mtaThread = new Thread(() =>
+        {
+            s_mtaReady.Set();
+            Thread.Sleep(Timeout.Infinite);
+        });
+        mtaThread.SetApartmentState(ApartmentState.MTA);
+        mtaThread.IsBackground = true;
+        mtaThread.Start();
+
+        s_staReady.Wait();
+        s_mtaReady.Wait();
+
+        // If a debugger is attached, break into it. Otherwise just wait.
+        if (Debugger.IsAttached)
+        {
+            Debugger.Break();
+        }
+        else
+        {
+            Console.WriteLine("Ready for dump capture");
+            Thread.Sleep(Timeout.Infinite);
+        }
+    }
+}

--- a/src/tests/SOS.UnitTests/Debuggees/ThreadApartment/ThreadApartment.cs
+++ b/src/tests/SOS.UnitTests/Debuggees/ThreadApartment/ThreadApartment.cs
@@ -36,15 +36,8 @@ internal sealed class ThreadApartment
         s_staReady.Wait();
         s_mtaReady.Wait();
 
-        // If a debugger is attached, break into it. Otherwise just wait.
-        if (Debugger.IsAttached)
-        {
-            Debugger.Break();
-        }
-        else
-        {
-            Console.WriteLine("Ready for dump capture");
-            Thread.Sleep(Timeout.Infinite);
-        }
+        Debugger.Break();
+
+        throw new Exception("ThreadApartment test complete");
     }
 }

--- a/src/tests/SOS.UnitTests/Debuggees/ThreadApartment/ThreadApartment.csproj
+++ b/src/tests/SOS.UnitTests/Debuggees/ThreadApartment/ThreadApartment.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework Condition="'$(BuildProjectFramework)' != ''">$(BuildProjectFramework)</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildProjectFramework)' == ''">$(SupportedSubProcessTargetFrameworks)</TargetFrameworks>
+    <!-- SetApartmentState is Windows-only; this debuggee is only used for Windows tests. -->
+    <NoWarn>$(NoWarn);CA1416</NoWarn>
+  </PropertyGroup>
+</Project>

--- a/src/tests/SOS.UnitTests/SOS.cs
+++ b/src/tests/SOS.UnitTests/SOS.cs
@@ -464,6 +464,17 @@ public class SOS
     }
 
     [SkippableTheory, MemberData(nameof(Configurations))]
+    public async Task ThreadApartment(TestConfiguration config)
+    {
+        if (OS.Kind != OSKind.Windows)
+        {
+            throw new SkipTestException("Apartment state is a Windows COM concept");
+        }
+
+        await SOSTestHelpers.RunTest(config, debuggeeName: "ThreadApartment", scriptName: "ThreadApartment.script", Output);
+    }
+
+    [SkippableTheory, MemberData(nameof(Configurations))]
     public async Task AsyncMain(TestConfiguration config)
     {
         await SOSTestHelpers.RunTest(config, debuggeeName: "AsyncMain", scriptName: "AsyncMain.script", Output, testTriage: true);

--- a/src/tests/SOS.UnitTests/Scripts/ThreadApartment.script
+++ b/src/tests/SOS.UnitTests/Scripts/ThreadApartment.script
@@ -3,6 +3,8 @@
 # This test is Windows-only since apartment state is a Windows COM concept.
 #
 
+CONTINUE
+
 LOADSOS
 
 # Verify that clrthreads shows the apartment state column with STA and MTA values.

--- a/src/tests/SOS.UnitTests/Scripts/ThreadApartment.script
+++ b/src/tests/SOS.UnitTests/Scripts/ThreadApartment.script
@@ -1,0 +1,16 @@
+#
+# Tests that clrthreads properly displays COM apartment state (STA/MTA).
+# This test is Windows-only since apartment state is a Windows COM concept.
+#
+
+LOADSOS
+
+# Verify that clrthreads shows the apartment state column with STA and MTA values.
+# The ThreadApartment debuggee creates one STA and one MTA thread before breaking.
+IFDEF:WINDOWS
+SOSCOMMAND:clrthreads
+VERIFY:\s*ThreadCount:\s+<DECVAL>\s+
+VERIFY:\s+ID\s+OSID\s+ThreadOBJ\s+State.*Apt.*
+VERIFY:.*\bSTA\b.*
+VERIFY:.*\bMTA\b.*
+ENDIF:WINDOWS


### PR DESCRIPTION
> [!NOTE]
> This PR was generated with the assistance of GitHub Copilot.

## Summary

Stop reading the TEB from `DacpThreadData.teb` in the `!Threads` command and instead look it up via `IDebuggerServices::GetThreadTeb(osThreadId)`. This decouples SOS from a runtime-internal field that is being removed from the DAC/cDAC Thread data contract.

## Changes

### strike.cpp
The `!Threads` command reads the COM apartment state (STA/MTA/NTA) by dereferencing `TEB.ReservedForOle`. Previously it used `Thread.teb` from `DacpThreadData`; now it calls `GetDebuggerServices()->GetThreadTeb(Thread.osThreadId)` to get the TEB address.

### New test: ThreadApartment
Added a new SOS integration test that validates `clrthreads` properly displays COM apartment state:
- **Debuggee**: Creates one STA thread (`SetApartmentState(STA)`) and one MTA thread before breaking
- **Script**: Verifies the Apt column contains both STA and MTA values
- **Windows-only**: Guarded in both the test method (`OS.Kind != OSKind.Windows`) and the script (`IFDEF:WINDOWS`)

## Verification

Manually verified with cdb against a dump containing STA/MTA threads:
- Original SOS: STA 1, MTA 4
- New SOS: STA 1, MTA 4 (identical output)

## Related PRs

- dotnet/runtime#126902 — Removes TEB from the Thread data contract and DAC (always returns 0)