### PR TITLE
Update Microsoft.DotNet.RemoteExecutor to match Arcade version

### DIFF
--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -10,7 +10,7 @@ This file should be imported by eng/Versions.props
     <!-- dotnet-arcade dependencies -->
     <MicrosoftDotNetArcadeSdkPackageVersion>10.0.0-beta.26358.3</MicrosoftDotNetArcadeSdkPackageVersion>
     <MicrosoftDotNetCodeAnalysisPackageVersion>10.0.0-beta.26358.3</MicrosoftDotNetCodeAnalysisPackageVersion>
-    <MicrosoftDotNetRemoteExecutorPackageVersion>7.0.0-beta.22316.2</MicrosoftDotNetRemoteExecutorPackageVersion>
+    <MicrosoftDotNetRemoteExecutorPackageVersion>10.0.0-beta.26358.3</MicrosoftDotNetRemoteExecutorPackageVersion>
     <!-- dotnet-command-line-api dependencies -->
     <SystemCommandLinePackageVersion>2.0.0-beta5.25210.1</SystemCommandLinePackageVersion>
     <!-- dotnet-dotnet dependencies -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -27,9 +27,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>4e21b419f8adadeb519bee472464824b1cff603e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="7.0.0-beta.22316.2" Pinned="true">
+    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="10.0.0-beta.26358.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>ccfe6da198c5f05534863bbb1bff66e830e0c6ab</Sha>
+      <Sha>4e21b419f8adadeb519bee472464824b1cff603e</Sha>
     </Dependency>
     <!-- dotnet/installer: Testing version of the SDK. Needed for the signed & entitled host. -->
     <Dependency Name="Microsoft.NET.Sdk" Version="11.0.100-preview.7.26327.102">


### PR DESCRIPTION
Bumps `Microsoft.DotNet.RemoteExecutor` from `7.0.0-beta.22316.2` to `10.0.0-beta.26358.3` and removes the `Pinned="true"` flag, which is no longer needed.