### PR TITLE
Use universal DBI for cDAC debugging

### DIFF
--- a/src/dbgshim/debugshim.cpp
+++ b/src/dbgshim/debugshim.cpp
@@ -1192,7 +1192,7 @@ static bool GetDbiPath(SString& dbiPath)
 {
     return GetBundledLibraryPath(
         W("DOTNET_DBI_PATH"),
-        MAKEDLLNAME_W(MAIN_DBI_MODULE_NAME_W),
+        MAKEDLLNAME_W(UNIVERSAL_DBI_MODULE_NAME_W),
         dbiPath);
 }
 

--- a/src/dbgshim/debugshim.h
+++ b/src/dbgshim/debugshim.h
@@ -48,8 +48,9 @@
 #define CLR_DAC_MODULE_NAME_W W("mscordacwks")
 #define MAIN_DBI_MODULE_NAME_W W("mscordbi")
 
-// The cDAC (contract-based data access) is bundled next to dbgshim and is never downloaded.
+// The cDAC and universal DBI are bundled next to dbgshim and are never downloaded.
 #define CORECLR_CDAC_MODULE_NAME_W W("mscordaccore_universal")
+#define UNIVERSAL_DBI_MODULE_NAME_W W("mscordbi_universal")
 
 // A small dbgshim-owned control interface, implemented by the same object as ICLRDebugging, that
 // lets a consumer attach a cDAC load policy to the debugging object before requesting a data-access

--- a/src/dbgshim/pkg/Microsoft.Diagnostics.DbgShim.props
+++ b/src/dbgshim/pkg/Microsoft.Diagnostics.DbgShim.props
@@ -29,6 +29,10 @@
             Include="$(NativeBinDir)$(LibPrefix)mscordaccore_universal$(LibSuffix)"
             PackagePath="runtimes/$(PackageRID)/native"
             Pack="true" />
+      <None Condition="'$(PackageWithCDac)' == 'true'"
+            Include="$(NativeBinDir)$(LibPrefix)mscordbi_universal$(LibSuffix)"
+            PackagePath="runtimes/$(PackageRID)/native"
+            Pack="true" />
     </ItemGroup>
 
     <Target Name="AddRuntimeSpecificNativeSymbolToPackage">


### PR DESCRIPTION
The bundled cDAC path needs a DBI that owns its PAL.

- Load `mscordbi_universal` for cDAC debugging.
- Package it with dbgshim when cDAC packaging is enabled.