### PR TITLE
Fix Microsoft.Diagnostics.Repl to support AltGr Keyboard layouts

### DIFF
--- a/src/Microsoft.Diagnostics.Repl/ConsoleService.cs
+++ b/src/Microsoft.Diagnostics.Repl/ConsoleService.cs
@@ -485,7 +485,10 @@ namespace Microsoft.Diagnostics.Repl
                 default:
                     if (keyInfo.KeyChar != 0)
                     {
-                        if ((keyInfo.Modifiers & (ConsoleModifiers.Control | ConsoleModifiers.Alt)) == 0)
+                        ConsoleModifiers ctrlAltModifiers = keyInfo.Modifiers & (ConsoleModifiers.Control | ConsoleModifiers.Alt);
+                        bool noCtrlAltModifiers = ctrlAltModifiers == 0;
+                        bool isAltGr = ctrlAltModifiers == (ConsoleModifiers.Control | ConsoleModifiers.Alt);
+                        if (noCtrlAltModifiers || isAltGr)
                         {
                             AppendNewText(new string(keyInfo.KeyChar, 1));
                         }


### PR DESCRIPTION
On non-ENU keyboards, typing a `\` for apps using `Microsoft.Diagnostics.Repl ` requires entering a combination of keys, such as `control`+`alt`+`<`.  This PR addresses this by allowing Alt and Control to be pressed at the same time.  This affects `dotnet-dump` (and any tool using the diagnostics REPL).
