### PR TITLE
Constrain GetExport RuntimeInfo dereference to module bounds in dbgshim

### DIFF
--- a/src/dbgshim/dbgshim.cpp
+++ b/src/dbgshim/dbgshim.cpp
@@ -1191,6 +1191,11 @@ GetTargetCLRMetrics(
             {
                 return E_FAIL;
             }
+            // Make sure the entire RuntimeInfo structure is contained within the module before reading it.
+            if (!pedecoder.CheckRva(pedecoder.GetDataRva((TADDR)runtimeInfoExport), sizeof(RuntimeInfo)))
+            {
+                return E_FAIL;
+            }
             RuntimeInfo* pRuntimeInfo = reinterpret_cast<RuntimeInfo*>(runtimeInfoExport);
             if (strncmp(pRuntimeInfo->Signature, RUNTIME_INFO_SIGNATURE, sizeof(pRuntimeInfo->Signature)) != 0)
             {


### PR DESCRIPTION
GetTargetCLRMetrics dereferenced the DotNetRuntimeInfo export returned by PEDecoder::GetExport without verifying the whole RuntimeInfo struct lies within the module. Add a CheckRva over sizeof(RuntimeInfo) before reading it, matching the existing bounds checks on the engine-metrics path.