### PR TITLE
Support Windows PDB format in dotnet-symbol for ngen and ReadyToRun binaries

### DIFF
--- a/src/Microsoft.SymbolStore/ChecksumValidator.cs
+++ b/src/Microsoft.SymbolStore/ChecksumValidator.cs
@@ -7,6 +7,8 @@ using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
+using Microsoft.FileFormats;
+using Microsoft.FileFormats.PDB;
 using Microsoft.FileFormats.PE;
 
 namespace Microsoft.SymbolStore
@@ -18,8 +20,66 @@ namespace Microsoft.SymbolStore
 
         internal static void Validate(ITracer tracer, Stream pdbStream, IEnumerable<PdbChecksum> pdbChecksums)
         {
+            // A portable PDB checksum is computed over the metadata image with the embedded
+            // PDB id zeroed out, so it can be fully recomputed and validated here.
+            //
+            // Windows PDBs (MSF container) and PDZ files (MSFZ container) use a completely
+            // different on-disk format that this code cannot recompute. The symbol server has
+            // already matched the returned content against the SymbolChecksum request header,
+            // so for those we only confirm the download is a structurally valid PDB and accept it.
+            //
+            // This happens for ngen or ReadyToRun images.
+            if (IsPortablePdb(pdbStream))
+            {
+                ValidatePortablePdb(tracer, pdbStream, pdbChecksums);
+            }
+            else
+            {
+                ValidateWindowsPdb(tracer, pdbStream);
+            }
+        }
+
+        /// <summary>
+        /// Returns true if the stream is a portable PDB (an ECMA-335 metadata image, which
+        /// starts with the "BSJB" signature).
+        /// </summary>
+        private static bool IsPortablePdb(Stream pdbStream)
+        {
+            pdbStream.Position = 0;
+            byte[] signature = new byte[4];
+            int read = pdbStream.Read(signature, 0, signature.Length);
+            pdbStream.Position = 0;
+            return read == signature.Length &&
+                   signature[0] == 0x42 && // 'B'
+                   signature[1] == 0x53 && // 'S'
+                   signature[2] == 0x4A && // 'J'
+                   signature[3] == 0x42;   // 'B'
+        }
+
+        /// <summary>
+        /// Structurally validates a Windows PDB (MSF) or PDZ (MSFZ) download and accepts it.
+        /// The cryptographic content match was already enforced by the symbol server through
+        /// the SymbolChecksum request header, so a byte-level re-validation is not performed.
+        /// </summary>
+        private static void ValidateWindowsPdb(ITracer tracer, Stream pdbStream)
+        {
+            pdbStream.Position = 0;
+            using (PDBFile pdbFile = new(new StreamAddressSpace(pdbStream)))
+            {
+                if (!pdbFile.IsValid())
+                {
+                    throw new InvalidChecksumException("The downloaded file is neither a portable PDB nor a valid Windows PDB (MSF/MSFZ) container");
+                }
+                tracer.Information($"Accepting Windows PDB ({pdbFile.ContainerKind}); content was validated by the symbol server via the SymbolChecksum header");
+            }
+            pdbStream.Position = 0;
+        }
+
+        private static void ValidatePortablePdb(ITracer tracer, Stream pdbStream, IEnumerable<PdbChecksum> pdbChecksums)
+        {
             uint offset = 0;
 
+            pdbStream.Position = 0;
             byte[] bytes = new byte[pdbStream.Length];
             byte[] pdbId = new byte[pdbIdSize];
             if (pdbStream.Read(bytes, offset: 0, count: bytes.Length) != bytes.Length)

--- a/src/Microsoft.SymbolStore/ChecksumValidator.cs
+++ b/src/Microsoft.SymbolStore/ChecksumValidator.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
+using System.Web;
 using Microsoft.FileFormats;
 using Microsoft.FileFormats.PDB;
 using Microsoft.FileFormats.PE;
@@ -24,9 +25,8 @@ namespace Microsoft.SymbolStore
             // PDB id zeroed out, so it can be fully recomputed and validated here.
             //
             // Windows PDBs (MSF container) and PDZ files (MSFZ container) use a completely
-            // different on-disk format that this code cannot recompute. The symbol server has
-            // already matched the returned content against the SymbolChecksum request header,
-            // so for those we only confirm the download is a structurally valid PDB and accept it.
+            // different on-disk format that this code cannot recompute. So for those, we
+            // check with PDBFile class and accept it.
             //
             // This happens for ngen or ReadyToRun images.
             if (IsPortablePdb(pdbStream))
@@ -58,19 +58,27 @@ namespace Microsoft.SymbolStore
 
         /// <summary>
         /// Structurally validates a Windows PDB (MSF) or PDZ (MSFZ) download and accepts it.
-        /// The cryptographic content match was already enforced by the symbol server through
-        /// the SymbolChecksum request header, so a byte-level re-validation is not performed.
+        /// A byte-level re-validation is not performed.
         /// </summary>
         private static void ValidateWindowsPdb(ITracer tracer, Stream pdbStream)
         {
+            const string checksumExceptionMessage = "The downloaded file is neither a portable PDB nor a valid Windows PDB (MSF/MSFZ) container";
             pdbStream.Position = 0;
-            using (PDBFile pdbFile = new(new StreamAddressSpace(pdbStream)))
+            try
             {
-                if (!pdbFile.IsValid())
+                using (PDBFile pdbFile = new(new StreamAddressSpace(pdbStream)))
                 {
-                    throw new InvalidChecksumException("The downloaded file is neither a portable PDB nor a valid Windows PDB (MSF/MSFZ) container");
+                    if (!pdbFile.IsValid())
+                    {
+                        throw new InvalidChecksumException(checksumExceptionMessage);
+                    }
+                    tracer.Information($"Accepting Windows PDB ({pdbFile.ContainerKind}); No checksum validation is available for this file format");
                 }
-                tracer.Information($"Accepting Windows PDB ({pdbFile.ContainerKind}); content was validated by the symbol server via the SymbolChecksum header");
+            }
+            catch (Exception)  // The PDBFile constructor or IsValid method can throw an Exception exception
+            {
+                // Note: the InvalidChecksumException constructor does not accept an inner exception
+                throw new InvalidChecksumException(checksumExceptionMessage);
             }
             pdbStream.Position = 0;
         }

--- a/src/Microsoft.SymbolStore/SymbolStores/HttpSymbolStore.cs
+++ b/src/Microsoft.SymbolStore/SymbolStores/HttpSymbolStore.cs
@@ -141,7 +141,21 @@ namespace Microsoft.SymbolStore.SymbolStores
             {
                 if (needsChecksumMatch)
                 {
-                    ChecksumValidator.Validate(Tracer, stream, key.PdbChecksums);
+                    // Portable PDBs are validated against their checksum here. Windows PDBs (MSF)
+                    // and PDZ (MSFZ) are structurally validated and accepted (the server already
+                    // matched them via the SymbolChecksum header). A truncated/corrupt portable
+                    // PDB can still throw an EndOfStreamException while parsing its metadata; in
+                    // that case skip this candidate so any other bound PDB can be tried (e.g. ngen
+                    // or ReadyToRun images can have multiple bound PDBs).
+                    try
+                    {
+                        ChecksumValidator.Validate(Tracer, stream, key.PdbChecksums);
+                    }
+                    catch (EndOfStreamException)
+                    {
+                        Tracer.Verbose($"       {key.FullPathName} is not a valid PDB file.");
+                        return null;
+                    }
                 }
                 return new SymbolStoreFile(stream, uri.ToString());
             }

--- a/src/Microsoft.SymbolStore/SymbolStores/HttpSymbolStore.cs
+++ b/src/Microsoft.SymbolStore/SymbolStores/HttpSymbolStore.cs
@@ -142,11 +142,10 @@ namespace Microsoft.SymbolStore.SymbolStores
                 if (needsChecksumMatch)
                 {
                     // Portable PDBs are validated against their checksum here. Windows PDBs (MSF)
-                    // and PDZ (MSFZ) are structurally validated and accepted (the server already
-                    // matched them via the SymbolChecksum header). A truncated/corrupt portable
-                    // PDB can still throw an EndOfStreamException while parsing its metadata; in
-                    // that case skip this candidate so any other bound PDB can be tried (e.g. ngen
-                    // or ReadyToRun images can have multiple bound PDBs).
+                    // and PDZ (MSFZ) are structurally validated and accepted. A truncated/corrupt
+                    // portable PDB can still throw an EndOfStreamException while parsing its
+                    // metadata; in that case skip this candidate so any other bound PDB can be
+                    // tried (e.g. ngen or ReadyToRun images can have multiple bound PDBs).
                     try
                     {
                         ChecksumValidator.Validate(Tracer, stream, key.PdbChecksums);

--- a/src/Tools/dotnet-symbol/Program.cs
+++ b/src/Tools/dotnet-symbol/Program.cs
@@ -243,17 +243,24 @@ namespace Microsoft.Diagnostics.Tools.Symbol
         {
             using (Microsoft.SymbolStore.SymbolStores.SymbolStore symbolStore = BuildSymbolStore())
             {
-                foreach (SymbolStoreKeyWrapper wrapper in GetKeys().Distinct())
+                if (symbolStore != null)
                 {
-                    SymbolStoreKey key = wrapper.Key;
-                    if (symbolStore != null)
+                    foreach (SymbolStoreKeyWrapper wrapper in GetKeys().Distinct())
                     {
-                        using (SymbolStoreFile symbolFile = await symbolStore.GetFile(key, CancellationToken.None).ConfigureAwait(false))
+                        SymbolStoreKey key = wrapper.Key;
+                        try
                         {
-                            if (symbolFile != null)
+                            using (SymbolStoreFile symbolFile = await symbolStore.GetFile(key, CancellationToken.None).ConfigureAwait(false))
                             {
-                                await WriteFile(symbolFile, wrapper).ConfigureAwait(false);
+                                if (symbolFile != null)
+                                {
+                                    await WriteFile(symbolFile, wrapper).ConfigureAwait(false);
+                                }
                             }
+                        }
+                        catch (InvalidChecksumException)
+                        {
+                            Tracer.Verbose($"   Skipped invalid {key.FullPathName} file");
                         }
                     }
                 }


### PR DESCRIPTION
Fix https://github.com/dotnet/diagnostics/issues/5111.

Some ngen and ReadyToRun assemblies contain debugging information for both Core PDB and Windows PDB files.
This pull request implements the missing Windows PDB format support.

For example, ASP.NET Core Microsoft.AspNetCore.Antiforgery.dll is bound to Microsoft.AspNetCore.Antiforgery.pdb (Core) and Microsoft.AspNetCore.Antiforgery.ni.pdb (Windows). With the current version, an exception happens when trying to validate the format of the Windows PDB file:
```
C:\dev> dotnet symbol --symbols -d --recurse-subdirectories "C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App\10.0.8\Microsoft.AspNetCore.Antiforgery.dll"
Downloading from https://msdl.microsoft.com/download/symbols/
Generating SymbolStore lookup keys for `C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App\10.0.8\Microsoft.AspNetCore.Antiforgery.dll`...
SymbolChecksum: SHA256:412863983d88d4471e2394ff97b295152d9e7b475dc2458d7ef772688ec0d7e0
ERROR: Unable to read beyond the end of the stream.
ERROR: Unable to read beyond the end of the stream.
```
Note that the existing Core PDB file is not even fetched due to the exception (displayed twice due to cascading catch blocks)


With the fix, both versions are downloaded, validated and copied:

```
Downloading from https://msdl.microsoft.com/download/symbols/
Generating SymbolStore lookup keys for `C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App\10.0.8\Microsoft.AspNetCore.Antiforgery.dll`...
SymbolChecksum: SHA256:412863983d88d4471e2394ff97b295152d9e7b475dc2458d7ef772688ec0d7e0
Accepting Windows PDB (MSF); content was validated by the symbol server via the SymbolChecksum header
Cached: C:\Users\Christophe Nasarre\AppData\Local\Temp\SymbolCache\microsoft.aspnetcore.antiforgery.ni.pdb/2530d9bd64692552018c512f8a5ada981/microsoft.aspnetcore.antiforgery.ni.pdb
Writing: C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App\10.0.8\Microsoft.AspNetCore.Antiforgery.ni.pdb
SymbolChecksum: SHA256:412863983d88d4471e2394ff97b295152d9e7b475dc2458d7ef772688ec0d7e0
Testing checksum: SHA256:412863983d88d4471e2394ff97b295152d9e7b475dc2458d7ef772688ec0d7e0
Found checksum match SHA256:412863983d88d4471e2394ff97b295152d9e7b475dc2458d7ef772688ec0d7e0
Cached: C:\Users\Christophe Nasarre\AppData\Local\Temp\SymbolCache\microsoft.aspnetcore.antiforgery.pdb/98632841883d47d49e2394ff97b29515FFFFFFFF/microsoft.aspnetcore.antiforgery.pdb
Writing: C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App\10.0.8\Microsoft.AspNetCore.Antiforgery.pdb
PEFile `C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App\10.0.8\Microsoft.AspNetCore.Antiforgery.dll`: no perfmap records found. No perfmap keys will be produced.
Generated 2 SymbolStoreKeys for `C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App\10.0.8\Microsoft.AspNetCore.Antiforgery.dll`.
```