### PR TITLE
Pin riscv64 to march=rv64gc baseline

### DIFF
--- a/eng/native/configurecompiler.cmake
+++ b/eng/native/configurecompiler.cmake
@@ -775,6 +775,11 @@ if(CLR_CMAKE_HOST_UNIX_ARMV6)
    add_compile_options(-mfloat-abi=hard)
 endif(CLR_CMAKE_HOST_UNIX_ARMV6)
 
+if(CLR_CMAKE_HOST_UNIX_RISCV64)
+  add_compile_options(-march=rv64gc)
+  add_compile_options(-mabi=lp64d)
+endif(CLR_CMAKE_HOST_UNIX_RISCV64)
+
 if(CLR_CMAKE_HOST_UNIX_X86)
   add_compile_options(-msse2)
 endif()


### PR DESCRIPTION
This change allows loading `libsosplugin` built on Ubuntu 26.04 when used with a rootfs based on the same OS.

Clang on Ubuntu 26.04 defaults to the RVA23 profile, which requires the V extension (among others). The toolchain and most other distros, however, target the Linux kernel baseline (`rv64gc`). This mismatch leads to issues when loading the plugin.

Context: https://github.com/dotnet/runtime/pull/127919#issuecomment-4399608265
