### PR TITLE
Add performance tracing for modules -v slowness on macOS

### DIFF
--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/ImageMappingMemoryService.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/ImageMappingMemoryService.cs
@@ -86,14 +86,40 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
             // If the read failed or a successful partial read
             if (bytesRequested != bytesRead)
             {
+                _fallbackCallCount++;
                 // Check if the memory is in a module and cache it if it is
                 if (_memoryCache.ReadMemory(address + (uint)bytesRead, buffer.Slice(bytesRead), out int read))
                 {
                     bytesRead += read;
+                    _fallbackSuccessCount++;
                 }
             }
+            _totalReadCount++;
             return bytesRead > 0;
         }
+
+        /// <summary>
+        /// Dumps accumulated performance counters for memory reads.
+        /// Call this periodically or at end of commands to see fallback behavior.
+        /// </summary>
+        internal void DumpPerfCounters()
+        {
+            Trace.TraceInformation($"[PERF] ImageMappingMemoryService: totalReads={_totalReadCount} fallbackCalls={_fallbackCallCount} fallbackSuccess={_fallbackSuccessCount} readFromModuleCalls={_readFromModuleCallCount} readFromModuleSlow={_readFromModuleSlowCount} memoryCacheFlushes={_memoryCacheFlushCount}");
+            // Reset counters
+            _totalReadCount = 0;
+            _fallbackCallCount = 0;
+            _fallbackSuccessCount = 0;
+            _readFromModuleCallCount = 0;
+            _readFromModuleSlowCount = 0;
+            _memoryCacheFlushCount = 0;
+        }
+
+        private long _totalReadCount;
+        private long _fallbackCallCount;
+        private long _fallbackSuccessCount;
+        private long _readFromModuleCallCount;
+        private long _readFromModuleSlowCount;
+        private long _memoryCacheFlushCount;
 
         /// <summary>
         /// Write memory into target process for supported targets.
