### PR TITLE
Elide version string extraction from dyld cache

### DIFF
--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/MachOModule.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/MachOModule.cs
@@ -12,6 +12,9 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
     /// </summary>
     public class MachOModule : IDisposable
     {
+        // MachO header flag indicating the dylib is part of the dyld shared cache (macOS 11+).
+        internal const uint MH_DYLIB_IN_CACHE = 0x80000000;
+
         private readonly IModule _module;
         private readonly ISymbolService _symbolService;
         private readonly IDisposable _onChangeEvent;
@@ -23,14 +26,23 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
         [ServiceExport(Scope = ServiceScope.Module)]
         public static MachOModule CreateMachOModule(ISymbolService symbolService, IModule module)
         {
-            if (module.Target.OperatingSystem == OSPlatform.OSX)
+            // Skip modules that have no build id, are not macOS, or are part of the dyld shared cache.
+            // Since macOS 11 (Big Sur), system libraries are in the shared cache and cannot be downloaded
+            // as individual files from symbol servers. The MachOFile service reads the in-memory header
+            // (already cached from BuildId resolution) to check the MH_DYLIB_IN_CACHE flag.
+            if (module.Target.OperatingSystem == OSPlatform.OSX &&
+                !module.BuildId.IsDefaultOrEmpty &&
+                !IsDyldSharedCacheModule(module))
             {
-                if (!module.BuildId.IsDefaultOrEmpty)
-                {
-                    return new MachOModule(module, symbolService);
-                }
+                return new MachOModule(module, symbolService);
             }
             return null;
+        }
+
+        private static bool IsDyldSharedCacheModule(IModule module)
+        {
+            MachOFile machOFile = module.Services.GetService<MachOFile>();
+            return machOFile is not null && (machOFile.Header.Flags & MH_DYLIB_IN_CACHE) != 0;
         }
 
         private MachOModule(IModule module, ISymbolService symbolService)

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/ModuleService.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/ModuleService.cs
@@ -383,7 +383,10 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
                 else
                 {
                     MachOFile machOFile = module.Services.GetService<MachOFile>();
-                    if (machOFile is not null)
+                    // Skip version string scan for dyld shared cache modules. Since macOS 11 (Big Sur), system
+                    // libraries are in the shared cache and their writable segment pages are often not in dumps.
+                    // Scanning them triggers DownloadModuleFile fallbacks that time out.
+                    if (machOFile is not null && (machOFile.Header.Flags & MachOModule.MH_DYLIB_IN_CACHE) == 0)
                     {
                         foreach (MachSegmentLoadCommand loadCommand in machOFile.Segments.Select((segment) => segment.LoadCommand))
                         {


### PR DESCRIPTION
This pull request improves the handling of Mach-O modules on macOS, specifically addressing modules that are part of the dyld shared cache introduced in macOS 11 (Big Sur). The changes ensure that modules within the shared cache are properly identified and skipped during certain operations, avoiding unnecessary symbol server downloads and timeouts.