### PR TITLE
Update test asset baselines for ClrMD ELF ImageSize fix

### DIFF
--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -30,8 +30,8 @@ This file should be imported by eng/Versions.props
     <runtimewinarm64MicrosoftDotNetCdacTransportPackageVersion>11.0.0-preview.6.26319.105</runtimewinarm64MicrosoftDotNetCdacTransportPackageVersion>
     <runtimewinx64MicrosoftDotNetCdacTransportPackageVersion>11.0.0-preview.6.26319.105</runtimewinx64MicrosoftDotNetCdacTransportPackageVersion>
     <!-- microsoft-clrmd dependencies -->
-    <MicrosoftDiagnosticsRuntimePackageVersion>4.1.735601</MicrosoftDiagnosticsRuntimePackageVersion>
-    <MicrosoftDiagnosticsRuntimeUtilitiesPackageVersion>4.1.735601</MicrosoftDiagnosticsRuntimeUtilitiesPackageVersion>
+    <MicrosoftDiagnosticsRuntimePackageVersion>4.1.735801</MicrosoftDiagnosticsRuntimePackageVersion>
+    <MicrosoftDiagnosticsRuntimeUtilitiesPackageVersion>4.1.735801</MicrosoftDiagnosticsRuntimeUtilitiesPackageVersion>
   </PropertyGroup>
   <!--Property group for alternate package version names-->
   <PropertyGroup>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,13 +1,13 @@
 <Dependencies>
   <Source Uri="https://github.com/dotnet/dotnet" Mapping="diagnostics" Sha="b756a8d8a0e64905e16c81911bb09a8110bc3395" BarId="319511" />
   <ProductDependencies>
-    <Dependency Name="Microsoft.Diagnostics.Runtime" Version="4.1.735601">
+    <Dependency Name="Microsoft.Diagnostics.Runtime" Version="4.1.735801">
       <Uri>https://github.com/microsoft/clrmd</Uri>
-      <Sha>5113e5f022c3171d2763a728fa3613c1af04fef9</Sha>
+      <Sha>e33245a1964d196e911c5578741842ed52d22e12</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Diagnostics.Runtime.Utilities" Version="4.1.735601">
+    <Dependency Name="Microsoft.Diagnostics.Runtime.Utilities" Version="4.1.735801">
       <Uri>https://github.com/microsoft/clrmd</Uri>
-      <Sha>5113e5f022c3171d2763a728fa3613c1af04fef9</Sha>
+      <Sha>e33245a1964d196e911c5578741842ed52d22e12</Sha>
     </Dependency>
     <Dependency Name="System.CommandLine" Version="2.0.0-beta5.25210.1">
       <Uri>https://github.com/dotnet/command-line-api</Uri>

--- a/src/tests/DbgShim.UnitTests/DbgShim.UnitTests.csproj
+++ b/src/tests/DbgShim.UnitTests/DbgShim.UnitTests.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>$(NetCoreAppMinTargetFramework)</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DbgShimConfigFileName>$(OutputPath)$(TargetFramework)\Debugger.Tests.Common.txt</DbgShimConfigFileName>
-    <TestAssetsVersion>1.0.351101</TestAssetsVersion>
+    <TestAssetsVersion>1.0.736301</TestAssetsVersion>
     <CopyDebuggeeSourcesToArtifacts>true</CopyDebuggeeSourcesToArtifacts>
   </PropertyGroup>
 

--- a/src/tests/Microsoft.Diagnostics.DebugServices.UnitTests/Microsoft.Diagnostics.DebugServices.UnitTests.csproj
+++ b/src/tests/Microsoft.Diagnostics.DebugServices.UnitTests/Microsoft.Diagnostics.DebugServices.UnitTests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCoreAppMinTargetFramework)</TargetFramework>
     <DebugServicesConfigFileName>$(OutputPath)$(TargetFramework)\Debugger.Tests.Common.txt</DebugServicesConfigFileName>
-    <TestAssetsVersion>1.0.351101</TestAssetsVersion>
+    <TestAssetsVersion>1.0.736301</TestAssetsVersion>
     <!-- Controls the test asset package restore and the tests that use them -->
     <RunTests>true</RunTests>
   </PropertyGroup>


### PR DESCRIPTION
## Problem

`DebugServicesTests.ModuleTests` fails on all Linux dumps (x64 + arm64) after the ClrMD dependency bump, e.g.:

```
Assert.Equal() Failure: Values differ
Expected: 118784
Actual:   140616
```

The failing member is `IModule.ImageSize`, and only for **native ELF** modules (Windows PE modules are unaffected, so Windows subresults pass).

## Root cause

ClrMD `4.1.735601 -> 4.1.735801` includes [microsoft/clrmd#1495](https://github.com/microsoft/clrmd/pull/1495) (commit `6ac1d967e`, "Fix ELF core dump ImageSize to include PT_LOAD anonymous tail"). For ELF modules whose final `PT_LOAD` segment has `MemSiz > FileSiz` (a `.bss`/NOBITS zero-fill tail), the old NT_FILE-derived size under-reported the module footprint. The new, larger `ImageSize` is correct - it now includes the loader-mapped anonymous tail. This is expected baseline drift from a deliberate ClrMD fix, not a diagnostics regression.

## Fix

- Includes the ClrMD `4.1.735801` bump (the change that requires new baselines).
- Regenerated the Linux x64/arm64 `testassets` baseline XMLs (**`ImageSize` values only**) and bumped `TestAssetsVersion` `1.0.351101 -> 1.0.736301`. All four 6.0 packages share this pin, so the two Windows packages are republished at the new version with unchanged content.
- Refreshes the `eng/testassets` rebuild helper scripts (net8.0 tool paths; `1.0.257801 -> 1.0.351101` source version) so the next regeneration is turn-key. Tooling-only; not consumed by CI.

## Test asset packages (published)

The regenerated packages have been published to the `dotnet-diagnostics-tests` feed at `1.0.736301`:

- `TestAssets.Linux.x64.6.0` (baselines updated)
- `TestAssets.Linux.arm64.6.0` (baselines updated)
- `TestAssets.Windows.x64.6.0` (content unchanged)
- `TestAssets.Windows.x86.6.0` (content unchanged)

They were produced with the repo''s own `eng/testassets/rebuild/pack.csproj` tooling (Arcade date-based version `1.0.736301`).

## Verification

End-to-end with the published packages (clean restore from the feed, no local overlays), `ModuleTests` goes from **Failed 6 / Passed 3** to **Passed 9 / Failed 0**. Each corrected value was independently confirmed against the dump''s actual ELF `PT_LOAD` program headers.
