### PR TITLE
Changes to improve SOS test perf

### DIFF
--- a/src/tests/SOS.UnitTests/DumpGenerationFixture.cs
+++ b/src/tests/SOS.UnitTests/DumpGenerationFixture.cs
@@ -4,101 +4,112 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Microsoft.Diagnostics.TestHelpers;
 using Microsoft.Win32;
-using Xunit;
 
-public class DumpGenerationFixture : IDisposable
+/// <summary>
+/// Registers Windows dump generation registry keys once per test assembly and
+/// cleans them up at process exit. Uses [ModuleInitializer] so that setup runs
+/// before any test, allowing tests to execute in parallel without a serializing
+/// xUnit collection fixture.
+/// </summary>
+internal static class DumpGenerationSetup
 {
-    private static readonly string _root = RuntimeInformation.ProcessArchitecture == Architecture.X86 ? @"SOFTWARE\WOW6432Node\" : @"SOFTWARE\";
-    private static readonly string _nodePath = _root + @"Microsoft\Windows NT\CurrentVersion\";
-    private static readonly string _auxiliaryNode = _nodePath + "MiniDumpAuxiliaryDlls";
-    private static readonly string _knownNode = _nodePath + "KnownManagedDebuggingDlls";
-    private static readonly string _settingsNode = _nodePath + "MiniDumpSettings";
-    private static readonly string _disableCheckValue = "DisableAuxProviderSignatureCheck";
+    private static readonly string s_root = RuntimeInformation.ProcessArchitecture == Architecture.X86 ? @"SOFTWARE\WOW6432Node\" : @"SOFTWARE\";
+    private static readonly string s_nodePath = s_root + @"Microsoft\Windows NT\CurrentVersion\";
+    private static readonly string s_auxiliaryNode = s_nodePath + "MiniDumpAuxiliaryDlls";
+    private static readonly string s_knownNode = s_nodePath + "KnownManagedDebuggingDlls";
+    private static readonly string s_settingsNode = s_nodePath + "MiniDumpSettings";
+    private static readonly string s_disableCheckValue = "DisableAuxProviderSignatureCheck";
 
-    private HashSet<string> _paths;
+    private static HashSet<string> s_paths;
 
-    public DumpGenerationFixture()
+    [ModuleInitializer]
+    internal static void Initialize()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            // Create the key for the newer Windows (11 or greater) 
+            return;
+        }
+
+        // Create the key for the newer Windows (11 or greater)
+        try
+        {
+            using RegistryKey settingsKey = Registry.LocalMachine.CreateSubKey(s_settingsNode, writable: true);
+            settingsKey.SetValue(s_disableCheckValue, 1, RegistryValueKind.DWord);
+        }
+        catch (Exception ex) when (ex is UnauthorizedAccessException)
+        {
+        }
+
+        // Create a unique list of all the installed test runtime paths
+        HashSet<string> paths = new();
+        foreach (TestConfiguration config in TestRunConfiguration.Instance.Configurations)
+        {
+            // Enumerate configs until we see this property
+            if (config.AllSettings.TryGetValue("MicrosoftNETCoreAppPath", out string path))
+            {
+                if (!string.IsNullOrEmpty(path))
+                {
+                    path = TestConfiguration.MakeCanonicalPath(path);
+                    try
+                    {
+                        foreach (string directory in Directory.GetDirectories(path))
+                        {
+                            if (Path.GetFileName(directory).StartsWith("10"))
+                            {
+                                paths.Add(directory);
+                            }
+                        }
+                    }
+                    catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                    {
+                    }
+                    break;
+                }
+            }
+        }
+
+        if (paths.Count > 0)
+        {
+            // Now try to create the keys for the older Windows versions
             try
             {
-                using RegistryKey settingsKey = Registry.LocalMachine.CreateSubKey(_settingsNode, writable: true);
-                settingsKey.SetValue(_disableCheckValue, 1, RegistryValueKind.DWord);
+                using RegistryKey auxiliaryKey = Registry.LocalMachine.CreateSubKey(s_auxiliaryNode, writable: true);
+                using RegistryKey knownKey = Registry.LocalMachine.CreateSubKey(s_knownNode, writable: true);
+
+                foreach (string path in paths)
+                {
+                    string dacPath = Path.Combine(path, "mscordaccore.dll");
+                    string runtimePath = Path.Combine(path, "coreclr.dll");
+                    knownKey.SetValue(dacPath, 0, RegistryValueKind.DWord);
+                    auxiliaryKey.SetValue(runtimePath, dacPath, RegistryValueKind.String);
+                }
+
+                // Save the paths after writing them successfully to registry
+                s_paths = paths;
             }
             catch (Exception ex) when (ex is UnauthorizedAccessException)
             {
             }
-
-            // Create a unique list of all the installed test runtime paths
-            HashSet<string> paths = new();
-            foreach (TestConfiguration config in TestRunConfiguration.Instance.Configurations)
-            {
-                // Enumerate configs until we see this property
-                if (config.AllSettings.TryGetValue("MicrosoftNETCoreAppPath", out string path))
-                {
-                    if (!string.IsNullOrEmpty(path))
-                    {
-                        path = TestConfiguration.MakeCanonicalPath(path);
-                        try
-                        {
-                            foreach (string directory in Directory.GetDirectories(path))
-                            {
-                                if (Path.GetFileName(directory).StartsWith("10"))
-                                {
-                                    paths.Add(directory);
-                                }
-                            }
-                        }
-                        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
-                        {
-                        }
-                        break;
-                    }
-                }
-            }
-
-            if (paths.Count > 0)
-            {
-                // Now try to create the keys for the older Windows versions 
-                try
-                {
-                    using RegistryKey auxiliaryKey = Registry.LocalMachine.CreateSubKey(_auxiliaryNode, writable: true);
-                    using RegistryKey knownKey = Registry.LocalMachine.CreateSubKey(_knownNode, writable: true);
-
-                    foreach (string path in paths)
-                    {
-                        string dacPath = Path.Combine(path, "mscordaccore.dll");
-                        string runtimePath = Path.Combine(path, "coreclr.dll");
-                        knownKey.SetValue(dacPath, 0, RegistryValueKind.DWord);
-                        auxiliaryKey.SetValue(runtimePath, dacPath, RegistryValueKind.String);
-                    }
-
-                    // Save the paths after writing them successfully to registry
-                    _paths = paths;
-                }
-                catch (Exception ex) when (ex is UnauthorizedAccessException)
-                {
-                }
-            }
         }
+
+        AppDomain.CurrentDomain.ProcessExit += Cleanup;
     }
 
