### PR TITLE
Fix infinite loop in Repl

### DIFF
--- a/src/Microsoft.Diagnostics.Repl/ConsoleService.cs
+++ b/src/Microsoft.Diagnostics.Repl/ConsoleService.cs
@@ -98,13 +98,15 @@ namespace Microsoft.Diagnostics.Repl
                 {
                     // The input has been redirected (i.e. testing or in script)
                     string line = Console.ReadLine();
-                    if (line == null)
-                    {
-                        // End of the redirected input stream (EOF) - e.g. the parent process
-                        // driving us exited or closed our stdin. There will never be more
-                        // input, so stop the REPL instead of looping forever.
-                        break;
-                    }
+if (line == null)
+{
+    // End of the redirected input stream (EOF) - e.g. the parent process
+    // driving us has exited or closed our stdin. There will never be more
+    // input, so stop the REPL instead of looping forever.
+    m_shutdown = true;
+    Console.CancelKeyPress -= new ConsoleCancelEventHandler(OnCtrlBreakKeyPress);
+    break;
+}
 
                     if (line.Length == 0)
                     {

--- a/src/Microsoft.Diagnostics.Repl/ConsoleService.cs
+++ b/src/Microsoft.Diagnostics.Repl/ConsoleService.cs
@@ -98,10 +98,19 @@ namespace Microsoft.Diagnostics.Repl
                 {
                     // The input has been redirected (i.e. testing or in script)
                     string line = Console.ReadLine();
-                    if (string.IsNullOrEmpty(line))
+                    if (line == null)
+                    {
+                        // End of the redirected input stream (EOF) - e.g. the parent process
+                        // driving us exited or closed our stdin. There will never be more
+                        // input, so stop the REPL instead of looping forever.
+                        break;
+                    }
+
+                    if (line.Length == 0)
                     {
                         continue;
                     }
+
                     bool result = Dispatch(line, dispatchCommand);
                     if (!m_shutdown)
                     {


### PR DESCRIPTION
Using ReadLine + IsNullOrEmpty + continue:

```C#
string line = Console.ReadLine();
if (string.IsNullOrEmpty(line))
    continue;
```

Produces an infinite loop if stdin was closed.  For example, running under an llm and it closes the pipe to the tool.