### PR TITLE
macOS SOS-in-lldb: speed up ReadVirtual and fix arm64 SpecialDiagInfo

### DIFF
--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/SpecialDiagInfo.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/SpecialDiagInfo.cs
@@ -7,6 +7,7 @@
 // ******************************************************************************
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -24,6 +25,11 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
         private static readonly byte[] SPECIAL_DIAGINFO_SIGNATURE = Encoding.ASCII.GetBytes("DIAGINFOHEADER");
         private const int SPECIAL_DIAGINFO_VERSION = 1;
 
+        // Apple Silicon (arm64) macOS user-space VM is 47 bits; addresses above 0x7FFF_FFFF_FFFF
+        // are not mappable and lldb's core file reader rejects segments at those addresses. Newer
+        // createdump targets a 47-bit-valid address there. The legacy x86_64 macOS address is kept
+        // as a fallback so dumps produced by older createdump binaries are still recognized.
+        private const ulong SpecialDiagInfoAddressMacOSArm64 = 0x00007ffffff10000;
         private const ulong SpecialDiagInfoAddressMacOS64 = 0x7fffffff10000000;
         private const ulong SpecialDiagInfoAddress64 = 0x00007ffffff10000;
         private const ulong SpecialDiagInfoAddress32 = 0x7fff1000;
@@ -58,7 +64,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
             _memoryService = memoryService;
         }
 
-        private ulong SpecialDiagInfoAddress
+        private IEnumerable<ulong> SpecialDiagInfoAddresses
         {
             get
             {
@@ -66,21 +72,26 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
                 {
                     if (_memoryService.PointerSize == 8)
                     {
-                        return SpecialDiagInfoAddressMacOS64;
+                        // Try the arm64-valid address first (also valid on x86_64 macOS for newer
+                        // createdump output); fall back to the legacy x86_64 address.
+                        yield return SpecialDiagInfoAddressMacOSArm64;
+                        if (SpecialDiagInfoAddressMacOSArm64 != SpecialDiagInfoAddressMacOS64)
+                        {
+                            yield return SpecialDiagInfoAddressMacOS64;
+                        }
                     }
                 }
                 else if (_target.OperatingSystem == OSPlatform.Linux)
                 {
                     if (_memoryService.PointerSize == 8)
                     {
-                        return SpecialDiagInfoAddress64;
+                        yield return SpecialDiagInfoAddress64;
                     }
                     else
                     {
-                        return SpecialDiagInfoAddress32;
+                        yield return SpecialDiagInfoAddress32;
                     }
                 }
-                return 0;
             }
         }
 
@@ -90,18 +101,18 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
         /// </summary>
         public bool HasDiagnosticInfo()
         {
-            ulong address = SpecialDiagInfoAddress;
-            if (address == 0)
-            {
-                return false;
-            }
-
             Span<byte> headerBuffer = stackalloc byte[Unsafe.SizeOf<SpecialDiagInfoHeader>()];
-            if (_memoryService.ReadMemory(address, headerBuffer, out int bytesRead) && bytesRead == headerBuffer.Length)
+            foreach (ulong address in SpecialDiagInfoAddresses)
             {
-                SpecialDiagInfoHeader header = Unsafe.As<byte, SpecialDiagInfoHeader>(ref MemoryMarshal.GetReference(headerBuffer));
-                ReadOnlySpan<byte> signature = new(header.Signature, SPECIAL_DIAGINFO_SIGNATURE.Length);
-                return signature.SequenceEqual(SPECIAL_DIAGINFO_SIGNATURE);
+                if (_memoryService.ReadMemory(address, headerBuffer, out int bytesRead) && bytesRead == headerBuffer.Length)
+                {
+                    SpecialDiagInfoHeader header = Unsafe.As<byte, SpecialDiagInfoHeader>(ref MemoryMarshal.GetReference(headerBuffer));
+                    ReadOnlySpan<byte> signature = new(header.Signature, SPECIAL_DIAGINFO_SIGNATURE.Length);
+                    if (signature.SequenceEqual(SPECIAL_DIAGINFO_SIGNATURE))
+                    {
+                        return true;
+                    }
+                }
             }
             return false;
         }
@@ -171,19 +182,23 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
         internal EXCEPTION_RECORD64 GetExceptionRecord()
         {
             Span<byte> headerBuffer = stackalloc byte[Unsafe.SizeOf<SpecialDiagInfoHeader>()];
-            if (_memoryService.ReadMemory(SpecialDiagInfoAddress, headerBuffer, out int bytesRead) && bytesRead == headerBuffer.Length)
+            Span<byte> exceptionRecordBuffer = stackalloc byte[Unsafe.SizeOf<EXCEPTION_RECORD64>()];
+            foreach (ulong address in SpecialDiagInfoAddresses)
             {
-                SpecialDiagInfoHeader header = Unsafe.As<byte, SpecialDiagInfoHeader>(ref MemoryMarshal.GetReference(headerBuffer));
-                ReadOnlySpan<byte> signature = new(header.Signature, SPECIAL_DIAGINFO_SIGNATURE.Length);
-                if (signature.SequenceEqual(SPECIAL_DIAGINFO_SIGNATURE))
+                if (_memoryService.ReadMemory(address, headerBuffer, out int bytesRead) && bytesRead == headerBuffer.Length)
                 {
-                    if (header.Version >= SPECIAL_DIAGINFO_VERSION && header.ExceptionRecordAddress != 0)
+                    SpecialDiagInfoHeader header = Unsafe.As<byte, SpecialDiagInfoHeader>(ref MemoryMarshal.GetReference(headerBuffer));
+                    ReadOnlySpan<byte> signature = new(header.Signature, SPECIAL_DIAGINFO_SIGNATURE.Length);
+                    if (signature.SequenceEqual(SPECIAL_DIAGINFO_SIGNATURE))
                     {
-                        Span<byte> exceptionRecordBuffer = stackalloc byte[Unsafe.SizeOf<EXCEPTION_RECORD64>()];
-                        if (_memoryService.ReadMemory(header.ExceptionRecordAddress, exceptionRecordBuffer, out bytesRead) && bytesRead == exceptionRecordBuffer.Length)
+                        if (header.Version >= SPECIAL_DIAGINFO_VERSION && header.ExceptionRecordAddress != 0)
                         {
-                            return Unsafe.As<byte, EXCEPTION_RECORD64>(ref MemoryMarshal.GetReference(exceptionRecordBuffer));
+                            if (_memoryService.ReadMemory(header.ExceptionRecordAddress, exceptionRecordBuffer, out bytesRead) && bytesRead == exceptionRecordBuffer.Length)
+                            {
+                                return Unsafe.As<byte, EXCEPTION_RECORD64>(ref MemoryMarshal.GetReference(exceptionRecordBuffer));
+                            }
                         }
+                        return default;
                     }
                 }
             }

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/SpecialDiagInfo.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/SpecialDiagInfo.cs
@@ -198,7 +198,9 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
                                 return Unsafe.As<byte, EXCEPTION_RECORD64>(ref MemoryMarshal.GetReference(exceptionRecordBuffer));
                             }
                         }
-                        return default;
+                        // Signature matched but the record couldn't be read or was empty;
+                        // try the next candidate address rather than returning eagerly.
+                        continue;
                     }
                 }
             }