-    public void Dispose()
+    private static void Cleanup(object sender, EventArgs e)
     {
-        if (_paths is not null && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (s_paths is not null && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             try
             {
-                IEnumerable<string> paths = _paths;
-                _paths = null;
+                HashSet<string> paths = s_paths;
+                s_paths = null;
 
-                using RegistryKey auxiliaryKey = Registry.LocalMachine.CreateSubKey(_auxiliaryNode, writable: true);
-                using RegistryKey knownKey = Registry.LocalMachine.CreateSubKey(_knownNode, writable: true);
+                using RegistryKey auxiliaryKey = Registry.LocalMachine.CreateSubKey(s_auxiliaryNode, writable: true);
+                using RegistryKey knownKey = Registry.LocalMachine.CreateSubKey(s_knownNode, writable: true);
 
                 foreach (string path in paths)
                 {
@@ -113,9 +124,4 @@ public class DumpGenerationFixture : IDisposable
             }
         }
     }
-}
-
-[CollectionDefinition("Windows Dump Generation")]
-public class DumpGenerationCollection : ICollectionFixture<DumpGenerationFixture>
-{
 }

--- a/src/tests/SOS.UnitTests/SOS.UnitTests.csproj
+++ b/src/tests/SOS.UnitTests/SOS.UnitTests.csproj
@@ -32,10 +32,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NewtonSoft.Json" Version="$(NewtonSoftJsonVersion)" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="$(SrcDir)/Microsoft.Diagnostics.TestHelpers/Microsoft.Diagnostics.TestHelpers.csproj" />
     <ProjectReference Include="$(TestDir)/TestExtension/TestExtension.csproj" />
   </ItemGroup>

--- a/src/tests/SOS.UnitTests/SOS.UnitTests.csproj
+++ b/src/tests/SOS.UnitTests/SOS.UnitTests.csproj
@@ -17,6 +17,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Content Include="$(MSBuildThisFileDirectory)ConfigFiles\Windows\Debugger.Tests.Config.txt" Condition="'$(OS)' == 'Windows_NT'">
       <Link>Debugger.Tests.Config.txt</Link>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/src/tests/SOS.UnitTests/SOS.cs
+++ b/src/tests/SOS.UnitTests/SOS.cs
@@ -15,6 +15,12 @@ using Xunit.Extensions;
 
 public static class SOSTestHelpers
 {
+    // Desktop CLR configurations are temporarily excluded because CDB SecureLoadDotNetExtensions
+    // and dotnet-dump DacSignatureVerification reject desktop CLR DAC DLLs.
+    // Tracking: https://github.com/dotnet/diagnostics/issues/5757
+    public static IEnumerable<object[]> Configurations => GetConfigurations("TestName", value: null)
+        .Where(args => !((TestConfiguration)args[0]).IsDesktop);
+
     public static IEnumerable<object[]> GetConfigurations(string key, string value)
     {
         return TestRunConfiguration.Instance.Configurations.Where((c) => key == null || c.AllSettings.GetValueOrDefault(key) == value).DefaultIfEmpty(TestConfiguration.Empty).Select(c => new[] { c });
@@ -235,61 +241,197 @@ public static class SOSTestHelpers
     }
 }
 
-public class SOS
+public class SOSStackTraceTests
 {
-    public SOS(ITestOutputHelper output)
+    public SOSStackTraceTests(ITestOutputHelper output)
     {
         Output = output;
     }
 
     private ITestOutputHelper Output { get; set; }
 
-    // Desktop CLR configurations are temporarily excluded because CDB SecureLoadDotNetExtensions
-    // and dotnet-dump DacSignatureVerification reject desktop CLR DAC DLLs.
-    // Tracking: https://github.com/dotnet/diagnostics/issues/5757
-    public static IEnumerable<object[]> Configurations => SOSTestHelpers.GetConfigurations("TestName", value: null)
-        .Where(args => !((TestConfiguration)args[0]).IsDesktop);
-
-    [SkippableTheory, MemberData(nameof(SOSTestHelpers.GetNetCoreConfigurations), MemberType = typeof(SOSTestHelpers))]
-    public async Task MiniDumpLocalVarLookup(TestConfiguration config)
+    [SkippableTheory, MemberData(nameof(SOSTestHelpers.Configurations), MemberType = typeof(SOSTestHelpers))]
+    public async Task StackTraceSoftwareExceptionFrame(TestConfiguration config)
     {
-        if (OS.Kind != OSKind.Windows)
+        if (config.RuntimeFrameworkVersionMajor < 10)
         {
-            throw new SkipTestException("Test only supports CDB and therefore only runs on Windows");
+            throw new SkipTestException("This test validates SoftwareExceptionFrame handling, before .NET10, these aren't used in this debuggee scenario.");
         }
 
-        if (config.PublishSingleFile)
-        {
-            throw new SkipTestException("Single file does not support mini dumps");
-        }
+        SOSTestHelpers.SkipIfWinX86(config);
 
-        // The default dumpGenerator, CreateDump, only supports taking dumps at exceptions.
-        // DotnetDump could support taking a dump at a breakpoint, but this SOS test framework doesn't currently support this operation.
-        // Therefore we use the NativeDebugger to take a dump at the DebugBreak() call in the debuggee.
         await SOSTestHelpers.RunTest(
             config,
-            debuggeeName: "MiniDumpLocalVarLookup",
-            scriptName: "MiniDumpLocalVarLookup.script",
+            debuggeeName: "SimpleThrow",
+            scriptName: "StackTraceSoftwareExceptionFrame.script",
             Output,
-            testName: "SOS.MiniDumpLocalVarLookup",
-            testMini: true,
-            dumpGenerator: SOSRunner.DumpGenerator.NativeDebugger);
+            testName: "SOS.StackTraceSoftwareExceptionFrame",
+            testTriage: true);
     }
 
-    [SkippableTheory, MemberData(nameof(SOSTestHelpers.GetNetCoreConfigurations), MemberType = typeof(SOSTestHelpers))]
-    public async Task VarargPInvokeInteropMD(TestConfiguration config)
+    [SkippableTheory, MemberData(nameof(SOSTestHelpers.Configurations), MemberType = typeof(SOSTestHelpers))]
+    public async Task StackTraceFaultingExceptionFrame(TestConfiguration config)
     {
-        if (OS.Kind != OSKind.Windows)
+        SOSTestHelpers.SkipIfWinX86(config);
+
+        await SOSTestHelpers.RunTest(
+            config,
+            debuggeeName: "DivZero",
+            scriptName: "StackTraceFaultingExceptionFrame.script",
+            Output,
+            testName: "SOS.StackTraceFaultingExceptionFrame",
+            testTriage: true);
+    }
+
+    [SkippableTheory, MemberData(nameof(SOSTestHelpers.Configurations), MemberType = typeof(SOSTestHelpers))]
+    public async Task StackTests(TestConfiguration config)
+    {
+        if (config.RuntimeFrameworkVersionMajor == 10)
         {
-            throw new SkipTestException("Test only supports CDB and therefore only runs on Windows");
+            // The clrstack -i command regressed on .NET 10 win-x86, so skip this test for now.
+            SOSTestHelpers.SkipIfWinX86(config);
         }
 
         await SOSTestHelpers.RunTest(
             config,
-            debuggeeName: "VarargPInvokeInteropMD",
-            scriptName: "VarargPInvokeInteropMD.script",
+            debuggeeName: "NestedExceptionTest",
+            scriptName: "StackTests.script",
             Output,
-            testName: "SOS.VarargPInvokeInteropMD",
+            testName: "SOS.StackTests");
+    }
+
+    [SkippableTheory, MemberData(nameof(SOSTestHelpers.Configurations), MemberType = typeof(SOSTestHelpers))]
+    public async Task ClrStackWithNumberOfFrames(TestConfiguration config)
+    {
+        if (config.IsDesktop)
+        {
+            throw new SkipTestException("The behavior of ClrStack -i is not the same on Desktop");
+        }
+        await SOSTestHelpers.RunTest(
+            config,
+            debuggeeName: "DivZero",
+            scriptName: "ClrStackWithNumberOfFrames.script",
+            Output,
+            testTriage: true);
+    }
+}
+
+public class SOSExceptionTests
+{
+    public SOSExceptionTests(ITestOutputHelper output)
+    {
+        Output = output;
+    }
+
+    private ITestOutputHelper Output { get; set; }
+
+    [SkippableTheory, MemberData(nameof(SOSTestHelpers.Configurations), MemberType = typeof(SOSTestHelpers))]
+    public async Task DivZero(TestConfiguration config)
+    {
+        await SOSTestHelpers.RunTest(
+            config,
+            debuggeeName: "DivZero",
+            scriptName: "DivZero.script",
+            Output,
+            testTriage: true);
+    }
+
+    [SkippableTheory, MemberData(nameof(SOSTestHelpers.Configurations), MemberType = typeof(SOSTestHelpers))]
+    public async Task SimpleThrow(TestConfiguration config)
+    {
+        await SOSTestHelpers.RunTest(config, debuggeeName: "SimpleThrow", scriptName: "SimpleThrow.script", Output, testTriage: true);
+    }
+
+    [SkippableTheory, MemberData(nameof(SOSTestHelpers.Configurations), MemberType = typeof(SOSTestHelpers))]
+    public async Task NestedExceptionTest(TestConfiguration config)
+    {
+        await SOSTestHelpers.RunTest(
+            config,
+            debuggeeName: "NestedExceptionTest",
+            scriptName: "NestedExceptionTest.script",
+            Output,
+            testTriage: true);
+    }
+
+    [SkippableTheory, MemberData(nameof(SOSTestHelpers.Configurations), MemberType = typeof(SOSTestHelpers))]
+    public async Task TaskNestedException(TestConfiguration config)
+    {
+        await SOSTestHelpers.RunTest(
+            config,
+            debuggeeName: "TaskNestedException",
+            scriptName: "TaskNestedException.script",
+            Output,
+            testTriage: true);
+    }
+}
+
+public class SOSOverflowTests
+{
+    public SOSOverflowTests(ITestOutputHelper output)
+    {
+        Output = output;
+    }
+
+    private ITestOutputHelper Output { get; set; }
+
+    [SkippableTheory, MemberData(nameof(SOSTestHelpers.Configurations), MemberType = typeof(SOSTestHelpers))]
+    public async Task Overflow(TestConfiguration config)
+    {
+        await SOSTestHelpers.RunTest(
+            scriptName: "Overflow.script",
+            new SOSRunner.TestInformation
+            {
+                TestConfiguration = config,
+                DebuggeeName = "Overflow",
+                // Generating the logging for overflow test causes so much output from createdump that it hangs/timesout the test run
+                DumpDiagnostics = config.IsNETCore && config.RuntimeFrameworkVersionMajor >= 6,
+                // Single file dumps don't capture the overflow exception info so disable testing against a dump
+                // Issue: https://github.com/dotnet/diagnostics/issues/2515
+                TestDump = !config.PublishSingleFile,
+                // The .NET Core createdump facility may not catch stack overflow so use gdb to generate dump
+                DumpGenerator = config.StackOverflowCreatesDump ? SOSRunner.DumpGenerator.CreateDump : SOSRunner.DumpGenerator.NativeDebugger
+            },
+            Output);
+    }
+}
+
+public class SOSGCTests
+{
+    public SOSGCTests(ITestOutputHelper output)
+    {
+        Output = output;
+    }
+
+    private ITestOutputHelper Output { get; set; }
+
+    [SkippableTheory, MemberData(nameof(SOSTestHelpers.Configurations), MemberType = typeof(SOSTestHelpers))]
+    public async Task GCTests(TestConfiguration config)
+    {
+        SOSTestHelpers.SkipIfArm(config);
+
+        // Live only
+        await SOSTestHelpers.RunTest(
+            config,
+            debuggeeName: "GCWhere",
+            scriptName: "GCTests.script",
+            Output,
+            testName: "SOS.GCTests",
+            testDump: false);
+    }
+
+    [SkippableTheory, MemberData(nameof(SOSTestHelpers.Configurations), MemberType = typeof(SOSTestHelpers))]
+    public async Task GCPOHTests(TestConfiguration config)
+    {
+        if (config.IsDesktop || config.RuntimeFrameworkVersionMajor < 5)
+        {
+            throw new SkipTestException("This test validates POH behavior, which was introduced in .net 5");
+        }
+        await SOSTestHelpers.RunTest(
+            config,
+            debuggeeName: "GCPOH",
+            scriptName: "GCPOH.script",
+            Output,
+            testName: "SOS.GCPOHTests",
             testDump: false);
     }
 
@@ -332,102 +474,111 @@ public class SOS
             testDump: false);
     }
 
