### PR TITLE
Replace dn-bot-all-drop-rw-code-rw-release-all PAT with WIF token

### DIFF
--- a/eng/pipelines/prepare-release.yml
+++ b/eng/pipelines/prepare-release.yml
@@ -53,12 +53,14 @@ stages:
         inputs:
           azureSubscription: 'DotNetStaging'
           scriptType: ps
-          scriptPath: '$(Build.Repository.LocalPath)/eng/release/Scripts/AcquireBuild.ps1'
-          arguments: >-
-            -BarBuildId "$(BARBuildId)"
-            -ReleaseVersion "$(Build.Repository.Name)_$(Build.BuildNumber)"
-            -DownloadTargetPath "$(System.ArtifactsDirectory)\ReleaseTarget"
-            -AzdoToken "$(dn-bot-all-drop-rw-code-rw-release-all)"
+          scriptLocation: inlineScript
+          inlineScript: |
+            $azdoToken = az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv
+            & '$(Build.Repository.LocalPath)/eng/release/Scripts/AcquireBuild.ps1' `
+              -BarBuildId "$(BARBuildId)" `
+              -ReleaseVersion "$(Build.Repository.Name)_$(Build.BuildNumber)" `
+              -DownloadTargetPath "$(System.ArtifactsDirectory)\ReleaseTarget" `
+              -AzdoToken $azdoToken
           workingDirectory: '$(Build.Repository.LocalPath)'
       - task: AzureCLI@2
         displayName: 'Manifest generation and asset publishing'


### PR DESCRIPTION
## Summary

Migrate the DARC Gather build task in \ng/pipelines/prepare-release.yml\ from using the \dn-bot-all-drop-rw-code-rw-release-all\ PAT to acquiring an AzDO access token from the **DotNetStaging** service connection via \z account get-access-token\.

## What changed

The \AzureCLI@2\ task already runs with the \DotNetStaging\ service connection (WIF), so the Azure CLI is already authenticated. Instead of passing the PAT variable, we now:
1. Acquire an AzDO token: \z account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798\
2. Pass that token to \AcquireBuild.ps1 -AzdoToken\

This switches from \scriptPath\+\rguments\ to \inlineScript\ to allow the token acquisition step.

## Why

Part of the 1ES PAT Disable Policy migration. The \dn-bot-all-drop-rw-code-rw-release-all\ PAT is being retired in favor of Entra-based authentication.

Tracked by: https://dev.azure.com/dnceng/internal/_workitems/edit/10105

## Validation

- The DotNetStaging SP is already enrolled in the \dnceng\ AzDO org with appropriate group memberships
- The SP already authenticates blob storage downloads (\--use-azure-credential-for-blobs\) in the same task
- Post-merge, the first release pipeline run on a \elease/*\ branch will validate end-to-end