### PR TITLE
Only label SOS tests .interpreter when they actually use the interpreter

### DIFF
--- a/src/Microsoft.Diagnostics.TestHelpers/TestConfiguration.cs
+++ b/src/Microsoft.Diagnostics.TestHelpers/TestConfiguration.cs
@@ -73,8 +73,7 @@ namespace Microsoft.Diagnostics.TestHelpers
                 ["TargetArchitecture"] = OS.TargetArchitecture.ToString().ToLowerInvariant(),
                 ["NuGetPackageCacheDir"] = nugetPackages,
                 ["TestCDAC"] = Environment.GetEnvironmentVariable("SOS_TEST_CDAC"),
-                ["TestCDACNoFallback"] = Environment.GetEnvironmentVariable("SOS_TEST_CDAC_NO_FALLBACK"),
-                ["TestInterpreter"] = Environment.GetEnvironmentVariable("SOS_TEST_INTERPRETER")
+                ["TestCDACNoFallback"] = Environment.GetEnvironmentVariable("SOS_TEST_CDAC_NO_FALLBACK")
             };
             if (OS.Kind == OSKind.Windows)
             {
@@ -464,7 +463,7 @@ namespace Microsoft.Diagnostics.TestHelpers
             {
                 sb.Append(".cdac");
             }
-            if (TestInterpreter)
+            if (UseInterpreter)
             {
                 sb.Append(".interpreter");
             }
@@ -579,13 +578,15 @@ namespace Microsoft.Diagnostics.TestHelpers
         }
 
         /// <summary>
-        /// Returns true if interpreter-frame SOS tests should run. Requires a Debug/Checked
-        /// CoreCLR drop with FEATURE_INTERPRETER compiled in. When true, opted-in tests
-        /// launch their debuggee with DOTNET_Interpreter set so user methods are interpreted.
+        /// Returns true if this configuration runs its debuggee on the CoreCLR interpreter.
+        /// Set only on the dedicated interpreter-variant configurations cloned by
+        /// SOSTestHelpers.InterpreterConfigurations; opt-in tests consume those via their
+        /// own MemberData source. When set, SOSRunner launches the debuggee with
+        /// DOTNET_Interpreter=InterpTestMethod*
         /// </summary>
-        public bool TestInterpreter
+        public bool UseInterpreter
         {
-            get { return string.Equals(GetValue("TestInterpreter"), "true", StringComparison.InvariantCultureIgnoreCase); }
+            get { return string.Equals(GetValue("UseInterpreter"), "true", StringComparison.InvariantCultureIgnoreCase); }
         }
 
         /// <summary>

--- a/src/tests/SOS.UnitTests/SOS.cs
+++ b/src/tests/SOS.UnitTests/SOS.cs
@@ -22,6 +22,28 @@ public static class SOSTestHelpers
     public static IEnumerable<object[]> Configurations => GetConfigurations("TestName", value: null)
         .Where(args => !((TestConfiguration)args[0]).IsDesktop);
 