-    [SkippableTheory, MemberData(nameof(Configurations))]
-    public async Task StackTraceSoftwareExceptionFrame(TestConfiguration config)
-    {
-        if (config.RuntimeFrameworkVersionMajor < 10)
-        {
-            throw new SkipTestException("This test validates SoftwareExceptionFrame handling, before .NET10, these aren't used in this debuggee scenario.");
-        }
-
-        SOSTestHelpers.SkipIfWinX86(config);
-
-        await SOSTestHelpers.RunTest(
-            config,
-            debuggeeName: "SimpleThrow",
-            scriptName: "StackTraceSoftwareExceptionFrame.script",
-            Output,
-            testName: "SOS.StackTraceSoftwareExceptionFrame",
-            testTriage: true);
-    }
-
-    [SkippableTheory, MemberData(nameof(Configurations))]
-    public async Task StackTraceFaultingExceptionFrame(TestConfiguration config)
-    {
-        SOSTestHelpers.SkipIfWinX86(config);
-
-        await SOSTestHelpers.RunTest(
-            config,
-            debuggeeName: "DivZero",
-            scriptName: "StackTraceFaultingExceptionFrame.script",
-            Output,
-            testName: "SOS.StackTraceFaultingExceptionFrame",
-            testTriage: true);
-    }
-
-    [SkippableTheory, MemberData(nameof(Configurations))]
-    public async Task DivZero(TestConfiguration config)
+    [SkippableTheory, MemberData(nameof(SOSTestHelpers.Configurations), MemberType = typeof(SOSTestHelpers))]
+    public async Task DumpGen(TestConfiguration config)
     {
         await SOSTestHelpers.RunTest(
-            config,
-            debuggeeName: "DivZero",
-            scriptName: "DivZero.script",
-            Output,
-            testTriage: true);
-    }
-
-    [SkippableTheory, MemberData(nameof(Configurations))]
-    public async Task GCTests(TestConfiguration config)
-    {
-        SOSTestHelpers.SkipIfArm(config);
-
-        // Live only
-        await SOSTestHelpers.RunTest(
-            config,
-            debuggeeName: "GCWhere",
-            scriptName: "GCTests.script",
-            Output,
-            testName: "SOS.GCTests",
-            testDump: false);
-    }
-
-    [SkippableTheory, MemberData(nameof(Configurations))]
-    public async Task GCPOHTests(TestConfiguration config)
-    {
-        if (config.IsDesktop || config.RuntimeFrameworkVersionMajor < 5)
-        {
-            throw new SkipTestException("This test validates POH behavior, which was introduced in .net 5");
-        }
-        await SOSTestHelpers.RunTest(
-            config,
-            debuggeeName: "GCPOH",
-            scriptName: "GCPOH.script",
-            Output,
-            testName: "SOS.GCPOHTests",
-            testDump: false);
-    }
-
-    [SkippableTheory, MemberData(nameof(Configurations))]
-    public async Task Overflow(TestConfiguration config)
-    {
-        await SOSTestHelpers.RunTest(
-            scriptName: "Overflow.script",
+            scriptName: "DumpGen.script",
             new SOSRunner.TestInformation
             {
                 TestConfiguration = config,
-                DebuggeeName = "Overflow",
-                // Generating the logging for overflow test causes so much output from createdump that it hangs/timesout the test run
-                DumpDiagnostics = config.IsNETCore && config.RuntimeFrameworkVersionMajor >= 6,
-                // Single file dumps don't capture the overflow exception info so disable testing against a dump
-                // Issue: https://github.com/dotnet/diagnostics/issues/2515
-                TestDump = !config.PublishSingleFile,
-                // The .NET Core createdump facility may not catch stack overflow so use gdb to generate dump
-                DumpGenerator = config.StackOverflowCreatesDump ? SOSRunner.DumpGenerator.CreateDump : SOSRunner.DumpGenerator.NativeDebugger
+                TestLive = false,
+                DebuggeeName = "DotnetDumpCommands",
+                DebuggeeArguments = "dumpgen",
+                DumpNameSuffix = "dumpgen",
+                UsePipeSync = true,
+                DumpGenerator = SOSRunner.DumpGenerator.DotNetDump,
+            },
+            Output);
+    }
+}
+
+public class SOSDumpTests
+{
+    public SOSDumpTests(ITestOutputHelper output)
+    {
+        Output = output;
+    }
+
+    private ITestOutputHelper Output { get; set; }
+
+    [SkippableTheory, MemberData(nameof(SOSTestHelpers.GetNetCoreConfigurations), MemberType = typeof(SOSTestHelpers))]
+    public async Task MiniDumpLocalVarLookup(TestConfiguration config)
+    {
+        if (OS.Kind != OSKind.Windows)
+        {
+            throw new SkipTestException("Test only supports CDB and therefore only runs on Windows");
+        }
+
+        if (config.PublishSingleFile)
+        {
+            throw new SkipTestException("Single file does not support mini dumps");
+        }
+
+        // The default dumpGenerator, CreateDump, only supports taking dumps at exceptions.
+        // DotnetDump could support taking a dump at a breakpoint, but this SOS test framework doesn't currently support this operation.
+        // Therefore we use the NativeDebugger to take a dump at the DebugBreak() call in the debuggee.
+        await SOSTestHelpers.RunTest(
+            config,
+            debuggeeName: "MiniDumpLocalVarLookup",
+            scriptName: "MiniDumpLocalVarLookup.script",
+            Output,
+            testName: "SOS.MiniDumpLocalVarLookup",
+            testMini: true,
+            dumpGenerator: SOSRunner.DumpGenerator.NativeDebugger);
+    }
+
+    [SkippableTheory, MemberData(nameof(SOSTestHelpers.Configurations), MemberType = typeof(SOSTestHelpers))]
+    public async Task ConcurrentDictionaries(TestConfiguration config)
+    {
+        if (OS.Kind != OSKind.Windows && config.RuntimeFrameworkVersionMajor == 10)
+        {
+            throw new SkipTestException("Dumping concurrent dict objects in dumps hits unavailable memory on linux dumps. Tracking: dotnet/diagnostics#5491");
+        }
+
+        await SOSTestHelpers.RunTest(
+            scriptName: "ConcurrentDictionaries.script",
+            new SOSRunner.TestInformation
+            {
+                TestConfiguration = config,
+                TestLive = false,
+                DebuggeeName = "DotnetDumpCommands",
+                DebuggeeArguments = "dcd",
+                DumpNameSuffix = "dcd",
+                UsePipeSync = true,
+                DumpGenerator = SOSRunner.DumpGenerator.DotNetDump,
             },
             Output);
     }
 
-    [SkippableTheory, MemberData(nameof(Configurations))]
+    [SkippableTheory, MemberData(nameof(SOSTestHelpers.Configurations), MemberType = typeof(SOSTestHelpers))]
+    public async Task OtherCommands(TestConfiguration config)
+    {
+        // This debuggee needs the directory of the exes/dlls to load the SymbolTestDll assembly.
+        await SOSTestHelpers.RunTest(
+            scriptName: "OtherCommands.script",
+            new SOSRunner.TestInformation
+            {
+                TestConfiguration = config,
+                TestName = "SOS.OtherCommands",
+                DebuggeeName = "SymbolTestApp",
+                // Assumes that SymbolTestDll.dll that is dynamically loaded is the parent directory of the single file app
+                DebuggeeArguments = config.PublishSingleFile ? Path.Combine("%DEBUG_ROOT%", "..") : "%DEBUG_ROOT%"
+            },
+            Output);
+    }
+}
+
+public class SOSMethodTests
+{
+    public SOSMethodTests(ITestOutputHelper output)
+    {
+        Output = output;
+    }
+
+    private ITestOutputHelper Output { get; set; }
+
+    [SkippableTheory, MemberData(nameof(SOSTestHelpers.Configurations), MemberType = typeof(SOSTestHelpers))]
     public async Task DynamicMethod(TestConfiguration config)
     {
         if (config.PublishSingleFile || config.IsDesktop)
@@ -444,19 +595,40 @@ public class SOS
         await SOSTestHelpers.RunTest(config, debuggeeName: "DynamicMethod", scriptName: "DynamicMethod.script", Output);
     }
 
-    [SkippableTheory, MemberData(nameof(Configurations))]
+    [SkippableTheory, MemberData(nameof(SOSTestHelpers.Configurations), MemberType = typeof(SOSTestHelpers))]
     public async Task Reflection(TestConfiguration config)
     {
         await SOSTestHelpers.RunTest(config, debuggeeName: "ReflectionTest", scriptName: "Reflection.script", Output, testTriage: true);
     }
 
-    [SkippableTheory, MemberData(nameof(Configurations))]
-    public async Task SimpleThrow(TestConfiguration config)
+    [SkippableTheory, MemberData(nameof(SOSTestHelpers.GetNetCoreConfigurations), MemberType = typeof(SOSTestHelpers))]
+    public async Task VarargPInvokeInteropMD(TestConfiguration config)
     {
-        await SOSTestHelpers.RunTest(config, debuggeeName: "SimpleThrow", scriptName: "SimpleThrow.script", Output, testTriage: true);
+        if (OS.Kind != OSKind.Windows)
+        {
+            throw new SkipTestException("Test only supports CDB and therefore only runs on Windows");
+        }
+
+        await SOSTestHelpers.RunTest(
+            config,
+            debuggeeName: "VarargPInvokeInteropMD",
+            scriptName: "VarargPInvokeInteropMD.script",
+            Output,
+            testName: "SOS.VarargPInvokeInteropMD",
+            testDump: false);
+    }
+}
+
+public class SOSThreadingTests
+{
+    public SOSThreadingTests(ITestOutputHelper output)
+    {
+        Output = output;
     }
 
-    [SkippableTheory, MemberData(nameof(Configurations))]
+    private ITestOutputHelper Output { get; set; }
+
+    [SkippableTheory, MemberData(nameof(SOSTestHelpers.Configurations), MemberType = typeof(SOSTestHelpers))]
     public async Task ThreadApartment(TestConfiguration config)
     {
         if (OS.Kind != OSKind.Windows)
@@ -467,13 +639,7 @@ public class SOS
         await SOSTestHelpers.RunTest(config, debuggeeName: "ThreadApartment", scriptName: "ThreadApartment.script", Output);
     }
 
-    [SkippableTheory, MemberData(nameof(Configurations))]
-    public async Task AsyncMain(TestConfiguration config)
-    {
-        await SOSTestHelpers.RunTest(config, debuggeeName: "AsyncMain", scriptName: "AsyncMain.script", Output, testTriage: true);
-    }
-
-    [SkippableTheory, MemberData(nameof(Configurations))]
+    [SkippableTheory, MemberData(nameof(SOSTestHelpers.Configurations), MemberType = typeof(SOSTestHelpers))]
     public async Task LineNums(TestConfiguration config)
     {
         await SOSTestHelpers.RunTest(
@@ -483,45 +649,32 @@ public class SOS
             Output,
             testTriage: true);
     }
+}
 
