### PR TITLE
[SymbolManifestGenerator] Extend case-insensitive matching

### DIFF
--- a/src/Microsoft.SymbolManifestGenerator/SymbolManifestGenerator.cs
+++ b/src/Microsoft.SymbolManifestGenerator/SymbolManifestGenerator.cs
@@ -111,11 +111,10 @@ public static class SymbolManifestGenerator
 
             if (specialFilesRequireAdjacentRuntime)
             {
-                FileInfo[] adjacentCorrelatedFiles = allFiles
-                    .Where(file =>
-                        file.DirectoryName.Equals(runtimeModule.DirectoryName, StringComparison.Ordinal) &&
-                        file.Name.Equals(correlatedFileName, StringComparison.OrdinalIgnoreCase))
-                    .ToArray();
+                FileInfo[] adjacentCorrelatedFiles = runtimeModule.Directory?.GetFiles()
+                    .Where(file => file.Name.Equals(correlatedFileName, StringComparison.OrdinalIgnoreCase))
+                    .ToArray()
+                    ?? Array.Empty<FileInfo>();
 
                 if (adjacentCorrelatedFiles.Length > 1)
                 {

--- a/src/Microsoft.SymbolManifestGenerator/SymbolManifestGenerator.cs
+++ b/src/Microsoft.SymbolManifestGenerator/SymbolManifestGenerator.cs
@@ -111,9 +111,23 @@ public static class SymbolManifestGenerator
 
             if (specialFilesRequireAdjacentRuntime)
             {
-                FileInfo correlatedFile = new(Path.Combine(runtimeModule.DirectoryName, correlatedFileName));
-                return (FoundMultipleCandidates: false,
-                        File: correlatedFile.Exists ? correlatedFile : default);
+                FileInfo[] adjacentCorrelatedFiles = allFiles
+                    .Where(file =>
+                        file.DirectoryName.Equals(runtimeModule.DirectoryName, StringComparison.Ordinal) &&
+                        file.Name.Equals(correlatedFileName, StringComparison.OrdinalIgnoreCase))
+                    .ToArray();
+
+                if (adjacentCorrelatedFiles.Length > 1)
+                {
+                    tracer.Error($"Multiple adjacent files '${correlatedFileName}' found for runtime '{runtimeModule.FullName}': {string.Join<FileInfo>(", ", adjacentCorrelatedFiles)}.");
+                }
+
+                return adjacentCorrelatedFiles.Length switch
+                {
+                    0 => (FoundMultipleCandidates: false, default),
+                    1 => (FoundMultipleCandidates: false, adjacentCorrelatedFiles[0]),
+                    _ => (FoundMultipleCandidates: true, default)
+                };
             }
 
             FileInfo[] correlatedFiles = allFiles.Where(file => file.Name.Equals(correlatedFileName, StringComparison.OrdinalIgnoreCase)).ToArray();

--- a/src/Microsoft.SymbolManifestGenerator/SymbolManifestGenerator.cs
+++ b/src/Microsoft.SymbolManifestGenerator/SymbolManifestGenerator.cs
@@ -118,7 +118,7 @@ public static class SymbolManifestGenerator
 
                 if (adjacentCorrelatedFiles.Length > 1)
                 {
-                    tracer.Error($"Multiple adjacent files '${correlatedFileName}' found for runtime '{runtimeModule.FullName}': {string.Join<FileInfo>(", ", adjacentCorrelatedFiles)}.");
+                    tracer.Error($"Multiple adjacent files '{correlatedFileName}' found for runtime '{runtimeModule.FullName}': {string.Join<FileInfo>(", ", adjacentCorrelatedFiles)}.");
                 }
 
                 return adjacentCorrelatedFiles.Length switch
@@ -133,7 +133,7 @@ public static class SymbolManifestGenerator
 
             if (correlatedFiles.Length > 1)
             {
-                tracer.Error($"Multiple files '${correlatedFileName}' found for runtime '{runtimeModule.FullName}': {string.Join<FileInfo>(", ", correlatedFiles)}.");
+                tracer.Error($"Multiple files '{correlatedFileName}' found for runtime '{runtimeModule.FullName}': {string.Join<FileInfo>(", ", correlatedFiles)}.");
             }
 
             return correlatedFiles.Length switch

--- a/src/Microsoft.SymbolStore/KeyGenerators/PEFileKeyGenerator.cs
+++ b/src/Microsoft.SymbolStore/KeyGenerators/PEFileKeyGenerator.cs
@@ -51,7 +51,10 @@ namespace Microsoft.SymbolStore.KeyGenerators
                 {
                     yield return GetKey(_path, _peFile.Timestamp, _peFile.SizeOfImage);
                 }
-                if ((flags & KeyTypeFlags.RuntimeKeys) != 0 && (GetFileName(_path) == CoreClrFileName || GetFileName(_path) == ClrFileName))
+                string runtimeFileName = GetFileName(_path);
+                if ((flags & KeyTypeFlags.RuntimeKeys) != 0 &&
+                    (runtimeFileName.Equals(CoreClrFileName, StringComparison.OrdinalIgnoreCase) ||
+                     runtimeFileName.Equals(ClrFileName, StringComparison.OrdinalIgnoreCase)))
                 {
                     yield return GetKey(_path, _peFile.Timestamp, _peFile.SizeOfImage);
                 }
@@ -107,10 +110,10 @@ namespace Microsoft.SymbolStore.KeyGenerators
                 if ((flags & KeyTypeFlags.ClrKeys) != 0)
                 {
                     string coreclrId = BuildId(_peFile.Timestamp, _peFile.SizeOfImage);
-                    string[] sosFiles = GetSOSFiles(GetFileName(_path)).ToArray();
+                    string[] sosFiles = GetSOSFiles(runtimeFileName).ToArray();
                     if (sosFiles.Length == 0)
                     {
-                        Tracer.Verbose("PEFile `{0}`: no SOS special files generated for runtime file {1}. No SOS keys will be produced.", _path, GetFileName(_path));
+                        Tracer.Verbose("PEFile `{0}`: no SOS special files generated for runtime file {1}. No SOS keys will be produced.", _path, runtimeFileName);
                     }
                     foreach (string specialFileName in sosFiles)
                     {
@@ -122,10 +125,10 @@ namespace Microsoft.SymbolStore.KeyGenerators
                 if ((flags & (KeyTypeFlags.ClrKeys | KeyTypeFlags.DacDbiKeys)) != 0)
                 {
                     string coreclrId = BuildId(_peFile.Timestamp, _peFile.SizeOfImage);
-                    string[] dacFiles = GetDACFiles(GetFileName(_path)).ToArray();
+                    string[] dacFiles = GetDACFiles(runtimeFileName).ToArray();
                     if (dacFiles.Length == 0)
                     {
-                        Tracer.Verbose("PEFile `{0}`: no DAC/DBI special files generated for runtime file {1}. No DAC/DBI keys will be produced.", _path, GetFileName(_path));
+                        Tracer.Verbose("PEFile `{0}`: no DAC/DBI special files generated for runtime file {1}. No DAC/DBI keys will be produced.", _path, runtimeFileName);
                     }
                     foreach (string specialFileName in dacFiles)
                     {
@@ -155,7 +158,7 @@ namespace Microsoft.SymbolStore.KeyGenerators
 
         private IEnumerable<string> GetSOSFiles(string runtimeFileName)
         {
-            if (runtimeFileName == ClrFileName)
+            if (runtimeFileName.Equals(ClrFileName, StringComparison.OrdinalIgnoreCase))
             {
                 return GetFilesLongNameVariants(SosFileName);
             }
@@ -165,14 +168,14 @@ namespace Microsoft.SymbolStore.KeyGenerators
 
         private IEnumerable<string> GetDACFiles(string runtimeFileName)
         {
-            if (runtimeFileName == CoreClrFileName)
+            if (runtimeFileName.Equals(CoreClrFileName, StringComparison.OrdinalIgnoreCase))
             {
                 string[] coreClrDACFiles = new string[] { CoreClrDACFileName, DbiFileName };
                 IEnumerable<string> longNameDACFiles = GetFilesLongNameVariants(CoreClrDACFileName);
                 return coreClrDACFiles.Concat(longNameDACFiles);
             }
 
-            if (runtimeFileName == ClrFileName)
+            if (runtimeFileName.Equals(ClrFileName, StringComparison.OrdinalIgnoreCase))
             {
                 string[] clrDACFiles = new string[] { ClrDACFileName, DbiFileName };
                 IEnumerable<string> longNameDACFiles = GetFilesLongNameVariants(ClrDACFileName);
@@ -184,7 +187,7 @@ namespace Microsoft.SymbolStore.KeyGenerators
 
         private IEnumerable<string> GetFilesLongNameVariants(string fileWithLongNameVariant)
         {
-            if (!s_knownFilesWithLongNameVariant.Contains(fileWithLongNameVariant))
+            if (!s_knownFilesWithLongNameVariant.Contains(fileWithLongNameVariant, StringComparer.OrdinalIgnoreCase))
             {
                 Tracer.Warning("{0} is not a recognized file with a long name variant", fileWithLongNameVariant);
                 return Enumerable.Empty<string>();
@@ -251,8 +254,9 @@ namespace Microsoft.SymbolStore.KeyGenerators
             // The clr special file flag can not be based on the GetSpecialFiles() list because
             // that is only valid when "path" is the coreclr.dll.
             string fileName = GetFileName(path);
-            bool clrSpecialFile = s_knownRuntimeSpecialFiles.Contains(fileName) ||
-                                  (s_knownFilesWithLongNameVariant.Any((file) => fileName.StartsWith(Path.GetFileNameWithoutExtension(file).ToLowerInvariant() + "_")) && Path.GetExtension(fileName) == ".dll");
+            bool clrSpecialFile = s_knownRuntimeSpecialFiles.Contains(fileName, StringComparer.OrdinalIgnoreCase) ||
+                                  (s_knownFilesWithLongNameVariant.Any((file) => fileName.StartsWith(Path.GetFileNameWithoutExtension(file) + "_", StringComparison.OrdinalIgnoreCase))
+                                      && Path.GetExtension(fileName).Equals(".dll", StringComparison.OrdinalIgnoreCase));
 
             string id = BuildId(timestamp, sizeOfImage);
             return BuildKey(path, id, clrSpecialFile);

--- a/src/tests/Microsoft.SymbolStore.UnitTests/PEFileKeyGenerationTests.cs
+++ b/src/tests/Microsoft.SymbolStore.UnitTests/PEFileKeyGenerationTests.cs
@@ -135,5 +135,42 @@ namespace Microsoft.SymbolStore.Tests
                 Assert.Empty(runtimeKeys);
             }
         }
+
+        [Fact]
+        public void PEFileGenerateRuntimeKeysCaseInsensitiveRuntimeName()
+        {
+            using var mockFileStream = new FileStream("TestBinaries/mockclr_amd64.dll", FileMode.Open, FileAccess.Read);
+            var mockSymbolStoreFile = new SymbolStoreFile(mockFileStream, "CLR.DLL");
+            var generator = new PEFileKeyGenerator(_tracer, mockSymbolStoreFile);
+
+            var runtimeKeys = generator.GetKeys(KeyTypeFlags.RuntimeKeys);
+            Assert.Single(runtimeKeys);
+            Assert.Equal("clr.dll/4D4F434B434c52/clr.dll", runtimeKeys.Single().Index);
+        }
+
+        [Fact]
+        public void PEFileGenerateClrKeysCaseInsensitiveRuntimeName()
+        {
+            using var mockFileStream = new FileStream("TestBinaries/mockclr_amd64.dll", FileMode.Open, FileAccess.Read);
+            var mockSymbolStoreFile = new SymbolStoreFile(mockFileStream, "CLR.DLL");
+            var generator = new PEFileKeyGenerator(_tracer, mockSymbolStoreFile);
+
+            var clrKeys = generator.GetKeys(KeyTypeFlags.ClrKeys).ToDictionary((key) => key.Index);
+            Assert.Contains("sos_amd64_amd64_1.2.3.45.dll/4D4F434B434c52/sos_amd64_amd64_1.2.3.45.dll", clrKeys.Keys);
+            Assert.Contains("mscordacwks.dll/4D4F434B434c52/mscordacwks.dll", clrKeys.Keys);
+            Assert.Contains("mscordbi.dll/4D4F434B434c52/mscordbi.dll", clrKeys.Keys);
+        }
+
+        [Fact]
+        public void PEFileGenerateIdentityKeysCaseInsensitiveSpecialName()
+        {
+            using var mockFileStream = new FileStream("TestBinaries/mockdac.dll", FileMode.Open, FileAccess.Read);
+            var mockSymbolStoreFile = new SymbolStoreFile(mockFileStream, "MSCORDACWKS.DLL");
+            var generator = new PEFileKeyGenerator(_tracer, mockSymbolStoreFile);
+
+            SymbolStoreKey identityKey = generator.GetKeys(KeyTypeFlags.IdentityKey).Single();
+            Assert.Equal("mscordacwks.dll/4D4F434B444143/mscordacwks.dll", identityKey.Index);
+            Assert.True(identityKey.IsClrSpecialFile);
+        }
     }
 }


### PR DESCRIPTION
Some users have special diagnostic files that aren't lower-case, and the SymbolManifestGenerator logic currently expects exact lowercase matches.

This PR changes the logic to match files case-insensitive