### PR TITLE
Refactor build pipeline to separate test jobs

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,6 +22,12 @@
     <RepositoryName>diagnostics</RepositoryName>
   </PropertyGroup>
 
+  <!-- Inject overrides that must run after the Microsoft.Build.Traversal SDK targets
+       (e.g. dropping the Test->Build dependency on prebuilt test-only legs). -->
+  <PropertyGroup>
+    <CustomAfterTraversalTargets>$(MSBuildThisFileDirectory)eng/TraversalOverrides.targets</CustomAfterTraversalTargets>
+  </PropertyGroup>
+
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 
   <!--

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -69,18 +69,10 @@
      -->
     <NetCoreAppMinVersion>8.0</NetCoreAppMinVersion>
     <NetCoreAppMinTargetFramework>net$(NetCoreAppMinVersion)</NetCoreAppMinTargetFramework>
-    <!--
-        The TFM our unit tests run as. The tools must remain on $(NetCoreAppMinTargetFramework),
-        but the tests run on the SDK version from global.json, so they can target a newer TFM.
-        Keeping the tests on the live SDK's TFM means the SDK already ships the matching runtime,
-        so no extra shared runtime needs to be installed via global.json's tools.runtimes node.
-     -->
-    <NetCoreAppTestVersion>10.0</NetCoreAppTestVersion>
-    <NetCoreAppTestTargetFramework>net$(NetCoreAppTestVersion)</NetCoreAppTestTargetFramework>
     <!-- This is the list of TFMs we build our debuggees and tracees as. -->
     <SupportedSubProcessTargetFrameworks>net8.0;net9.0;net10.0;net11.0</SupportedSubProcessTargetFrameworks>
     <!-- This is the list of TFMs we build our unit tests as. -->
-    <SupportedXUnitTestTargetFrameworks>$(NetCoreAppTestTargetFramework)</SupportedXUnitTestTargetFrameworks>
+    <SupportedXUnitTestTargetFrameworks>net8.0</SupportedXUnitTestTargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -69,10 +69,18 @@
      -->
     <NetCoreAppMinVersion>8.0</NetCoreAppMinVersion>
     <NetCoreAppMinTargetFramework>net$(NetCoreAppMinVersion)</NetCoreAppMinTargetFramework>
+    <!--
+        The TFM our unit tests run as. The tools must remain on $(NetCoreAppMinTargetFramework),
+        but the tests run on the SDK version from global.json, so they can target a newer TFM.
+        Keeping the tests on the live SDK's TFM means the SDK already ships the matching runtime,
+        so no extra shared runtime needs to be installed via global.json's tools.runtimes node.
+     -->
+    <NetCoreAppTestVersion>10.0</NetCoreAppTestVersion>
+    <NetCoreAppTestTargetFramework>net$(NetCoreAppTestVersion)</NetCoreAppTestTargetFramework>
     <!-- This is the list of TFMs we build our debuggees and tracees as. -->
     <SupportedSubProcessTargetFrameworks>net8.0;net9.0;net10.0;net11.0</SupportedSubProcessTargetFrameworks>
     <!-- This is the list of TFMs we build our unit tests as. -->
-    <SupportedXUnitTestTargetFrameworks>net8.0</SupportedXUnitTestTargetFrameworks>
+    <SupportedXUnitTestTargetFrameworks>$(NetCoreAppTestTargetFramework)</SupportedXUnitTestTargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/diagnostics.yml
+++ b/diagnostics.yml
@@ -52,7 +52,7 @@ extends:
   parameters:
     stages:
     - stage: build
-      displayName: Build and Test Diagnostics
+      displayName: Build Diagnostics
       jobs:
 
         ############################
@@ -79,10 +79,11 @@ extends:
           jobTemplate: ${{ variables.jobTemplate }}
           name: Windows
           osGroup: Windows_NT
-          buildOnly: ${{ parameters.buildOnly }}
+          buildOnly: true
           buildConfigs:
           - configuration: Debug
             architecture: x64
+            artifactUploadPath: bin/Windows_NT.x64.Debug
           - configuration: Release
             architecture: x64
             artifactUploadPath: bin
@@ -134,7 +135,7 @@ extends:
         parameters:
           jobTemplate: ${{ variables.jobTemplate }}
           osGroup: MacOS
-          buildOnly: ${{ parameters.buildOnly }}
+          buildOnly: true
           buildConfigs:
           - configuration: Release
             architecture: x64
@@ -142,6 +143,7 @@ extends:
           - ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
             - configuration: Debug
               architecture: x64
+              artifactUploadPath: bin/osx.x64.Debug
 
       - template: /eng/pipelines/build.yml
         parameters:
@@ -212,13 +214,47 @@ extends:
               artifactUploadPath: bin/linux.arm64.Release
               artifactTargetPath: bin/linux-musl.arm64.Release
 
-      ############################
-      #                          #
-      #      Test only legs      #
-      #                          #
-      ############################
+    ############################
+    #                          #
+    #        Test stage        #
+    #                          #
+    ############################
 
-      - ${{ if ne(parameters.buildOnly, true) }}:
+    - ${{ if ne(parameters.buildOnly, true) }}:
+      - stage: test
+        displayName: Test Diagnostics
+        dependsOn: build
+        jobs:
+
+        - template: /eng/pipelines/build.yml
+          parameters:
+            jobTemplate: ${{ variables.jobTemplate }}
+            name: Windows_Test
+            osGroup: Windows_NT
+            dependsOn: Windows
+            testOnly: true
+            buildConfigs:
+            - configuration: Debug
+              architecture: x64
+            - configuration: Release
+              architecture: x64
+            - configuration: Release
+              architecture: x86
+
+        - template: /eng/pipelines/build.yml
+          parameters:
+            jobTemplate: ${{ variables.jobTemplate }}
+            name: MacOS_Test
+            osGroup: MacOS
+            dependsOn: MacOS
+            testOnly: true
+            buildConfigs:
+            - configuration: Release
+              architecture: x64
+            - ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
+              - configuration: Debug
+                architecture: x64
+
         - template: /eng/pipelines/build.yml
           parameters:
             jobTemplate: ${{ variables.jobTemplate }}