-    [SkippableTheory, MemberData(nameof(Configurations))]
-    public async Task NestedExceptionTest(TestConfiguration config)
+public class SOSAsyncTests
+{
+    public SOSAsyncTests(ITestOutputHelper output)
     {
-        await SOSTestHelpers.RunTest(
-            config,
-            debuggeeName: "NestedExceptionTest",
-            scriptName: "NestedExceptionTest.script",
-            Output,
-            testTriage: true);
+        Output = output;
     }
 
-    [SkippableTheory, MemberData(nameof(Configurations))]
-    public async Task TaskNestedException(TestConfiguration config)
+    private ITestOutputHelper Output { get; set; }
+
+    [SkippableTheory, MemberData(nameof(SOSTestHelpers.Configurations), MemberType = typeof(SOSTestHelpers))]
+    public async Task AsyncMain(TestConfiguration config)
     {
-        await SOSTestHelpers.RunTest(
-            config,
-            debuggeeName: "TaskNestedException",
-            scriptName: "TaskNestedException.script",
-            Output,
-            testTriage: true);
+        await SOSTestHelpers.RunTest(config, debuggeeName: "AsyncMain", scriptName: "AsyncMain.script", Output, testTriage: true);
+    }
+}
+
+public class SOSScenarioTests
+{
+    public SOSScenarioTests(ITestOutputHelper output)
+    {
+        Output = output;
     }
 
-    [SkippableTheory, MemberData(nameof(Configurations))]
-    public async Task StackTests(TestConfiguration config)
-    {
-        if (config.RuntimeFrameworkVersionMajor == 10)
-        {
-            // The clrstack -i command regressed on .NET 10 win-x86, so skip this test for now.
-            SOSTestHelpers.SkipIfWinX86(config);
-        }
-
-        await SOSTestHelpers.RunTest(
-            config,
-            debuggeeName: "NestedExceptionTest",
-            scriptName: "StackTests.script",
-            Output,
-            testName: "SOS.StackTests");
-    }
+    private ITestOutputHelper Output { get; set; }
 
     [SkippableTheory, MemberData(nameof(SOSTestHelpers.GetConfigurations), "TestName", "SOS.TestExtensions", MemberType = typeof(SOSTestHelpers))]
     public async Task TestExtensions(TestConfiguration config)
@@ -534,22 +687,70 @@ public class SOS
             testName: "SOS.TestExtensions");
     }
 