@@ -120,6 +146,8 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
         private byte[] ReadMemoryFromModule(ulong address, int bytesRequested)
         {
             Debug.Assert((address & ~_memoryService.SignExtensionMask()) == 0);
+            _readFromModuleCallCount++;
+            Stopwatch sw = Stopwatch.StartNew();
 
             // Default is to cache errors
             byte[] data = Array.Empty<byte>();
@@ -227,6 +255,13 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
             else
             {
                 throw new InvalidOperationException($"ReadMemoryFromModule: recursion: address {address:X16} size {bytesRequested:X8}");
+            }
+            sw.Stop();
+            if (sw.ElapsedMilliseconds > 100)
+            {
+                _readFromModuleSlowCount++;
+                IModule module = _moduleService.GetModuleFromAddress(address);
+                Trace.TraceInformation($"[PERF] ReadMemoryFromModule: SLOW {sw.ElapsedMilliseconds}ms address={address:X16} result={data.Length}bytes module={module?.FileName ?? "null"}");
             }
             return data;
         }

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/MachOModule.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/MachOModule.cs
@@ -45,7 +45,17 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
 
         public MachOFile GetMachOFile()
         {
-            _machOFile ??= Utilities.OpenMachOFile(_symbolService.DownloadModuleFile(_module));
+            if (_machOFile == null)
+            {
+                System.Diagnostics.Stopwatch sw = System.Diagnostics.Stopwatch.StartNew();
+                string path = _symbolService.DownloadModuleFile(_module);
+                sw.Stop();
+                if (sw.ElapsedMilliseconds > 50 || path != null)
+                {
+                    System.Diagnostics.Trace.TraceInformation($"[PERF] MachOModule.GetMachOFile: DownloadModuleFile took {sw.ElapsedMilliseconds}ms, result={path ?? "null"} module={_module.FileName}");
+                }
+                _machOFile = Utilities.OpenMachOFile(path);
+            }
             return _machOFile;
         }
 

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/MemoryCache.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/MemoryCache.cs
@@ -162,6 +162,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
             {
                 if (CacheSize >= CacheSizeLimit)
                 {
+                    Trace.TraceInformation($"[PERF] MemoryCache: SIZE LIMIT flush at {CacheSize / (1024 * 1024)}MB, {_map.Count} entries");
                     FlushCache();
                 }
 

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/ModuleService.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/ModuleService.cs
@@ -359,6 +359,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
         /// <returns>version string or null</returns>
         internal string GetVersionString(IModule module)
         {
+            Stopwatch sw = Stopwatch.StartNew();
             try
             {
                 ELFFile elfFile = module.Services.GetService<ELFFile>();
@@ -374,17 +375,20 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
                             long loadSize = (long)programHeader.VirtualSize;
                             if (SearchVersionString(module.ImageBase + loadAddress, loadSize, out string productVersion))
                             {
+                                Trace.TraceInformation($"[PERF] GetVersionString: found in ELF {module} in {sw.ElapsedMilliseconds}ms");
                                 return productVersion;
                             }
                         }
                     }
-                    Trace.TraceInformation($"GetVersionString: not found in ELF file {module}");
+                    Trace.TraceInformation($"[PERF] GetVersionString: not found in ELF file {module} in {sw.ElapsedMilliseconds}ms");
                 }
                 else
                 {
                     MachOFile machOFile = module.Services.GetService<MachOFile>();
                     if (machOFile is not null)
                     {
+                        long totalScanSize = 0;
+                        int segmentCount = 0;
                         foreach (MachSegmentLoadCommand loadCommand in machOFile.Segments.Select((segment) => segment.LoadCommand))
                         {
                             if (loadCommand.Command == LoadCommandType.Segment64 &&
@@ -393,13 +397,22 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
                             {
                                 ulong loadAddress = loadCommand.VMAddress + machOFile.PreferredVMBaseAddress;
                                 long loadSize = (long)loadCommand.VMSize;
+                                totalScanSize += loadSize;
+                                segmentCount++;
+                                Stopwatch segSw = Stopwatch.StartNew();
                                 if (SearchVersionString(loadAddress, loadSize, out string productVersion))
                                 {
+                                    Trace.TraceInformation($"[PERF] GetVersionString: found in MachO {module} segment {loadCommand.SegName} in {sw.ElapsedMilliseconds}ms (segment took {segSw.ElapsedMilliseconds}ms, size={loadSize})");
                                     return productVersion;
+                                }
+                                segSw.Stop();
+                                if (segSw.ElapsedMilliseconds > 100)
+                                {
+                                    Trace.TraceInformation($"[PERF] GetVersionString: slow segment {loadCommand.SegName} in {module}: {segSw.ElapsedMilliseconds}ms size={loadSize} ({loadSize / 1024}KB)");
                                 }
                             }
                         }
-                        Trace.TraceInformation($"GetVersionString: not found in MachO file {module}");
+                        Trace.TraceInformation($"[PERF] GetVersionString: not found in MachO {module} in {sw.ElapsedMilliseconds}ms ({segmentCount} segments, {totalScanSize / 1024}KB total)");
                     }
                     else
                     {
@@ -424,6 +437,8 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
         private bool SearchVersionString(ulong address, long size, out string fileVersion)
         {
             byte[] buffer = new byte[s_versionString.Length];
+            int readCount = 0;
+            int readFailCount = 0;
 
             // We use the mapped memory service to find the version string in case it isn't in the dump.
             _versionCache ??= new ReadVirtualCache(MemoryService);
@@ -431,6 +446,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
 
             while (size > 0)
             {
+                readCount++;
                 bool result = _versionCache.Read(address, buffer, s_versionString.Length, out int cbBytesRead);
                 if (result && cbBytesRead >= s_versionLength)
                 {
@@ -456,6 +472,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
                             if (ch[0] == '\0')
                             {
                                 fileVersion = sb.ToString();
+                                Trace.TraceInformation($"[PERF] SearchVersionString: FOUND after {readCount} reads ({readFailCount} failures)");
                                 return true;
                             }
                             sb.Append(Encoding.ASCII.GetChars(ch));
@@ -470,11 +487,16 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
                 }
                 else
                 {
+                    readFailCount++;
                     address += (ulong)s_versionLength;
                     size -= s_versionLength;
                 }
             }
 
+            if (readCount > 1000)
+            {
+                Trace.TraceInformation($"[PERF] SearchVersionString: NOT FOUND after {readCount} reads ({readFailCount} failures)");
+            }
             fileVersion = null;
             return false;
         }

--- a/src/Microsoft.Diagnostics.ExtensionCommands/Host/ModulesCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/Host/ModulesCommand.cs
@@ -44,6 +44,7 @@ namespace Microsoft.Diagnostics.ExtensionCommands
 
         public override void Invoke()
         {
+            Stopwatch commandSw = Stopwatch.StartNew();
             if (Address.HasValue)
             {
                 IModule module = ModuleService.GetModuleFromAddress(Address.Value);
@@ -60,15 +61,22 @@ namespace Microsoft.Diagnostics.ExtensionCommands
             {
                 Regex regex = ModuleName is not null ? new Regex(ModuleName, RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant) : null;
                 ulong totalSize = 0;
+                int moduleCount = 0;
                 foreach (IModule module in ModuleService.EnumerateModules().OrderBy((m) => m.ModuleIndex))
                 {
                     totalSize += module.ImageSize;
                     if (regex is null || !string.IsNullOrEmpty(module.FileName) && regex.IsMatch(Path.GetFileName(module.FileName)))
                     {
                         DisplayModule(module);
+                        moduleCount++;
                     }
                 }
                 WriteLine("Total image size: {0}", totalSize);
+                if (Verbose)
+                {
+                    commandSw.Stop();
+                    Trace.TraceInformation($"[PERF] ModulesCommand: {moduleCount} modules displayed in {commandSw.ElapsedMilliseconds}ms");
+                }
             }
         }
 

--- a/src/tests/SOS.UnitTests/Scripts/OtherCommands.script
+++ b/src/tests/SOS.UnitTests/Scripts/OtherCommands.script
@@ -4,6 +4,9 @@
 
 LOADSOS
 
+# Enable diagnostic logging early to capture performance traces
+EXTCOMMAND:logging %LOG_PATH%/%TEST_NAME%.%LOG_SUFFIX%.diaglog
+
 # Verify that bpmd works
 IFDEF:LIVE
 # Issue: https://github.com/dotnet/diagnostics/issues/2459


### PR DESCRIPTION
Instrumentation to diagnose why 'sos modules -v' takes ~275s on macOS
dumps vs ~1.8s on Linux. Traces cover:

- ModulesCommand: total command time
- GetVersionString: per-module time, segment sizes, segment-level timing
- SearchVersionString: read count and failure count per scan
- ImageMappingMemoryService: fallback call counts, slow ReadMemoryFromModule
- MachOModule.GetMachOFile: DownloadModuleFile timing per module
- MemoryCache: logs when 64MB size limit triggers a flush

All traces use [PERF] prefix for easy grepping. Logging is enabled
early in OtherCommands.script to capture the modules -v output.

This is diagnostic-only — no behavioral changes.
