### PR TITLE
Enable dotnet-arcade-skills Copilot plugin

### DIFF
--- a/.github/copilot/settings.json
+++ b/.github/copilot/settings.json
@@ -1,0 +1,13 @@
+{
+  "extraKnownMarketplaces": {
+    "dotnet-arcade-skills": {
+      "source": {
+        "source": "github",
+        "repo": "dotnet/arcade-skills"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "dotnet-dnceng@dotnet-arcade-skills": true
+  }
+}


### PR DESCRIPTION
Adds `.github/copilot/settings.json` enabling the `dotnet-dnceng@dotnet-arcade-skills` Copilot plugin, mirroring the configuration already in [dotnet/runtime](https://github.com/dotnet/runtime/blob/main/.github/copilot/settings.json). This makes the dnceng arcade skills available to GitHub Copilot in this repository.

> [!NOTE]
> This PR was authored with assistance from GitHub Copilot.