-    [SkippableTheory, MemberData(nameof(Configurations))]
-    public async Task OtherCommands(TestConfiguration config)
+    [SkippableTheory, MemberData(nameof(SOSTestHelpers.GetConfigurations), "TestName", "SOS.WebApp3", MemberType = typeof(SOSTestHelpers))]
+    public async Task WebApp3(TestConfiguration config)
     {
-        // This debuggee needs the directory of the exes/dlls to load the SymbolTestDll assembly.
+        await SOSTestHelpers.RunTest("WebApp.script", new SOSRunner.TestInformation
+        {
+            TestConfiguration = config,
+            TestLive = false,
+            DebuggeeName = "WebApp3",
+            UsePipeSync = true,
+            DumpGenerator = SOSRunner.DumpGenerator.DotNetDump
+        },
+        Output);
+    }
+
+    [SkippableTheory, MemberData(nameof(SOSTestHelpers.GetConfigurations), "TestName", "SOS.DualRuntimes", MemberType = typeof(SOSTestHelpers))]
+    public async Task DualRuntimes(TestConfiguration config)
+    {
+        // This test on linux/macOS can be called with an empty config because vstest and dotnet test fail/complain about no test parameters. The
+        // linux/macOS config file doesn't contain a SOS.DualRuntimes TestName because this is Windows only.
+        if (config.IsEmpty)
+        {
+            throw new SkipTestException("Skipping DualRuntimes test");
+        }
+        if (config.PublishSingleFile)
+        {
+            throw new SkipTestException("Single file not supported");
+        }
+        // Desktop CLR DAC signature verification fails with CDB SecureLoadDotNetExtensions
+        // and dotnet-dump DacSignatureVerification.
+        // Tracking: https://github.com/dotnet/diagnostics/issues/5757
+        if (OS.Kind == OSKind.Windows)
+        {
+            throw new SkipTestException("Desktop CLR DAC signature verification failure (https://github.com/dotnet/diagnostics/issues/5757)");
+        }
+        // The assembly path, class and function name of the desktop test code to load/run
+        string desktopTestParameters = TestConfiguration.MakeCanonicalPath(config.GetValue("DesktopTestParameters"));
+        if (string.IsNullOrEmpty(desktopTestParameters))
+        {
+            throw new SkipTestException("DesktopTestParameters config value does not exists");
+        }
         await SOSTestHelpers.RunTest(
-            scriptName: "OtherCommands.script",
+            scriptName: "DualRuntimes.script",
             new SOSRunner.TestInformation
             {
                 TestConfiguration = config,
-                TestName = "SOS.OtherCommands",
-                DebuggeeName = "SymbolTestApp",
-                // Assumes that SymbolTestDll.dll that is dynamically loaded is the parent directory of the single file app
-                DebuggeeArguments = config.PublishSingleFile ? Path.Combine("%DEBUG_ROOT%", "..") : "%DEBUG_ROOT%"
+                TestLive = false,
+                TestName = "SOS.DualRuntimes",
+                DebuggeeName = "WebApp3",
+                DebuggeeArguments = desktopTestParameters,
+                UsePipeSync = true,
+                DumpGenerator = SOSRunner.DumpGenerator.DotNetDump
             },
             Output);
     }
+}
+
+public class SOSStackAndOtherTests
+{
+    public SOSStackAndOtherTests(ITestOutputHelper output)
+    {
+        Output = output;
+    }
+
+    private ITestOutputHelper Output { get; set; }
 
     [SkippableTheory, MemberData(nameof(SOSTestHelpers.GetConfigurations), "TestName", "SOS.StackAndOtherTests", MemberType = typeof(SOSTestHelpers))]
     public async Task StackAndOtherTests(TestConfiguration config)
@@ -610,104 +811,18 @@ public class SOS
             }
         }
     }
+}
 
