### PR TITLE
Handle null SystemDomain in SOS commands

### DIFF
--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -4188,7 +4188,7 @@ DECLARE_API(DumpDomain)
         {
             DMLOut("Shared Domain:      %s\n", DMLDomain(adsData.sharedDomain));
         }
-        else if (adsData.systemDomain != (TADDR)0 && p_DomainAddr == adsData.systemDomain)
+        else if (p_DomainAddr == adsData.systemDomain)
         {
             DMLOut("System Domain:      %s\n", DMLDomain(adsData.systemDomain));
         }
@@ -4202,10 +4202,10 @@ DECLARE_API(DumpDomain)
     }
 
     ExtOut("--------------------------------------\n");
+    DacpAppDomainData appDomain;
     if (adsData.systemDomain != (TADDR)0)
     {
         DMLOut("System Domain:      %s\n", DMLDomain(adsData.systemDomain));
-        DacpAppDomainData appDomain;
         if ((Status=appDomain.Request(g_sos,adsData.systemDomain))!=S_OK)
         {
             ExtOut("Unable to get system domain info.\n");
@@ -6401,7 +6401,7 @@ DECLARE_API(FindAppDomain)
             ExtOut("Name:      Shared Domain\n");
             ExtOut("ID:        (shared domain)\n");
         }
-        else if (adstore.systemDomain != (TADDR)0 && appDomain == adstore.systemDomain)
+        else if (appDomain == adstore.systemDomain)
         {
             ExtOut("Name:      System Domain\n");
             ExtOut("ID:        (system domain)\n");

--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -4188,7 +4188,7 @@ DECLARE_API(DumpDomain)
         {
             DMLOut("Shared Domain:      %s\n", DMLDomain(adsData.sharedDomain));
         }
-        else if (p_DomainAddr == adsData.systemDomain)
+        else if (adsData.systemDomain != (TADDR)0 && p_DomainAddr == adsData.systemDomain)
         {
             DMLOut("System Domain:      %s\n", DMLDomain(adsData.systemDomain));
         }
@@ -4202,14 +4202,17 @@ DECLARE_API(DumpDomain)
     }
 
     ExtOut("--------------------------------------\n");
-    DMLOut("System Domain:      %s\n", DMLDomain(adsData.systemDomain));
-    DacpAppDomainData appDomain;
-    if ((Status=appDomain.Request(g_sos,adsData.systemDomain))!=S_OK)
+    if (adsData.systemDomain != (TADDR)0)
     {
-        ExtOut("Unable to get system domain info.\n");
-        return Status;
+        DMLOut("System Domain:      %s\n", DMLDomain(adsData.systemDomain));
+        DacpAppDomainData appDomain;
+        if ((Status=appDomain.Request(g_sos,adsData.systemDomain))!=S_OK)
+        {
+            ExtOut("Unable to get system domain info.\n");
+            return Status;
+        }
+        DomainInfo(&appDomain);
     }
-    DomainInfo(&appDomain);
 
     if (adsData.sharedDomain != (TADDR)0)
     {
@@ -6398,7 +6401,7 @@ DECLARE_API(FindAppDomain)
             ExtOut("Name:      Shared Domain\n");
             ExtOut("ID:        (shared domain)\n");
         }
-        else if (appDomain == adstore.systemDomain)
+        else if (adstore.systemDomain != (TADDR)0 && appDomain == adstore.systemDomain)
         {
             ExtOut("Name:      System Domain\n");
             ExtOut("ID:        (system domain)\n");
@@ -8609,7 +8612,11 @@ public:
             if (adsData.Request(g_sos) != S_OK)
                 return FALSE;
 
-            LONG numSpecialDomains = (adsData.sharedDomain != (TADDR)0) ? 2 : 1;
+            LONG numSpecialDomains = 0;
+            if (adsData.sharedDomain != (TADDR)0)
+                numSpecialDomains++;
+            if (adsData.systemDomain != (TADDR)0)
+                numSpecialDomains++;
             m_numDomains = adsData.DomainCount + numSpecialDomains;
             ArrayHolder<CLRDATA_ADDRESS> pArray = new NOTHROW CLRDATA_ADDRESS[m_numDomains];
             if (pArray == NULL)
@@ -8621,10 +8628,14 @@ public:
                 pArray[i++] = adsData.sharedDomain;
             }
 
-            pArray[i] = adsData.systemDomain;
-
             m_sharedDomainIndex = i - 1; // The m_sharedDomainIndex is set to -1 if there is no shared domain
-            m_systemDomainIndex = i;
+
+            if (adsData.systemDomain != (TADDR)0)
+            {
+                pArray[i] = adsData.systemDomain;
+                m_systemDomainIndex = i;
+                i++;
+            }
 
             if (g_sos->GetAppDomainList(adsData.DomainCount, pArray+numSpecialDomains, NULL) != S_OK)
                 return FALSE;

--- a/src/SOS/Strike/util.cpp
+++ b/src/SOS/Strike/util.cpp
@@ -2171,7 +2171,11 @@ DWORD_PTR *ModuleFromName(__in_opt LPSTR mName, int *numModule)
     ArrayHolder<CLRDATA_ADDRESS> pAssemblyArray = NULL;
     ArrayHolder<CLRDATA_ADDRESS> pModules = NULL;
     int arrayLength = 0;
-    int numSpecialDomains = (adsData.sharedDomain != (TADDR)0) ? 2 : 1;
+    int numSpecialDomains = 0;
+    if (adsData.systemDomain != (TADDR)0)
+        numSpecialDomains++;
+    if (adsData.sharedDomain != (TADDR)0)
+        numSpecialDomains++;
     if (!ClrSafeInt<int>::addition(adsData.DomainCount, numSpecialDomains, arrayLength))
     {
         ExtOut("<integer overflow>\n");
@@ -2184,10 +2188,14 @@ DWORD_PTR *ModuleFromName(__in_opt LPSTR mName, int *numModule)
         return NULL;
     }
 
-    pArray[0] = adsData.systemDomain;
+    int i = 0;
+    if (adsData.systemDomain != (TADDR)0)
+    {
+        pArray[i++] = adsData.systemDomain;
+    }
     if (adsData.sharedDomain != (TADDR)0)
     {
-        pArray[1] = adsData.sharedDomain;
+        pArray[i++] = adsData.sharedDomain;
     }
     if ((hr = g_sos->GetAppDomainList(adsData.DomainCount, pArray.GetPtr() + numSpecialDomains, NULL)) != S_OK)
     {
@@ -2839,7 +2847,11 @@ void GetDomainList (DWORD_PTR *&domainList, int &numDomain)
     // Do prefast integer checks before the malloc.
     size_t AllocSize;
     LONG DomainAllocCount;
-    LONG NumExtraDomains = (adsData.sharedDomain != (TADDR)0) ? 2 : 1;
+    LONG NumExtraDomains = 0;
+    if (adsData.systemDomain != (TADDR)0)
+        NumExtraDomains++;
+    if (adsData.sharedDomain != (TADDR)0)
+        NumExtraDomains++;
     if (!ClrSafeInt<LONG>::addition(adsData.DomainCount, NumExtraDomains, DomainAllocCount) ||
         !ClrSafeInt<size_t>::multiply(DomainAllocCount, sizeof(PVOID), AllocSize) ||
         (domainList = new DWORD_PTR[DomainAllocCount]) == NULL)
@@ -2847,7 +2859,10 @@ void GetDomainList (DWORD_PTR *&domainList, int &numDomain)
         return;
     }
 
-    domainList[numDomain++] = (DWORD_PTR) adsData.systemDomain;
+    if (adsData.systemDomain != (TADDR)0)
+    {
+        domainList[numDomain++] = (DWORD_PTR) adsData.systemDomain;
+    }
     if (adsData.sharedDomain != (TADDR)0)
     {
         domainList[numDomain++] = (DWORD_PTR) adsData.sharedDomain;


### PR DESCRIPTION
> [!NOTE]
> This PR was created with assistance from GitHub Copilot.

The runtime will begin reporting `systemDomain` as NULL (0) from `GetAppDomainStoreData` (see dotnet/runtime#129260). This PR guards all SOS code that previously assumed `systemDomain` was always valid, matching the existing pattern used for `SharedDomain`.

**Affected call sites:**

- **`DumpDomain`** -- wraps SystemDomain info section in null guard; guards the single-domain label path
- **`FindAppDomain`** -- guards the "System Domain" label comparison
- **`GCHandleStatsForDomains::Init`** -- conditionally counts and adds SystemDomain to the domain array
- **`ModuleFromName` (util.cpp)** -- conditionally adds SystemDomain to domain array
- **`GetDomainList` (util.cpp)** -- conditionally adds SystemDomain to domain list

Two existing call sites were already safe: `SaveModules` (has `!= 0` check) and `EEHeapCommand.cs` (`PrintAppDomain` already null-checks).