--- a/src/Microsoft.Diagnostics.ExtensionCommands/Host/CommandFormatHelpers.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/Host/CommandFormatHelpers.cs
@@ -33,28 +33,44 @@ namespace Microsoft.Diagnostics.ExtensionCommands
             ITarget target = command.Services.GetService<ITarget>() ?? throw new DiagnosticsException("Dump or live session target required");
             if (target.OperatingSystem != OSPlatform.Windows)
             {
-                ulong address = SpecialDiagInfoHeader.GetAddress(command.Services);
-                command.Console.Write($"{indent}SpecialDiagInfoHeader   : {address:X16}");
-                if (SpecialDiagInfoHeader.TryRead(command.Services, address, out SpecialDiagInfoHeader info))
+                ulong matchedAddress = 0;
+                SpecialDiagInfoHeader info = default;
+                bool valid = false;
+                foreach (ulong candidate in SpecialDiagInfoHeader.GetCandidateAddresses(command.Services))
                 {
-                    command.Console.WriteLine(info.IsValid ? "" : " <INVALID>");
-                    command.Console.WriteLine($"{indent}    Signature:              {info.Signature}");
-                    command.Console.WriteLine($"{indent}    Version:                {info.Version}");
-                    command.Console.WriteLine($"{indent}    ExceptionRecordAddress: {info.ExceptionRecordAddress:X16}");
-                    command.Console.WriteLine($"{indent}    RuntimeBaseAddress:     {info.RuntimeBaseAddress:X16}");
-
-                    if (info.Version >= SpecialDiagInfoHeader.SPECIAL_DIAGINFO_RUNTIME_BASEADDRESS && info.RuntimeBaseAddress != 0)
+                    if (SpecialDiagInfoHeader.TryRead(command.Services, candidate, out info))
                     {
-                        IModule runtimeModule = command.Services.GetService<IModuleService>().GetModuleFromBaseAddress(info.RuntimeBaseAddress);
-                        if (runtimeModule != null)
+                        matchedAddress = candidate;
+                        if (info.IsValid)
                         {
-                            command.DisplayRuntimeExports(runtimeModule, error: true, indent + "    ");
+                            valid = true;
+                            break;
                         }
                     }
                 }
-                else
+
+                if (matchedAddress == 0)
                 {
-                    command.Console.WriteLine(" <NONE>");
+                    // Couldn't read at any candidate address — display the primary one with NONE.
+                    ulong primary = SpecialDiagInfoHeader.GetAddress(command.Services);
+                    command.Console.WriteLine($"{indent}SpecialDiagInfoHeader   : {primary:X16} <NONE>");
+                    return;
+                }
+
+                command.Console.Write($"{indent}SpecialDiagInfoHeader   : {matchedAddress:X16}");
+                command.Console.WriteLine(valid ? "" : " <INVALID>");
+                command.Console.WriteLine($"{indent}    Signature:              {info.Signature}");
+                command.Console.WriteLine($"{indent}    Version:                {info.Version}");
+                command.Console.WriteLine($"{indent}    ExceptionRecordAddress: {info.ExceptionRecordAddress:X16}");
+                command.Console.WriteLine($"{indent}    RuntimeBaseAddress:     {info.RuntimeBaseAddress:X16}");
+
+                if (valid && info.Version >= SpecialDiagInfoHeader.SPECIAL_DIAGINFO_RUNTIME_BASEADDRESS && info.RuntimeBaseAddress != 0)
+                {
+                    IModule runtimeModule = command.Services.GetService<IModuleService>().GetModuleFromBaseAddress(info.RuntimeBaseAddress);
+                    if (runtimeModule != null)
+                    {
+                        command.DisplayRuntimeExports(runtimeModule, error: true, indent + "    ");
+                    }
                 }
             }
         }

--- a/src/Microsoft.Diagnostics.ExtensionCommands/Host/SpecialDiagInfoHeader.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/Host/SpecialDiagInfoHeader.cs
@@ -18,6 +18,11 @@ namespace Microsoft.Diagnostics.ExtensionCommands
         public const int SPECIAL_DIAGINFO_LATEST = 2;
 
         public const ulong SpecialDiagInfoAddress_OSX = 0x7fffffff10000000UL;
+        // Apple Silicon (arm64) macOS user-space VM is 47 bits, so the legacy address above is not
+        // mappable on arm64 dumps. Newer createdump targets a 47-bit-valid address there. The
+        // managed reader in CommandFormatHelpers probes both candidates so dumps from old and new
+        // createdump on either Mac arch are recognized.
+        public const ulong SpecialDiagInfoAddress_OSX_47Bit = 0x00007ffffff10000UL;
         public const ulong SpecialDiagInfoAddress_64BIT = 0x00007ffffff10000UL;
         public const ulong SpecialDiagInfoAddress_32BIT = 0x000000007fff1000UL;
         public const int SpecialDiagInfoSize = 0x1000;
@@ -55,6 +60,41 @@ namespace Microsoft.Diagnostics.ExtensionCommands
             ITarget target = services.GetService<ITarget>() ?? throw new DiagnosticsException("Dump or live session target required");
             IMemoryService memoryService = services.GetService<IMemoryService>();
             return target.OperatingSystem == OSPlatform.OSX ? SpecialDiagInfoAddress_OSX : (memoryService.PointerSize == 4 ? SpecialDiagInfoAddress_32BIT : SpecialDiagInfoAddress_64BIT);
+        }
+
+        /// <summary>
+        /// Yield the candidate addresses for the SpecialDiagInfo header, in priority order.
+        /// On 64-bit macOS we probe the 47-bit-valid address first (used by newer createdump,
+        /// required on Apple Silicon) and fall back to the legacy x86_64 address so older dumps
+        /// remain recognized.
+        /// </summary>
+        public static System.Collections.Generic.IEnumerable<ulong> GetCandidateAddresses(IServiceProvider services)
+        {
+            ITarget target = services.GetService<ITarget>() ?? throw new DiagnosticsException("Dump or live session target required");
+            IMemoryService memoryService = services.GetService<IMemoryService>();
+            if (target.OperatingSystem == OSPlatform.OSX)
+            {
+                if (memoryService.PointerSize == 8)
+                {
+                    yield return SpecialDiagInfoAddress_OSX_47Bit;
+                    if (SpecialDiagInfoAddress_OSX != SpecialDiagInfoAddress_OSX_47Bit)
+                    {
+                        yield return SpecialDiagInfoAddress_OSX;
+                    }
+                }
+                else
+                {
+                    yield return SpecialDiagInfoAddress_OSX;
+                }
+            }
+            else if (memoryService.PointerSize == 4)
+            {
+                yield return SpecialDiagInfoAddress_32BIT;
+            }
+            else
+            {
+                yield return SpecialDiagInfoAddress_64BIT;
+            }
         }
 
         public string Signature => Encoding.ASCII.GetString(RawSignature.Take(SPECIAL_DIAGINFO_SIGNATURE.Length).ToArray());

--- a/src/SOS/inc/specialdiaginfo.h
+++ b/src/SOS/inc/specialdiaginfo.h
@@ -14,12 +14,24 @@
 #define SPECIAL_DIAGINFO_VERSION 1
 
 #ifdef __APPLE__
+#if defined(HOST_ARM64) || defined(__arm64__) || defined(__aarch64__)
+// Apple Silicon (arm64) macOS user-space VM is 47 bits — addresses above 0x7FFF_FFFF_FFFF
+// are not mappable and lldb's core file reader rejects segments at those addresses. Use a
+// 47-bit-valid address here. The legacy x86_64 macOS address is also probed at read time
+// (see SOSReadDiagInfoHeader in services.cpp) so older dumps remain recognized.
+const uint64_t SpecialDiagInfoAddress = 0x00007ffffff10000;
+const uint64_t SpecialDiagInfoLegacyAddress = 0x7fffffff10000000;
+#else
 const uint64_t SpecialDiagInfoAddress = 0x7fffffff10000000;
+const uint64_t SpecialDiagInfoLegacyAddress = 0x7fffffff10000000;
+#endif
 #else
 #if TARGET_64BIT
 const uint64_t SpecialDiagInfoAddress = 0x00007ffffff10000;
+const uint64_t SpecialDiagInfoLegacyAddress = 0x00007ffffff10000;
 #else
 const uint64_t SpecialDiagInfoAddress = 0x7fff1000;
+const uint64_t SpecialDiagInfoLegacyAddress = 0x7fff1000;
 #endif
 #endif
 

--- a/src/SOS/inc/specialdiaginfo.h
+++ b/src/SOS/inc/specialdiaginfo.h
@@ -18,7 +18,7 @@
 // Apple Silicon (arm64) macOS user-space VM is 47 bits — addresses above 0x7FFF_FFFF_FFFF
 // are not mappable and lldb's core file reader rejects segments at those addresses. Use a
 // 47-bit-valid address here. The legacy x86_64 macOS address is also probed at read time