-    [SkippableTheory, MemberData(nameof(SOSTestHelpers.GetConfigurations), "TestName", "SOS.WebApp3", MemberType = typeof(SOSTestHelpers))]
-    public async Task WebApp3(TestConfiguration config)
+public class SOSPluginTests
+{
+    public SOSPluginTests(ITestOutputHelper output)
     {
-        await SOSTestHelpers.RunTest("WebApp.script", new SOSRunner.TestInformation
-        {
-            TestConfiguration = config,
-            TestLive = false,
-            DebuggeeName = "WebApp3",
-            UsePipeSync = true,
-            DumpGenerator = SOSRunner.DumpGenerator.DotNetDump
-        },
-        Output);
+        Output = output;
     }
 
-    [SkippableTheory, MemberData(nameof(SOSTestHelpers.GetConfigurations), "TestName", "SOS.DualRuntimes", MemberType = typeof(SOSTestHelpers))]
-    public async Task DualRuntimes(TestConfiguration config)
-    {
-        // This test on linux/macOS can be called with an empty config because vstest and dotnet test fail/complain about no test parameters. The
-        // linux/macOS config file doesn't contain a SOS.DualRuntimes TestName because this is Windows only.
-        if (config.IsEmpty)
-        {
-            throw new SkipTestException("Skipping DualRuntimes test");
-        }
-        if (config.PublishSingleFile)
-        {
-            throw new SkipTestException("Single file not supported");
-        }
-        // Desktop CLR DAC signature verification fails with CDB SecureLoadDotNetExtensions
-        // and dotnet-dump DacSignatureVerification.
-        // Tracking: https://github.com/dotnet/diagnostics/issues/5757
-        if (OS.Kind == OSKind.Windows)
-        {
-            throw new SkipTestException("Desktop CLR DAC signature verification failure (https://github.com/dotnet/diagnostics/issues/5757)");
-        }
-        // The assembly path, class and function name of the desktop test code to load/run
-        string desktopTestParameters = TestConfiguration.MakeCanonicalPath(config.GetValue("DesktopTestParameters"));
-        if (string.IsNullOrEmpty(desktopTestParameters))
-        {
-            throw new SkipTestException("DesktopTestParameters config value does not exists");
-        }
-        await SOSTestHelpers.RunTest(
-            scriptName: "DualRuntimes.script",
-            new SOSRunner.TestInformation
-            {
-                TestConfiguration = config,
-                TestLive = false,
-                TestName = "SOS.DualRuntimes",
-                DebuggeeName = "WebApp3",
-                DebuggeeArguments = desktopTestParameters,
-                UsePipeSync = true,
-                DumpGenerator = SOSRunner.DumpGenerator.DotNetDump
-            },
-            Output);
-    }
+    private ITestOutputHelper Output { get; set; }
 
-    [SkippableTheory, MemberData(nameof(Configurations))]
-    public async Task ConcurrentDictionaries(TestConfiguration config)
-    {
-        if (OS.Kind != OSKind.Windows && config.RuntimeFrameworkVersionMajor == 10)
-        {
-            throw new SkipTestException("Dumping concurrent dict objects in dumps hits unavailable memory on linux dumps. Tracking: dotnet/diagnostics#5491");
-        }
-
-        await SOSTestHelpers.RunTest(
-            scriptName: "ConcurrentDictionaries.script",
-            new SOSRunner.TestInformation
-            {
-                TestConfiguration = config,
-                TestLive = false,
-                DebuggeeName = "DotnetDumpCommands",
-                DebuggeeArguments = "dcd",
-                DumpNameSuffix = "dcd",
-                UsePipeSync = true,
-                DumpGenerator = SOSRunner.DumpGenerator.DotNetDump,
-            },
-            Output);
-    }
-
-    [SkippableTheory, MemberData(nameof(Configurations))]
-    public async Task DumpGen(TestConfiguration config)
-    {
-        await SOSTestHelpers.RunTest(
-            scriptName: "DumpGen.script",
-            new SOSRunner.TestInformation
-            {
-                TestConfiguration = config,
-                TestLive = false,
-                DebuggeeName = "DotnetDumpCommands",
-                DebuggeeArguments = "dumpgen",
-                DumpNameSuffix = "dumpgen",
-                UsePipeSync = true,
-                DumpGenerator = SOSRunner.DumpGenerator.DotNetDump,
-            },
-            Output);
-    }
-
-    [SkippableTheory, MemberData(nameof(Configurations))]
+    [SkippableTheory, MemberData(nameof(SOSTestHelpers.Configurations), MemberType = typeof(SOSTestHelpers))]
     public async Task LLDBPluginTests(TestConfiguration config)
     {
         SOSTestHelpers.SkipIfArm(config);
@@ -811,19 +926,5 @@ public class SOS
             outputHelper?.WriteLine("}");
             outputHelper?.Dispose();
         }
-    }
-    [SkippableTheory, MemberData(nameof(Configurations))]
-    public async Task ClrStackWithNumberOfFrames(TestConfiguration config)
-    {
-        if (config.IsDesktop)
-        {
-            throw new SkipTestException("The behavior of ClrStack -i is not the same on Desktop");
-        }
-        await SOSTestHelpers.RunTest(
-            config,
-            debuggeeName: "DivZero",
-            scriptName: "ClrStackWithNumberOfFrames.script",
-            Output,
-            testTriage: true);
     }
 }

--- a/src/tests/SOS.UnitTests/SOS.cs
+++ b/src/tests/SOS.UnitTests/SOS.cs
@@ -8,7 +8,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Diagnostics.TestHelpers;
-using Newtonsoft.Json;
+using System.Text.Json;
 using Xunit;
 using Xunit.Abstractions;
 using Xunit.Extensions;
@@ -201,31 +201,29 @@ public static class SOSTestHelpers
 
             AssertX.FileExists("CrashReport", crashReportPath, outputHelper.IndentedOutput);
 
-            dynamic crashReport = JsonConvert.DeserializeObject(File.ReadAllText(crashReportPath));
-            Assert.NotNull(crashReport);
+            using JsonDocument crashReport = JsonDocument.Parse(File.ReadAllText(crashReportPath));
+            JsonElement root = crashReport.RootElement;
 
-            dynamic payload = crashReport.payload;
-            Assert.NotNull(payload);
-            Version protocol_version = Version.Parse((string)payload.protocol_version);
+            Assert.True(root.TryGetProperty("payload", out JsonElement payload));
+            Version protocol_version = Version.Parse(payload.GetProperty("protocol_version").GetString());
             Assert.True(protocol_version >= new Version("1.0.0"));
             outputHelper.IndentedOutput.WriteLine($"protocol_version {protocol_version}");
 
-            string process_name = (string)payload.process_name;
+            string process_name = payload.GetProperty("process_name").GetString();
             Assert.NotNull(process_name);
             outputHelper.IndentedOutput.WriteLine($"process_name {process_name}");
 
-            Assert.NotNull(payload.threads);
-            IEnumerable<dynamic> threads = payload.threads;
-            Assert.True(threads.Any());
-            outputHelper.IndentedOutput.WriteLine($"threads # {threads.Count()}");
+            Assert.True(payload.TryGetProperty("threads", out JsonElement threads));
+            int threadCount = threads.GetArrayLength();
+            Assert.True(threadCount > 0);
+            outputHelper.IndentedOutput.WriteLine($"threads # {threadCount}");
 
             if (OS.Kind == OSKind.OSX)
             {
-                dynamic parameters = crashReport.parameters;
-                Assert.NotNull(parameters);
-                Assert.NotNull(parameters.ExceptionType);
-                Assert.NotNull(parameters.OSVersion);
-                Assert.Equal("apple", (string)parameters.SystemManufacturer);
+                Assert.True(root.TryGetProperty("parameters", out JsonElement parameters));
+                Assert.True(parameters.TryGetProperty("ExceptionType", out _));
+                Assert.True(parameters.TryGetProperty("OSVersion", out _));
+                Assert.Equal("apple", parameters.GetProperty("SystemManufacturer").GetString());
             }
         }
         catch (Exception ex)

