### PR TITLE
Restore correct Version.Details.xml Source Sha

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,5 +1,5 @@
 <Dependencies>
-  <Source Uri="https://github.com/dotnet/dotnet" Mapping="diagnostics" Sha="58dadbc4a07fa7215da2da6e2d18c6d90c89edc7" BarId="284895" />
+  <Source Uri="https://github.com/dotnet/dotnet" Mapping="diagnostics" Sha="4e6cfd9762f7562d398be31e2bff79f3e993a9c2" BarId="284895" />
   <ProductDependencies>
     <Dependency Name="Microsoft.Diagnostics.Runtime" Version="4.0.722801">
       <Uri>https://github.com/microsoft/clrmd</Uri>


### PR DESCRIPTION
The backflow from the VMR is failing after the Source Sha in `eng/Version.Details.xml` was changed to an unknown value in #5789. This PR restore it back to the value it had prior to that, which was set by #5589 