### PR TITLE
dbgshim: activate cDAC via contract descriptor

### DIFF
--- a/src/SOS/Strike/platform/runtimeimpl.cpp
+++ b/src/SOS/Strike/platform/runtimeimpl.cpp
@@ -624,7 +624,7 @@ IXCLRDataProcess* Runtime::CreateClrDataProcessInstance(LPCSTR dacFilePath, ULON
 \**********************************************************************/
 ULONG64 Runtime::GetContractDescriptorAddress()
 {
-    const char* symbolName = "DotNetRuntimeContractDescriptor";
+    const char* symbolName = CONTRACT_DESCRIPTOR_SYMBOL;
     ULONG64 symbolAddress = 0;
     if (m_target->GetOperatingSystem() == ITarget::OperatingSystem::Linux ||
         m_target->GetOperatingSystem() == ITarget::OperatingSystem::OSX)

--- a/src/dbgshim/debugshim.cpp
+++ b/src/dbgshim/debugshim.cpp
@@ -68,6 +68,16 @@ static HRESULT SelectActivationResult(
     HRESULT cdacHr,
     HRESULT fallbackHr,
     bool cdacEvaluated);
+static HRESULT TryGetContractDescriptorAddress(
+    ULONG64 moduleBaseAddress,
+    IUnknown* pDataTarget,
+    ULONG64* pContractDescriptor);
+static HRESULT CDacCreateInstanceFromContractDescriptor(
+    const WCHAR* cdacModulePath,
+    IUnknown* pDataTarget,
+    ULONG64 contractDescriptor,
+    REFIID riid,
+    IUnknown** ppInstance);
 
 typedef HRESULT (STDAPICALLTYPE  *OpenVirtualProcessImpl2FnPtr)(ULONG64 clrInstanceId,
     IUnknown * pDataTarget,
@@ -93,6 +103,15 @@ typedef HRESULT (STDAPICALLTYPE  *OpenVirtualProcess2FnPtr)(ULONG64 clrInstanceI
     CLR_DEBUGGING_PROCESS_FLAGS * pdwFlags);
 
 typedef HMODULE (STDAPICALLTYPE  *LoadLibraryWFnPtr)(LPCWSTR lpLibFileName);
+
+// Private to dbgshim: the contract-based entry point exported only by the cDAC universal binary
+// (mscordaccore_universal). The caller supplies the runtime module's contract descriptor address
+// directly, so the data target does not need to implement ICLRContractLocator.
+typedef HRESULT (STDAPICALLTYPE  *PFN_DbgShimCreateInstanceFromContractDescriptor)(
+    REFIID riid,
+    ICLRDataTarget* pTarget,
+    ULONG64 contractDescriptor,
+    void** ppInstance);
 
 static bool IsTargetWindows(ICorDebugDataTarget* pDataTarget)
 {
@@ -1232,6 +1251,96 @@ static HRESULT DacCreateInstance(
     return hr;
 }
 
+// Resolves the address of the runtime module's exported DotNetRuntimeContractDescriptor symbol.
+// Returns S_OK with *pContractDescriptor set to the non-zero address on success. A failed HRESULT
+// (with *pContractDescriptor == 0) means the descriptor could not be resolved.
+static HRESULT TryGetContractDescriptorAddress(
+    ULONG64 moduleBaseAddress,
+    IUnknown* pDataTarget,
+    ULONG64* pContractDescriptor)
+{
+    *pContractDescriptor = 0;
+
+    ReleaseHolder<ICorDebugDataTarget> pCorDbgDataTarget;
+    HRESULT hr = pDataTarget->QueryInterface(__uuidof(ICorDebugDataTarget), (void**)&pCorDbgDataTarget);
+    if (FAILED(hr))
+    {
+        ReleaseHolder<ICLRDataTarget> pLegacyTarget;
+        if (FAILED(pDataTarget->QueryInterface(__uuidof(ICLRDataTarget), (void**)&pLegacyTarget)))
+        {
+            return CORDBG_E_MISSING_DATA_TARGET_INTERFACE;
+        }
+        ICorDebugDataTarget* pAdapter = NULL;
+        hr = CreateCordbDataTargetFromClrDataTarget(moduleBaseAddress, pLegacyTarget, &pAdapter);
+        if (FAILED(hr))
+        {
+            return hr;
+        }
+        pCorDbgDataTarget = pAdapter;
+    }
+
+    const char* symbolName = CONTRACT_DESCRIPTOR_SYMBOL;
+    uint64_t symbolAddress = 0;
+#ifdef HOST_WINDOWS
+    if (IsTargetWindows(pCorDbgDataTarget))
+    {
+        if (TryGetPEExportSymbol(pCorDbgDataTarget, moduleBaseAddress, symbolName, &symbolAddress))
+        {
+            *pContractDescriptor = symbolAddress;
+            return S_OK;
+        }
+        return E_FAIL;
+    }
+#endif // HOST_WINDOWS
+    if (TryGetSymbol(pCorDbgDataTarget, moduleBaseAddress, symbolName, &symbolAddress))
+    {
+        *pContractDescriptor = symbolAddress;
+        return S_OK;
+    }
+    return E_FAIL;
+}
+
+// Loads the cDAC universal binary and activates the requested data-access interface. Prefers the
+// contract-based entry point, supplying the contract descriptor address directly so the data target
+// does not need to implement ICLRContractLocator. When the cDAC binary is too old to expose that
+// entry point, falls back to CLRDataCreateInstance on the same binary, which sources the descriptor
+// through ICLRContractLocator. The module is intentionally left resident.
+static HRESULT CDacCreateInstanceFromContractDescriptor(
+    const WCHAR* cdacModulePath,
+    IUnknown* pDataTarget,
+    ULONG64 contractDescriptor,
+    REFIID riid,
+    IUnknown** ppInstance)
+{
+    HMODULE hCDac = LoadLibraryW(cdacModulePath);
+    if (hCDac == NULL)
+    {
+        return HRESULT_FROM_WIN32(GetLastError());
+    }
+
+    PFN_DbgShimCreateInstanceFromContractDescriptor pfnCreate =
+        (PFN_DbgShimCreateInstanceFromContractDescriptor)GetProcAddress(hCDac, "DbgShimCreateInstanceFromContractDescriptor");
+    if (pfnCreate == NULL)
+    {
+        // This cDAC binary is too old to expose the contract-based entry point; source the descriptor
+        // through ICLRContractLocator instead. Leave the module resident (never unload the cDAC).
+        return DacCreateInstance(cdacModulePath, pDataTarget, riid, ppInstance);
+    }
+
+    // The contract-based entry point takes an ICLRDataTarget but does not query it for
+    // ICLRContractLocator - the descriptor address is passed explicitly.
+    ICLRDataTarget* pDacDataTarget = NULL;
+    HRESULT hr = pDataTarget->QueryInterface(__uuidof(ICLRDataTarget), (void**)&pDacDataTarget);
+    if (FAILED(hr))
+    {
+        return CORDBG_E_MISSING_DATA_TARGET_INTERFACE;
+    }
+
+    hr = pfnCreate(riid, pDacDataTarget, contractDescriptor, (void**)ppInstance);
+    pDacDataTarget->Release();
+    return hr;
+}
+
 HRESULT CLRDebuggingImpl::OpenDataAccessProcess(
     ULONG64 moduleBaseAddress,
     IUnknown* pDataTarget,
@@ -1252,10 +1361,16 @@ HRESULT CLRDebuggingImpl::OpenDataAccessProcess(
     bool cdacEvaluated = policy != CDacLoadPolicy_LegacyDacOnly;
     if (cdacEvaluated)
     {
+        // The cDAC can only inspect a target whose runtime module exports its contract descriptor
+        // (DotNetRuntimeContractDescriptor). If the descriptor cannot be resolved, no cDAC path can
+        // succeed, so we skip cDAC entirely and let the legacy DAC fallback handle the target.
         SString cdacPath;
-        if (GetCDacPath(cdacPath))
+        ULONG64 contractDescriptor = 0;
+        if (GetCDacPath(cdacPath) &&
+            SUCCEEDED(TryGetContractDescriptorAddress(moduleBaseAddress, pDataTarget, &contractDescriptor)))
         {
-            cdacHr = DacCreateInstance(cdacPath.GetUnicode(), pDataTarget, riid, ppInstance);
+            cdacHr = CDacCreateInstanceFromContractDescriptor(
+                cdacPath.GetUnicode(), pDataTarget, contractDescriptor, riid, ppInstance);
         }
         if (FAILED(cdacHr))
         {

--- a/src/shared/debug/dbgutil/dbgutil.cpp
+++ b/src/shared/debug/dbgutil/dbgutil.cpp
@@ -418,6 +418,13 @@ bool TryGetPEExportSymbol(ICorDebugDataTarget* dataTarget, uint64_t baseAddress,
         return false;
     }
 
+    // A module with no export directory reports a zero RVA here; there is nothing to search and
+    // reading at baseAddress would parse the PE headers as an IMAGE_EXPORT_DIRECTORY.
+    if (exportTableRva == 0)
+    {
+        return false;
+    }
+
     // Manually read the export directory from the target to find the requested symbol.
     IMAGE_EXPORT_DIRECTORY exportDir{};
     if (FAILED(ReadFromDataTarget(dataTarget, baseAddress + exportTableRva, (BYTE*)&exportDir, sizeof(exportDir))))
@@ -426,6 +433,7 @@ bool TryGetPEExportSymbol(ICorDebugDataTarget* dataTarget, uint64_t baseAddress,
     }
 
     uint32_t namePointerCount = VAL32(exportDir.NumberOfNames);
+    uint32_t exportAddressCount = VAL32(exportDir.NumberOfFunctions);
     uint32_t addressTableRVA = VAL32(exportDir.AddressOfFunctions);
     uint32_t ordinalTableRVA = VAL32(exportDir.AddressOfNameOrdinals);
     uint32_t nameTableRVA = VAL32(exportDir.AddressOfNames);
@@ -447,7 +455,7 @@ bool TryGetPEExportSymbol(ICorDebugDataTarget* dataTarget, uint64_t baseAddress,
             }
             // Allocate a buffer for the memory that we'll read out of the target image.
             // We can allocate as much space as the target symbol name as we gracefully handle reading
-            // inaccessable memory.
+            // inaccessible memory.
             std::unique_ptr<char[]> namePointer(new char[symbolNameLength + 1]);
             // If we fail to read the memory or the name doesn't match, then we don't have the right export.
             if (SUCCEEDED(ReadFromDataTarget(dataTarget, baseAddress + namePointerRVA, (BYTE*)namePointer.get(), (UINT32)symbolNameLength + 1))
@@ -456,6 +464,12 @@ bool TryGetPEExportSymbol(ICorDebugDataTarget* dataTarget, uint64_t baseAddress,
                 // If the name matches, we should be able to get the ordinal
                 uint16_t ordinalForNamedExport = 0;
                 if (FAILED(ReadFromDataTarget(dataTarget, baseAddress + ordinalTableRVA + sizeof(uint16_t) * nameIndex, (BYTE*)&ordinalForNamedExport, sizeof(ordinalForNamedExport))))
+                {
+                    return false;
+                }
+                // The ordinal indexes the export address table; reject an out-of-range value from
+                // untrusted image data before using it to compute a read offset.
+                if (ordinalForNamedExport >= exportAddressCount)
                 {
                     return false;
                 }

--- a/src/shared/debug/dbgutil/dbgutil.cpp
+++ b/src/shared/debug/dbgutil/dbgutil.cpp
@@ -401,6 +401,79 @@ HRESULT GetNextLevelResourceEntryRVAByName(ICorDebugDataTarget* pDataTarget,
     return hr;
 }
 
+// Reads the PE export directory of the module at baseAddress through the data target and returns
+// the address of the named export.
+//
+// This intentionally does not reuse the name TryGetSymbol (the ELF/MachO reader in elfreader.cpp /
+// machoreader.cpp): the diagnostics dbgutil compiles elfreader.cpp on the Windows host so it can
+// read cross-OS ELF dumps, which already defines TryGetSymbol. A distinct name avoids a duplicate
+// symbol at link time.
+bool TryGetPEExportSymbol(ICorDebugDataTarget* dataTarget, uint64_t baseAddress, const char* symbolName, uint64_t* symbolAddress)
+{
+    *symbolAddress = 0;
+
+    DWORD exportTableRva;
+    if (FAILED(GetMachineAndDirectoryAddress(dataTarget, baseAddress, IMAGE_DIRECTORY_ENTRY_EXPORT, nullptr, &exportTableRva)))
+    {
+        return false;
+    }
+
+    // Manually read the export directory from the target to find the requested symbol.
+    IMAGE_EXPORT_DIRECTORY exportDir{};
+    if (FAILED(ReadFromDataTarget(dataTarget, baseAddress + exportTableRva, (BYTE*)&exportDir, sizeof(exportDir))))
+    {
+        return false;
+    }
+
+    uint32_t namePointerCount = VAL32(exportDir.NumberOfNames);
+    uint32_t addressTableRVA = VAL32(exportDir.AddressOfFunctions);
+    uint32_t ordinalTableRVA = VAL32(exportDir.AddressOfNameOrdinals);
+    uint32_t nameTableRVA = VAL32(exportDir.AddressOfNames);
+
+    for (uint32_t nameIndex = 0; nameIndex < namePointerCount; nameIndex++)
+    {
+        uint32_t namePointerRVA = 0;
+        if (FAILED(ReadFromDataTarget(dataTarget, baseAddress + nameTableRVA + sizeof(uint32_t) * nameIndex, (BYTE*)&namePointerRVA, sizeof(namePointerRVA))))
+        {
+            return false;
+        }
+        if (namePointerRVA != 0)
+        {
+            size_t symbolNameLength = strlen(symbolName);
+            if (symbolNameLength > UINT32_MAX)
+            {
+                // Symbol name is too large, we won't discover it.
+                return false;
+            }
+            // Allocate a buffer for the memory that we'll read out of the target image.
+            // We can allocate as much space as the target symbol name as we gracefully handle reading
+            // inaccessable memory.
+            std::unique_ptr<char[]> namePointer(new char[symbolNameLength + 1]);
+            // If we fail to read the memory or the name doesn't match, then we don't have the right export.
+            if (SUCCEEDED(ReadFromDataTarget(dataTarget, baseAddress + namePointerRVA, (BYTE*)namePointer.get(), (UINT32)symbolNameLength + 1))
+                && strncmp(namePointer.get(), symbolName, symbolNameLength + 1) == 0)
+            {
+                // If the name matches, we should be able to get the ordinal
+                uint16_t ordinalForNamedExport = 0;
+                if (FAILED(ReadFromDataTarget(dataTarget, baseAddress + ordinalTableRVA + sizeof(uint16_t) * nameIndex, (BYTE*)&ordinalForNamedExport, sizeof(ordinalForNamedExport))))
+                {
+                    return false;
+                }
+                // If the name matches, we should be able to get the export
+                uint32_t exportRVA = 0;
+                if (FAILED(ReadFromDataTarget(dataTarget, baseAddress + addressTableRVA + sizeof(uint32_t) * ordinalForNamedExport, (BYTE*)&exportRVA, sizeof(exportRVA))))
+                {
+                    return false;
+                }
+                *symbolAddress = baseAddress + exportRVA;
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
 #endif // HOST_WINDOWS
 
 // A small wrapper that reads from the data target and throws on error

--- a/src/shared/debug/inc/dbgutil.h
+++ b/src/shared/debug/inc/dbgutil.h
@@ -90,3 +90,12 @@ HRESULT ReadFromDataTarget(ICorDebugDataTarget* pDataTarget,
     ULONG64 addr,
     BYTE* pBuffer,
     ULONG32 bytesToRead);
+
+#ifdef HOST_WINDOWS
+// Reads the named export from the PE export directory of the module at baseAddress through the
+// data target. Returns true and sets *symbolAddress on success. Windows-host only.
+bool TryGetPEExportSymbol(ICorDebugDataTarget* pDataTarget,
+    uint64_t baseAddress,
+    const char* symbolName,
+    uint64_t* symbolAddress);
+#endif // HOST_WINDOWS

--- a/src/shared/debug/inc/runtimeinfo.h
+++ b/src/shared/debug/inc/runtimeinfo.h
@@ -8,6 +8,10 @@ typedef unsigned char SYMBOL_INDEX;
 #define RUNTIME_INFO_SIGNATURE  "DotNetRuntimeInfo"
 #define RUNTIME_INFO_VERSION    2
 
+// Name of the symbol the runtime module exports whose address is the cDAC contract descriptor
+// (DotNetRuntimeContractDescriptor). Shared by every component that resolves it over a target.
+#define CONTRACT_DESCRIPTOR_SYMBOL  "DotNetRuntimeContractDescriptor"
+
 // Make sure that if you update this structure
 //    - You do so in a in a way that it is backwards compatible. For example, only tail append to this.
 //    - Rev the version.


### PR DESCRIPTION
When servicing a data-access interface (`IXCLRDataProcess` / `ISOSDacInterface`), dbgshim now resolves the target runtime module's `DotNetRuntimeContractDescriptor` export itself and activates the cDAC through the universal binary's new `DbgShimCreateInstanceFromContractDescriptor` entry point (dotnet/runtime#131357), passing the descriptor address directly.

This is needed because dbgshim's data targets don't always implement `ICLRContractLocator`, so the existing `CLRDataCreateInstance` path can't source the descriptor on them.

Behavior:
- Descriptor not resolvable -> cDAC can't succeed, so it's skipped and we fall through to the legacy DAC.
- Descriptor resolvable but the cDAC binary predates the new export -> falls back to `CLRDataCreateInstance` on the same binary (temporary while cDAC gets updated in the tools).
- `LegacyDacOnly` policy and the public dbgshim API are unchanged; this is purely additive.
-  On Windows-host targets the descriptor is read via a small PE export-directory walk (`TryGetPEExportSymbol`) that we already use in runtime; ELF/Mach-O use the existing `TryGetSymbol`.