--- a/src/tests/SOS.UnitTests/SOS.cs
+++ b/src/tests/SOS.UnitTests/SOS.cs
@@ -13,10 +13,6 @@ using Xunit;
 using Xunit.Abstractions;
 using Xunit.Extensions;
 
-// Newer SDKs flag MemberData(nameof(Configurations)) with this error
-// Avoid unnecessary zero-length array allocations.  Use Array.Empty<object>() instead.
-#pragma warning disable CA1825
-
 public static class SOSTestHelpers
 {
     public static IEnumerable<object[]> GetConfigurations(string key, string value)

--- a/src/tests/SOS.UnitTests/SOS.cs
+++ b/src/tests/SOS.UnitTests/SOS.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -82,54 +83,72 @@ public static class SOSTestHelpers
         ITestOutputHelper output)
     {
         information.OutputHelper = output;
+        string testLabel = $"{information.DebuggeeName}/{scriptName}";
+        Stopwatch sw = Stopwatch.StartNew();
+        output.WriteLine($"[TIMING] {testLabel} started at {DateTime.UtcNow:HH:mm:ss.fff}");
 
-        if (information.TestLive)
+        try
         {
-            // Live
-            using (SOSRunner runner = await SOSRunner.StartDebugger(information, SOSRunner.DebuggerAction.Live))
+            if (information.TestLive)
             {
-                await runner.RunScript(scriptName);
-            }
-        }
-
-        if (information.TestDump)
-        {
-            string dumpName = null;
-
-            // Generate a crash dump.
-            if (information.DebuggeeDumpOutputRootDir != null)
-            {
-                dumpName = await SOSRunner.CreateDump(information);
-            }
-
-            // Test against a crash dump.
-            if (information.DebuggeeDumpInputRootDir != null)
-            {
-                // With cdb (Windows) or lldb (Linux)
-                using (SOSRunner runner = await SOSRunner.StartDebugger(information, SOSRunner.DebuggerAction.LoadDump))
+                Stopwatch phaseSw = Stopwatch.StartNew();
+                // Live
+                using (SOSRunner runner = await SOSRunner.StartDebugger(information, SOSRunner.DebuggerAction.Live))
                 {
                     await runner.RunScript(scriptName);
                 }
+                output.WriteLine($"[TIMING] {testLabel} Live phase completed in {phaseSw.Elapsed.TotalSeconds:F1}s");
+            }
 
-                // Using the dotnet-dump analyze tool if the path exists in the config file.
-                if (information.TestConfiguration.DotNetDumpPath() != null)
+            if (information.TestDump)
+            {
+                string dumpName = null;
+
+                // Generate a crash dump.
+                if (information.DebuggeeDumpOutputRootDir != null)
                 {
-                    // Don't test dotnet-dump on triage dumps when running on desktop CLR.
-                    if (information.TestConfiguration.IsNETCore || information.DumpType != SOSRunner.DumpType.Triage)
+                    Stopwatch phaseSw = Stopwatch.StartNew();
+                    dumpName = await SOSRunner.CreateDump(information);
+                    output.WriteLine($"[TIMING] {testLabel} CreateDump completed in {phaseSw.Elapsed.TotalSeconds:F1}s");
+                }
+
+                // Test against a crash dump.
+                if (information.DebuggeeDumpInputRootDir != null)
+                {
+                    // With cdb (Windows) or lldb (Linux)
+                    Stopwatch phaseSw = Stopwatch.StartNew();
+                    using (SOSRunner runner = await SOSRunner.StartDebugger(information, SOSRunner.DebuggerAction.LoadDump))
                     {
-                        using (SOSRunner runner = await SOSRunner.StartDebugger(information, SOSRunner.DebuggerAction.LoadDumpWithDotNetDump))
+                        await runner.RunScript(scriptName);
+                    }
+                    output.WriteLine($"[TIMING] {testLabel} LoadDump phase completed in {phaseSw.Elapsed.TotalSeconds:F1}s");
+
+                    // Using the dotnet-dump analyze tool if the path exists in the config file.
+                    if (information.TestConfiguration.DotNetDumpPath() != null)
+                    {
+                        // Don't test dotnet-dump on triage dumps when running on desktop CLR.
+                        if (information.TestConfiguration.IsNETCore || information.DumpType != SOSRunner.DumpType.Triage)
                         {
-                            await runner.RunScript(scriptName);
+                            phaseSw = Stopwatch.StartNew();
+                            using (SOSRunner runner = await SOSRunner.StartDebugger(information, SOSRunner.DebuggerAction.LoadDumpWithDotNetDump))
+                            {
+                                await runner.RunScript(scriptName);
+                            }
+                            output.WriteLine($"[TIMING] {testLabel} DotNetDump phase completed in {phaseSw.Elapsed.TotalSeconds:F1}s");
                         }
                     }
                 }
-            }
 
-            // Test the crash report json file
-            if (dumpName != null && information.TestCrashReport)
-            {
-                TestCrashReport(dumpName, information);
+                // Test the crash report json file
+                if (dumpName != null && information.TestCrashReport)
+                {
+                    TestCrashReport(dumpName, information);
+                }
             }
+        }
+        finally
+        {
+            output.WriteLine($"[TIMING] {testLabel} finished in {sw.Elapsed.TotalSeconds:F1}s (total)");
         }
     }
 
@@ -145,6 +164,9 @@ public static class SOSTestHelpers
         bool testMini = false,
         SOSRunner.DumpGenerator dumpGenerator = SOSRunner.DumpGenerator.CreateDump)
     {
+        Stopwatch overallSw = Stopwatch.StartNew();
+        output.WriteLine($"[TIMING] RunTest({debuggeeName}, {scriptName}) started at {DateTime.UtcNow:HH:mm:ss.fff}");
+
         await RunTest(scriptName,
             new SOSRunner.TestInformation
             {
@@ -190,6 +212,8 @@ public static class SOSTestHelpers
                 },
                 output);
         }
+
+        output.WriteLine($"[TIMING] RunTest({debuggeeName}, {scriptName}) finished in {overallSw.Elapsed.TotalSeconds:F1}s (total)");
     }
 
     internal static void TestCrashReport(string dumpName, SOSRunner.TestInformation information)

--- a/src/tests/SOS.UnitTests/SOS.cs
+++ b/src/tests/SOS.UnitTests/SOS.cs
@@ -336,6 +336,7 @@ public class SOSStackTraceTests
             debuggeeName: "DivZero",
             scriptName: "ClrStackWithNumberOfFrames.script",
             Output,
+            testName: "SOS.ClrStackWithNumberOfFrames",
             testTriage: true);
     }
 }