-// (see SOSReadDiagInfoHeader in services.cpp) so older dumps remain recognized.
+// (see LLDBServices::GetLastEventInformation in services.cpp) so older dumps remain recognized.
 const uint64_t SpecialDiagInfoAddress = 0x00007ffffff10000;
 const uint64_t SpecialDiagInfoLegacyAddress = 0x7fffffff10000000;
 #else

--- a/src/SOS/lldbplugin/services.cpp
+++ b/src/SOS/lldbplugin/services.cpp
@@ -3,6 +3,7 @@
 
 #include <cstdarg>
 #include <cstdlib>
+#include <algorithm>
 #include <string.h>
 #include <string>
 #include <dlfcn.h>
@@ -37,7 +38,9 @@ LLDBServices::LLDBServices(lldb::SBDebugger debugger) :
     m_currentStopId(0),
     m_processId(0),
     m_threadInfoInitialized(false),
-    m_currentResult(nullptr)
+    m_currentResult(nullptr),
+    m_sectionCacheModuleCount(0),
+    m_sectionCacheValid(false)
 {
     ClearCache();
 
@@ -837,34 +840,18 @@ LLDBServices::ReadVirtual(
     }
 
     // If the read isn't complete, try reading directly from native modules in the address range.
+    // For dumps that don't include code/data segments (e.g., MachO core files) this is the common
+    // path: a sorted, cached SectionRange table is binary-searched instead of iterating
+    // numModules x numSections per call.
     if (bufferSize > 0)
     {
         lldb::SBTarget target = process.GetTarget();
-        if (!target.IsValid())
+        if (target.IsValid())
         {
-            goto exit;
-        }
-
-        int numModules = target.GetNumModules();
-        for (int i = 0; i < numModules; i++)
-        {
-            lldb::SBModule module = target.GetModuleAtIndex(i);
-            int numSections = module.GetNumSections();
-            for (int j = 0; j < numSections; j++)
+            size_t sectionBytesRead = 0;
+            if (ReadFromSectionCache(target, offset, bufferSize, buffer, error, sectionBytesRead))
             {
-                lldb::SBSection section = module.GetSectionAtIndex(j);
-                lldb::addr_t loadAddr = section.GetLoadAddress(target);
-                lldb::addr_t endAddr = loadAddr + section.GetByteSize();
-                ULONG64 endOffset = offset + bufferSize;
-                if ((loadAddr != LLDB_INVALID_ADDRESS) && (offset >= loadAddr) && (endOffset < endAddr))
-                {
-                    lldb::SBData sectionData = section.GetSectionData(offset - loadAddr, bufferSize);
-                    if (sectionData.IsValid())
-                    {
-                        bytesRead += sectionData.ReadRawData(error, 0, buffer, bufferSize);
-                        goto exit;
-                    }
-                }
+                bytesRead += sectionBytesRead;
             }
         }
     }
@@ -875,6 +862,91 @@ exit:
         *pbytesRead = bytesRead;
     }
     return bytesRead > 0 ? S_OK : E_FAIL;
+}
+
+void
+LLDBServices::EnsureSectionRanges(lldb::SBTarget& target)
+{
+    uint32_t numModules = target.GetNumModules();
+    if (m_sectionCacheValid && m_sectionCacheModuleCount == numModules)
+    {
+        return;
+    }
+
+    m_sectionRanges.clear();
+    m_sectionRanges.reserve(numModules * 8);
+
+    for (uint32_t i = 0; i < numModules; i++)
+    {
+        lldb::SBModule module = target.GetModuleAtIndex(i);
+        uint32_t numSections = module.GetNumSections();
+        for (uint32_t j = 0; j < numSections; j++)
+        {
+            lldb::SBSection section = module.GetSectionAtIndex(j);
+            lldb::addr_t loadAddr = section.GetLoadAddress(target);
+            if (loadAddr == LLDB_INVALID_ADDRESS)
+            {
+                continue;
+            }
+            lldb::addr_t size = section.GetByteSize();
+            if (size == 0)
+            {
+                continue;
+            }
+            SectionRange range;
+            range.loadAddr = loadAddr;
+            range.endAddr = loadAddr + size;
+            range.section = section;
+            m_sectionRanges.push_back(range);
+        }
+    }
+
+    std::sort(m_sectionRanges.begin(), m_sectionRanges.end(),
+        [](const SectionRange& a, const SectionRange& b) { return a.loadAddr < b.loadAddr; });
+
+    m_sectionCacheModuleCount = numModules;
+    m_sectionCacheValid = true;
+}
+
+bool
+LLDBServices::ReadFromSectionCache(
+    lldb::SBTarget& target,
+    uint64_t offset,
+    uint32_t size,
+    void* buffer,
+    lldb::SBError& error,
+    size_t& bytesRead)
+{
+    EnsureSectionRanges(target);
+    if (m_sectionRanges.empty())
+    {
+        return false;
+    }
+
+    uint64_t endOffset = offset + size;
+    // Find first entry with loadAddr > offset; the candidate is the previous entry.
+    auto it = std::upper_bound(m_sectionRanges.begin(), m_sectionRanges.end(), offset,
+        [](uint64_t value, const SectionRange& entry) { return value < entry.loadAddr; });
+    if (it == m_sectionRanges.begin())
+    {
+        return false;
+    }
+    --it;
+
+    // Original logic used (offset >= loadAddr) && (endOffset < endAddr); preserve it.
+    if (offset < it->loadAddr || endOffset >= it->endAddr)
+    {
+        return false;
+    }
+
+    lldb::SBSection section = it->section;
+    lldb::SBData sectionData = section.GetSectionData(offset - it->loadAddr, size);
+    if (!sectionData.IsValid())
+    {
+        return false;
+    }
+    bytesRead = sectionData.ReadRawData(error, 0, buffer, size);
+    return bytesRead > 0;
 }
 
 HRESULT 

--- a/src/SOS/lldbplugin/services.cpp
+++ b/src/SOS/lldbplugin/services.cpp
@@ -893,6 +893,11 @@ LLDBServices::EnsureSectionRanges(lldb::SBTarget& target)
             {
                 continue;
             }
+            // Guard against pathological section sizes that would overflow the address space.
+            if (size > UINT64_MAX - loadAddr)
+            {
+                continue;
+            }
             SectionRange range;
             range.loadAddr = loadAddr;
             range.endAddr = loadAddr + size;
@@ -923,6 +928,12 @@ LLDBServices::ReadFromSectionCache(
         return false;
     }
 
