### PR TITLE
Add TestCDACNoFallback flag for cDAC-only testing

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -12,6 +12,7 @@ Param(
     [switch] $skipnative,
     [switch] $bundletools,
     [switch] $useCdac,
+    [switch] $noFallback,
     [string] $methodfilter = '',
     [string] $classfilter = '',
     [ValidatePattern("(default|\d+\.\d+.\d+(-[a-z0-9\.]+)?)")][string] $dotnetruntimeversion = 'default',
@@ -24,6 +25,11 @@ Param(
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
+
+if ($noFallback -and -not $useCdac) {
+    Write-Error "-noFallback requires -useCdac to also be specified."
+    exit 1
+}
 
 $crossbuild = $false
 if (($architecture -eq "arm") -or ($architecture -eq "arm64")) {
@@ -99,6 +105,10 @@ if ($test) {
     if (-not $crossbuild) {
         if ($useCdac) {
             $env:SOS_TEST_CDAC="true"
+        }
+
+        if ($noFallback) {
+            $env:SOS_TEST_CDAC_NO_FALLBACK="true"
         }
 
         # Build the test filter argument if provided

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -32,6 +32,7 @@ __Test=0
 __TestFilter=
 __UnprocessedBuildArgs=
 __UseCdac=0
+__NoFallback=0
 __LiveRuntimeDir=
 
 usage_list+=("-skipmanaged: do not build managed components.")
@@ -122,6 +123,10 @@ handle_arguments() {
             __UseCdac=1
             ;;
 
+        nofallback|-nofallback)
+            __NoFallback=1
+            ;;
+
         -warnaserror|-nodereuse)
             __ManagedBuildArgs="$__ManagedBuildArgs $1 $2"
             __ShiftArgs=1
@@ -134,6 +139,11 @@ handle_arguments() {
 }
 
 source "$__RepoRootDir"/eng/native/build-commons.sh
+
+if [[ "$__NoFallback" == 1 && "$__UseCdac" != 1 ]]; then
+    echo "-nofallback requires -usecdac to also be specified."
+    exit 1
+fi
 
 __LogsDir="$__RootBinDir/log/$__BuildType"
 __ConfigTriplet="$__TargetOS.$__TargetArch.$__BuildType"
@@ -313,6 +323,10 @@ if [[ "$__Test" == 1 ]]; then
 
       if [[ "$__UseCdac" == 1 ]]; then
           export SOS_TEST_CDAC="true"
+      fi
+
+      if [[ "$__NoFallback" == 1 ]]; then
+          export SOS_TEST_CDAC_NO_FALLBACK="true"
       fi
 
       # Build the test filter argument if provided

--- a/src/Microsoft.Diagnostics.TestHelpers/TestConfiguration.cs
+++ b/src/Microsoft.Diagnostics.TestHelpers/TestConfiguration.cs
@@ -72,7 +72,8 @@ namespace Microsoft.Diagnostics.TestHelpers
                 ["TargetRid"] = GetRid(),
                 ["TargetArchitecture"] = OS.TargetArchitecture.ToString().ToLowerInvariant(),
                 ["NuGetPackageCacheDir"] = nugetPackages,
-                ["TestCDAC"] = Environment.GetEnvironmentVariable("SOS_TEST_CDAC")
+                ["TestCDAC"] = Environment.GetEnvironmentVariable("SOS_TEST_CDAC"),
+                ["TestCDACNoFallback"] = Environment.GetEnvironmentVariable("SOS_TEST_CDAC_NO_FALLBACK")
             };
             if (OS.Kind == OSKind.Windows)
             {
@@ -454,7 +455,11 @@ namespace Microsoft.Diagnostics.TestHelpers
             {
                 sb.Append(".singlefile");
             }
-            if (TestCDAC)
+            if (TestCDACNoFallback)
+            {
+                sb.Append(".cdac_no_fallback");
+            }
+            else if (TestCDAC)
             {
                 sb.Append(".cdac");
             }
@@ -558,6 +563,14 @@ namespace Microsoft.Diagnostics.TestHelpers
         public bool TestCDAC
         {
             get { return string.Equals(GetValue("TestCDAC"), "true", StringComparison.InvariantCultureIgnoreCase); }
+        }
+
+        /// <summary>
+        /// Returns true if tests should use the cDAC with no fallback to the legacy DAC.
+        /// </summary>
+        public bool TestCDACNoFallback
+        {
+            get { return string.Equals(GetValue("TestCDACNoFallback"), "true", StringComparison.InvariantCultureIgnoreCase); }
         }
 
         /// <summary>

--- a/src/tests/SOS.UnitTests/SOSRunner.cs
+++ b/src/tests/SOS.UnitTests/SOSRunner.cs
@@ -699,7 +699,12 @@ public class SOSRunner : IDisposable
                 WithLog(scriptLogger).
                 WithTimeout(TimeSpan.FromMinutes(10));
 
-            if (config.TestCDAC)
+            if (config.TestCDACNoFallback)
+            {
+                processRunner.WithEnvironmentVariable("DOTNET_ENABLE_CDAC", "1");
+                processRunner.WithEnvironmentVariable("CDAC_NO_FALLBACK", "1");
+            }
+            else if (config.TestCDAC)
             {
                 processRunner.WithEnvironmentVariable("DOTNET_ENABLE_CDAC", "1");
             }
@@ -1557,6 +1562,10 @@ public class SOSRunner : IDisposable
         if (!string.IsNullOrEmpty(setHostRuntime) && setHostRuntime == "-none")
         {
             defines.Add("HOST_RUNTIME_NONE");
+        }
+        if (_config.TestCDACNoFallback)
+        {
+            defines.Add("CDAC_NO_FALLBACK_TESTING");
         }
         return defines;
     }

--- a/src/tests/SOS.UnitTests/Scripts/ClrStackWithNumberOfFrames.script
+++ b/src/tests/SOS.UnitTests/Scripts/ClrStackWithNumberOfFrames.script
@@ -37,6 +37,7 @@ VERIFY:(?:[^\r\n]*\r?\n){6}[ \t]*\r?\n
 !VERIFY:(?:[^\r\n]*\r?\n){8}[ \t]*\r?\n
 
 # Verify that ClrStack with number of frames works using ICorDebug
+!IFDEF:CDAC_NO_FALLBACK_TESTING
 SOSCOMMAND:ClrStack -i -c 1
 VERIFY:(?:[^\r\n]*\r?\n){8}[ \t]*\r?\n
 !VERIFY:(?:[^\r\n]*\r?\n){10}[ \t]*\r?\n
@@ -55,3 +56,4 @@ VERIFY:(?:[^\r\n]*\r?\n){10}[ \t]*\r?\n
 SOSCOMMAND:ClrStack -i -c 4
 VERIFY:(?:[^\r\n]*\r?\n){11}[ \t]*\r?\n
 !VERIFY:(?:[^\r\n]*\r?\n){13}[ \t]*\r?\n
+ENDIF:CDAC_NO_FALLBACK_TESTING

--- a/src/tests/SOS.UnitTests/Scripts/DualRuntimes.script
+++ b/src/tests/SOS.UnitTests/Scripts/DualRuntimes.script
@@ -29,10 +29,12 @@ VERIFY:.*OS Thread Id:\s+0x<HEXVAL>\s+.*
 VERIFY:\s+Child\s+SP\s+IP\s+Call Site\s+
 
 # Verify that ClrStack with the ICorDebug options works
+!IFDEF:CDAC_NO_FALLBACK_TESTING
 SOSCOMMAND:ClrStack -i
 VERIFY:.*\s+Dumping managed stack and managed variables using ICorDebug.\s+
 VERIFY:.*\s+Child\s+SP\s+IP\s+Call Site\s+
 VERIFY:.*\s+Stack walk complete.\s+
+ENDIF:CDAC_NO_FALLBACK_TESTING
 
 # Verify that Threads (clrthreads) works
 IFDEF:DOTNETDUMP

--- a/src/tests/SOS.UnitTests/Scripts/DynamicMethod.script
+++ b/src/tests/SOS.UnitTests/Scripts/DynamicMethod.script
@@ -3,9 +3,11 @@ CONTINUE
 
 LOADSOS
 
+!IFDEF:CDAC_NO_FALLBACK_TESTING
 SOSCOMMAND:ClrStack -i -a
 VERIFY:\s+LOCALS:\s+
 
 SOSCOMMAND:DumpIL <POUT>.*System\.Reflection\.Emit\.DynamicMethod dynamicMethod @ 0x(<HEXVAL>).*\s+<POUT>
 VERIFY:\s+IL_0000: ldarg.0\s+
 VERIFY:\s+IL_0001: ldc.i4.0\s+
+ENDIF:CDAC_NO_FALLBACK_TESTING

--- a/src/tests/SOS.UnitTests/Scripts/MiniDumpLocalVarLookup.script
+++ b/src/tests/SOS.UnitTests/Scripts/MiniDumpLocalVarLookup.script
@@ -11,5 +11,7 @@ LOADSOS
 SOSCOMMAND:clrstack -l
 
 # stackwalk through ICorDebug with locals
+!IFDEF:CDAC_NO_FALLBACK_TESTING
 SOSCOMMAND:clrstack -i -l
 VERIFY:int\s+length\s+=\s+13
+ENDIF:CDAC_NO_FALLBACK_TESTING

--- a/src/tests/SOS.UnitTests/Scripts/StackAndOtherTests.script
+++ b/src/tests/SOS.UnitTests/Scripts/StackAndOtherTests.script
@@ -153,6 +153,7 @@ VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.Program\.Main\(.*\)\s+\[(?i:.*[
 IFDEF:NETCORE_OR_DOTNETDUMP
 
 # Verify that ClrStack with the ICorDebug options works
+!IFDEF:CDAC_NO_FALLBACK_TESTING
 SOSCOMMAND:ClrStack -i
 VERIFY:.*\s+Dumping managed stack and managed variables using ICorDebug.\s+
 VERIFY:.*\s+Child\s+SP\s+IP\s+Call Site\s+
@@ -179,6 +180,7 @@ VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+\[DEFAULT\] I4 SymbolTestApp\.Program\.Foo2\(.
 VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+\[DEFAULT\] I4 SymbolTestApp\.Program\.Foo1\(.*\)\s+\(.*\)\s+
 VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+\[DEFAULT\] Void SymbolTestApp\.Program\.Main\(.*\)\s+\(.*\)\s+
 VERIFY:.*\s+Stack walk complete.\s+
+ENDIF:CDAC_NO_FALLBACK_TESTING
 
 SOSCOMMAND: runtimes
 

--- a/src/tests/SOS.UnitTests/Scripts/StackTests.script
+++ b/src/tests/SOS.UnitTests/Scripts/StackTests.script
@@ -108,6 +108,7 @@ IFDEF:NETCORE_OR_DOTNETDUMP
 !IFDEF:ALPINE
 
 # 5) Verifying that ClrStack with the ICorDebug options works
+!IFDEF:CDAC_NO_FALLBACK_TESTING
 SOSCOMMAND:ClrStack -i
 VERIFY:.*\s+Dumping managed stack and managed variables using ICorDebug.\s+
 VERIFY:.*\s+Child\s+SP\s+IP\s+Call Site\s+
@@ -130,6 +131,7 @@ VERIFY:\s+\+ System.FormatException ex @ 0x<HEXVAL>\s+
 ENDIF:SINGLE_FILE_APP
 VERIFY:.*\s+<HEXVAL>\s+<HEXVAL>\s+\[DEFAULT\] Void NestedExceptionTest\.Program\.Main\(.*\)\s+\(.*\)\s+
 VERIFY:.*\s+Stack walk complete.\s+
+ENDIF:CDAC_NO_FALLBACK_TESTING
 
 ENDIF:ALPINE
 ENDIF:NETCORE_OR_DOTNETDUMP

--- a/src/tests/SOS.UnitTests/Scripts/WebApp.script
+++ b/src/tests/SOS.UnitTests/Scripts/WebApp.script
@@ -95,10 +95,12 @@ VERIFY:\s+eax=<HEXVAL>\s+ebx=<HEXVAL>\s+ecx=<HEXVAL>\s+
 ENDIF:X86
 
 # Verify that ClrStack with the ICorDebug options works
+!IFDEF:CDAC_NO_FALLBACK_TESTING
 SOSCOMMAND:ClrStack -i
 VERIFY:.*\s+Dumping managed stack and managed variables using ICorDebug.\s+
 VERIFY:.*\s+Child\s+SP\s+IP\s+Call Site\s+
 VERIFY:.*\s+Stack walk complete.\s+
+ENDIF:CDAC_NO_FALLBACK_TESTING
 
 # Verify that Threads (clrthreads) works
 SOSCOMMAND:clrthreads


### PR DESCRIPTION
Add a new `TestCDACNoFallback` test configuration flag (`SOS_TEST_CDAC_NO_FALLBACK` env var) that enables cDAC with no fallback to the legacy DAC.

When enabled:
- Sets `DOTNET_ENABLE_CDAC=1` and `CDAC_NO_FALLBACK=1` on the debugger process
- Adds `CDAC_NO_FALLBACK_TESTING` define to skip `ClrStack -i` tests (ICorDebug is not implemented in the cDAC)
- `TestCDACNoFallback` takes precedence over `TestCDAC` when both are set

Wraps `ClrStack -i` commands with `!IFDEF:CDAC_NO_FALLBACK_TESTING` / `ENDIF:CDAC_NO_FALLBACK_TESTING` in 7 script files.

The `CDAC_NO_FALLBACK` environment variable is added by dotnet/runtime#126752, which introduces the no-fallback mode to the cDAC runtime and adds a no-fallback test leg to the runtime-diagnostics pipeline.