### PR TITLE
Fix LLDB module size calculation

### DIFF
--- a/src/SOS/lldbplugin/services.cpp
+++ b/src/SOS/lldbplugin/services.cpp
@@ -1540,11 +1540,11 @@ LLDBServices::GetModuleBase(
 
 ULONG64
 LLDBServices::GetModuleSize(
+    /* const */ lldb::SBTarget& target,
     ULONG64 baseAddress,
     /* const */ lldb::SBModule& module)
 {
     ULONG64 size = 0;
-    lldb::SBTarget target = m_debugger.GetSelectedTarget();
 
     // Include section alignment gaps in the module range.
     int numSections = module.GetNumSections();
@@ -1993,7 +1993,7 @@ LLDBServices::LoadNativeSymbols(
                 path.append("/");
                 path.append(filename);
 
-                int moduleSize = GetModuleSize(moduleAddress, module);
+                int moduleSize = GetModuleSize(target, moduleAddress, module);
 
                 callback(&module, path.c_str(), moduleAddress, moduleSize);
             }
@@ -2082,7 +2082,7 @@ HRESULT LLDBServices::GetModuleInfo(
     }
     if (pSize)
     {
-        *pSize = GetModuleSize(moduleBase, module);
+        *pSize = GetModuleSize(target, moduleBase, module);
     }
     if (pTimestamp)
     {

--- a/src/SOS/lldbplugin/services.cpp
+++ b/src/SOS/lldbplugin/services.cpp
@@ -1544,8 +1544,9 @@ LLDBServices::GetModuleSize(
     /* const */ lldb::SBModule& module)
 {
     ULONG64 size = 0;
+    lldb::SBTarget target = m_debugger.GetSelectedTarget();
 
-    // Find the first section with an valid base address
+    // Include section alignment gaps in the module range.
     int numSections = module.GetNumSections();
     for (int si = 0; si < numSections; si++)
     {
@@ -1558,7 +1559,15 @@ LLDBServices::GetModuleSize(
                 continue;
             }
  #endif
-            size += section.GetByteSize();
+            lldb::addr_t sectionAddress = section.GetLoadAddress(target);
+            lldb::addr_t sectionSize = section.GetByteSize();
+            if (sectionAddress == LLDB_INVALID_ADDRESS ||
+                sectionAddress < baseAddress ||
+                sectionSize > UINT64_MAX - sectionAddress)
+            {
+                continue;
+            }
+            size = std::max(size, sectionAddress + sectionSize - baseAddress);
         }
     }
     // For core dumps lldb doesn't return the section sizes when it

--- a/src/SOS/lldbplugin/services.h
+++ b/src/SOS/lldbplugin/services.h
@@ -43,7 +43,7 @@ private:
     uint32_t m_sectionCacheStopId;
 
     ULONG64 GetModuleBase(lldb::SBTarget& target, lldb::SBModule& module);
-    ULONG64 GetModuleSize(ULONG64 baseAddress, lldb::SBModule& module);
+    ULONG64 GetModuleSize(lldb::SBTarget& target, ULONG64 baseAddress, lldb::SBModule& module);
     ULONG64 GetExpression(lldb::SBFrame& frame, lldb::SBError& error, PCSTR exp);
     void GetContextFromFrame(lldb::SBFrame& frame, DT_CONTEXT *dtcontext);
     DWORD_PTR GetRegister(lldb::SBFrame& frame, const char *name);


### PR DESCRIPTION
## Summary

Calculate LLDB module size from the loaded section address range instead of summing section sizes.

Summing sizes excludes alignment gaps between sections and can truncate the reported module range. This causes diagnostics to reject valid addresses in later sections before attempting symbol lookup.

## Testing

- Built the native diagnostics components on Linux under WSL.
- Re-ran the dump reproduction.
- Reported module size changed from `0x241F71` to `0x244110`.
- Previously unresolved symbols now resolve successfully.
