### PR TITLE
Add CLRMA diagnostic command runnable under dotnet-dump

### DIFF
--- a/documentation/clrma.md
+++ b/documentation/clrma.md
@@ -68,8 +68,59 @@ IXCLRDataStackWalk::GetContext()
 IXCLRDataStackWalk::Next()
 ```
 
+### Testing CLRMA locally with the `clrma` command
+
+The `clrma` SOS command exercises the CLRMA contract end-to-end (`CLRMACreateInstance` →
+`ICLRManagedAnalysis.AssociateClient` → `GetThread`/`GetException`) and prints the managed thread
+stack, the current/nested exceptions, their types, messages, HResults and exception stack traces.
+This is the same data Watson/`!analyze` extract from CLRMA, so the command is a local proxy for
+"upload to Watson and see how it buckets" — without needing the debugger engine's `!clrma`/`!analyze`.
+
+The command runs in any SOS host. In particular it works under `dotnet-dump`, so no Windows
+debugger (windbg/cdb) or lldb is required:
+
+```
+dotnet-dump analyze <dump> -c "clrma" -c "exit"
+```
+
+By default it analyzes the current/faulting thread and its current exception. Pass `-t <osThreadId>`
+to target a specific managed thread. Use `clrmaconfig` to switch between the managed (Native AOT
+crash-info) provider and the direct-DAC provider, e.g. `clrmaconfig -enable -dac`.
+
+To produce a dump to test against, run a managed app under `createdump` (no debugger needed):
+
+```
+set DOTNET_DbgEnableMiniDump=1
+set DOTNET_DbgMiniDumpType=4
+set DOTNET_DbgMiniDumpName=<path-to-dump>
+<run the crashing app>
+```
+
+Example output for an `InvalidOperationException` that wraps an inner `ArgumentException`:
+
+```
+Managed analysis provider: SOSCLRMA
+OSThreadId: 800c
+Managed stack trace:
+    ... clrmatest.dll!Program.Main()+0x8b
+    ... clrmatest.dll!Program.Inner()+0x67
+Current exception:
+    Exception type:   System.InvalidOperationException
+    Message:          Outer failure from CLRMA test debuggee
+    HResult:          80131509
+    StackTrace (generated):
+        ... clrmatest.dll!Program.Main+0x8a
+    InnerException:
+        Exception type:   System.ArgumentException
+        Message:          Inner failure: bad argument value
+        HResult:          80070057
+```
+
+> Note: under `dotnet-dump` the `Extensions` debugger-services layer is not registered (SOS uses the
+> legacy dbgeng-compat layer there), so CLRMA `-logging` output is suppressed in that host.
+
 ### References
 
-SOS CLRMA export code: https://github.com/dotnet/diagnostics/blob/main/src/SOS/Strike/clrma/clrma.cpp. 
+SOS CLRMA export code: https://github.com/dotnet/diagnostics/blob/main/src/SOS/Strike/clrma/clrma.cpp.
 
 SOS CLRMA wrapper code: https://github.com/dotnet/diagnostics/blob/main/src/SOS/SOS.Extensions/Clrma/ClrmaServiceWrapper.cs. 

--- a/documentation/clrma.md
+++ b/documentation/clrma.md
@@ -70,10 +70,14 @@ IXCLRDataStackWalk::Next()
 
 ### Testing CLRMA locally with the `clrma` command
 
+> **Note:** `clrma` is an internal diagnostic/validation command used to exercise the CLRMA path.
+> It is intentionally hidden from the `help`/`soshelp` command list and is not a supported,
+> publicly advertised triage command. It is still invocable by name in any SOS host.
+
 The `clrma` SOS command exercises the CLRMA contract end-to-end (`CLRMACreateInstance` →
 `ICLRManagedAnalysis.AssociateClient` → `GetThread`/`GetException`) and prints the managed thread
 stack, the current/nested exceptions, their types, messages, HResults and exception stack traces.
-This is the same data Watson/`!analyze` extract from CLRMA, so the command is a local proxy for
+This is the same data Watson/`!analyze` extracts from CLRMA, so the command is a local proxy for
 "upload to Watson and see how it buckets" — without needing the debugger engine's `!clrma`/`!analyze`.
 
 The command runs in any SOS host. In particular it works under `dotnet-dump`, so no Windows

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/CommandService.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/CommandService.cs
@@ -161,7 +161,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
                 {
                     try
                     {
-                        if (handler.IsCommandSupported(group.Parser, services))
+                        if (!handler.Hidden && handler.IsCommandSupported(group.Parser, services))
                         {
                             string invocation = handler.HelpInvocation;
                             help.Add((invocation, handler.Help));
@@ -545,6 +545,12 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
             /// Returns the command's help text
             /// </summary>
             internal string Help => _commandAttribute.Help;
+
+            /// <summary>
+            /// When true, the command is omitted from the help command's command list, but
+            /// remains registered and invocable.
+            /// </summary>
+            internal bool Hidden => _commandAttribute.Hidden;
 
             /// <summary>
             /// Filter invoke message or null if no attribute or message

--- a/src/Microsoft.Diagnostics.DebugServices/CommandAttributes.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/CommandAttributes.cs
@@ -31,6 +31,13 @@ namespace Microsoft.Diagnostics.DebugServices
         /// A string of options that are parsed before the command line options
         /// </summary>
         public string DefaultOptions;
+
+        /// <summary>
+        /// When true, the command is still registered and invocable but is omitted from the
+        /// command list shown by the help command. Use for internal diagnostic/validation
+        /// commands that should not be advertised to users.
+        /// </summary>
+        public bool Hidden;
     }
 
     /// <summary>

--- a/src/SOS/SOS.Hosting/Commands/SOSCommand.cs
+++ b/src/SOS/SOS.Hosting/Commands/SOSCommand.cs
@@ -8,7 +8,7 @@ using Microsoft.Diagnostics.DebugServices;
 
 namespace SOS.Hosting
 {
-    [Command(Name = "clrma",             DefaultOptions = "clrma",               Help = "Diagnostic that drives the CLRMA provider used by Watson/!analyze and prints the managed thread and exception analysis. Primarily for validating the CLRMA path; not a general triage command.")]
+    [Command(Name = "clrma",             DefaultOptions = "clrma",               Hidden = true, Help = "Diagnostic that drives the CLRMA provider used by Watson/!analyze and prints the managed thread and exception analysis. Primarily for validating the CLRMA path; not a general triage command.")]
     [Command(Name = "clrstack",          DefaultOptions = "ClrStack",            Help = "Provides a stack trace of managed code only.")]
     [Command(Name = "clrthreads",        DefaultOptions = "Threads",             Help = "Lists the managed threads running.")]
     [Command(Name = "dbgout",            DefaultOptions = "dbgout",              Help = "Enables/disables (-off) internal SOS logging.")]

--- a/src/SOS/SOS.Hosting/Commands/SOSCommand.cs
+++ b/src/SOS/SOS.Hosting/Commands/SOSCommand.cs
@@ -8,6 +8,7 @@ using Microsoft.Diagnostics.DebugServices;
 
 namespace SOS.Hosting
 {
+    [Command(Name = "clrma",             DefaultOptions = "clrma",               Help = "Diagnostic that drives the CLRMA provider used by Watson/!analyze and prints the managed thread and exception analysis. Primarily for validating the CLRMA path; not a general triage command.")]
     [Command(Name = "clrstack",          DefaultOptions = "ClrStack",            Help = "Provides a stack trace of managed code only.")]
     [Command(Name = "clrthreads",        DefaultOptions = "Threads",             Help = "Lists the managed threads running.")]
     [Command(Name = "dbgout",            DefaultOptions = "dbgout",              Help = "Enables/disables (-off) internal SOS logging.")]

--- a/src/SOS/Strike/CMakeLists.txt
+++ b/src/SOS/Strike/CMakeLists.txt
@@ -158,6 +158,10 @@ else(CLR_CMAKE_HOST_WIN32)
     sos.cpp
     sosextensions.cpp
     util.cpp
+    clrma/clrma.cpp
+    clrma/managedanalysis.cpp
+    clrma/exception.cpp
+    clrma/thread.cpp
     platform/datatarget.cpp
     platform/hostimpl.cpp
     platform/targetimpl.cpp

--- a/src/SOS/Strike/clrma/clrma.cpp
+++ b/src/SOS/Strike/clrma/clrma.cpp
@@ -174,8 +174,8 @@ PrintClrmaFrames(T* frameProvider, PCSTR indent)
                 indent,
                 SOS_PTR(sp),
                 SOS_PTR(ip),
-                module != nullptr ? module : L"<unknown_module>",
-                function != nullptr ? function : L"<unknown_function>",
+                module != nullptr ? module : W("<unknown_module>"),
+                function != nullptr ? function : W("<unknown_function>"),
                 (unsigned long long)displacement);
         }
         SysFreeString(module);
@@ -208,8 +208,8 @@ PrintClrmaException(ICLRMAClrException* exception, int nestingLevel)
     exception->get_Message(&message);
 
     ExtOut("%sException object: %p\n", indent, SOS_PTR(address));
-    ExtOut("%sException type:   %S\n", indent, type != nullptr ? type : L"<Unknown>");
-    ExtOut("%sMessage:          %S\n", indent, message != nullptr ? message : L"<none>");
+    ExtOut("%sException type:   %S\n", indent, type != nullptr ? type : W("<Unknown>"));
+    ExtOut("%sMessage:          %S\n", indent, message != nullptr ? message : W("<none>"));
     ExtOut("%sHResult:          %08x\n", indent, exceptionHResult);
     ExtOut("%sStackTrace (generated):\n", indent);
     PrintClrmaFrames(exception, indent);

--- a/src/SOS/Strike/clrma/clrma.cpp
+++ b/src/SOS/Strike/clrma/clrma.cpp
@@ -139,6 +139,198 @@ DECLARE_API(clrmaconfig)
     return Status;
 }
 
+//
+// !clrma command
+//
+// Drives the CLRMA (CLR Managed Analysis) interfaces the same way Watson/!analyze does so the
+// managed crash bucketing path can be exercised locally with any SOS host (e.g. dotnet-dump),
+// without requiring the debugger engine's built-in !clrma/!analyze commands.
+//
+
+template <typename T>
+static void
+PrintClrmaFrames(T* frameProvider, PCSTR indent)
+{
+    UINT frameCount = 0;
+    if (FAILED(frameProvider->get_FrameCount(&frameCount)) || frameCount == 0)
+    {
+        ExtOut("%s<no managed frames>\n", indent);
+        return;
+    }
+    for (UINT i = 0; i < frameCount; i++)
+    {
+        if (IsInterrupt())
+        {
+            return;
+        }
+        ULONG64 ip = 0;
+        ULONG64 sp = 0;
+        ULONG64 displacement = 0;
+        BSTR module = nullptr;
+        BSTR function = nullptr;
+        if (SUCCEEDED(frameProvider->Frame(i, &ip, &sp, &module, &function, &displacement)))
+        {
+            ExtOut("%s%p %p %S!%S+0x%llx\n",
+                indent,
+                SOS_PTR(sp),
+                SOS_PTR(ip),
+                module != nullptr ? module : L"<unknown_module>",
+                function != nullptr ? function : L"<unknown_function>",
+                (unsigned long long)displacement);
+        }
+        SysFreeString(module);
+        SysFreeString(function);
+    }
+}
+
+static void
+PrintClrmaException(ICLRMAClrException* exception, int nestingLevel)
+{
+    if (exception == nullptr)
+    {
+        return;
+    }
+
+    const char* indent = nestingLevel <= 0 ? "    " :
+                         nestingLevel == 1 ? "        " :
+                         nestingLevel == 2 ? "            " : "                ";
+
+    ULONG64 address = 0;
+    exception->get_Address(&address);
+
+    HRESULT exceptionHResult = 0;
+    exception->get_HResult(&exceptionHResult);
+
+    BSTR type = nullptr;
+    exception->get_Type(&type);
+
+    BSTR message = nullptr;
+    exception->get_Message(&message);
+
+    ExtOut("%sException object: %p\n", indent, SOS_PTR(address));
+    ExtOut("%sException type:   %S\n", indent, type != nullptr ? type : L"<Unknown>");
+    ExtOut("%sMessage:          %S\n", indent, message != nullptr ? message : L"<none>");
+    ExtOut("%sHResult:          %08x\n", indent, exceptionHResult);
+    ExtOut("%sStackTrace (generated):\n", indent);
+    PrintClrmaFrames(exception, indent);
+
+    SysFreeString(type);
+    SysFreeString(message);
+
+    USHORT innerCount = 0;
+    if (SUCCEEDED(exception->get_InnerExceptionCount(&innerCount)))
+    {
+        for (USHORT i = 0; i < innerCount; i++)
+        {
+            if (IsInterrupt())
+            {
+                return;
+            }
+            ReleaseHolder<ICLRMAClrException> inner;
+            if (exception->InnerException(i, inner.GetAddr()) == S_OK && inner != nullptr)
+            {
+                ExtOut("%sInnerException:\n", indent);
+                PrintClrmaException(inner, nestingLevel + 1);
+            }
+        }
+    }
+}
+
+DECLARE_API(clrma)
+{
+    INIT_API_EXT();
+
+    ULONG64 osThreadId = 0;
+
+    CMDOption option[] =
+    {   // name, vptr, type, hasValue
+        {"-t", &osThreadId, COSIZE_T, TRUE},
+    };
+
+    if (!GetCMDOption(args, option, ARRAY_SIZE(option), NULL, 0, NULL))
+    {
+        return E_INVALIDARG;
+    }
+
+    ReleaseHolder<ICLRManagedAnalysis> managedAnalysis;
+    if (FAILED(Status = CLRMACreateInstance(managedAnalysis.GetAddr())))
+    {
+        ExtErr("CLRMACreateInstance FAILED %08x\n", Status);
+        return Status;
+    }
+
+    if (FAILED(Status = managedAnalysis->AssociateClient(client)))
+    {
+        ExtErr("No managed analysis provider available (AssociateClient FAILED %08x).\n", Status);
+        ExtErr("Use 'clrmaconfig' to check the enabled CLRMA providers.\n");
+        return Status;
+    }
+
+    BSTR providerName = nullptr;
+    if (SUCCEEDED(managedAnalysis->get_ProviderName(&providerName)) && providerName != nullptr)
+    {
+        ExtOut("Managed analysis provider: %S\n", providerName);
+        SysFreeString(providerName);
+    }
+
+    if (osThreadId == 0)
+    {
+        ULONG currentThreadId = 0;
+        if (FAILED(Status = g_ExtSystem->GetCurrentThreadSystemId(&currentThreadId)))
+        {
+            ExtErr("GetCurrentThreadSystemId FAILED %08x\n", Status);
+            return Status;
+        }
+        osThreadId = currentThreadId;
+    }
+
+    ReleaseHolder<ICLRMAClrThread> thread;
+    Status = managedAnalysis->GetThread((ULONG)osThreadId, thread.GetAddr());
+    if (FAILED(Status) || thread == nullptr)
+    {
+        ExtOut("Thread %04x is not a managed thread or has no managed analysis (%08x).\n", (ULONG)osThreadId, Status);
+        return S_OK;
+    }
+
+    ULONG reportedThreadId = (ULONG)osThreadId;
+    thread->get_OSThreadId(&reportedThreadId);
+    ExtOut("OSThreadId: %04x\n", reportedThreadId);
+
+    ExtOut("Managed stack trace:\n");
+    PrintClrmaFrames(thread.GetPtr(), "    ");
+
+    ReleaseHolder<ICLRMAClrException> currentException;
+    if (thread->get_CurrentException(currentException.GetAddr()) == S_OK && currentException != nullptr)
+    {
+        ExtOut("Current exception:\n");
+        PrintClrmaException(currentException, 0);
+    }
+    else
+    {
+        ExtOut("Current exception: <none>\n");
+    }
+
+    USHORT nestedCount = 0;
+    if (SUCCEEDED(thread->get_NestedExceptionCount(&nestedCount)) && nestedCount > 0)
+    {
+        for (USHORT i = 0; i < nestedCount; i++)
+        {
+            if (IsInterrupt())
+            {
+                break;
+            }
+            ReleaseHolder<ICLRMAClrException> nested;
+            if (thread->NestedException(i, nested.GetAddr()) == S_OK && nested != nullptr)
+            {
+                ExtOut("Nested exception #%d:\n", i);
+                PrintClrmaException(nested, 0);
+            }
+        }
+    }
+
+    return S_OK;
+}
+
 extern void InternalOutputVaList(ULONG mask, PCSTR format, va_list args);
 
 void

--- a/src/SOS/Strike/clrma/clrma.cpp
+++ b/src/SOS/Strike/clrma/clrma.cpp
@@ -1,8 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#include "exts.h"
 #include "managedanalysis.h"
+#include "exts.h"
 
 HRESULT CLRMACreateInstance(ICLRManagedAnalysis** ppCLRMA);
 HRESULT CLRMAReleaseInstance();

--- a/src/SOS/Strike/clrma/exception.cpp
+++ b/src/SOS/Strike/clrma/exception.cpp
@@ -92,6 +92,11 @@ ClrmaException::Initialize()
             if (m_exceptionData.Message == 0)
             {
                 // To match the built-in SOS provider that scrapes !pe output.
+                //
+                // Use W() and a manual length/copy rather than L"<none>" with wcslen/wcscpy: on
+                // Unix wchar_t is 4 bytes while WCHAR (and BSTR) are UTF-16, so the wide CRT
+                // functions don't operate on WCHAR buffers. W() yields a UTF-16 literal on all
+                // platforms.
                 const WCHAR* none = W("<none>");
                 size_t noneLen = 0;
                 while (none[noneLen] != 0)
@@ -239,7 +244,8 @@ ClrmaException::get_Type(
     const WCHAR* typeName = m_typeName;
     if (typeName == nullptr)
     {
-        // To match the built-in SOS provider that scrapes !pe output
+        // To match the built-in SOS provider that scrapes !pe output. W() (not L"") so the
+        // literal is UTF-16 to match WCHAR/BSTR where wchar_t differs from WCHAR on Unix.
         typeName = W("<Unknown>");
     }
 

--- a/src/SOS/Strike/clrma/exception.cpp
+++ b/src/SOS/Strike/clrma/exception.cpp
@@ -92,9 +92,17 @@ ClrmaException::Initialize()
             if (m_exceptionData.Message == 0)
             {
                 // To match the built-in SOS provider that scrapes !pe output.
-                const WCHAR* none = L"<none>";
-                m_message = new (std::nothrow) WCHAR[wcslen(none) + 1];
-                wcscpy(m_message, none);
+                const WCHAR* none = W("<none>");
+                size_t noneLen = 0;
+                while (none[noneLen] != 0)
+                {
+                    noneLen++;
+                }
+                m_message = new (std::nothrow) WCHAR[noneLen + 1];
+                if (m_message != nullptr)
+                {
+                    memcpy(m_message, none, (noneLen + 1) * sizeof(WCHAR));
+                }
             }
             else
             {
@@ -232,7 +240,7 @@ ClrmaException::get_Type(
     if (typeName == nullptr)
     {
         // To match the built-in SOS provider that scrapes !pe output
-        typeName = L"<Unknown>";
+        typeName = W("<Unknown>");
     }
 
     *pValue = SysAllocString(typeName);

--- a/src/SOS/Strike/clrma/managedanalysis.cpp
+++ b/src/SOS/Strike/clrma/managedanalysis.cpp
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #include "managedanalysis.h"
+#include "exts.h"
 
 extern bool IsWindowsTarget();
 extern "C" IXCLRDataProcess * GetClrDataFromDbgEng();
@@ -33,6 +34,7 @@ HRESULT
 ClrmaManagedAnalysis::QueryDebugClient(IUnknown* pUnknown)
 {
     HRESULT hr;
+#ifndef FEATURE_PAL
     ReleaseHolder<IDebugClient> debugClient;
     if (FAILED(hr = pUnknown->QueryInterface(__uuidof(IDebugClient), (void**)&debugClient)))
     {
@@ -63,6 +65,25 @@ ClrmaManagedAnalysis::QueryDebugClient(IUnknown* pUnknown)
     m_debugSystem = debugSystem.Detach();
     m_debugControl = debugControl.Detach();
     m_debugSymbols = debugSymbols.Detach();
+#else
+    // On Unix there is no COM IDebugClient. The cross-platform debugger services (ILLDBServices,
+    // wrapped by the xplat dbgeng compat) are exposed through the ExtQuery globals that the
+    // INIT_API_EXT in the clrma command already initialized from this same client.
+    if (pUnknown == nullptr || g_ExtData == nullptr || g_ExtSystem == nullptr || g_ExtControl == nullptr || g_ExtSymbols == nullptr)
+    {
+        return E_UNEXPECTED;
+    }
+    m_debugClient = pUnknown;
+    m_debugClient->AddRef();
+    m_debugData = g_ExtData;
+    m_debugData->AddRef();
+    m_debugSystem = g_ExtSystem;
+    m_debugSystem->AddRef();
+    m_debugControl = g_ExtControl;
+    m_debugControl->AddRef();
+    m_debugSymbols = g_ExtSymbols;
+    m_debugSymbols->AddRef();
+#endif
 
     if (FAILED(hr = m_debugControl->GetExecutingProcessorType(&m_processorType)))
     {
@@ -312,7 +333,7 @@ ClrmaManagedAnalysis::get_ProviderName(
         return E_INVALIDARG;
     }
 
-    *bstrProvider = SysAllocString(L"SOSCLRMA");
+    *bstrProvider = SysAllocString(W("SOSCLRMA"));
 
     if ((*bstrProvider) == nullptr)
     {
@@ -358,6 +379,7 @@ ClrmaManagedAnalysis::GetThread(
     // Last event thread?
     else if (osThreadId == (ULONG)-1)
     {
+#ifndef FEATURE_PAL
         ULONG lastEventType = 0;
         ULONG lastEventProcessId = 0;
         ULONG lastEventThreadIdIndex = DEBUG_ANY_ID;
@@ -379,6 +401,13 @@ ClrmaManagedAnalysis::GetThread(
             return hr;
         }
         osThreadId = sysIds;
+#else
+        // The Unix cross-platform debugger services don't expose thread enumeration by index, so
+        // the "last event thread" lookup isn't available. The clrma command never requests it
+        // (it defaults to the current thread), so this only affects external CLRMA API callers.
+        TraceError("GetThread last-event thread (osThreadId == -1) is not supported on this host\n");
+        return E_NOTIMPL;
+#endif
     }
 
     if (m_clrmaService != nullptr)
@@ -535,6 +564,7 @@ ClrmaManagedAnalysis::GetMethodDescInfo(CLRDATA_ADDRESS methodDesc, StackFrame& 
             ArrayHolder<WCHAR> wszModuleName = new WCHAR[MAX_LONGPATH + 1];
             if (baseAddress != 0 || index != DEBUG_ANY_ID)
             {
+#ifndef FEATURE_PAL
                 if (SUCCEEDED(hr = m_debugSymbols->GetModuleNameStringWide(DEBUG_MODNAME_MODULE, index, baseAddress, wszModuleName, MAX_LONGPATH, nullptr)))
                 {
                     frame.Module = wszModuleName;
@@ -543,6 +573,25 @@ ClrmaManagedAnalysis::GetMethodDescInfo(CLRDATA_ADDRESS methodDesc, StackFrame& 
                 {
                     TraceError("GetMethodDescInfo(%016llx) GetModuleNameStringWide(%d, %016llx) FAILED %08x\n", methodDesc, index, baseAddress, hr);
                 }
+#else
+                // The Unix cross-platform debugger services only provide the narrow (ASCII)
+                // GetModuleNames, so read the module name and widen it.
+                ArrayHolder<char> szModuleName = new char[MAX_LONGPATH + 1];
+                szModuleName[0] = '\0';
+                if (SUCCEEDED(hr = m_debugSymbols->GetModuleNames(index, baseAddress, nullptr, 0, nullptr, szModuleName, MAX_LONGPATH, nullptr, nullptr, 0, nullptr)))
+                {
+                    std::basic_string<WCHAR> moduleName;
+                    for (const char* p = szModuleName; *p != '\0'; ++p)
+                    {
+                        moduleName.push_back((WCHAR)(unsigned char)*p);
+                    }
+                    frame.Module = moduleName;
+                }
+                else
+                {
+                    TraceError("GetMethodDescInfo(%016llx) GetModuleNames(%d, %016llx) FAILED %08x\n", methodDesc, index, baseAddress, hr);
+                }
+#endif
             }
 
             // Fallback if we can't get it from the debugger
@@ -622,11 +671,11 @@ ClrmaManagedAnalysis::GetMethodDescInfo(CLRDATA_ADDRESS methodDesc, StackFrame& 
     }
     if (frame.Module.empty())
     {
-        frame.Module = L"UNKNOWN";
+        frame.Module = W("UNKNOWN");
     }
     if (frame.Function.empty())
     {
-        frame.Function = L"UNKNOWN";
+        frame.Function = W("UNKNOWN");
     }
     return S_OK;
 }

--- a/src/SOS/Strike/clrma/managedanalysis.cpp
+++ b/src/SOS/Strike/clrma/managedanalysis.cpp
@@ -225,8 +225,10 @@ ClrmaManagedAnalysis::AssociateClient(
     }
 
     Extensions* extensions = Extensions::GetInstance();
-    if (extensions != nullptr && extensions->GetDebuggerServices() != nullptr)
+    if (extensions != nullptr)
     {
+        // FlushCheck is a no-op when there are no debugger services (e.g. the dotnet-dump host),
+        // but the target/runtime are still available through the host so CLRMA can run there too.
         extensions->FlushCheck();
 
         ITarget* target = extensions->GetTarget();

--- a/src/SOS/Strike/clrma/managedanalysis.h
+++ b/src/SOS/Strike/clrma/managedanalysis.h
@@ -22,6 +22,25 @@
 #include <runtime.h>
 #include <vector>
 
+#ifdef FEATURE_PAL
+// On Unix the cross-platform debugger services (xplat/dbgeng.h, backed by ILLDBServices)
+// expose only a subset of the dbgeng interfaces. Map the CLRMA debugger interface usage to
+// the available compat interfaces: there is no COM IDebugClient (the ILLDBServices client is
+// passed directly), no base IDebugControl (only IDebugControl2), and no IDebugSymbols3.
+typedef IUnknown        IClrmaDebugClient;
+typedef IDebugControl2  IClrmaDebugControl;
+typedef IDebugSymbols   IClrmaDebugSymbols;
+#else
+typedef IDebugClient    IClrmaDebugClient;
+typedef IDebugControl   IClrmaDebugControl;
+typedef IDebugSymbols3  IClrmaDebugSymbols;
+#endif
+
+// E_BOUNDS (a WinRT HRESULT) isn't defined by the PAL headers used on non-Windows platforms.
+#ifndef E_BOUNDS
+#define E_BOUNDS ((HRESULT)0x8000000BL)
+#endif
+
 enum ClrmaGlobalFlags
 {
     LoggingEnabled = 0x01,                  // CLRMA logging enabled
@@ -40,8 +59,8 @@ typedef struct StackFrame
     ULONG64 SP = 0;
     ULONG64 IP = 0;
     ULONG64 Displacement = 0;
-    std::wstring Module;
-    std::wstring Function;
+    std::basic_string<WCHAR> Module;
+    std::basic_string<WCHAR> Function;
 } StackFrame;
 
 extern int g_clrmaGlobalFlags;
@@ -112,11 +131,11 @@ private:
     int m_pointerSize;
     WCHAR m_fileSeparator;
     ULONG m_processorType;
-    IDebugClient* m_debugClient;
+    IClrmaDebugClient* m_debugClient;
     IDebugDataSpaces*  m_debugData;
     IDebugSystemObjects*  m_debugSystem;
-    IDebugControl*  m_debugControl;
-    IDebugSymbols3*  m_debugSymbols;
+    IClrmaDebugControl*  m_debugControl;
+    IClrmaDebugSymbols*  m_debugSymbols;
 
     // CLRMA service from managed code
     ICLRMAService* m_clrmaService;

--- a/src/SOS/Strike/clrma/thread.cpp
+++ b/src/SOS/Strike/clrma/thread.cpp
@@ -434,7 +434,7 @@ ClrmaThread::GetFrameLocation(
     CLRDATA_ADDRESS* sp)
 {
     ULONG32 contextSize = 0;
-    ULONG32 contextFlags = CONTEXT_ARM64_CONTROL;
+    ULONG32 contextFlags = 0;
     ULONG processorType = m_managedAnalysis->ProcessorType();
     switch (processorType)
     {

--- a/src/SOS/Strike/sos.def
+++ b/src/SOS/Strike/sos.def
@@ -13,6 +13,7 @@ EXPORTS
     clrstack=ClrStack
     CLRStack=ClrStack
     clrmaconfig
+    clrma
     crashinfo
     DumpALC
     dumpalc=DumpALC

--- a/src/SOS/Strike/sos_unixexports.src
+++ b/src/SOS/Strike/sos_unixexports.src
@@ -3,6 +3,7 @@
 ; See the LICENSE file in the project root for more information.
 
 bpmd
+clrma
 ClrStack
 dbgout
 DumpALC

--- a/src/SOS/extensions/extensions.cpp
+++ b/src/SOS/extensions/extensions.cpp
@@ -271,6 +271,14 @@ void InternalOutputVaList(
     PCSTR format,
     va_list args)
 {
+    IDebuggerServices* debuggerServices = GetDebuggerServices();
+    if (debuggerServices == nullptr)
+    {
+        // No debugger services to output to (e.g. the dotnet-dump host). Avoid dereferencing a
+        // null pointer; callers like the CLRMA logging helpers can run in this configuration.
+        return;
+    }
+
     char str[1024];
     va_list argsCopy;
     va_copy(argsCopy, args);
@@ -279,7 +287,7 @@ void InternalOutputVaList(
     size_t length = vsnprintf(str, sizeof(str), format, args);
     if (length < sizeof(str))
     {
-        GetDebuggerServices()->OutputString(mask, str);
+        debuggerServices->OutputString(mask, str);
     }
     else
     {
@@ -288,7 +296,7 @@ void InternalOutputVaList(
         if (str_ptr != nullptr)
         {
             vsnprintf(str_ptr, length + 1, format, argsCopy);
-            GetDebuggerServices()->OutputString(mask, str_ptr);
+            debuggerServices->OutputString(mask, str_ptr);
             ::free(str_ptr);
         }
     }
@@ -299,9 +307,14 @@ void InternalOutputVaList(
 /// </summary>
 void TraceHostingError(PCSTR format, ...)
 {
+    IDebuggerServices* debuggerServices = GetDebuggerServices();
+    if (debuggerServices == nullptr)
+    {
+        return;
+    }
     va_list args;
     va_start(args, format);
-    GetDebuggerServices()->OutputString(DEBUG_OUTPUT_ERROR, "SOS_HOSTING: ");
+    debuggerServices->OutputString(DEBUG_OUTPUT_ERROR, "SOS_HOSTING: ");
     InternalOutputVaList(DEBUG_OUTPUT_ERROR, format, args);
     va_end(args);
 }

--- a/src/SOS/extensions/extensions.cpp
+++ b/src/SOS/extensions/extensions.cpp
@@ -284,8 +284,14 @@ void InternalOutputVaList(
     va_copy(argsCopy, args);
 
     // Try and format our string into a fixed buffer first and see if it fits
-    size_t length = vsnprintf(str, sizeof(str), format, args);
-    if (length < sizeof(str))
+    int length = vsnprintf(str, sizeof(str), format, args);
+    if (length < 0)
+    {
+        // Encoding error; nothing we can safely output.
+        va_end(argsCopy);
+        return;
+    }
+    if ((size_t)length < sizeof(str))
     {
         debuggerServices->OutputString(mask, str);
     }
@@ -300,6 +306,7 @@ void InternalOutputVaList(
             ::free(str_ptr);
         }
     }
+    va_end(argsCopy);
 }
 
 /// <summary>

--- a/src/tests/SOS.UnitTests/Scripts/NestedExceptionTest.script
+++ b/src/tests/SOS.UnitTests/Scripts/NestedExceptionTest.script
@@ -125,3 +125,20 @@ ENDIF:DESKTOP
 !IFDEF:DESKTOP
 VERIFY:\[.*[\\|/]Debuggees[\\|/].*[Nn]ested[Ee]xception[Tt]est[\\|/][Nn]ested[Ee]xception[Tt]est\.cs @ 20\s*\]\s*
 ENDIF:DESKTOP
+
+# Verify the SOS clrma command (CLRMA managed analysis) under dotnet-dump. This exercises the
+# CLRMACreateInstance/ICLRManagedAnalysis path used by Watson/!analyze, but in the dotnet-dump
+# host so it can be validated locally without windbg/lldb. We only check the structural fields
+# (provider, current exception type/HResult and the inner exception type/HResult) that !pe above
+# already proved are available on these dumps.
+IFDEF:DOTNETDUMP
+SOSCOMMAND:clrma
+VERIFY:Managed analysis provider:\s+SOSCLRMA\s+
+VERIFY:OSThreadId:\s+<HEXVAL>\s+
+VERIFY:Current exception:\s+
+VERIFY:\s+Exception type:\s+System\.InvalidOperationException\s+
+VERIFY:\s+HResult:\s+80131509\s+
+VERIFY:\s+InnerException:\s+
+VERIFY:\s+Exception type:\s+System\.FormatException\s+
+VERIFY:\s+HResult:\s+80131537\s+
+ENDIF:DOTNETDUMP


### PR DESCRIPTION
Adds a native SOS 'clrma' command that drives the CLRMA contract (CLRMACreateInstance -> ICLRManagedAnalysis: AssociateClient/GetThread/GetException) and prints the managed thread stack and current/nested exceptions. This lets the Watson/!analyze code path be exercised locally in any SOS host (notably dotnet-dump) without windbg/lldb, as a proxy for Watson bucketing. Registered as a top-level command for DbgEng !clrma parity and framed as a CLRMA-provider diagnostic.

Fixes two latent blockers that only surface in the dotnet-dump host (where Extensions debugger services are null):

- AssociateClient gated the whole CLRMA path on GetDebuggerServices() != null; now uses the target obtained from the host.

- InternalOutputVaList/TraceHostingError dereferenced a null GetDebuggerServices() when CLRMA logging was enabled; now null-guarded.

Adds a dotnet-dump-scoped clrma verification to NestedExceptionTest.script and documents the local workflow in documentation/clrma.md.