@@ -267,9 +303,16 @@ extends:
         #         - configuration: Debug
         #           architecture: x64
 
+    ############################
+    #                          #
+    #      Package stage       #
+    #                          #
+    ############################
+
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       - stage: package
         displayName: Package, Sign, and Generate BAR Manifests
+        dependsOn: build
         jobs:
         - template: /eng/common/templates-official/job/job.yml
           parameters:

--- a/diagnostics.yml
+++ b/diagnostics.yml
@@ -80,6 +80,7 @@ extends:
           name: Windows
           osGroup: Windows_NT
           buildOnly: true
+          publishTestArtifacts: true
           buildConfigs:
           - configuration: Debug
             architecture: x64
@@ -102,6 +103,7 @@ extends:
           container: linux_x64
           crossBuild: true
           buildOnly: true
+          publishTestArtifacts: true
           buildConfigs:
           - configuration: Release
             architecture: x64
@@ -120,6 +122,7 @@ extends:
           container: linux_musl_x64
           crossBuild: true
           buildOnly: true
+          publishTestArtifacts: true
           buildConfigs:
           - configuration: Release
             architecture: x64
@@ -136,6 +139,7 @@ extends:
           jobTemplate: ${{ variables.jobTemplate }}
           osGroup: MacOS
           buildOnly: true
+          publishTestArtifacts: true
           buildConfigs:
           - configuration: Release
             architecture: x64

--- a/eng/AuxMsbuildFiles/SdkPackOverrides.targets
+++ b/eng/AuxMsbuildFiles/SdkPackOverrides.targets
@@ -13,7 +13,7 @@
        <AspNetVersion11>@(RuntimeTestVersions->WithMetadataValue('TargetFramework', 'net11.0')->Metadata('AspNet'))</AspNetVersion11>
     </PropertyGroup>
 
-    <Message Importance="High" Text="OverrideTestingVersions: RuntimeTestVersions='@(RuntimeTestVersions)'" />
+    <Message Importance="Low" Text="OverrideTestingVersions: RuntimeTestVersions=@(RuntimeTestVersions -> '%(Runtime)')" />
 
     <!-- Skip overrides when RuntimeTestVersions is not populated (e.g. test-time CLI builds
          where eng/Versions.props is not imported). The SDK's built-in versions are used instead. -->

--- a/eng/TraversalOverrides.targets
+++ b/eng/TraversalOverrides.targets
@@ -1,0 +1,22 @@
+<Project>
+
+  <!--
+    Imported via $(CustomAfterTraversalTargets) after the Microsoft.Build.Traversal SDK targets,
+    so it can override properties the SDK sets unconditionally.
+
+    The Traversal SDK hardcodes <TestDependsOn>Build</TestDependsOn>, which makes every traversal's
+    "Test" target build its entire subgraph (product + tests + their project references) before
+    running tests, regardless of whether -build was passed. On the test-only CI legs the product and
+    test binaries are downloaded as prebuilt TestArtifacts, so rebuilding them is pure waste - and
+    because pipeline artifact downloads do not preserve file timestamps, the up-to-date check fails
+    and it becomes a full recompile.
+
+    Drop the Build dependency when the managed build was skipped ($(SkipTestArtifactsBuild) is set by
+    build.ps1 / build.sh for -skipmanaged). The traversal "Test" target still invokes "Test" on each
+    referenced project, so tests run directly against the downloaded binaries with no build.
+  -->
+  <PropertyGroup Condition="'$(SkipTestArtifactsBuild)' == 'true'">
+    <TestDependsOn></TestDependsOn>
+  </PropertyGroup>
+
+</Project>

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -125,28 +125,10 @@ if ($test) {
         }
 
         # When the managed build was skipped (e.g. the test-only CI legs that download prebuilt
-        # product binaries), the test SDK and runtimes that are normally installed during the
-        # managed build (InstallRuntimes.proj, InstallTestRuntimes AfterTargets=Build) were never
-        # installed on this machine. Build just that project here so the runtimes are present
-        # before the tests run. This is ordered ahead of -test, unlike relying on the parallel
-        # test traversal, and avoids rebuilding the downloaded product.
-        if ($skipmanaged) {
-            & "$engroot\common\build.ps1" `
-              -restore `
-              -build `
-              -projects "$engroot\InstallRuntimes.proj" `
-              -configuration $configuration `
-              -verbosity $verbosity `
-              -ci:$ci `
-              /bl:$logdir\InstallTestRuntimes.binlog `
-              /p:TargetOS=$os `
-              /p:TargetArch=$architecture `
-              /p:LiveRuntimeDir="$liveRuntimeDir"
-
-            if ($lastExitCode -ne 0) {
-                exit $lastExitCode
-            }
-        }
+        # product binaries), the test SDK, runtimes, and debuggees that are normally produced by
+        # the managed build (InstallRuntimes.proj + BuildDebuggees in src/tests/dirs.proj) were
+        # downloaded as part of TestArtifacts. Skip rebuilding them so this leg only runs tests.
+        $skipTestArtifactsBuild = if ($skipmanaged) { 'true' } else { 'false' }
 
         & "$engroot\common\build.ps1" `
           -test `
