### PR TITLE
Allow the GcInfoDumper to report scratch registers at safe points (DECODE_NO_VALIDATION)

### DIFF
--- a/src/shared/inc/gcinfo.h
+++ b/src/shared/inc/gcinfo.h
@@ -37,7 +37,7 @@ const unsigned   this_OFFSET_FLAG  = 0x2;  // the offset is "this"
 // The current GCInfo Version
 //-----------------------------------------------------------------------------
 
-#define GCINFO_VERSION 4
+#define GCINFO_VERSION 5
 
 #ifdef SOS_INCLUDE
 extern bool IsRuntimeVersionAtLeast(DWORD major);
@@ -46,7 +46,11 @@ inline int GCInfoVersion()
     // In SOS we only care about ability to parse/dump the GC Info.
     // Since v2 and v3 had the same file format and v1 is no longer supported,
     // we can assume that everything before net10.0 uses GCInfo v3.
-    return IsRuntimeVersionAtLeast(10) ? 4 : 3;
+    if (IsRuntimeVersionAtLeast(11))
+        return 5;
+    if (IsRuntimeVersionAtLeast(10))
+        return 4;
+    return 3;
 }
 #endif
 
@@ -80,6 +84,9 @@ struct GCInfoToken
     // Keep this in sync with GetR2RGCInfoVersion in cDac (ExecutionManagerCore.ReadyToRunJitManager.cs)
     static uint32_t ReadyToRunVersionToGcInfoVersion(uint32_t readyToRunMajorVersion, uint32_t readyToRunMinorVersion)
     {
+        if (readyToRunMajorVersion >= 21)
+            return 5;
+
         if (readyToRunMajorVersion >= 11)
             return 4;
 

--- a/src/shared/vm/gcinfodecoder.cpp
+++ b/src/shared/vm/gcinfodecoder.cpp
@@ -1584,8 +1584,10 @@ template <typename GcInfoEncoding> void TGcInfoDecoder<GcInfoEncoding>::ReportRe
 #ifdef _DEBUG
     if(IsScratchRegister(regNum, pRD))
     {
-        // Scratch registers cannot be reported for non-leaf frames
-        _ASSERTE(flags & ActiveStackFrame);
+        // Scratch registers cannot be reported for non-leaf frames.
+        // DECODE_NO_VALIDATION is used by the gcinfodumper for display purposes,
+        // which intentionally reports scratch registers at all offsets including safe points.
+        _ASSERTE((flags & ActiveStackFrame) || (m_Flags & DECODE_NO_VALIDATION));
     }
 
     LOG((LF_GCROOTS, LL_INFO1000, /* Part Two */
@@ -1692,8 +1694,10 @@ template <typename GcInfoEncoding> void TGcInfoDecoder<GcInfoEncoding>::ReportRe
 #ifdef _DEBUG
     if(IsScratchRegister(regNum, pRD))
     {
-        // Scratch registers cannot be reported for non-leaf frames
-        _ASSERTE(flags & ActiveStackFrame);
+        // Scratch registers cannot be reported for non-leaf frames.
+        // DECODE_NO_VALIDATION is used by the gcinfodumper for display purposes,
+        // which intentionally reports scratch registers at all offsets including safe points.
+        _ASSERTE((flags & ActiveStackFrame) || (m_Flags & DECODE_NO_VALIDATION));
     }
 
     LOG((LF_GCROOTS, LL_INFO1000, /* Part Two */
@@ -1795,8 +1799,10 @@ template <typename GcInfoEncoding> void TGcInfoDecoder<GcInfoEncoding>::ReportRe
 #ifdef _DEBUG
     if(IsScratchRegister(regNum, pRD))
     {
-        // Scratch registers cannot be reported for non-leaf frames
-        _ASSERTE(flags & ActiveStackFrame);
+        // Scratch registers cannot be reported for non-leaf frames.
+        // DECODE_NO_VALIDATION is used by the gcinfodumper for display purposes,
+        // which intentionally reports scratch registers at all offsets including safe points.
+        _ASSERTE((flags & ActiveStackFrame) || (m_Flags & DECODE_NO_VALIDATION));
     }
 
     LOG((LF_GCROOTS, LL_INFO1000, /* Part Two */
@@ -1935,8 +1941,10 @@ template <typename GcInfoEncoding> void TGcInfoDecoder<GcInfoEncoding>::ReportRe
 #ifdef _DEBUG
     if(IsScratchRegister(regNum, pRD))
     {
-        // Scratch registers cannot be reported for non-leaf frames
-        _ASSERTE(flags & ActiveStackFrame);
+        // Scratch registers cannot be reported for non-leaf frames.
+        // DECODE_NO_VALIDATION is used by the gcinfodumper for display purposes,
+        // which intentionally reports scratch registers at all offsets including safe points.
+        _ASSERTE((flags & ActiveStackFrame) || (m_Flags & DECODE_NO_VALIDATION));
     }
 
     LOG((LF_GCROOTS, LL_INFO1000, /* Part Two */
@@ -2059,8 +2067,10 @@ template <typename GcInfoEncoding> void TGcInfoDecoder<GcInfoEncoding>::ReportRe
 #ifdef _DEBUG
     if(IsScratchRegister(regNum, pRD))
     {
-        // Scratch registers cannot be reported for non-leaf frames
-        _ASSERTE(flags & ActiveStackFrame);
+        // Scratch registers cannot be reported for non-leaf frames.
+        // DECODE_NO_VALIDATION is used by the gcinfodumper for display purposes,
+        // which intentionally reports scratch registers at all offsets including safe points.
+        _ASSERTE((flags & ActiveStackFrame) || (m_Flags & DECODE_NO_VALIDATION));
     }
 
     LOG((LF_GCROOTS, LL_INFO1000, /* Part Two */


### PR DESCRIPTION
- Update missed gcinfo change. 
- A checked/debug build can hit  _ASSERTE(flags & ActiveStackFrame) in TGcInfoDecoder<...>::ReportRegisterToGC when the  GcInfoDumper  is used to dump a method whose GC info reports a scratch register live at a safe point. This is reachable today through SOS's gcinfo, e.g. AMD64 GC info reporting rax live at a partially interruptible safe point. GcInfoDumper::EnumerateStateChanges constructs its decoder with DECODE_NO_VALIDATION and calls  EnumerateLiveSlots(&regdisp, /*reportScratchSlots*/ true, flags | NoReportUntracked, ...). At safe points it deliberately sets flags = 0 (not ActiveStackFrame ) but still asks for scratch slots, because the dumper's job is to display every encoded slot at every offset - it is not performing a real stackwalk. The assert was written for the real-GC contract (scratch registers are only valid on the active/leaf frame) and does not account for the dumper's explicit  DECODE_NO_VALIDATION mode. Fix up those asserts to account for the flag.