@@ -507,6 +508,7 @@ public class SOSGCTests
             {
                 TestConfiguration = config,
                 TestLive = false,
+                TestName = "SOS.DumpGen",
                 DebuggeeName = "DotnetDumpCommands",
                 DebuggeeArguments = "dumpgen",
                 DumpNameSuffix = "dumpgen",
@@ -566,6 +568,7 @@ public class SOSDumpTests
             {
                 TestConfiguration = config,
                 TestLive = false,
+                TestName = "SOS.ConcurrentDictionaries",
                 DebuggeeName = "DotnetDumpCommands",
                 DebuggeeArguments = "dcd",
                 DumpNameSuffix = "dcd",

--- a/src/tests/SOS.UnitTests/SOS.cs
+++ b/src/tests/SOS.UnitTests/SOS.cs
@@ -241,7 +241,6 @@ public static class SOSTestHelpers
     }
 }
 
-[Collection("Windows Dump Generation")]
 public class SOS
 {
     public SOS(ITestOutputHelper output)

--- a/src/tests/SOS.UnitTests/SOSRunner.cs
+++ b/src/tests/SOS.UnitTests/SOSRunner.cs
@@ -306,8 +306,9 @@ public class SOSRunner : IDisposable
                 // Setup a pipe server for the debuggee to connect to sync when to take a dump
                 if (information.UsePipeSync)
                 {
-                    int runnerId = Process.GetCurrentProcess().Id;
-                    pipeName = $"SOSRunner.{runnerId}.{information.DebuggeeName}";
+                    // Use TestName for diagnostics + random suffix to avoid collisions in parallel runs.
+                    // Unix domain sockets (used on Linux/macOS) have ~104 byte path limit, so keep name short.
+                    pipeName = $"SOSRunner.{information.TestName}.{Random.Shared.Next():x8}";
                     pipeServer = new NamedPipeServerStream(pipeName);
                     arguments.Append(' ');
                     arguments.Append(pipeName);

--- a/src/tests/SOS.UnitTests/SOSRunner.cs
+++ b/src/tests/SOS.UnitTests/SOSRunner.cs
@@ -306,9 +306,11 @@ public class SOSRunner : IDisposable
                 // Setup a pipe server for the debuggee to connect to sync when to take a dump
                 if (information.UsePipeSync)
                 {
-                    // Use TestName for diagnostics + random suffix to avoid collisions in parallel runs.
-                    // Unix domain sockets (used on Linux/macOS) have ~104 byte path limit, so keep name short.
-                    pipeName = $"SOSRunner.{information.TestName}.{Random.Shared.Next():x8}";
+                    // Use random suffix to avoid collisions in parallel runs.
+                    // Unix domain sockets (used on Linux/macOS) have a 104-byte path limit.
+                    // .NET prepends "CoreFxPipe_" (11 chars) and the temp dir path (~52 chars on macOS).
+                    // This leaves ~41 chars for the pipe name. Use a short prefix + random hex.
+                    pipeName = $"sos.{Random.Shared.Next():x8}";
                     pipeServer = new NamedPipeServerStream(pipeName);
                     arguments.Append(' ');
                     arguments.Append(pipeName);

--- a/src/tests/SOS.UnitTests/SOSRunner.cs
+++ b/src/tests/SOS.UnitTests/SOSRunner.cs
@@ -474,7 +474,9 @@ public class SOSRunner : IDisposable
             NativeDebugger debugger = GetNativeDebuggerToUse(config, action);
 
             // Restore and build the debuggee.
+            Stopwatch compileSw = Stopwatch.StartNew();
             DebuggeeConfiguration debuggeeConfig = await DebuggeeCompiler.Execute(config, information.DebuggeeName, outputHelper);
+            outputHelper.WriteLine("[TIMING] DebuggeeCompiler.Execute took {0:F1}s", compileSw.Elapsed.TotalSeconds);
 
             outputHelper.WriteLine("SOSRunner processing {0}", information.TestName);
             outputHelper.WriteLine("{");
@@ -753,6 +755,7 @@ public class SOSRunner : IDisposable
             sosRunner = new SOSRunner(debugger, config, outputHelper, variables, scriptLogger, processRunner, dumpType);
 
             // Start the native debugger
+            Stopwatch launchSw = Stopwatch.StartNew();
             processRunner.Start();
 
             // Set the coredump_filter flags on the gdb process so the coredump it
@@ -764,6 +767,8 @@ public class SOSRunner : IDisposable
 
             // Execute the initial debugger commands
             await sosRunner.RunCommands(initialCommands);
+            outputHelper.WriteLine("[TIMING] Debugger launch + initial commands took {0:F1}s ({1} initial commands, debugger={2}, action={3})",
+                launchSw.Elapsed.TotalSeconds, initialCommands.Count, debugger, action);
 
             return sosRunner;
         }
@@ -783,6 +788,8 @@ public class SOSRunner : IDisposable
 
     public async Task RunScript(string scriptRelativePath)
     {
+        Stopwatch scriptSw = Stopwatch.StartNew();
+        int commandCount = 0;
         try
         {
             string scriptFile = Path.Combine(_config.ScriptRootDir, scriptRelativePath);
@@ -933,6 +940,7 @@ public class SOSRunner : IDisposable
                 }
 
                 await QuitDebugger();
+                commandCount++;
             }
             catch (Exception)
             {
@@ -958,6 +966,10 @@ public class SOSRunner : IDisposable
         {
             WriteLine(ex.ToString());
             throw;
+        }
+        finally
+        {
+            WriteLine("[TIMING] RunScript({0}) completed in {1:F1}s", scriptRelativePath, scriptSw.Elapsed.TotalSeconds);
         }
     }
 
@@ -1361,10 +1373,12 @@ public class SOSRunner : IDisposable
 
     private async Task<bool> HandleCommand(string input, bool addPrefix)
     {
+        Stopwatch waitPromptSw = Stopwatch.StartNew();
         if (!await _scriptLogger.WaitForCommandPrompt())
         {
             throw new Exception(string.Format("{0} exited unexpectedly executing '{1}'", DebuggerToString, input));
         }
+        long waitPromptMs = waitPromptSw.ElapsedMilliseconds;
 
         // The PREVPOUT convention is to write a command like this:
         // COMMAND: Some stuff <PREVPOUT> more stuff
@@ -1427,7 +1441,15 @@ public class SOSRunner : IDisposable
         }
         _processRunner.StandardInputWriteLine(command);
 
+        Stopwatch cmdSw = Stopwatch.StartNew();
         ScriptLogger.CommandResult result = await _scriptLogger.WaitForCommandOutput();
+        long cmdMs = cmdSw.ElapsedMilliseconds;
+
+        // Log per-command timing for commands taking more than 500ms
+        if (waitPromptMs + cmdMs > 500)
+        {
+            WriteLine("    [CMD_TIMING] wait={0}ms exec={1}ms total={2}ms cmd=\"{3}\"", waitPromptMs, cmdMs, waitPromptMs + cmdMs, input.Length > 80 ? input.Substring(0, 80) + "..." : input);
+        }
         _lastCommandOutput = result.CommandOutput;
         if (Debugger == NativeDebugger.Cdb)
         {

--- a/src/tests/SOS.UnitTests/xunit.runner.json
+++ b/src/tests/SOS.UnitTests/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "preEnumerateTheories": false
+}


### PR DESCRIPTION
This pull request refactors the Windows dump generation test setup to improve reliability and parallelism. The most significant change is replacing the `DumpGenerationFixture` xUnit fixture with a static module initializer, ensuring registry keys are set up and cleaned up exactly once per test assembly, which allows tests to run in parallel without serialization. It also splits SOS tests into classes to allow for some level of parallelism (xUnit v2 doesn't support Method level parallelism).