@@ -158,6 +140,7 @@ if ($test) {
           /p:TargetOS=$os `
           /p:TargetArch=$architecture `
           /p:TestArchitectures=$architecture `
+          /p:SkipTestArtifactsBuild=$skipTestArtifactsBuild `
           /p:DotnetRuntimeVersion="$dotnetruntimeversion" `
           /p:DotnetRuntimeDownloadVersion="$dotnetruntimedownloadversion" `
           /p:RuntimeSourceFeed="$runtimesourcefeed" `

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -125,10 +125,26 @@ if ($test) {
         }
 
         # When the managed build was skipped (e.g. the test-only CI legs that download prebuilt
-        # product binaries), the test SDK, runtimes, and debuggees that are normally produced by
-        # the managed build (InstallRuntimes.proj + BuildDebuggees in src/tests/dirs.proj) were
+        # product binaries), the debuggees built by BuildDebuggees in src/tests/dirs.proj were
         # downloaded as part of TestArtifacts. Skip rebuilding them so this leg only runs tests.
+        # Test runtimes are still installed locally below (cheap, ensures correct file permissions).
         $skipTestArtifactsBuild = if ($skipmanaged) { 'true' } else { 'false' }
+
+        # The managed build normally installs the test SDK/runtimes via an InstallRuntimes.proj
+        # ProjectReference. The -test step runs with Build=false, so install them explicitly here.
+        if ($skipmanaged) {
+            & "$engroot\common\build.ps1" `
+              -restore -build `
+              -projects "$engroot\InstallRuntimes.proj" `
+              -configuration $configuration `
+              -verbosity $verbosity `
+              -ci:$ci `
+              /p:TargetOS=$os `
+              /p:TargetArch=$architecture
+            if ($lastExitCode -ne 0) {
+                exit $lastExitCode
+            }
+        }
 
         & "$engroot\common\build.ps1" `
           -test `

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -124,8 +124,33 @@ if ($test) {
             $testFilterArg = "/p:TestRunnerAdditionalArguments=\`"-class $classfilter\`""
         }
 
+        # When the managed build was skipped (e.g. the test-only CI legs that download prebuilt
+        # product binaries), the test SDK and runtimes that are normally installed during the
+        # managed build (InstallRuntimes.proj, InstallTestRuntimes AfterTargets=Build) were never
+        # installed on this machine. Build just that project here so the runtimes are present
+        # before the tests run. This is ordered ahead of -test, unlike relying on the parallel
+        # test traversal, and avoids rebuilding the downloaded product.
+        if ($skipmanaged) {
+            & "$engroot\common\build.ps1" `
+              -restore `
+              -build `
+              -projects "$engroot\InstallRuntimes.proj" `
+              -configuration $configuration `
+              -verbosity $verbosity `
+              -ci:$ci `
+              /bl:$logdir\InstallTestRuntimes.binlog `
+              /p:TargetOS=$os `
+              /p:TargetArch=$architecture `
+              /p:LiveRuntimeDir="$liveRuntimeDir"
+
+            if ($lastExitCode -ne 0) {
+                exit $lastExitCode
+            }
+        }
+
         & "$engroot\common\build.ps1" `
           -test `
+          -restore:$skipmanaged `
           -configuration $configuration `
           -verbosity $verbosity `
           -ci:$ci `

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -353,9 +353,36 @@ if [[ "$__Test" == 1 ]]; then
           __TestFilterArg="/p:TestRunnerAdditionalArguments=\"$__TestFilter\""
       fi
 
+      # When the managed build was skipped (e.g. the test-only CI legs that download prebuilt
+      # product binaries), the test SDK and runtimes that are normally installed during the
+      # managed build (InstallRuntimes.proj, InstallTestRuntimes AfterTargets=Build) were never
+      # installed on this machine. Build just that project here so the runtimes are present
+      # before the tests run. This is ordered ahead of --test, unlike relying on the parallel
+      # test traversal, and avoids rebuilding the downloaded product.
+      __TestRestoreArg=
+      if [[ "$__ManagedBuild" == 0 ]]; then
+          __TestRestoreArg=--restore
+
+          "$__RepoRootDir/eng/common/build.sh" \
+            --restore \
+            --build \
+            --projects "$__RepoRootDir/eng/InstallRuntimes.proj" \
+            --configuration "$__BuildType" \
+            /bl:"$__LogsDir"/InstallTestRuntimes.binlog \
+            /p:TargetArch="$__TargetArch" \
+            /p:TargetRid="$__TargetRid" \
+            /p:LiveRuntimeDir="$__LiveRuntimeDir" \
+            $__CommonMSBuildArgs
+
+          if [ "$?" != 0 ]; then
+              exit 1
+          fi
+      fi
+
       # __CommonMSBuildArgs contains TargetOS property
       "$__RepoRootDir/eng/common/build.sh" \
         --test \
+        $__TestRestoreArg \
         --configuration "$__BuildType" \
         /bl:"$__LogsDir"/Test.binlog \
         /p:TargetArch="$__TargetArch" \

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -354,29 +354,14 @@ if [[ "$__Test" == 1 ]]; then
       fi
 
       # When the managed build was skipped (e.g. the test-only CI legs that download prebuilt
-      # product binaries), the test SDK and runtimes that are normally installed during the
-      # managed build (InstallRuntimes.proj, InstallTestRuntimes AfterTargets=Build) were never
-      # installed on this machine. Build just that project here so the runtimes are present
-      # before the tests run. This is ordered ahead of --test, unlike relying on the parallel
-      # test traversal, and avoids rebuilding the downloaded product.
+      # product binaries), the test SDK, runtimes, and debuggees that are normally produced by
+      # the managed build (InstallRuntimes.proj + BuildDebuggees in src/tests/dirs.proj) were
+      # downloaded as part of TestArtifacts. Skip rebuilding them so this leg only runs tests.
       __TestRestoreArg=
+      __SkipTestArtifactsBuild=false
       if [[ "$__ManagedBuild" == 0 ]]; then
           __TestRestoreArg=--restore
-
-          "$__RepoRootDir/eng/common/build.sh" \
-            --restore \
-            --build \
-            --projects "$__RepoRootDir/eng/InstallRuntimes.proj" \
-            --configuration "$__BuildType" \
-            /bl:"$__LogsDir"/InstallTestRuntimes.binlog \
-            /p:TargetArch="$__TargetArch" \
-            /p:TargetRid="$__TargetRid" \
-            /p:LiveRuntimeDir="$__LiveRuntimeDir" \
-            $__CommonMSBuildArgs
-
-          if [ "$?" != 0 ]; then
-              exit 1
-          fi
+          __SkipTestArtifactsBuild=true
       fi
 
       # __CommonMSBuildArgs contains TargetOS property
@@ -387,6 +372,7 @@ if [[ "$__Test" == 1 ]]; then
         /bl:"$__LogsDir"/Test.binlog \
         /p:TargetArch="$__TargetArch" \
         /p:TargetRid="$__TargetRid" \
+        /p:SkipTestArtifactsBuild="$__SkipTestArtifactsBuild" \
         /p:DotnetRuntimeVersion="$__DotnetRuntimeVersion" \
         /p:DotnetRuntimeDownloadVersion="$__DotnetRuntimeDownloadVersion" \
         /p:RuntimeSourceFeed="$__RuntimeSourceFeed" \

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -354,14 +354,27 @@ if [[ "$__Test" == 1 ]]; then
       fi
 
       # When the managed build was skipped (e.g. the test-only CI legs that download prebuilt
-      # product binaries), the test SDK, runtimes, and debuggees that are normally produced by
-      # the managed build (InstallRuntimes.proj + BuildDebuggees in src/tests/dirs.proj) were
+      # product binaries), the debuggees built by BuildDebuggees in src/tests/dirs.proj were
       # downloaded as part of TestArtifacts. Skip rebuilding them so this leg only runs tests.
+      # Test runtimes are still installed locally below (cheap, ensures correct file permissions).
       __TestRestoreArg=
       __SkipTestArtifactsBuild=false
       if [[ "$__ManagedBuild" == 0 ]]; then
           __TestRestoreArg=--restore
           __SkipTestArtifactsBuild=true
+
+          # The managed build normally installs the test SDK/runtimes via an InstallRuntimes.proj
+          # ProjectReference. The --test step runs with Build=false, so install them explicitly here.
+          "$__RepoRootDir/eng/common/build.sh" \
+            --restore --build \
+            --projects "$__RepoRootDir/eng/InstallRuntimes.proj" \
+            --configuration "$__BuildType" \
+            /p:TargetArch="$__TargetArch" \
+            /p:TargetRid="$__TargetRid" \
+            $__CommonMSBuildArgs
+          if [ $? != 0 ]; then
+              exit 1
+          fi
       fi
 
       # __CommonMSBuildArgs contains TargetOS property

--- a/eng/pipelines/build.yml
+++ b/eng/pipelines/build.yml
@@ -113,7 +113,7 @@ jobs:
       ${{ if ne(parameters.strategy, '') }}:
         'error, we can no longer support the strategy feature in the new pipeline system. Please remove the strategy from the job template.': error
 
-      ${{ if ne(parameters.dependsOn, '') }}:
+      ${{ if and(ne(parameters.dependsOn, ''), ne(parameters.testOnly, true)) }}:
         dependsOn: ${{ parameters.dependsOn }}_${{ config.architecture }}_${{ config.configuration }}
 
       workspace:
@@ -132,6 +132,19 @@ jobs:
         - _buildScript: $(Build.SourcesDirectory)\build.cmd
       - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
         - _buildScript: $(Build.SourcesDirectory)/build.sh
+
+      # Native artifact folder names used by the test-only legs.
+      # _downloadOSFolder: the folder name as published by the build leg.
+      # _localOSFolder: the folder name expected by the build script on the test machine.
+      - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
+        - _downloadOSFolder: Windows_NT
+        - _localOSFolder: Windows_NT
+      - ${{ elseif eq(parameters.osGroup, 'MacOS') }}:
+        - _downloadOSFolder: osx
+        - _localOSFolder: osx
+      - ${{ else }}:
+        - _downloadOSFolder: linux${{ parameters.osSuffix }}
+        - _localOSFolder: linux
 
       - ${{ if and(eq(parameters.testOnly, 'true'), eq(parameters.buildOnly, 'true')) }}:
         'error, testOnly and buildOnly cannot be true at the same time': error
@@ -157,8 +170,8 @@ jobs:
 
       steps:
       - ${{ if eq(parameters.testOnly, true) }}:
-        - ${{ if ne(parameters.osGroup, 'Linux') }}:
-          - 'error, testOnly is only supported on Linux': error
+        - ${{ if notIn(parameters.osGroup, 'Windows_NT', 'MacOS', 'Linux') }}:
+          - 'error, testOnly is only supported on Windows_NT, MacOS, and Linux': error
         - task: DownloadPipelineArtifact@2
           displayName: 'Download Build Artifacts'
           inputs:
@@ -168,8 +181,8 @@ jobs:
         - task: CopyFiles@2
           displayName: 'Binplace Downloaded Product'
           inputs:
-            sourceFolder: $(Build.ArtifactStagingDirectory)/__download__/Build_${{ parameters.dependsOn }}_${{ config.architecture }}_${{ config.configuration }}/bin/linux${{ parameters.osSuffix }}.${{ config.architecture }}.${{ config.configuration }}
-            targetFolder: '$(Build.SourcesDirectory)/artifacts/bin/linux.${{ config.architecture }}.${{ config.configuration }}'
+            sourceFolder: $(Build.ArtifactStagingDirectory)/__download__/Build_${{ parameters.dependsOn }}_${{ config.architecture }}_${{ config.configuration }}/bin/$(_downloadOSFolder).${{ config.architecture }}.${{ config.configuration }}
+            targetFolder: '$(Build.SourcesDirectory)/artifacts/bin/$(_localOSFolder).${{ config.architecture }}.${{ config.configuration }}'
 
       - script: $(_buildScript)
           -ci

--- a/eng/pipelines/build.yml
+++ b/eng/pipelines/build.yml
@@ -134,16 +134,24 @@ jobs:
       - _TestArgs: '-test'
       - _Cross: ''
 
-      - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
-        - _buildScript: $(Build.SourcesDirectory)\build.cmd
-      - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
-        - _buildScript: $(Build.SourcesDirectory)/build.sh
-
       - ${{ if and(eq(parameters.testOnly, 'true'), eq(parameters.buildOnly, 'true')) }}:
         'error, testOnly and buildOnly cannot be true at the same time': error
 
+      # Test-only legs invoke test.cmd/test.sh, which already encode
+      # '-test -skipmanaged -skipnative' and do not prepend '-restore -build'. All other legs
+      # (build-only and build+test) use build.cmd/build.sh, which prepend '-restore -build'.
       - ${{ if eq(parameters.testOnly, 'true') }}:
-        - _TestArgs: '-test -skipnative -skipmanaged'
+        - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
+          - _buildScript: $(Build.SourcesDirectory)\test.cmd
+        - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
+          - _buildScript: $(Build.SourcesDirectory)/test.sh
+        - _TestArgs: ''
+
+      - ${{ if ne(parameters.testOnly, 'true') }}:
+        - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
+          - _buildScript: $(Build.SourcesDirectory)\build.cmd
+        - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
+          - _buildScript: $(Build.SourcesDirectory)/build.sh
 
       - ${{ if eq(parameters.buildOnly, 'true') }}:
         - _TestArgs: ''
@@ -217,6 +225,7 @@ jobs:
             SourceFolder: '$(Build.SourcesDirectory)/artifacts'
             Contents: |
               bin/**
+              obj/**
               test/**
             TargetFolder: $(Build.ArtifactStagingDirectory)/testartifacts
 

--- a/eng/pipelines/build.yml
+++ b/eng/pipelines/build.yml
@@ -218,6 +218,7 @@ jobs:
             Contents: |
               bin/**
               test/**
+              dotnet-test/**
             TargetFolder: $(Build.ArtifactStagingDirectory)/testartifacts
 
         - template: /eng/pipelines/publish-pipeline-artifact-shim.yml@self

--- a/eng/pipelines/build.yml
+++ b/eng/pipelines/build.yml
@@ -218,7 +218,6 @@ jobs:
             Contents: |
               bin/**
               test/**
-              dotnet-test/**
             TargetFolder: $(Build.ArtifactStagingDirectory)/testartifacts
 
         - template: /eng/pipelines/publish-pipeline-artifact-shim.yml@self

--- a/eng/pipelines/build.yml
+++ b/eng/pipelines/build.yml
@@ -60,6 +60,12 @@ parameters:
   type: boolean
   default: false
 
+  # Optional: publish the full build outputs (managed + native + debuggees) as a
+  # 'TestArtifacts_<phase>' artifact so the matching test-only legs can run without rebuilding.
+- name: publishTestArtifacts
+  type: boolean
+  default: false
+
 # Optional: architecture cross build if true
 - name: crossBuild
   type: boolean
@@ -133,24 +139,11 @@ jobs:
       - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
         - _buildScript: $(Build.SourcesDirectory)/build.sh
 
-      # Native artifact folder names used by the test-only legs.
-      # _downloadOSFolder: the folder name as published by the build leg.
-      # _localOSFolder: the folder name expected by the build script on the test machine.
-      - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
-        - _downloadOSFolder: Windows_NT
-        - _localOSFolder: Windows_NT
-      - ${{ elseif eq(parameters.osGroup, 'MacOS') }}:
-        - _downloadOSFolder: osx
-        - _localOSFolder: osx
-      - ${{ else }}:
-        - _downloadOSFolder: linux${{ parameters.osSuffix }}
-        - _localOSFolder: linux
-
       - ${{ if and(eq(parameters.testOnly, 'true'), eq(parameters.buildOnly, 'true')) }}:
         'error, testOnly and buildOnly cannot be true at the same time': error
 
       - ${{ if eq(parameters.testOnly, 'true') }}:
-        - _TestArgs: '-test -skipnative'
+        - _TestArgs: '-test -skipnative -skipmanaged'
 
       - ${{ if eq(parameters.buildOnly, 'true') }}:
         - _TestArgs: ''
@@ -172,17 +165,16 @@ jobs:
       - ${{ if eq(parameters.testOnly, true) }}:
         - ${{ if notIn(parameters.osGroup, 'Windows_NT', 'MacOS', 'Linux') }}:
           - 'error, testOnly is only supported on Windows_NT, MacOS, and Linux': error
+        # The matching build leg published its full outputs (managed assemblies, native
+        # binaries, and debuggees) as TestArtifacts_<phase>. Restore them into the repo
+        # artifacts directory so the test run can skip both the native and managed builds
+        # (-skipnative -skipmanaged) and only execute the tests.
         - task: DownloadPipelineArtifact@2
           displayName: 'Download Build Artifacts'
           inputs:
-            targetPath: '$(Build.ArtifactStagingDirectory)/__download__'
-            itemPattern: Build_${{ parameters.dependsOn }}_${{ config.architecture }}_${{ config.configuration }}/bin/**
+            artifact: TestArtifacts_${{ parameters.dependsOn }}_${{ config.architecture }}_${{ config.configuration }}
+            targetPath: '$(Build.SourcesDirectory)/artifacts'
             checkDownloadedFiles: true
-        - task: CopyFiles@2
-          displayName: 'Binplace Downloaded Product'
-          inputs:
-            sourceFolder: $(Build.ArtifactStagingDirectory)/__download__/Build_${{ parameters.dependsOn }}_${{ config.architecture }}_${{ config.configuration }}/bin/$(_downloadOSFolder).${{ config.architecture }}.${{ config.configuration }}
-            targetFolder: '$(Build.SourcesDirectory)/artifacts/bin/$(_localOSFolder).${{ config.architecture }}.${{ config.configuration }}'
 
       - script: $(_buildScript)
           -ci
@@ -214,6 +206,26 @@ jobs:
             inputs:
               targetPath: '$(Build.ArtifactStagingDirectory)/artifacts'
               artifactName: Build_$(_PhaseName)
+
+      # Publish the full build outputs for the matching test-only legs to consume. This lets the
+      # test legs run with -skipnative -skipmanaged instead of rebuilding the product themselves.
+      # Only valid on build-only legs (publishTestArtifacts without buildOnly is a configuration error).
+      - ${{ if and(eq(parameters.publishTestArtifacts, true), eq(parameters.buildOnly, true)) }}:
+        - task: CopyFiles@2
+          displayName: Gather test artifacts for publish
+          inputs:
+            SourceFolder: '$(Build.SourcesDirectory)/artifacts'
+            Contents: |
+              bin/**
+              test/**
+            TargetFolder: $(Build.ArtifactStagingDirectory)/testartifacts
+
+        - template: /eng/pipelines/publish-pipeline-artifact-shim.yml@self
+          parameters:
+            displayName: Publish Test Artifacts
+            inputs:
+              targetPath: '$(Build.ArtifactStagingDirectory)/testartifacts'
+              artifactName: TestArtifacts_$(_PhaseName)
 
       - ${{ if ne(parameters.buildOnly, 'true') }}:
         # Publish test results to Azure Pipelines

--- a/global.json
+++ b/global.json
@@ -5,7 +5,15 @@
     "rollForward": "major"
   },
   "tools": {
-    "dotnet": "10.0.108"
+    "dotnet": "10.0.108",
+    "runtimes": {
+      "dotnet": [
+        "$(MicrosoftNETCoreApp80Version)"
+      ],
+      "dotnet/x86": [
+        "$(MicrosoftNETCoreApp80Version)"
+      ]
+    }
   },
   "msbuild-sdks": {
     "Microsoft.Build.NoTargets": "3.7.0",

--- a/global.json
+++ b/global.json
@@ -5,7 +5,12 @@
     "rollForward": "major"
   },
   "tools": {
-    "dotnet": "10.0.108"
+    "dotnet": "10.0.108",
+    "runtimes": {
+      "dotnet/x86": [
+        "$(MicrosoftNETCoreApp100Version)"
+      ]
+    }
   },
   "msbuild-sdks": {
     "Microsoft.Build.NoTargets": "3.7.0",

--- a/global.json
+++ b/global.json
@@ -5,15 +5,7 @@
     "rollForward": "major"
   },
   "tools": {
-    "dotnet": "10.0.108",
-    "runtimes": {
-      "dotnet": [
-        "$(MicrosoftNETCoreApp80Version)"
-      ],
-      "dotnet/x86": [
-        "$(MicrosoftNETCoreApp80Version)"
-      ]
-    }
+    "dotnet": "10.0.108"
   },
   "msbuild-sdks": {
     "Microsoft.Build.NoTargets": "3.7.0",

--- a/src/tests/DbgShim.UnitTests/DbgShim.UnitTests.csproj
+++ b/src/tests/DbgShim.UnitTests/DbgShim.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(NetCoreAppMinTargetFramework)</TargetFramework>
+    <TargetFramework>$(NetCoreAppTestTargetFramework)</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DbgShimConfigFileName>$(OutputPath)$(TargetFramework)\Debugger.Tests.Common.txt</DbgShimConfigFileName>
     <TestAssetsVersion>1.0.351101</TestAssetsVersion>

--- a/src/tests/DbgShim.UnitTests/DbgShim.UnitTests.csproj
+++ b/src/tests/DbgShim.UnitTests/DbgShim.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(NetCoreAppTestTargetFramework)</TargetFramework>
+    <TargetFramework>$(NetCoreAppMinTargetFramework)</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DbgShimConfigFileName>$(OutputPath)$(TargetFramework)\Debugger.Tests.Common.txt</DbgShimConfigFileName>
     <TestAssetsVersion>1.0.351101</TestAssetsVersion>

--- a/src/tests/Microsoft.Diagnostics.DebugServices.UnitTests/Microsoft.Diagnostics.DebugServices.UnitTests.csproj
+++ b/src/tests/Microsoft.Diagnostics.DebugServices.UnitTests/Microsoft.Diagnostics.DebugServices.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(NetCoreAppMinTargetFramework)</TargetFramework>
+    <TargetFramework>$(NetCoreAppTestTargetFramework)</TargetFramework>
     <DebugServicesConfigFileName>$(OutputPath)$(TargetFramework)\Debugger.Tests.Common.txt</DebugServicesConfigFileName>
     <TestAssetsVersion>1.0.351101</TestAssetsVersion>
     <!-- Controls the test asset package restore and the tests that use them -->

--- a/src/tests/Microsoft.Diagnostics.DebugServices.UnitTests/Microsoft.Diagnostics.DebugServices.UnitTests.csproj
+++ b/src/tests/Microsoft.Diagnostics.DebugServices.UnitTests/Microsoft.Diagnostics.DebugServices.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(NetCoreAppTestTargetFramework)</TargetFramework>
+    <TargetFramework>$(NetCoreAppMinTargetFramework)</TargetFramework>
     <DebugServicesConfigFileName>$(OutputPath)$(TargetFramework)\Debugger.Tests.Common.txt</DebugServicesConfigFileName>
     <TestAssetsVersion>1.0.351101</TestAssetsVersion>
     <!-- Controls the test asset package restore and the tests that use them -->

--- a/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventLogsPipelineUnitTests.cs
+++ b/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventLogsPipelineUnitTests.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
             ValidateAppLoggerCategoryWarningMessage(reader);
             ValidateAppLoggerCategoryErrorMessage(reader);
 
-            Assert.True(reader.EndOfStream, "Expected to have read all entries from stream.");
+            Assert.True(string.IsNullOrEmpty(await reader.ReadToEndAsync()), "Expected to have read all entries from stream.");
         }
 
         /// <summary>
@@ -84,7 +84,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
             ValidateAppLoggerCategoryWarningMessage(reader);
             ValidateAppLoggerCategoryErrorMessage(reader);
 
-            Assert.True(reader.EndOfStream, "Expected to have read all entries from stream.");
+            Assert.True(string.IsNullOrEmpty(await reader.ReadToEndAsync()), "Expected to have read all entries from stream.");
         }
 
         /// <summary>
@@ -116,7 +116,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
             ValidateLoggerRemoteCategoryWarningMessage(reader);
             ValidateAppLoggerCategoryErrorMessage(reader);
 
-            Assert.True(reader.EndOfStream, "Expected to have read all entries from stream.");
+            Assert.True(string.IsNullOrEmpty(await reader.ReadToEndAsync()), "Expected to have read all entries from stream.");
         }
 
         /// <summary>
@@ -157,7 +157,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
             ValidateAppLoggerCategoryWarningMessage(reader);
             ValidateAppLoggerCategoryErrorMessage(reader);
 
-            Assert.True(reader.EndOfStream, "Expected to have read all entries from stream.");
+            Assert.True(string.IsNullOrEmpty(await reader.ReadToEndAsync()), "Expected to have read all entries from stream.");
         }
 
         /// <summary>
@@ -182,7 +182,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
             ValidateAppLoggerCategoryWarningMessage(reader);
             ValidateAppLoggerCategoryErrorMessage(reader);
 
-            Assert.True(reader.EndOfStream, "Expected to have read all entries from stream.");
+            Assert.True(string.IsNullOrEmpty(await reader.ReadToEndAsync()), "Expected to have read all entries from stream.");
         }
 
         /// <summary>
@@ -213,7 +213,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
             ValidateAppLoggerCategoryWarningMessage(reader);
             ValidateAppLoggerCategoryErrorMessage(reader);
 
-            Assert.True(reader.EndOfStream, "Expected to have read all entries from stream.");
+            Assert.True(string.IsNullOrEmpty(await reader.ReadToEndAsync()), "Expected to have read all entries from stream.");
         }
 
         private async Task<Stream> GetLogsAsync(TestConfiguration config, Action<EventLogsPipelineSettings> settingsCallback = null)

--- a/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventLogsPipelineUnitTests.cs
+++ b/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/EventLogsPipelineUnitTests.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
             ValidateAppLoggerCategoryWarningMessage(reader);
             ValidateAppLoggerCategoryErrorMessage(reader);
 
-            Assert.True(string.IsNullOrEmpty(await reader.ReadToEndAsync()), "Expected to have read all entries from stream.");
+            Assert.True(reader.EndOfStream, "Expected to have read all entries from stream.");
         }
 
         /// <summary>
@@ -84,7 +84,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
             ValidateAppLoggerCategoryWarningMessage(reader);
             ValidateAppLoggerCategoryErrorMessage(reader);
 
-            Assert.True(string.IsNullOrEmpty(await reader.ReadToEndAsync()), "Expected to have read all entries from stream.");
+            Assert.True(reader.EndOfStream, "Expected to have read all entries from stream.");
         }
 
         /// <summary>
@@ -116,7 +116,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
             ValidateLoggerRemoteCategoryWarningMessage(reader);
             ValidateAppLoggerCategoryErrorMessage(reader);
 
-            Assert.True(string.IsNullOrEmpty(await reader.ReadToEndAsync()), "Expected to have read all entries from stream.");
+            Assert.True(reader.EndOfStream, "Expected to have read all entries from stream.");
         }
 
         /// <summary>
@@ -157,7 +157,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
             ValidateAppLoggerCategoryWarningMessage(reader);
             ValidateAppLoggerCategoryErrorMessage(reader);
 
-            Assert.True(string.IsNullOrEmpty(await reader.ReadToEndAsync()), "Expected to have read all entries from stream.");
+            Assert.True(reader.EndOfStream, "Expected to have read all entries from stream.");
         }
 
         /// <summary>
@@ -182,7 +182,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
             ValidateAppLoggerCategoryWarningMessage(reader);
             ValidateAppLoggerCategoryErrorMessage(reader);
 
-            Assert.True(string.IsNullOrEmpty(await reader.ReadToEndAsync()), "Expected to have read all entries from stream.");
+            Assert.True(reader.EndOfStream, "Expected to have read all entries from stream.");
         }
 
         /// <summary>
@@ -213,7 +213,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
             ValidateAppLoggerCategoryWarningMessage(reader);
             ValidateAppLoggerCategoryErrorMessage(reader);
 
-            Assert.True(string.IsNullOrEmpty(await reader.ReadToEndAsync()), "Expected to have read all entries from stream.");
+            Assert.True(reader.EndOfStream, "Expected to have read all entries from stream.");
         }
 
         private async Task<Stream> GetLogsAsync(TestConfiguration config, Action<EventLogsPipelineSettings> settingsCallback = null)

--- a/src/tests/Microsoft.FileFormats.UnitTests/Microsoft.FileFormats.UnitTests.csproj
+++ b/src/tests/Microsoft.FileFormats.UnitTests/Microsoft.FileFormats.UnitTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>$(NetCoreAppMinTargetFramework)</TargetFramework>
+    <TargetFramework>$(NetCoreAppTestTargetFramework)</TargetFramework>
     <NoWarn>;1591;1701</NoWarn>
   </PropertyGroup>
 

--- a/src/tests/Microsoft.FileFormats.UnitTests/Microsoft.FileFormats.UnitTests.csproj
+++ b/src/tests/Microsoft.FileFormats.UnitTests/Microsoft.FileFormats.UnitTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>$(NetCoreAppTestTargetFramework)</TargetFramework>
+    <TargetFramework>$(NetCoreAppMinTargetFramework)</TargetFramework>
     <NoWarn>;1591;1701</NoWarn>
   </PropertyGroup>
 

--- a/src/tests/Microsoft.SymbolStore.UnitTests/Microsoft.SymbolStore.UnitTests.csproj
+++ b/src/tests/Microsoft.SymbolStore.UnitTests/Microsoft.SymbolStore.UnitTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>$(NetCoreAppMinTargetFramework)</TargetFramework>
+    <TargetFramework>$(NetCoreAppTestTargetFramework)</TargetFramework>
     <NoWarn>;1591;1701</NoWarn>
   </PropertyGroup>
 

--- a/src/tests/Microsoft.SymbolStore.UnitTests/Microsoft.SymbolStore.UnitTests.csproj
+++ b/src/tests/Microsoft.SymbolStore.UnitTests/Microsoft.SymbolStore.UnitTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>$(NetCoreAppTestTargetFramework)</TargetFramework>
+    <TargetFramework>$(NetCoreAppMinTargetFramework)</TargetFramework>
     <NoWarn>;1591;1701</NoWarn>
   </PropertyGroup>
 

--- a/src/tests/SOS.UnitTests/Debuggees/Directory.Build.targets
+++ b/src/tests/SOS.UnitTests/Debuggees/Directory.Build.targets
@@ -40,8 +40,7 @@
   </PropertyGroup>
 
   <Target Name="_SkipUngatedInterpreterTestBuild">
-    <Message Importance="High"
-             Text="Skipping interpreter-test debuggee '$(MSBuildProjectName)' because SOS_TEST_INTERPRETER is not set. Set SOS_TEST_INTERPRETER=true (or pass -testInterpreter to Build.cmd / build.sh) to enable." />
+    <Message Text="Skipping interpreter-test debuggee '$(MSBuildProjectName)' because SOS_TEST_INTERPRETER is not set. Set SOS_TEST_INTERPRETER=true (or pass -testInterpreter to Build.cmd / build.sh) to enable." />
   </Target>
 
 </Project>

--- a/src/tests/SOS.UnitTests/SOS.UnitTests.csproj
+++ b/src/tests/SOS.UnitTests/SOS.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>$(NetCoreAppMinTargetFramework)</TargetFramework>
+    <TargetFramework>$(NetCoreAppTestTargetFramework)</TargetFramework>
     <IsPackable>false</IsPackable>
     <NoWarn>;1591;1701</NoWarn>
     <DefineConstants>$(DefineConstants);CORE_CLR</DefineConstants>

--- a/src/tests/SOS.UnitTests/SOS.UnitTests.csproj
+++ b/src/tests/SOS.UnitTests/SOS.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>$(NetCoreAppTestTargetFramework)</TargetFramework>
+    <TargetFramework>$(NetCoreAppMinTargetFramework)</TargetFramework>
     <IsPackable>false</IsPackable>
     <NoWarn>;1591;1701</NoWarn>
     <DefineConstants>$(DefineConstants);CORE_CLR</DefineConstants>

--- a/src/tests/dirs.proj
+++ b/src/tests/dirs.proj
@@ -16,8 +16,10 @@
 
     <!-- Install test runtimes (SDK, shared frameworks) into artifacts/dotnet-test/.
          Using ProjectReference ensures the install runs exactly once via MSBuild's
-         result cache, even when multiple test projects depend on it. -->
-    <ProjectReference Include="$(RepositoryEngineeringDir)InstallRuntimes.proj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" />
+         result cache, even when multiple test projects depend on it.
+         Skipped on test-only legs ($(SkipTestArtifactsBuild)) which download a
+         prebuilt artifacts/dotnet-test directory instead of installing locally. -->
+    <ProjectReference Include="$(RepositoryEngineeringDir)InstallRuntimes.proj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" Condition="'$(SkipTestArtifactsBuild)' != 'true'" />
   </ItemGroup>
 
   <!--
@@ -39,7 +41,7 @@
 
   <Target Name="BuildDebuggees"
           AfterTargets="Build"
-          Condition="'$(SkipTests)' != 'true'">
+          Condition="'$(SkipTests)' != 'true' and '$(SkipTestArtifactsBuild)' != 'true'">
     <!-- Remove stale SDKs from the build dotnet dir so the repo root global.json
          (rollForward:major) resolves to the correct test SDK.  InstallTestRuntimes
          only installs $(MicrosoftNETSdkVersion); older SDKs are leftovers. -->

--- a/src/tests/dirs.proj
+++ b/src/tests/dirs.proj
@@ -17,9 +17,9 @@
     <!-- Install test runtimes (SDK, shared frameworks) into artifacts/dotnet-test/.
          Using ProjectReference ensures the install runs exactly once via MSBuild's
          result cache, even when multiple test projects depend on it.
-         Skipped on test-only legs ($(SkipTestArtifactsBuild)) which download a
-         prebuilt artifacts/dotnet-test directory instead of installing locally. -->
-    <ProjectReference Include="$(RepositoryEngineeringDir)InstallRuntimes.proj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" Condition="'$(SkipTestArtifactsBuild)' != 'true'" />
+         Test-only legs install runtimes locally too (cheap, gets correct file perms)
+         and only skip the expensive debuggee rebuild via $(SkipTestArtifactsBuild). -->
+    <ProjectReference Include="$(RepositoryEngineeringDir)InstallRuntimes.proj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" />
   </ItemGroup>
 
   <!--

--- a/src/tests/dotnet-counters/DotnetCounters.UnitTests.csproj
+++ b/src/tests/dotnet-counters/DotnetCounters.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(NetCoreAppMinTargetFramework)</TargetFramework>
+    <TargetFramework>$(NetCoreAppTestTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/dotnet-counters/DotnetCounters.UnitTests.csproj
+++ b/src/tests/dotnet-counters/DotnetCounters.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(NetCoreAppTestTargetFramework)</TargetFramework>
+    <TargetFramework>$(NetCoreAppMinTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/dotnet-trace/DotnetTrace.UnitTests.csproj
+++ b/src/tests/dotnet-trace/DotnetTrace.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(NetCoreAppMinTargetFramework)</TargetFramework>
+    <TargetFramework>$(NetCoreAppTestTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/dotnet-trace/DotnetTrace.UnitTests.csproj
+++ b/src/tests/dotnet-trace/DotnetTrace.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(NetCoreAppTestTargetFramework)</TargetFramework>
+    <TargetFramework>$(NetCoreAppMinTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR changes diagnostics CI from "build and test in every leg" to "build once, then run separate test legs from published artifacts".

New state:
- the `build` stage produces the binaries/debuggees/test assets once
- the `test` stage depends on those build jobs and runs tests from downloaded artifacts - it also installs the appropriate SDKs
- tools stay on **net8**, but unit tests move to **net10** to avoid installing more runtimes.
- a couple of overly noisy MSBuild messages are downgraded

## How this PR fixes it

- `diagnostics.yml` and `eng/pipelines/build.yml` now model build and test as separate stages/jobs. Build legs publish `TestArtifacts_*`; test-only legs download them and run `test.cmd`/`test.sh`.
- Build legs now publish `bin/**`, `obj/**`, and `test/**` so test legs can run from prebuilt outputs.
- `eng/build.ps1` / `eng/build.sh` explicitly install test runtimes on `-skipmanaged` legs and pass `SkipTestArtifactsBuild=true` so debuggees are not rebuilt there.
- `eng/TraversalOverrides.targets` is imported after the Traversal SDK and clears `TestDependsOn` when `SkipTestArtifactsBuild=true`. That is the key fix that actually stops implicit build-before-test.
- `src/tests/dirs.proj` skips `BuildDebuggees` on those prebuilt test legs.
- Test TFMs now use `$(NetCoreAppTestTargetFramework)` (`net10.0`) while tool TFMs remain `$(NetCoreAppMinTargetFramework)` (`net8.0`), which lets us drop the extra net8 test runtime install from `global.json`.
- `global.json` keeps an x86 runtime, but now at net10, so Arcade can launch an x86 host on the x86 leg.
- `EventLogsPipelineUnitTests` replaces `reader.EndOfStream` assertions with `ReadToEndAsync()` checks so those tests remain stable on the newer runtime.
- Logging cleanup:
  - `eng/AuxMsbuildFiles/SdkPackOverrides.targets`: `High -> Low` (from #5869)
  - `src/tests/SOS.UnitTests/Debuggees/Directory.Build.targets`: skip message lowered
