### PR TITLE
Gate cDAC live debugging on DOTNET_CDAC_LIVE_DEBUGGING env var

### DIFF
--- a/src/dbgshim/dbgshim.cpp
+++ b/src/dbgshim/dbgshim.cpp
@@ -249,7 +249,7 @@ static HRESULT TryCreateCoreDbgWithCDac(
 {
     SString enabledVar;
     if (WszGetEnvironmentVariable(DOTNET_CDAC_LIVE_DEBUGGING, enabledVar) == 0
-        || !enabledVar.Equals(W("1")))
+        || !enabledVar.Equals(SL(W("1"))))
     {
         return E_NOTIMPL;
     }
@@ -433,6 +433,10 @@ public:
             if (cdacEvaluated)
             {
                 cdacHr = TryCreateCoreDbgWithCDac(hModule, m_processId, m_applicationGroupId, CorDebugVersion_2_0, &pCordb);
+                if (cdacHr == E_NOTIMPL)
+                {
+                    cdacEvaluated = false;
+                }
             }
 
             HRESULT fallbackHr = E_FAIL;
@@ -627,6 +631,10 @@ public:
                 if (cdacEvaluated)
                 {
                     cdacHr = TryCreateCoreDbgWithCDac(clrRuntimeInfo.ModuleHandle, m_processId, NULL, clrRuntimeInfo.EngineMetrics.dwDbiVersion, &pCordb);
+                    if (cdacHr == E_NOTIMPL)
+                    {
+                        cdacEvaluated = false;
+                    }
                 }
 
                 HRESULT fallbackHr = E_FAIL;
@@ -2157,6 +2165,10 @@ CreateDebuggingInterfaceFromVersion3(
         if (cdacEvaluated)
         {
             cdacHr = TryCreateCoreDbgWithCDac(hmodTargetCLR, pidDebuggee, szApplicationGroupId, iDebuggerVersion, &pCordb);
+            if (cdacHr == E_NOTIMPL)
+            {
+                cdacEvaluated = false;
+            }
         }
 
         if (FAILED(cdacHr) && policy != CDacLoadPolicy_CDacOnly)

--- a/src/dbgshim/dbgshim.cpp
+++ b/src/dbgshim/dbgshim.cpp
@@ -234,6 +234,10 @@ HRESULT CreateCoreDbg(
 // SetCDacLoadPolicy export.
 static Volatile<CDacLoadPolicy> g_cdacLoadPolicy = CDacLoadPolicy_PreferCDac;
 
+// cDAC live debugging is opt-in. Without this env var set to "1", TryCreateCoreDbgWithCDac
+// returns E_NOTIMPL and the caller falls back to the legacy DAC.
+#define DOTNET_CDAC_LIVE_DEBUGGING W("DOTNET_CDAC_LIVE_DEBUGGING")
+
 // Only the bundled DBI can report whether it can consume the cDAC for this target, so this invokes it
 // rather than pre-judging from file presence.
 static HRESULT TryCreateCoreDbgWithCDac(
@@ -243,6 +247,13 @@ static HRESULT TryCreateCoreDbgWithCDac(
     int iDebuggerVersion,
     IUnknown** ppCordb)
 {
+    SString enabledVar;
+    if (WszGetEnvironmentVariable(DOTNET_CDAC_LIVE_DEBUGGING, enabledVar) == 0
+        || !enabledVar.Equals(W("1")))
+    {
+        return E_NOTIMPL;
+    }
+
     SString cdacPath;
     SString dbiPath;
     if (!GetCDacAndDbiPaths(cdacPath, dbiPath))

--- a/src/dbgshim/dbgshim.cpp
+++ b/src/dbgshim/dbgshim.cpp
@@ -433,10 +433,6 @@ public:
             if (cdacEvaluated)
             {
                 cdacHr = TryCreateCoreDbgWithCDac(hModule, m_processId, m_applicationGroupId, CorDebugVersion_2_0, &pCordb);
-                if (cdacHr == E_NOTIMPL)
-                {
-                    cdacEvaluated = false;
-                }
             }
 
             HRESULT fallbackHr = E_FAIL;
@@ -631,10 +627,6 @@ public:
                 if (cdacEvaluated)
                 {
                     cdacHr = TryCreateCoreDbgWithCDac(clrRuntimeInfo.ModuleHandle, m_processId, NULL, clrRuntimeInfo.EngineMetrics.dwDbiVersion, &pCordb);
-                    if (cdacHr == E_NOTIMPL)
-                    {
-                        cdacEvaluated = false;
-                    }
                 }
 
                 HRESULT fallbackHr = E_FAIL;
@@ -2165,10 +2157,6 @@ CreateDebuggingInterfaceFromVersion3(
         if (cdacEvaluated)
         {
             cdacHr = TryCreateCoreDbgWithCDac(hmodTargetCLR, pidDebuggee, szApplicationGroupId, iDebuggerVersion, &pCordb);
-            if (cdacHr == E_NOTIMPL)
-            {
-                cdacEvaluated = false;
-            }
         }
 
         if (FAILED(cdacHr) && policy != CDacLoadPolicy_CDacOnly)

--- a/src/dbgshim/dbgshim.h
+++ b/src/dbgshim/dbgshim.h
@@ -14,6 +14,9 @@
 typedef VOID (*PSTARTUP_CALLBACK)(IUnknown *pCordb, PVOID parameter, HRESULT hr);
 
 // Selects how dbgshim locates the data-access layer (DAC/cDAC) for a target.
+// For the live-debugging paths (RegisterForRuntimeStartup* and CreateDebuggingInterfaceFromVersion*),
+// cDAC is additionally gated by the DOTNET_CDAC_LIVE_DEBUGGING=1 env var. Without it, the cDAC
+// attempt is skipped and the legacy DAC is used regardless of this policy.
 enum CDacLoadPolicy
 {
     // Prefer the debugging tool bundled cDAC, falling back to the legacy DAC. This is the default.

--- a/src/dbgshim/debugshim.cpp
+++ b/src/dbgshim/debugshim.cpp
@@ -706,7 +706,8 @@ static HRESULT LoadResolvedLibraries(
 
 // Picks the final HRESULT after a cDAC attempt (cdacHr) and a legacy fallback attempt (fallbackHr).
 // On total failure the cDAC error is surfaced when it was attempted so tools can log why the cDAC
-// rejected the target; otherwise the fallback error (seeded by callers) is surfaced.
+// rejected the target. E_NOTIMPL does not describe a target rejection, so the fallback error is more
+// actionable in that case.
 HRESULT SelectActivationResult(
     HRESULT cdacHr,
     HRESULT fallbackHr,
@@ -720,7 +721,7 @@ HRESULT SelectActivationResult(
     {
         return fallbackHr;
     }
-    if (cdacEvaluated)
+    if (cdacEvaluated && cdacHr != E_NOTIMPL)
     {
         return cdacHr;
     }


### PR DESCRIPTION
cDAC support for the live-debugging paths (`RegisterForRuntimeStartup*` and `CreateDebuggingInterfaceFromVersion*`) is experimental. Without an opt-in gate it activates by default for any process that has the bundled cDAC present, which is premature.

`TryCreateCoreDbgWithCDac` now returns `E_NOTIMPL` unless `DOTNET_CDAC_LIVE_DEBUGGING=1` is set. Callers with `PreferCDac` policy fall back to the legacy DAC transparently; `CDacOnly` callers fail as expected since they have explicitly demanded cDAC. `SetCDacLoadPolicy` and the `OpenVirtualProcess` (dump/attach) path are unaffected.

The `CDacLoadPolicy` enum comment in `dbgshim.h` is updated to document the gate.