### PR TITLE
Implement native runtimes command --usecdac option

### DIFF
--- a/src/SOS/Strike/clrma/managedanalysis.cpp
+++ b/src/SOS/Strike/clrma/managedanalysis.cpp
@@ -289,6 +289,11 @@ ClrmaManagedAnalysis::AssociateClient(
                 }
                 if (FAILED(hr = runtime->GetClrDataProcess(IRuntime::ClrDataProcessFlags::UseCDac, &m_clrData)))
                 {
+                    if (Runtime::GetCDacLoadPolicy() == CDacLoadPolicy::UseCDac)
+                    {
+                        TraceError("AssociateClient forced cDAC retrieval failed with code %08x\n", hr);
+                        return hr;
+                    }
                     TraceInformation("AssociateClient Runtime based DAC retrieval failed with code %08x, falling back to CLRMA\n", hr);
 
                     m_clrData = GetClrDataFromDbgEng();

--- a/src/SOS/Strike/platform/runtimeimpl.cpp
+++ b/src/SOS/Strike/platform/runtimeimpl.cpp
@@ -55,6 +55,8 @@ typedef HMODULE (STDAPICALLTYPE  *LoadLibraryWFnPtr)(LPCWSTR lpLibFileName);
 // Current runtime instance
 IRuntime* g_pRuntime = nullptr;
 
+static CDacLoadPolicy s_cdacLoadPolicy = CDacLoadPolicy::Default;
+
 extern "C" bool TryGetSymbolWithCallback(
     bool (*readMemory)(void* address, void* buffer, size_t size),
     ULONG64 baseAddress,
@@ -517,6 +519,11 @@ HRESULT Runtime::GetClrDataProcess(ClrDataProcessFlags flags, IXCLRDataProcess**
             *ppClrDataProcess = m_cdacDataProcess;
             return S_OK;
         }
+        if (s_cdacLoadPolicy == CDacLoadPolicy::UseCDac)
+        {
+            *ppClrDataProcess = nullptr;
+            return CORDBG_E_MISSING_DEBUGGER_EXPORTS;
+        }
         // Fall through to the DAC.
     }
 
@@ -555,6 +562,15 @@ static bool IsEnvironmentVariableSetToOne(const char* name)
 \**********************************************************************/
 bool Runtime::ShouldUseCDac()
 {
+    if (s_cdacLoadPolicy == CDacLoadPolicy::UseLegacyDac)
+    {
+        return false;
+    }
+    if (s_cdacLoadPolicy == CDacLoadPolicy::UseCDac)
+    {
+        return true;
+    }
+
     // When DOTNET_ENABLE_CDAC is requested, the in-box (legacy) DAC loads and drives the cDAC
     // contract reader itself (including its own dac-vs-cdac fallback/comparison). Defer to that
     // mechanism rather than loading the cDAC directly so those scenarios keep working.
@@ -571,6 +587,16 @@ bool Runtime::ShouldUseCDac()
     }
     DWORD majorVersion = (fileInfo.dwFileVersionMS >> 16) & 0xFFFF;
     return majorVersion >= MinCDacRuntimeMajorVersion;
+}
+
+CDacLoadPolicy Runtime::GetCDacLoadPolicy()
+{
+    return s_cdacLoadPolicy;
+}
+
+void Runtime::SetCDacLoadPolicy(CDacLoadPolicy policy)
+{
+    s_cdacLoadPolicy = policy;
 }
 
 /**********************************************************************\

--- a/src/SOS/Strike/platform/runtimeimpl.cpp
+++ b/src/SOS/Strike/platform/runtimeimpl.cpp
@@ -509,7 +509,15 @@ HRESULT Runtime::GetClrDataProcess(ClrDataProcessFlags flags, IXCLRDataProcess**
         if (m_cdacDataProcess == nullptr)
         {
             LPCSTR cdacFilePath = GetCDacFilePath();
-            if (cdacFilePath != nullptr)
+            if (cdacFilePath == nullptr)
+            {
+                if (s_cdacLoadPolicy == CDacLoadPolicy::UseCDac)
+                {
+                    *ppClrDataProcess = nullptr;
+                    return CORDBG_E_NO_IMAGE_AVAILABLE;
+                }
+            }
+            else
             {
                 m_cdacDataProcess = CreateClrDataProcessInstance(cdacFilePath, GetContractDescriptorAddress());
             }

--- a/src/SOS/Strike/platform/runtimeimpl.h
+++ b/src/SOS/Strike/platform/runtimeimpl.h
@@ -44,6 +44,13 @@
 
 extern IRuntime* g_pRuntime;
 
+enum class CDacLoadPolicy
+{
+    Default,
+    UseCDac,
+    UseLegacyDac,
+};
+
 // Returns the runtime configuration as a string
 inline static const char* GetRuntimeConfigurationName(IRuntime::RuntimeConfiguration config)
 {
@@ -164,6 +171,10 @@ private:
 
 public:
     static HRESULT CreateInstance(ITarget* target, RuntimeConfiguration configuration, Runtime** ppRuntime);
+
+    static CDacLoadPolicy GetCDacLoadPolicy();
+
+    static void SetCDacLoadPolicy(CDacLoadPolicy policy);
 
     void Flush();
 

--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -13432,21 +13432,70 @@ DECLARE_API(SetClrPath)
 //
 // Lists and selects the current runtime
 //
+static void DisplayCDacLoadPolicy()
+{
+    PCSTR cdacPolicy = "policy (default)";
+    switch (Runtime::GetCDacLoadPolicy())
+    {
+        case CDacLoadPolicy::UseCDac:
+            cdacPolicy = "true";
+            break;
+        case CDacLoadPolicy::UseLegacyDac:
+            cdacPolicy = "false";
+            break;
+        default:
+            break;
+    }
+    ExtOut("Settings:\n");
+    ExtOut("-> Use cDAC: %s\n", cdacPolicy);
+}
+
 DECLARE_API(runtimes)
 {
-    INIT_API_NODAC_PROBE_MANAGED("runtimes");
+    INIT_API_NOEE_PROBE_MANAGED("runtimes");
 
     BOOL bNetFx = FALSE;
     BOOL bNetCore = FALSE;
+    StringHolder useCDac;
     CMDOption option[] =
     {   // name, vptr, type, hasValue
         {"-netfx", &bNetFx, COBOOL, FALSE},
         {"-netcore", &bNetCore, COBOOL, FALSE},
+        {"--usecdac", &useCDac.data, COSTRING, TRUE},
     };
     if (!GetCMDOption(args, option, ARRAY_SIZE(option), NULL, 0, NULL))
     {
         return E_INVALIDARG;
     }
+    if (useCDac.data != nullptr)
+    {
+        CDacLoadPolicy policy;
+        if (_stricmp(useCDac.data, "true") == 0)
+        {
+            policy = CDacLoadPolicy::UseCDac;
+        }
+        else if (_stricmp(useCDac.data, "false") == 0)
+        {
+            policy = CDacLoadPolicy::UseLegacyDac;
+        }
+        else if (_stricmp(useCDac.data, "policy") == 0 || _stricmp(useCDac.data, "default") == 0)
+        {
+            policy = CDacLoadPolicy::Default;
+        }
+        else
+        {
+            ExtErr("Invalid --usecdac value '%s'. Expected true, false, or policy.\n", useCDac.data);
+            return E_INVALIDARG;
+        }
+        Runtime::SetCDacLoadPolicy(policy);
+        GetTarget()->Flush();
+    }
+    if (useCDac.data != nullptr && !bNetCore && !bNetFx)
+    {
+        DisplayCDacLoadPolicy();
+        return Status;
+    }
+    INIT_API_EE();
     if (bNetCore || bNetFx)
     {
 #ifndef FEATURE_PAL
@@ -13470,6 +13519,7 @@ DECLARE_API(runtimes)
     else
     {
         Target::DisplayStatus();
+        DisplayCDacLoadPolicy();
     }
     return Status;
 }

--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -13484,7 +13484,7 @@ DECLARE_API(runtimes)
         }
         else
         {
-            ExtErr("Invalid --usecdac value '%s'. Expected true, false, or policy.\n", useCDac.data);
+            ExtErr("Invalid --usecdac value '%s'. Expected true, false, policy, or default.\n", useCDac.data);
             return E_INVALIDARG;
         }
         Runtime::SetCDacLoadPolicy(policy);

--- a/src/SOS/Strike/util.cpp
+++ b/src/SOS/Strike/util.cpp
@@ -3813,6 +3813,10 @@ HRESULT LoadClrDebugDll(void)
     HRESULT hr = g_pRuntime->GetClrDataProcess(IRuntime::ClrDataProcessFlags::UseCDac, &g_clrData);
     if (FAILED(hr))
     {
+        if (Runtime::GetCDacLoadPolicy() == CDacLoadPolicy::UseCDac)
+        {
+            return hr;
+        }
         g_clrData = GetClrDataFromDbgEng();
         if (g_clrData == nullptr)
         {


### PR DESCRIPTION
Our tests expect to be able to toggle cDAC support on and off. Although most tests run with the managed host enabled, some of them explicitly disable it. Right now if a test disables managed SOS hosting and attempts to run:

!runtimes --usecdac false

the native host doesn't recognize the option and ignores it. The test then runs using default native host policy which will load cDAC. This means tests that claim to be validating the legacy DAC path are actually validating the SOS bundled cDAC instead. This was blocking Rachel's PR https://github.com/dotnet/runtime/pull/131027 because she had both runtime and cDAC changes included but the test was only using the runtime portion of the change without the matching cDAC portion.