+    public static IEnumerable<object[]> InterpreterConfigurations
+    {
+        get
+        {
+            // Global gate: SOS_TEST_INTERPRETER=true. Requires a Debug/Checked CoreCLR
+            // drop with FEATURE_INTERPRETER overlaid; see documentation/privatebuildtesting.md.
+            if (!string.Equals(Environment.GetEnvironmentVariable("SOS_TEST_INTERPRETER"), "true", StringComparison.OrdinalIgnoreCase))
+            {
+                return new[] { new object[] { TestConfiguration.Empty } };
+            }
+
+            List<object[]> configs = Configurations
+                .Where(args => !((TestConfiguration)args[0]).PublishSingleFile)
+                // FEATURE_INTERPRETER is not enabled for x86 (src/coreclr/clrfeatures.cmake in dotnet/runtime).
+                .Where(args => !string.Equals(((TestConfiguration)args[0]).TargetArchitecture, "x86", StringComparison.OrdinalIgnoreCase))
+                .Select(args => new object[] { new TestConfiguration(new Dictionary<string, string>(((TestConfiguration)args[0]).AllSettings) { ["UseInterpreter"] = "true" }) })
+                .ToList();
+
+            return configs.Count == 0 ? new[] { new object[] { TestConfiguration.Empty } } : configs;
+        }
+    }
+
     public static IEnumerable<object[]> GetConfigurations(string key, string value)
     {
         return TestRunConfiguration.Instance.Configurations.Where((c) => key == null || c.AllSettings.GetValueOrDefault(key) == value).DefaultIfEmpty(TestConfiguration.Empty).Select(c => new[] { c });
@@ -399,24 +421,12 @@ public class SOSInterpreterTests
 
     private ITestOutputHelper Output { get; set; }
 
-    [SkippableTheory, MemberData(nameof(SOSTestHelpers.Configurations), MemberType = typeof(SOSTestHelpers))]
+    [SkippableTheory, MemberData(nameof(SOSTestHelpers.InterpreterConfigurations), MemberType = typeof(SOSTestHelpers))]
     public async Task InterpreterStackTest(TestConfiguration config)
     {
-        if (!config.TestInterpreter)
+        if (!config.UseInterpreter)
         {
             throw new SkipTestException("Interpreter SOS tests are off by default. Set SOS_TEST_INTERPRETER=true and overlay a Debug/Checked CoreCLR drop with FEATURE_INTERPRETER to run them.");
-        }
-
-        // FEATURE_INTERPRETER is not enabled for x86 (see src/coreclr/clrfeatures.cmake in dotnet/runtime).
-        if (config.TargetArchitecture == "x86")
-        {
-            throw new SkipTestException("CoreCLR interpreter is not enabled for x86.");
-        }
-
-        // Single-file deployment is excluded from private-runtime-overlay testing.
-        if (config.PublishSingleFile)
-        {
-            throw new SkipTestException("Interpreter test does not run against single-file debuggees.");
         }
 
         await SOSTestHelpers.RunTest(
@@ -432,22 +442,12 @@ public class SOSInterpreterTests
             Output);
     }
 
-    [SkippableTheory, MemberData(nameof(SOSTestHelpers.Configurations), MemberType = typeof(SOSTestHelpers))]
+    [SkippableTheory, MemberData(nameof(SOSTestHelpers.InterpreterConfigurations), MemberType = typeof(SOSTestHelpers))]
     public async Task InterpreterStackInterleavedTest(TestConfiguration config)
     {
-        if (!config.TestInterpreter)
+        if (!config.UseInterpreter)
         {
             throw new SkipTestException("Interpreter SOS tests are off by default. Set SOS_TEST_INTERPRETER=true and overlay a Debug/Checked CoreCLR drop with FEATURE_INTERPRETER to run them.");
-        }
-
-        if (config.TargetArchitecture == "x86")
-        {
-            throw new SkipTestException("CoreCLR interpreter is not enabled for x86.");
-        }
-
-        if (config.PublishSingleFile)
-        {
-            throw new SkipTestException("Interpreter test does not run against single-file debuggees.");
         }
 
         await SOSTestHelpers.RunTest(

--- a/src/tests/SOS.UnitTests/SOSRunner.cs
+++ b/src/tests/SOS.UnitTests/SOSRunner.cs
@@ -328,7 +328,7 @@ public class SOSRunner : IDisposable
                     WithLog(new TestRunner.TestLogger(outputHelper.IndentedOutput)).
                     WithTimeout(TimeSpan.FromMinutes(10));
 
-                if (config.TestInterpreter)
+                if (config.UseInterpreter)
                 {
                     processRunner.WithEnvironmentVariable("DOTNET_Interpreter", "InterpTestMethod*");
                 }
@@ -749,7 +749,7 @@ public class SOSRunner : IDisposable
                 processRunner.WithEnvironmentVariable("DOTNET_gcName", gcName);
             }
 
-            if (config.TestInterpreter)
+            if (config.UseInterpreter)
             {
                 processRunner.WithEnvironmentVariable("DOTNET_Interpreter", "InterpTestMethod*");
             }


### PR DESCRIPTION
## Summary

Reworks interpreter-test gating so the ``.interpreter`` display suffix and the ``DOTNET_Interpreter`` debuggee env var apply only to the two ``SOSInterpreterTests`` test methods. Previously, setting ``SOS_TEST_INTERPRETER=true`` decorated every SOS test name with ``.interpreter`` and set ``DOTNET_Interpreter`` on every debuggee, even though only ``SOSInterpreterTests`` actually exercises the interpreter.

## Background

When ``SOS_TEST_INTERPRETER=true`` was set globally, two side effects had overly-broad scope:

1. **Test name decoration.** ``TestConfiguration.GetStringViewWithVersion`` unconditionally appended ``.interpreter`` to every config''s display name. Because ``TestConfiguration`` is shared across all SOS theory tests, unrelated tests (e.g. ``SOSScenarioTests.WebApp3``) showed up in xUnit results as ``WebApp3(*.interpreter.11.0.0-preview.5.xxxxx.yyy)``, misleading triage into thinking the failures were interpreter-related.
2. **Env-var plumbing.** ``SOSRunner`` set ``DOTNET_Interpreter=InterpTestMethod*`` on every debuggee it launched. For non-interpreter debuggees this is functionally a no-op (no method matches the glob), but it''s still incorrect.

The recent runtime-diagnostics WebApp3 R2R-skew failures (a ``MissingMethodException`` for ``AsyncHelpers.CaptureContexts`` triggered by an unrelated runtime change) were initially mis-attributed to interpreter mode because the test was labeled ``.interpreter`` -- that triage friction motivated this cleanup.

## Change

Interpreter mode is now a per-``TestConfiguration`` variant -- analogous to ``PublishSingleFile`` / ``TestCDAC`` -- rather than a global flag observed by every test:

- **``TestConfiguration.UseInterpreter``** is a new per-config bool. It drives both the ``.interpreter`` suffix in ``GetStringViewWithVersion`` and the ``DOTNET_Interpreter=InterpTestMethod*`` env-var emission in ``SOSRunner.CreateDump`` / ``StartDebugger``.
- **``SOSTestHelpers.InterpreterConfigurations``** is a new ``MemberData`` source. With ``SOS_TEST_INTERPRETER`` unset it returns the placeholder ``TestConfiguration.Empty`` row (so the theory enumerates one row and skips via ``SkippableTheory``). With the env var set, it clones each default non-single-file, non-x86 configuration with ``UseInterpreter=true``.
- **``SOSInterpreterTests.InterpreterStackTest``** and **``InterpreterStackInterleavedTest``** bind to ``InterpreterConfigurations`` and check ``!config.UseInterpreter`` for the skip message. The x86 / single-file / global-gate checks now live once in ``InterpreterConfigurations`` instead of being duplicated per test.
- **``TestConfiguration.TestInterpreter``** (and its initial-dict entry) is removed; nothing other than the new opt-in path needed it.

The interpreter variant is produced in code (cloning ``AllSettings`` and adding ``UseInterpreter=true``); no test config XML changes are required.

## Net behavior

| Test | ``SOS_TEST_INTERPRETER=true`` | Before | After |
|------|-----------------------------|--------|-------|
| ``SOSScenarioTests.WebApp3`` | yes | ``*.interpreter.<ver>`` + ``DOTNET_Interpreter`` set | ``*.<ver>``, no env var |
| ``SOSInterpreterTests.InterpreterStackTest`` | yes | ``*.interpreter.<ver>`` | ``*.interpreter.<ver>`` (only this class) |
| ``SOSInterpreterTests.InterpreterStackTest`` | unset | skipped | skipped |

No change for ``SOS_TEST_INTERPRETER`` unset.

> [!NOTE]
> This PR description and the code changes were authored with assistance from GitHub Copilot.



## Validation

runtime-diagnostics pipeline run against this PR: https://dev.azure.com/dnceng-public/public/_build/results?buildId=1435731