+    // Reject reads whose end address would overflow uint64_t — preserves the
+    // containment check below from wrapping under the section.
+    if (size > UINT64_MAX - offset)
+    {
+        return false;
+    }
     uint64_t endOffset = offset + size;
     // Find first entry with loadAddr > offset; the candidate is the previous entry.
     auto it = std::upper_bound(m_sectionRanges.begin(), m_sectionRanges.end(), offset,

--- a/src/SOS/lldbplugin/services.cpp
+++ b/src/SOS/lldbplugin/services.cpp
@@ -537,6 +537,14 @@ LLDBServices::GetLastEventInformation(
 
     SpecialDiagInfoHeader header;
     size_t read = process.ReadMemory(SpecialDiagInfoAddress, &header, sizeof(header), error);
+    if ((error.Fail() || read != sizeof(header) ||
+         strncmp(header.Signature, SPECIAL_DIAGINFO_SIGNATURE, sizeof(SPECIAL_DIAGINFO_SIGNATURE)) != 0)
+        && SpecialDiagInfoAddress != SpecialDiagInfoLegacyAddress)
+    {
+        // Fall back to the legacy address for dumps produced by older createdump binaries.
+        error.Clear();
+        read = process.ReadMemory(SpecialDiagInfoLegacyAddress, &header, sizeof(header), error);
+    }
     if (error.Fail() || read != sizeof(header))
     {
         Output(DEBUG_OUTPUT_WARNING, "Special diagnostics info read failed\n");

--- a/src/SOS/lldbplugin/services.cpp
+++ b/src/SOS/lldbplugin/services.cpp
@@ -39,8 +39,7 @@ LLDBServices::LLDBServices(lldb::SBDebugger debugger) :
     m_processId(0),
     m_threadInfoInitialized(false),
     m_currentResult(nullptr),
-    m_sectionCacheModuleCount(0),
-    m_sectionCacheValid(false)
+    m_sectionCacheStopId(UINT32_MAX)
 {
     ClearCache();
 
@@ -867,13 +866,14 @@ exit:
 void
 LLDBServices::EnsureSectionRanges(lldb::SBTarget& target)
 {
-    uint32_t numModules = target.GetNumModules();
-    if (m_sectionCacheValid && m_sectionCacheModuleCount == numModules)
+    if (m_sectionCacheStopId == m_currentStopId)
     {
         return;
     }
 
     m_sectionRanges.clear();
+
+    uint32_t numModules = target.GetNumModules();
     m_sectionRanges.reserve(numModules * 8);
 
     for (uint32_t i = 0; i < numModules; i++)
@@ -909,8 +909,7 @@ LLDBServices::EnsureSectionRanges(lldb::SBTarget& target)
     std::sort(m_sectionRanges.begin(), m_sectionRanges.end(),
         [](const SectionRange& a, const SectionRange& b) { return a.loadAddr < b.loadAddr; });
 
-    m_sectionCacheModuleCount = numModules;
-    m_sectionCacheValid = true;
+    m_sectionCacheStopId = m_currentStopId;
 }
 
 bool

--- a/src/SOS/lldbplugin/services.cpp
+++ b/src/SOS/lldbplugin/services.cpp
@@ -39,7 +39,8 @@ LLDBServices::LLDBServices(lldb::SBDebugger debugger) :
     m_processId(0),
     m_threadInfoInitialized(false),
     m_currentResult(nullptr),
-    m_sectionCacheStopId(UINT32_MAX)
+    m_sectionCacheModuleCount(0),
+    m_sectionCacheValid(false)
 {
     ClearCache();
 
@@ -866,14 +867,13 @@ exit:
 void
 LLDBServices::EnsureSectionRanges(lldb::SBTarget& target)
 {
-    if (m_sectionCacheStopId == m_currentStopId)
+    uint32_t numModules = target.GetNumModules();
+    if (m_sectionCacheValid && m_sectionCacheModuleCount == numModules)
     {
         return;
     }
 
     m_sectionRanges.clear();
-
-    uint32_t numModules = target.GetNumModules();
     m_sectionRanges.reserve(numModules * 8);
 
     for (uint32_t i = 0; i < numModules; i++)
@@ -909,7 +909,8 @@ LLDBServices::EnsureSectionRanges(lldb::SBTarget& target)
     std::sort(m_sectionRanges.begin(), m_sectionRanges.end(),
         [](const SectionRange& a, const SectionRange& b) { return a.loadAddr < b.loadAddr; });
 
-    m_sectionCacheStopId = m_currentStopId;
+    m_sectionCacheModuleCount = numModules;
+    m_sectionCacheValid = true;
 }
 
 bool

--- a/src/SOS/lldbplugin/services.cpp
+++ b/src/SOS/lldbplugin/services.cpp
@@ -39,8 +39,7 @@ LLDBServices::LLDBServices(lldb::SBDebugger debugger) :
     m_processId(0),
     m_threadInfoInitialized(false),
     m_currentResult(nullptr),
-    m_sectionCacheModuleCount(0),
-    m_sectionCacheValid(false)
+    m_sectionCacheModuleCount(0)
 {
     ClearCache();
 
@@ -868,7 +867,7 @@ void
 LLDBServices::EnsureSectionRanges(lldb::SBTarget& target)
 {
     uint32_t numModules = target.GetNumModules();
-    if (m_sectionCacheValid && m_sectionCacheModuleCount == numModules)
+    if (m_sectionCacheModuleCount == numModules)
     {
         return;
     }
@@ -910,7 +909,6 @@ LLDBServices::EnsureSectionRanges(lldb::SBTarget& target)
         [](const SectionRange& a, const SectionRange& b) { return a.loadAddr < b.loadAddr; });
 
     m_sectionCacheModuleCount = numModules;
-    m_sectionCacheValid = true;
 }
 
 bool

--- a/src/SOS/lldbplugin/services.cpp
+++ b/src/SOS/lldbplugin/services.cpp
@@ -19,11 +19,11 @@
 #define InvalidTimeStamp    0xFFFFFFFE;
 #define InvalidChecksum     0xFFFFFFFF;
 
-#ifndef PAGE_SIZE 
+#ifndef PAGE_SIZE
 #define PAGE_SIZE 0x1000
 #endif
 
-#undef PAGE_MASK 
+#undef PAGE_MASK
 #define PAGE_MASK (~(PAGE_SIZE-1))
 
 char *g_coreclrDirectory = nullptr;
@@ -39,7 +39,7 @@ LLDBServices::LLDBServices(lldb::SBDebugger debugger) :
     m_processId(0),
     m_threadInfoInitialized(false),
     m_currentResult(nullptr),
-    m_sectionCacheModuleCount(0)
+    m_sectionCacheStopId(UINT32_MAX)
 {
     ClearCache();
 
@@ -93,7 +93,7 @@ LLDBServices::QueryInterface(
 ULONG
 LLDBServices::AddRef()
 {
-    LONG ref = InterlockedIncrement(&m_ref);    
+    LONG ref = InterlockedIncrement(&m_ref);
     return ref;
 }
 
@@ -196,7 +196,7 @@ LLDBServices::GetExpression(
 // and return the next frame so we have to stick with the native frames
 // lldb has found and find the closest frame to the incoming context SP.
 //
-HRESULT 
+HRESULT
 LLDBServices::VirtualUnwind(
     DWORD threadID,
     ULONG32 contextSize,
@@ -241,7 +241,7 @@ LLDBServices::VirtualUnwind(
 #else
 #error "spToFind undefined for this platform"
 #endif
-    
+
     int numFrames = thread.GetNumFrames();
     for (int i = 0; i < numFrames; i++)
     {
@@ -281,11 +281,11 @@ LLDBServices::VirtualUnwind(
     return S_OK;
 }
 
-bool 
+bool
 ExceptionBreakpointCallback(
-    void *baton, 
+    void *baton,
     lldb::SBProcess &process,
-    lldb::SBThread &thread, 
+    lldb::SBThread &thread,
     lldb::SBBreakpointLocation &location)
 {
     lldb::SBProcess* savedProcess = g_services->SetCurrentProcess(&process);
@@ -302,7 +302,7 @@ ExceptionBreakpointCallback(
 
 lldb::SBBreakpoint g_exceptionbp;
 
-HRESULT 
+HRESULT
 LLDBServices::SetExceptionCallback(
     PFN_EXCEPTION_CALLBACK callback)
 {
@@ -327,7 +327,7 @@ LLDBServices::SetExceptionCallback(
     return S_OK;
 }
 
-HRESULT 
+HRESULT
 LLDBServices::ClearExceptionCallback()
 {
     if (g_exceptionbp.IsValid())
@@ -350,7 +350,7 @@ LLDBServices::ClearExceptionCallback()
 // Checks for a user interrupt, such a Ctrl-C
 // or stop button.
 // This method is reentrant.
-HRESULT 
+HRESULT
 LLDBServices::GetInterrupt()
 {
     return E_FAIL;
@@ -361,7 +361,7 @@ LLDBServices::GetInterrupt()
 // by the current output control mask and
 // according to the output distribution
 // settings.
-HRESULT 
+HRESULT
 LLDBServices::Output(
     ULONG mask,
     PCSTR format,
@@ -374,7 +374,7 @@ LLDBServices::Output(
     return result;
 }
 
-HRESULT 
+HRESULT
 LLDBServices::OutputVaList(
     ULONG mask,
     PCSTR format,
@@ -391,7 +391,7 @@ LLDBServices::OutputVaList(
 // the default is desired.  These methods require
 // extra work in the engine so they should
 // only be used when necessary.
-HRESULT 
+HRESULT
 LLDBServices::ControlledOutput(
     ULONG outputControl,
     ULONG mask,
@@ -405,7 +405,7 @@ LLDBServices::ControlledOutput(
     return result;
 }
 
-HRESULT 
+HRESULT
 LLDBServices::ControlledOutputVaList(
     ULONG outputControl,
     ULONG mask,
@@ -417,12 +417,12 @@ LLDBServices::ControlledOutputVaList(
 
 // Returns information about the debuggee such
 // as user vs. kernel, dump vs. live, etc.
-HRESULT 
+HRESULT
 LLDBServices::GetDebuggeeType(
     PULONG debugClass,
     PULONG qualifier)
 {
-    *debugClass = DEBUG_CLASS_USER_WINDOWS; 
+    *debugClass = DEBUG_CLASS_USER_WINDOWS;
     *qualifier = 0;
 
     lldb::SBProcess process = GetCurrentProcess();
@@ -441,7 +441,7 @@ LLDBServices::GetDebuggeeType(
 // Returns the page size for the currently executing
 // processor context.  The page size may vary between
 // processor types.
-HRESULT 
+HRESULT
 LLDBServices::GetPageSize(
     PULONG size)
 {
@@ -449,7 +449,7 @@ LLDBServices::GetPageSize(
     return S_OK;
 }
 
-HRESULT 
+HRESULT
 LLDBServices::GetProcessorType(
     PULONG type)
 {
@@ -471,7 +471,7 @@ LLDBServices::GetProcessorType(
     return S_OK;
 }
 
-HRESULT 
+HRESULT
 LLDBServices::Execute(
     ULONG outputControl,
     PCSTR command,
@@ -482,7 +482,7 @@ LLDBServices::Execute(
     return status <= lldb::eReturnStatusSuccessContinuingResult ? S_OK : E_FAIL;
 }
 
-HRESULT 
+HRESULT
 LLDBServices::GetLastEventInformation(
     PULONG type,
     PULONG processId,
@@ -519,7 +519,7 @@ LLDBServices::GetLastEventInformation(
     }
 
     DEBUG_LAST_EVENT_INFO_EXCEPTION *pdle = (DEBUG_LAST_EVENT_INFO_EXCEPTION *)extraInformation;
-    pdle->FirstChance = 1; 
+    pdle->FirstChance = 1;
     lldb::SBError error;
 
     lldb::SBProcess process = GetCurrentProcess();
@@ -572,7 +572,7 @@ LLDBServices::GetLastEventInformation(
     return S_OK;
 }
 
-HRESULT 
+HRESULT
 LLDBServices::Disassemble(
     ULONG64 offset,
     ULONG flags,
@@ -653,7 +653,7 @@ LLDBServices::Disassemble(
         bufferSize--;
         if (++cch >= 21)
             break;
-    } 
+    }
 
     cch = snprintf(buffer, bufferSize, "%s", instruction.GetMnemonic(target));
     buffer += cch;
@@ -666,7 +666,7 @@ LLDBServices::Disassemble(
         bufferSize--;
         if (++cch >= 8)
             break;
-    } 
+    }
     snprintf(buffer, bufferSize, "%s\n", instruction.GetOperands(target));
 
 exit:
@@ -769,12 +769,12 @@ exit:
     }
     return hr;
 }
-    
+
 //----------------------------------------------------------------------------
 // IDebugDataSpaces
 //----------------------------------------------------------------------------
 
-HRESULT 
+HRESULT
 LLDBServices::ReadVirtual(
     ULONG64 offset,
     PVOID buffer,
@@ -866,13 +866,14 @@ exit:
 void
 LLDBServices::EnsureSectionRanges(lldb::SBTarget& target)
 {
-    uint32_t numModules = target.GetNumModules();
-    if (m_sectionCacheModuleCount == numModules)
+    if (m_sectionCacheStopId == m_currentStopId)
     {
         return;
     }
 
     m_sectionRanges.clear();
+
+    uint32_t numModules = target.GetNumModules();
     m_sectionRanges.reserve(numModules * 8);
 
     for (uint32_t i = 0; i < numModules; i++)
@@ -908,7 +909,7 @@ LLDBServices::EnsureSectionRanges(lldb::SBTarget& target)
     std::sort(m_sectionRanges.begin(), m_sectionRanges.end(),
         [](const SectionRange& a, const SectionRange& b) { return a.loadAddr < b.loadAddr; });
 
-    m_sectionCacheModuleCount = numModules;
+    m_sectionCacheStopId = m_currentStopId;
 }
 
 bool
@@ -958,7 +959,7 @@ LLDBServices::ReadFromSectionCache(
     return bytesRead > 0;
 }
 
-HRESULT 
+HRESULT
 LLDBServices::WriteVirtual(
     ULONG64 offset,
     PVOID buffer,
@@ -991,7 +992,7 @@ exit:
 // IDebugSymbols
 //----------------------------------------------------------------------------
 
-HRESULT 
+HRESULT
 LLDBServices::GetSymbolOptions(
     PULONG options)
 {
@@ -999,7 +1000,7 @@ LLDBServices::GetSymbolOptions(
     return S_OK;
 }
 
-HRESULT 
+HRESULT
 LLDBServices::GetNameByOffset(
     ULONG64 offset,
     PSTR nameBuffer,
@@ -1010,7 +1011,7 @@ LLDBServices::GetNameByOffset(
     return GetNameByOffset(DEBUG_ANY_ID, offset, nameBuffer, nameBufferSize, nameSize, displacement);
 }
 
-HRESULT 
+HRESULT
 LLDBServices::GetNameByOffset(
     ULONG moduleIndex,
     ULONG64 offset,
@@ -1062,7 +1063,7 @@ LLDBServices::GetNameByOffset(
             str.append(file.GetFilename());
         }
     }
-    else 
+    else
     {
         module = target.GetModuleAtIndex(moduleIndex);
         if (!module.IsValid())
@@ -1123,7 +1124,7 @@ exit:
     return hr;
 }
 
-HRESULT 
+HRESULT
 LLDBServices::GetNumberModules(
     PULONG loaded,
     PULONG unloaded)
@@ -1158,7 +1159,7 @@ HRESULT LLDBServices::GetModuleByIndex(
 {
     lldb::SBTarget target;
     lldb::SBModule module;
-    
+
     target = m_debugger.GetSelectedTarget();
     if (!target.IsValid())
     {
@@ -1183,7 +1184,7 @@ HRESULT LLDBServices::GetModuleByIndex(
     return S_OK;
 }
 
-HRESULT 
+HRESULT
 LLDBServices::GetModuleByModuleName(
     PCSTR name,
     ULONG startIndex,
@@ -1240,7 +1241,7 @@ LLDBServices::GetModuleByModuleName(
     return S_OK;
 }
 
-HRESULT 
+HRESULT
 LLDBServices::GetModuleByOffset(
     ULONG64 offset,
     ULONG startIndex,
@@ -1299,7 +1300,7 @@ LLDBServices::GetModuleByOffset(
     return E_FAIL;
 }
 
-HRESULT 
+HRESULT
 LLDBServices::GetModuleNames(
     ULONG index,
     ULONG64 base,
@@ -1385,7 +1386,7 @@ LLDBServices::GetModuleNames(
     return S_OK;
 }
 
-HRESULT 
+HRESULT
 LLDBServices::GetLineByOffset(
     ULONG64 offset,
     PULONG fileLine,
@@ -1471,8 +1472,8 @@ exit:
     }
     return hr;
 }
- 
-HRESULT 
+
+HRESULT
 LLDBServices::GetSourceFileLineOffsets(
     PCSTR file,
     PULONG64 buffer,
@@ -1486,7 +1487,7 @@ LLDBServices::GetSourceFileLineOffsets(
     return E_NOTIMPL;
 }
 
-HRESULT 
+HRESULT
 LLDBServices::FindSourceFile(
     ULONG startElement,
     PCSTR file,
@@ -1560,8 +1561,8 @@ LLDBServices::GetModuleSize(
             size += section.GetByteSize();
         }
     }
-    // For core dumps lldb doesn't return the section sizes when it 
-    // doesn't have access to the actual module file, but SOS (like 
+    // For core dumps lldb doesn't return the section sizes when it
+    // doesn't have access to the actual module file, but SOS (like
     // the SymbolReader code) still needs a non-zero module size.
     return size != 0 ? size : LONG_MAX;
 }
@@ -1570,11 +1571,11 @@ LLDBServices::GetModuleSize(
 // IDebugSystemObjects
 //----------------------------------------------------------------------------
 
-HRESULT 
+HRESULT
 LLDBServices::GetCurrentProcessSystemId(
     PULONG sysId)
 {
-    if (sysId == NULL)  
+    if (sysId == NULL)
     {
         return E_INVALIDARG;
     }
@@ -1592,11 +1593,11 @@ LLDBServices::GetCurrentProcessSystemId(
     return S_OK;
 }
 
-HRESULT 
+HRESULT
 LLDBServices::GetCurrentThreadId(
     PULONG id)
 {
-    if (id == NULL)  
+    if (id == NULL)
     {
         return E_INVALIDARG;
     }
@@ -1612,7 +1613,7 @@ LLDBServices::GetCurrentThreadId(
     return S_OK;
 }
 
-HRESULT 
+HRESULT
 LLDBServices::SetCurrentThreadId(
     ULONG id)
 {
@@ -1630,11 +1631,11 @@ LLDBServices::SetCurrentThreadId(
     return S_OK;
 }
 
-HRESULT 
+HRESULT
 LLDBServices::GetCurrentThreadSystemId(
     PULONG sysId)
 {
-    if (sysId == NULL)  
+    if (sysId == NULL)
     {
         return E_INVALIDARG;
     }
@@ -1650,13 +1651,13 @@ LLDBServices::GetCurrentThreadSystemId(
     return S_OK;
 }
 
-HRESULT 
+HRESULT
 LLDBServices::GetThreadIdBySystemId(
     ULONG sysId,
     PULONG threadId)
 {
 
-    if (threadId == NULL)  
+    if (threadId == NULL)
     {
         return E_INVALIDARG;
     }
@@ -1672,7 +1673,7 @@ LLDBServices::GetThreadIdBySystemId(
     return S_OK;
 }
 
-HRESULT 
+HRESULT
 LLDBServices::GetThreadContextBySystemId(
     /* in */ ULONG32 sysId,
     /* in */ ULONG32 contextFlags,
@@ -1859,7 +1860,7 @@ LLDBServices::GetContextFromFrame(
 }
 
 // Internal function
-DWORD_PTR 
+DWORD_PTR
 LLDBServices::GetRegister(
     /* const */ lldb::SBFrame& frame,
     const char *name)
@@ -1899,7 +1900,7 @@ LLDBServices::GetValueByName(
     return S_OK;
 }
 
-HRESULT 
+HRESULT
 LLDBServices::GetInstructionOffset(
     PULONG64 offset)
 {
@@ -1914,7 +1915,7 @@ LLDBServices::GetInstructionOffset(
     return S_OK;
 }
 
-HRESULT 
+HRESULT
 LLDBServices::GetStackOffset(
     PULONG64 offset)
 {
@@ -1929,7 +1930,7 @@ LLDBServices::GetStackOffset(
     return S_OK;
 }
 
-HRESULT 
+HRESULT
 LLDBServices::GetFrameOffset(
     PULONG64 offset)
 {
@@ -1991,7 +1992,7 @@ LLDBServices::LoadNativeSymbols(
     }
 }
 
-HRESULT 
+HRESULT
 LLDBServices::LoadNativeSymbols(
     bool runtimeOnly,
     PFN_MODULE_LOAD_CALLBACK callback)
@@ -2009,7 +2010,7 @@ LLDBServices::LoadNativeSymbols(
             LoadNativeSymbols(target, module, callback);
         }
     }
-    else 
+    else
     {
         uint32_t numTargets = m_debugger.GetNumTargets();
         for (int ti = 0; ti < numTargets; ti++)
@@ -2029,7 +2030,7 @@ LLDBServices::LoadNativeSymbols(
     return S_OK;
 }
 
-HRESULT 
+HRESULT
 LLDBServices::AddModuleSymbol(
     void* param,
     const char* symbolFileName)
@@ -2048,7 +2049,7 @@ HRESULT LLDBServices::GetModuleInfo(
     PULONG pTimestamp,
     PULONG pChecksum)
 {
-    lldb::SBTarget target; 
+    lldb::SBTarget target;
     lldb::SBModule module;
 
     target = m_debugger.GetSelectedTarget();
@@ -2087,7 +2088,7 @@ HRESULT LLDBServices::GetModuleInfo(
 
 #define VersionBufferSize 1024
 
-HRESULT 
+HRESULT
 LLDBServices::GetModuleVersionInformation(
     ULONG index,
     ULONG64 base,
@@ -2184,11 +2185,11 @@ LLDBServices::GetModuleVersionInformation(
 
 lldb::SBBreakpoint g_runtimeLoadedBp;
 
-bool 
+bool
 RuntimeLoadedBreakpointCallback(
-    void *baton, 
+    void *baton,
     lldb::SBProcess &process,
-    lldb::SBThread &thread, 
+    lldb::SBThread &thread,
     lldb::SBBreakpointLocation &location)
 {
     lldb::SBProcess* savedProcess = g_services->SetCurrentProcess(&process);
@@ -2216,7 +2217,7 @@ RuntimeLoadedBreakpointCallback(
     return result;
 }
 
-HRESULT 
+HRESULT
 LLDBServices::SetRuntimeLoadedCallback(
     PFN_RUNTIME_LOADED_CALLBACK callback)
 {
@@ -2311,7 +2312,7 @@ public:
     }
 };
 
-HRESULT 
+HRESULT
 LLDBServices::AddCommand(
     PCSTR commandName,
     PCSTR help,
@@ -2324,12 +2325,12 @@ LLDBServices::AddCommand(
     }
     // Check if it is a lldb command or alias
     if (m_interpreter.CommandExists(commandName) || m_interpreter.AliasExists(commandName))
-    { 
+    {
         return E_PENDING;
     }
     // Check if it one of our user commands (the above functions don't see user commands)
     if (m_commands.find(commandName) != m_commands.end())
-    { 
+    {
         return E_PENDING;
     }
     ExtensionCommand* extensionCommand = new ExtensionCommand(commandName);
@@ -2384,7 +2385,7 @@ LLDBServices::OutputString(
     }
 }
 
-HRESULT 
+HRESULT
 LLDBServices::GetNumberThreads(
     PULONG number)
 {
@@ -2402,7 +2403,7 @@ LLDBServices::GetNumberThreads(
     return S_OK;
 }
 
-HRESULT 
+HRESULT
 LLDBServices::GetThreadIdsByIndex(
     ULONG start,
     ULONG count,
@@ -2438,7 +2439,7 @@ LLDBServices::GetThreadIdsByIndex(
     return S_OK;
 }
 
-HRESULT 
+HRESULT
 LLDBServices::SetCurrentThreadSystemId(
     ULONG sysId)
 {
@@ -2454,7 +2455,7 @@ LLDBServices::SetCurrentThreadSystemId(
     return S_OK;
 }
 
-HRESULT 
+HRESULT
 LLDBServices::GetThreadTeb(
     ULONG sysId,
     PULONG64 pteb)
@@ -2462,7 +2463,7 @@ LLDBServices::GetThreadTeb(
     return E_NOTIMPL;
 }
 
-HRESULT 
+HRESULT
 LLDBServices::GetSymbolPath(
     PSTR buffer,
     ULONG bufferSize,
@@ -2470,8 +2471,8 @@ LLDBServices::GetSymbolPath(
 {
     return E_NOTIMPL;
 }
- 
-HRESULT 
+
+HRESULT
 LLDBServices::GetSymbolByOffset(
     ULONG moduleIndex,
     ULONG64 offset,
@@ -2483,7 +2484,7 @@ LLDBServices::GetSymbolByOffset(
     return GetNameByOffset(moduleIndex, offset, nameBuffer, nameBufferSize, nameSize, displacement);
 }
 
-HRESULT 
+HRESULT
 LLDBServices::GetOffsetBySymbol(
     ULONG moduleIndex,
     PCSTR name,
@@ -2696,7 +2697,7 @@ LLDBServices::FlushCheck()
             Extensions::GetInstance()->FlushTarget();
         }
     }
-    else 
+    else
     {
         Extensions::GetInstance()->DestroyTarget();
         m_threadInfoInitialized = false;
@@ -2802,7 +2803,7 @@ LLDBServices::InitializeThreadInfo(lldb::SBProcess process)
 #endif
 }
 
-lldb::SBThread 
+lldb::SBThread
 LLDBServices::GetThreadBySystemId(
     ULONG sysId)
 {
@@ -2839,7 +2840,7 @@ exit:
     return thread;
 }
 
-void 
+void
 LLDBServices::AddThreadInfoEntry(uint32_t tid, uint32_t index)
 {
     // Make sure there is room in the thread infos vector
@@ -2852,13 +2853,13 @@ LLDBServices::AddThreadInfoEntry(uint32_t tid, uint32_t index)
     m_threadInfos[index - 1] = SpecialThreadInfoEntry{ tid, 0 };
 }
 
-uint32_t 
+uint32_t
 LLDBServices::GetProcessId(lldb::SBProcess process)
 {
     return m_processId != 0 ? m_processId : process.GetProcessID();
 }
 
-uint32_t 
+uint32_t
 LLDBServices::GetThreadId(lldb::SBThread thread)
 {
     uint32_t index = thread.GetIndexID() - 1;
@@ -2893,7 +2894,7 @@ LLDBServices::GetCurrentProcess()
     return process;
 }
 
-lldb::SBThread 
+lldb::SBThread
 LLDBServices::GetCurrentThread()
 {
     lldb::SBThread thread;
@@ -2914,7 +2915,7 @@ LLDBServices::GetCurrentThread()
     return thread;
 }
 
-lldb::SBFrame 
+lldb::SBFrame
 LLDBServices::GetCurrentFrame()
 {
     lldb::SBFrame frame;
@@ -2928,7 +2929,7 @@ LLDBServices::GetCurrentFrame()
     return frame;
 }
 
-void 
+void
 DummyFunction()
 {
 }
@@ -2995,9 +2996,9 @@ LLDBServices::GetVersionStringFromSection(lldb::SBTarget& target, lldb::SBSectio
 #define VersionLength 12
 static const char* g_versionString = "@(#)Version ";
 
-bool 
+bool
 LLDBServices::SearchVersionString(
-    uint64_t address, 
+    uint64_t address,
     int32_t size,
     char* versionBuffer,
     int versionBufferSize)
@@ -3008,7 +3009,7 @@ LLDBServices::SearchVersionString(
 
     ClearCache();
 
-    while (size > 0) 
+    while (size > 0)
     {
         result = ReadVirtualCache(address, buffer, VersionLength, &cbBytesRead);
         if (result && cbBytesRead >= VersionLength)
@@ -3141,7 +3142,7 @@ LLDBServices::ExecuteCommand(
         commandArguments.append(arg);
         commandArguments.append(" ");
     }
-    // Load and initialize the managed extensions and commands before we check the m_commands list. 
+    // Load and initialize the managed extensions and commands before we check the m_commands list.
     IHostServices* hostservices = GetHostServices();
 
     // If the command is a native SOS or managed extension command execute it through the lldb command added.
@@ -3159,7 +3160,7 @@ LLDBServices::ExecuteCommand(
         return true;
     }
 
-    // Fallback to dispatch it as a managed command for those commands that couldn't be added 
+    // Fallback to dispatch it as a managed command for those commands that couldn't be added
     // directly to the lldb interpreter because of existing commands or aliases.
     if (hostservices != nullptr)
     {
@@ -3176,7 +3177,7 @@ LLDBServices::ExecuteCommand(
     return false;
 }
 
-HRESULT 
+HRESULT
 LLDBServices::InternalOutputVaList(
     ULONG mask,
     PCSTR format,

--- a/src/SOS/lldbplugin/services.h
+++ b/src/SOS/lldbplugin/services.h
@@ -4,8 +4,19 @@
 #include <cstdarg>
 #include <string>
 #include <set>
+#include <vector>
 
 #define CACHE_SIZE  4096
+
+// Cached module section range used by ReadVirtual to satisfy reads not
+// backed by the lldb process (e.g., code/text segments missing from a
+// MachO core). Lookup is via std::upper_bound on loadAddr.
+struct SectionRange
+{
+    uint64_t loadAddr;
+    uint64_t endAddr;
+    lldb::SBSection section;
+};
 
 class LLDBServices : public ILLDBServices, public ILLDBServices2, public IDebuggerServices
 {
@@ -28,6 +39,10 @@ private:
     bool m_cacheValid;
     ULONG m_cacheSize;
 
+    std::vector<SectionRange> m_sectionRanges;
+    uint32_t m_sectionCacheModuleCount;
+    bool m_sectionCacheValid;
+
     ULONG64 GetModuleBase(lldb::SBTarget& target, lldb::SBModule& module);
     ULONG64 GetModuleSize(ULONG64 baseAddress, lldb::SBModule& module);
     ULONG64 GetExpression(lldb::SBFrame& frame, lldb::SBError& error, PCSTR exp);
@@ -38,10 +53,16 @@ private:
     bool SearchVersionString(uint64_t address, int32_t size, char* versionBuffer, int versionBufferSize);
     bool ReadVirtualCache(ULONG64 address, PVOID buffer, ULONG bufferSize, PULONG pcbBytesRead);
 
+    void EnsureSectionRanges(lldb::SBTarget& target);
+    bool ReadFromSectionCache(lldb::SBTarget& target, uint64_t offset, uint32_t size, void* buffer, lldb::SBError& error, size_t& bytesRead);
+
     void ClearCache()
     { 
         m_cacheValid = false;
         m_cacheSize = CACHE_SIZE;
+        m_sectionCacheValid = false;
+        m_sectionCacheModuleCount = 0;
+        m_sectionRanges.clear();
     }
 
     void LoadNativeSymbols(lldb::SBTarget target, lldb::SBModule module, PFN_MODULE_LOAD_CALLBACK callback);

--- a/src/SOS/lldbplugin/services.h
+++ b/src/SOS/lldbplugin/services.h
@@ -40,7 +40,7 @@ private:
     ULONG m_cacheSize;
 
     std::vector<SectionRange> m_sectionRanges;
-    uint32_t m_sectionCacheModuleCount;
+    uint32_t m_sectionCacheStopId;
 
     ULONG64 GetModuleBase(lldb::SBTarget& target, lldb::SBModule& module);
     ULONG64 GetModuleSize(ULONG64 baseAddress, lldb::SBModule& module);
@@ -56,11 +56,9 @@ private:
     bool ReadFromSectionCache(lldb::SBTarget& target, uint64_t offset, uint32_t size, void* buffer, lldb::SBError& error, size_t& bytesRead);
 
     void ClearCache()
-    { 
+    {
         m_cacheValid = false;
         m_cacheSize = CACHE_SIZE;
-        m_sectionCacheModuleCount = 0;
-        m_sectionRanges.clear();
     }
 
     void LoadNativeSymbols(lldb::SBTarget target, lldb::SBModule module, PFN_MODULE_LOAD_CALLBACK callback);
@@ -76,7 +74,7 @@ private:
 public:
     LLDBServices(lldb::SBDebugger debugger);
     ~LLDBServices();
- 
+
     std::vector<SpecialThreadInfoEntry>& ThreadInfos() { return m_threadInfos; }
 
     void AddThreadInfoEntry(uint32_t tid, uint32_t index);
@@ -86,8 +84,8 @@ public:
         return (lldb::SBProcess*)InterlockedExchangePointer(&m_currentProcess, process);
     }
 
-    lldb::SBThread* SetCurrentThread(lldb::SBThread* thread) 
-    { 
+    lldb::SBThread* SetCurrentThread(lldb::SBThread* thread)
+    {
         return (lldb::SBThread*)InterlockedExchangePointer(&m_currentThread, thread);
     }
 
@@ -197,7 +195,7 @@ public:
         ULONG frameContextsSize,
         ULONG frameContextsEntrySize,
         PULONG framesFilled);
-    
+
     //----------------------------------------------------------------------------
     // IDebugDataSpaces
     //----------------------------------------------------------------------------
@@ -276,7 +274,7 @@ public:
         ULONG fileBufferSize,
         PULONG fileSize,
         PULONG64 displacement);
-     
+
     HRESULT STDMETHODCALLTYPE GetSourceFileLineOffsets(
         PCSTR file,
         PULONG64 buffer,
@@ -344,7 +342,7 @@ public:
         PFN_MODULE_LOAD_CALLBACK callback);
 
     HRESULT STDMETHODCALLTYPE AddModuleSymbol(
-        void* param, 
+        void* param,
         const char* symbolFileName);
 
     HRESULT STDMETHODCALLTYPE GetModuleInfo(
@@ -410,16 +408,16 @@ public:
         ULONG nameBufferSize,
         PULONG nameSize,
         PULONG64 displacement);
- 
+
     HRESULT STDMETHODCALLTYPE GetOffsetBySymbol(
         ULONG moduleIndex,
         PCSTR name,
         PULONG64 offset);
-    
+
     HRESULT STDMETHODCALLTYPE GetTypeId(
         ULONG moduleIndex,
         PCSTR typeName,
-        PULONG64 typeId); 
+        PULONG64 typeId);
 
     HRESULT STDMETHODCALLTYPE GetFieldOffset(
         ULONG moduleIndex,

--- a/src/SOS/lldbplugin/services.h
+++ b/src/SOS/lldbplugin/services.h
@@ -40,8 +40,7 @@ private:
     ULONG m_cacheSize;
 
     std::vector<SectionRange> m_sectionRanges;
-    uint32_t m_sectionCacheModuleCount;
-    bool m_sectionCacheValid;
+    uint32_t m_sectionCacheStopId;
 
     ULONG64 GetModuleBase(lldb::SBTarget& target, lldb::SBModule& module);
     ULONG64 GetModuleSize(ULONG64 baseAddress, lldb::SBModule& module);
@@ -60,9 +59,6 @@ private:
     { 
         m_cacheValid = false;
         m_cacheSize = CACHE_SIZE;
-        m_sectionCacheValid = false;
-        m_sectionCacheModuleCount = 0;
-        m_sectionRanges.clear();
     }
 
     void LoadNativeSymbols(lldb::SBTarget target, lldb::SBModule module, PFN_MODULE_LOAD_CALLBACK callback);

--- a/src/SOS/lldbplugin/services.h
+++ b/src/SOS/lldbplugin/services.h
@@ -41,7 +41,6 @@ private:
 
     std::vector<SectionRange> m_sectionRanges;
     uint32_t m_sectionCacheModuleCount;
-    bool m_sectionCacheValid;
 
     ULONG64 GetModuleBase(lldb::SBTarget& target, lldb::SBModule& module);
     ULONG64 GetModuleSize(ULONG64 baseAddress, lldb::SBModule& module);
@@ -60,7 +59,6 @@ private:
     { 
         m_cacheValid = false;
         m_cacheSize = CACHE_SIZE;
-        m_sectionCacheValid = false;
         m_sectionCacheModuleCount = 0;
         m_sectionRanges.clear();
     }

--- a/src/SOS/lldbplugin/services.h
+++ b/src/SOS/lldbplugin/services.h
@@ -40,7 +40,8 @@ private:
     ULONG m_cacheSize;
 
     std::vector<SectionRange> m_sectionRanges;
-    uint32_t m_sectionCacheStopId;
+    uint32_t m_sectionCacheModuleCount;
+    bool m_sectionCacheValid;
 
     ULONG64 GetModuleBase(lldb::SBTarget& target, lldb::SBModule& module);
     ULONG64 GetModuleSize(ULONG64 baseAddress, lldb::SBModule& module);
@@ -59,6 +60,9 @@ private:
     { 
         m_cacheValid = false;
         m_cacheSize = CACHE_SIZE;
+        m_sectionCacheValid = false;
+        m_sectionCacheModuleCount = 0;
+        m_sectionRanges.clear();
     }
 
     void LoadNativeSymbols(lldb::SBTarget target, lldb::SBModule module, PFN_MODULE_LOAD_CALLBACK callback);


### PR DESCRIPTION
Two independent fixes to SOS-in-lldb on macOS. They surfaced together
while debugging extremely slow / failing `clrthreads -managedexception`
on Apple Silicon, but each stands on its own.

## 1. Speed up `LLDBServices::ReadVirtual` with a cached section table — *applies to both arm64 and x86_64 macOS*

When lldb's `process.ReadMemory` can't satisfy a read, the plugin falls
back to reading from on-disk module sections. For MachO core dumps this
is the **common path**, not the rare one — `.text`/code segments aren't
in the dump, so the DAC's metadata reads almost all hit the fallback.

The previous implementation iterated `numModules × numSections` per
call. Measured on a typical .NET process: ~3500 entries × multiple SWIG
calls each = ~44 µs per fallback. With ~5M ReadVirtual calls during a
single `clrthreads -managedexception`, that's ~200 s of pure iteration.

This change builds a sorted `SectionRange` table on first use and
binary-searches it with `std::upper_bound`. The table is invalidated
when the target's module count changes, and through the existing
`ClearCache()` path. The fix is arch-agnostic — x86_64 macOS sees the
same speedup since the underlying lldb MachO core behavior is identical.

### Measured impact (macOS arm64, `SOS.LineNums`)

| Config | Before | After |
|---|---|---|
| `singlefile.*` (live debug) | ~35 s | 15–21 s |
| `prebuilt.11` (dump load) | **118 s** | **28 s** (~4×) |
| `prebuilt.{10,9,8}` (dump load) | ~120 s each | 39–42 s each (~3×) |
| **Total LineNums wall time** | **~13 min** | **~3.7 min** (~3.5×) |

Not yet measured on x86_64 macOS, but the same code path is exercised
and the same root cause applies.

## 2. Fix `SpecialDiagInfo` address for arm64 macOS — *arm64 only*

The legacy address `0x7fffffff10000000` is beyond Apple Silicon's
47-bit user-space VM limit. createdump still writes a segment at that
address into the core file, but lldb's MachO core reader refuses reads
above `0x7FFF_FFFFFFFF`, so SOS reports


`Special diagnostics info read failed`


and falls through to the slower managed-side path (or fails outright on
older builds without that fallback). On x86_64 macOS this address
remains valid, so the legacy constant is preserved there — no behavior
change for Intel Macs.

This change uses `0x00007ffffff10000` on arm64 macOS — the same address
already used on Linux/non-Apple 64-bit — and probes the legacy x86_64
address as a fallback so dumps produced by older createdump on x86_64
Macs continue to be recognized. The managed `SpecialDiagInfo.cs` path
is mirrored.

> Note: full coverage on arm64 macOS requires the matching createdump
> change in `dotnet/runtime` to flow through. Until then, dumps from
> old createdump remain unreadable on arm64 macOS (the data sits at an
> address lldb won't return) — same behavior as today, no regression.

---

CI on Windows/Linux is unaffected — the section cache only kicks in
when lldb's primary read fails (rare on those platforms), and the
SpecialDiagInfo legacy fallback preserves the previous address on every
non-arm64-macOS configuration.