### PR TITLE
Workaround flaky bpmd-driven CONTINUEs in cdb tests by single-stepping before resuming

### DIFF
--- a/src/tests/SOS.UnitTests/SOSRunner.cs
+++ b/src/tests/SOS.UnitTests/SOSRunner.cs
@@ -1195,8 +1195,8 @@ public class SOSRunner : IDisposable
                 case NativeDebugger.Cdb:
                     // Workaround for a race condition in cdb: if a background thread fires an event
                     // while the debugger is processing the breakpoint, we can end up hitting the same
-                    // breakpoint again. Single stepping over the breakpoint then continuing prevents
-                    // this from happening.
+                    // breakpoint again. Single-stepping once (t) and then continuing prevents this
+                    // from happening.
                     command = "t; g";
                     // Don't add the !runcommand prefix because it gets printed when cdb stops
                     // again because the helper extension used .pcmd to set a stop command.

--- a/src/tests/SOS.UnitTests/SOSRunner.cs
+++ b/src/tests/SOS.UnitTests/SOSRunner.cs
@@ -1193,7 +1193,11 @@ public class SOSRunner : IDisposable
             switch (Debugger)
             {
                 case NativeDebugger.Cdb:
-                    command = "g";
+                    // Workaround for a race condition in cdb: if a background thread fires an event
+                    // while the debugger is processing the breakpoint, we can end up hitting the same
+                    // breakpoint again. Single stepping over the breakpoint then continuing prevents
+                    // this from happening.
+                    command = "t; g";
                     // Don't add the !runcommand prefix because it gets printed when cdb stops
                     // again because the helper extension used .pcmd to set a stop command.
                     addPrefix = false;


### PR DESCRIPTION
## Summary

`OtherCommands`, `StackAndOtherTests`, and related bpmd-heavy SOS tests have flaked at ~7% rate in CI for some time. The failure mode is that after a `bpmd` breakpoint hit, the next `g` reports a spurious second hit of the same breakpoint without advancing the IP — so subsequent `ClrStack` / verifications see the test sitting at the wrong location.

## Fix

Issue `t` (single-step) before `g` in `SOSRunner.ContinueExecution` for cdb. `t` advances IP past the current instruction (bp or not), then `g` resumes from a non-bp address — the buggy step-over-bp path is never taken. Harmless on non-bp continues and adds <1ms per CONTINUE.

## Verification

Same conditions that previously produced a 6.1% fail rate (32 parallel cdbs, single-file net10.0 debuggee, OtherCommands' stress env vars, 1600 iterations):

| Variant | Pass | Fail | Rate |
|---|---:|---:|---:|
| `g` (current) | 1503 | 97 | **6.1%** |
| **`t; g` (this PR)** | **1600** | **0** | **0.0%** |