### PR TITLE
Update SOS test expectations for null SystemDomain

### DIFF
--- a/src/tests/SOS.UnitTests/Scripts/GCPOH.script
+++ b/src/tests/SOS.UnitTests/Scripts/GCPOH.script
@@ -59,7 +59,6 @@ VERIFY:\s+<HEXVAL>\s+<DECVAL>\s+<DECVAL>\s+System.Byte\[\]\s+
 
 SOSCOMMAND:EEHeap
 VERIFY:\s*Loader Heap:\s+
-VERIFY:\s+System Domain:\s+<HEXVAL>\s+
 VERIFY:\s+LowFrequencyHeap:\s+<HEXVAL>.*bytes.*\s+
 VERIFY:\s+HighFrequencyHeap:\s+<HEXVAL>.*bytes.*\s+
 VERIFY:\s+Total size:\s+Size:\s+0x<HEXVAL>\s+\(<DECVAL>|lu\)\s+bytes\.\s+

--- a/src/tests/SOS.UnitTests/Scripts/GCTests.script
+++ b/src/tests/SOS.UnitTests/Scripts/GCTests.script
@@ -90,7 +90,9 @@ ENDIF:WINDOWS
 
 SOSCOMMAND:EEHeap
 VERIFY:\s*Loader Heap:\s+
+IFDEF:DESKTOP
 VERIFY:\s+System Domain:\s+<HEXVAL>\s+
+ENDIF:DESKTOP
 VERIFY:\s+LowFrequencyHeap:\s+<HEXVAL>.*bytes.*\s+
 VERIFY:\s+HighFrequencyHeap:\s+<HEXVAL>.*bytes.*\s+
 VERIFY:\s+Total size:\s+Size:\s+0x<HEXVAL>\s+\(<DECVAL>|lu\)\s+bytes\.\s+

--- a/src/tests/SOS.UnitTests/Scripts/OtherCommands.script
+++ b/src/tests/SOS.UnitTests/Scripts/OtherCommands.script
@@ -75,7 +75,9 @@ VERIFY:\s*<HEXVAL>\s+<DECVAL>\s+<DECVAL>\s+.*
 VERIFY:\s*Total\s+<DECVAL>\s+objects.*<DECVAL>\s+bytes\s*
 
 SOSCOMMAND:DumpDomain
+IFDEF:DESKTOP
 VERIFY:\s*System Domain:\s+<HEXVAL>\s+
+ENDIF:DESKTOP
 VERIFY:\s*LowFrequencyHeap:\s+<HEXVAL>\s+
 VERIFY:\s*HighFrequencyHeap:\s+<HEXVAL>\s+
 VERIFY:\s*Domain 1:\s+<HEXVAL>\s+


### PR DESCRIPTION
Follow-up to #5878.

dotnet/runtime#129260 makes `GetAppDomainStoreData::systemDomain` nullable (NULL on non-framework runtimes). #5878 added the null guards in SOS so the SystemDomain section is no longer emitted in that case, but the test scripts were not updated to match.

This PR removes/guards the now-conditional `System Domain:` VERIFY in the three affected scripts:

- `OtherCommands.script` (`DumpDomain`) and `GCTests.script` (`EEHeap`): wrap the `System Domain:` VERIFY in `IFDEF:DESKTOP`. The other heap lines (`LowFrequencyHeap`/`HighFrequencyHeap`/`Total size:`) still match against `Domain 1`'s heaps so they stay outside.
- `GCPOH.script` (`EEHeap`): delete the `System Domain:` VERIFY entirely. `GCPOHTests` is already skipped on Desktop (`config.IsDesktop` short-circuit; POH was introduced in .NET 5), so an `IFDEF:DESKTOP` block would be dead code.

Edit: See the following [runtime-diagnostics](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1466895&view=results) run showing success