### PR TITLE
Fix SOS CLRMA crash in the native (non-hosted) !analyze path

### DIFF
--- a/src/SOS/Strike/clrma/managedanalysis.cpp
+++ b/src/SOS/Strike/clrma/managedanalysis.cpp
@@ -4,7 +4,6 @@
 #include "managedanalysis.h"
 #include "exts.h"
 
-extern bool IsWindowsTarget();
 extern "C" IXCLRDataProcess * GetClrDataFromDbgEng();
 
 _Use_decl_annotations_
@@ -109,14 +108,6 @@ ClrmaManagedAnalysis::QueryDebugClient(IUnknown* pUnknown)
 
         default:
             return E_INVALIDARG;
-    }
-    if (IsWindowsTarget())
-    {
-        m_fileSeparator = L'\\';
-    }
-    else
-    {
-        m_fileSeparator = L'/';
     }
     return S_OK;
 }
@@ -255,6 +246,10 @@ ClrmaManagedAnalysis::AssociateClient(
         ITarget* target = extensions->GetTarget();
         if (target != nullptr)
         {
+            // The DAC reports module names as full target-OS paths; the separator is OS-specific
+            // (backslash is a legal filename character on Unix, so both cannot be matched blindly).
+            m_fileSeparator = target->GetOperatingSystem() == ITarget::OperatingSystem::Windows ? L'\\' : L'/';
+
             //
             // First try getting the managed CLRMA service instance
             //

--- a/src/SOS/Strike/platform/datatarget.cpp
+++ b/src/SOS/Strike/platform/datatarget.cpp
@@ -8,14 +8,28 @@
 #include "dacprivate.h"
 #include "sospriv.h"
 #include "corerror.h"
+#include "remotememoryservice.h"
 
 #define IMAGE_FILE_MACHINE_AMD64             0x8664  // AMD64 (K8)
 
 DataTarget::DataTarget(ULONG64 baseAddress, ULONG64 contractDescriptorAddress) :
     m_ref(0),
     m_baseAddress(baseAddress),
-    m_contractDescriptorAddress(contractDescriptorAddress)
+    m_contractDescriptorAddress(contractDescriptorAddress),
+    m_debuggerServices(GetDebuggerServices())
 {
+    if (m_debuggerServices != nullptr)
+    {
+        m_debuggerServices->AddRef();
+    }
+}
+
+DataTarget::~DataTarget()
+{
+    if (m_debuggerServices != nullptr)
+    {
+        m_debuggerServices->Release();
+    }
 }
 
 STDMETHODIMP
@@ -95,11 +109,11 @@ HRESULT STDMETHODCALLTYPE
 DataTarget::GetMachineType(
     /* [out] */ ULONG32 *machine)
 {
-    if (g_ExtControl == NULL)
+    if (m_debuggerServices == nullptr)
     {
         return E_UNEXPECTED;
     }
-    return g_ExtControl->GetExecutingProcessorType((PULONG)machine);
+    return m_debuggerServices->GetProcessorType((PULONG)machine);
 }
 
 HRESULT STDMETHODCALLTYPE
@@ -122,7 +136,7 @@ DataTarget::GetImageBase(
     /* [string][in] */ LPCWSTR name,
     /* [out] */ CLRDATA_ADDRESS *base)
 {
-    if (g_ExtSymbols == NULL)
+    if (m_debuggerServices == nullptr)
     {
         return E_UNEXPECTED;
     }
@@ -140,7 +154,7 @@ DataTarget::GetImageBase(
         *lp = '\0';
     }
 #endif
-    return g_ExtSymbols->GetModuleByModuleName(lpstr, 0, NULL, base);
+    return m_debuggerServices->GetModuleByModuleName(lpstr, 0, NULL, base);
 }
 
 HRESULT STDMETHODCALLTYPE
@@ -150,7 +164,7 @@ DataTarget::ReadVirtual(
     /* [in] */ ULONG32 request,
     /* [optional][out] */ ULONG32 *done)
 {
-    if (g_ExtData == NULL)
+    if (m_debuggerServices == nullptr)
     {
         return E_UNEXPECTED;
     }
@@ -171,7 +185,7 @@ DataTarget::ReadVirtual(
         }
     }
 #endif
-    HRESULT hr = g_ExtData->ReadVirtual(address, (PVOID)buffer, request, (PULONG)done);
+    HRESULT hr = m_debuggerServices->ReadVirtual(address, (PVOID)buffer, request, (PULONG)done);
     if (FAILED(hr)) 
     {
         ExtDbgOut("DataTarget::ReadVirtual FAILED %08x address %08llx size %08x\n", hr, address, request);
@@ -186,11 +200,11 @@ DataTarget::WriteVirtual(
     /* [in] */ ULONG32 request,
     /* [optional][out] */ ULONG32 *done)
 {
-    if (g_ExtData == NULL)
+    if (m_debuggerServices == nullptr)
     {
         return E_UNEXPECTED;
     }
-    return g_ExtData->WriteVirtual(address, (PVOID)buffer, request, (PULONG)done);
+    return m_debuggerServices->WriteVirtual(address, (PVOID)buffer, request, (PULONG)done);
 }
 
 HRESULT STDMETHODCALLTYPE
@@ -215,11 +229,11 @@ HRESULT STDMETHODCALLTYPE
 DataTarget::GetCurrentThreadID(
     /* [out] */ ULONG32 *threadID)
 {
-    if (g_ExtSystem == NULL)
+    if (m_debuggerServices == nullptr)
     {
         return E_UNEXPECTED;
     }
-    return g_ExtSystem->GetCurrentThreadSystemId((PULONG)threadID);
+    return m_debuggerServices->GetCurrentThreadSystemId((PULONG)threadID);
 }
 
 HRESULT STDMETHODCALLTYPE
@@ -229,55 +243,11 @@ DataTarget::GetThreadContext(
     /* [in] */ ULONG32 contextSize,
     /* [out, size_is(contextSize)] */ PBYTE context)
 {
-    HRESULT hr;
-#ifdef FEATURE_PAL
-    if (g_ExtServices == NULL)
+    if (m_debuggerServices == nullptr)
     {
         return E_UNEXPECTED;
     }
-    hr = g_ExtServices->GetThreadContextBySystemId(threadID, contextFlags, contextSize, context);
-#else
-    if (g_ExtSystem == NULL || g_ExtAdvanced == NULL)
-    {
-        return E_UNEXPECTED;
-    }
-    ULONG ulThreadIDOrig;
-    ULONG ulThreadIDRequested;
-
-    hr = g_ExtSystem->GetCurrentThreadId(&ulThreadIDOrig);
-    if (FAILED(hr))
-    {
-        return hr;
-    }
-
-    hr = g_ExtSystem->GetThreadIdBySystemId(threadID, &ulThreadIDRequested);
-    if (FAILED(hr))
-    {
-        return hr;
-    }
-
-    hr = g_ExtSystem->SetCurrentThreadId(ulThreadIDRequested);
-    if (FAILED(hr))
-    {
-        return hr;
-    }
-
-    // Prepare context structure
-    ZeroMemory(context, contextSize);
-    g_targetMachine->SetContextFlags(context, contextFlags);
-
-    // Ok, do it!
-    hr = g_ExtAdvanced->GetThreadContext((LPVOID) context, contextSize);
-
-    // This is cleanup; failure here doesn't mean GetThreadContext should fail
-    // (that's determined by hr).
-    g_ExtSystem->SetCurrentThreadId(ulThreadIDOrig);
-#endif
-
-    // GetThreadContext clears ContextFlags or sets them incorrectly and DBI needs it set to know what registers to copy
-    g_targetMachine->SetContextFlags(context, contextFlags);
-
-    return hr;
+    return m_debuggerServices->GetThreadContextBySystemId(threadID, contextFlags, contextSize, context);
 }
 
 HRESULT STDMETHODCALLTYPE
@@ -310,21 +280,16 @@ DataTarget::AllocVirtual(
     /* [in] */ ULONG32 protectFlags,
     /* [out] */ CLRDATA_ADDRESS* virt)
 {
-#ifdef FEATURE_PAL
-    return E_NOTIMPL;
-#else
-    ULONG64 hProcess;
-    HRESULT hr = g_ExtSystem->GetCurrentProcessHandle(&hProcess);
+    if (m_debuggerServices == nullptr)
+    {
+        return E_UNEXPECTED;
+    }
+    ReleaseHolder<IRemoteMemoryService> remoteMemoryService;
+    HRESULT hr = m_debuggerServices->QueryInterface(__uuidof(IRemoteMemoryService), (void**)&remoteMemoryService);
     if (FAILED(hr)) {
-        return hr;
+        return E_NOTIMPL;
     }
-    LPVOID allocation = ::VirtualAllocEx((HANDLE)hProcess, (LPVOID)addr, size, typeFlags, protectFlags);
-    if (allocation == NULL) {
-        return HRESULT_FROM_WIN32(::GetLastError());
-    }
-    *virt = (CLRDATA_ADDRESS)allocation;
-    return S_OK;
-#endif
+    return remoteMemoryService->AllocVirtual(addr, size, typeFlags, protectFlags, virt);
 }
         
 HRESULT STDMETHODCALLTYPE 
@@ -333,17 +298,16 @@ DataTarget::FreeVirtual(
     /* [in] */ ULONG32 size,
     /* [in] */ ULONG32 typeFlags)
 {
-#ifdef FEATURE_PAL
-    return E_NOTIMPL;
-#else
-    ULONG64 hProcess;
-    HRESULT hr = g_ExtSystem->GetCurrentProcessHandle(&hProcess);
-    if (FAILED(hr)) {
-        return hr;
+    if (m_debuggerServices == nullptr)
+    {
+        return E_UNEXPECTED;
     }
-    ::VirtualFreeEx((HANDLE)hProcess, (LPVOID)addr, size, typeFlags);
-    return S_OK;
-#endif
+    ReleaseHolder<IRemoteMemoryService> remoteMemoryService;
+    HRESULT hr = m_debuggerServices->QueryInterface(__uuidof(IRemoteMemoryService), (void**)&remoteMemoryService);
+    if (FAILED(hr)) {
+        return E_NOTIMPL;
+    }
+    return remoteMemoryService->FreeVirtual(addr, size, typeFlags);
 }
 
 // ICorDebugDataTarget4
@@ -355,11 +319,11 @@ DataTarget::VirtualUnwind(
     /* [in, out, size_is(contextSize)] */ PBYTE context)
 {
 #ifdef FEATURE_PAL
-    if (g_ExtServices == NULL)
+    if (m_debuggerServices == nullptr)
     {
         return E_UNEXPECTED;
     }
-    return g_ExtServices->VirtualUnwind(threadId, contextSize, context);
+    return m_debuggerServices->VirtualUnwind(threadId, contextSize, context);
 #else
     return E_NOTIMPL;
 #endif

--- a/src/SOS/Strike/platform/datatarget.h
+++ b/src/SOS/Strike/platform/datatarget.h
@@ -7,10 +7,11 @@ private:
     LONG m_ref;                         // Reference count.
     ULONG64 m_baseAddress;              // Runtime base address
     ULONG64 m_contractDescriptorAddress; // cDAC contract descriptor address (0 if not applicable/resolved)
+    IDebuggerServices* m_debuggerServices;
 
 public:
     DataTarget(ULONG64 baseAddress, ULONG64 contractDescriptorAddress = 0);
-    virtual ~DataTarget() {}
+    virtual ~DataTarget();
     
     // IUnknown.
     STDMETHOD(QueryInterface)(

--- a/src/SOS/Strike/platform/hostimpl.cpp
+++ b/src/SOS/Strike/platform/hostimpl.cpp
@@ -12,13 +12,16 @@ Host* Host::s_host = nullptr;
 // Host
 //----------------------------------------------------------------------------
 
-Host::Host() :
-    m_ref(1)
-{ 
+Host::Host(IDebuggerServices* debuggerServices) :
+    m_ref(1),
+    m_debuggerServices(debuggerServices)
+{
+    m_debuggerServices->AddRef();
 }
 
 Host::~Host()
 {
+    m_debuggerServices->Release();
     s_host = nullptr;
 }
 
@@ -26,11 +29,11 @@ Host::~Host()
 /// Creates a local service provider instance or returns the existing one 
 /// </summary>
 /// <returns></returns>
-IHost* Host::GetInstance()
+IHost* Host::GetInstance(IDebuggerServices* debuggerServices)
 {
-    if (s_host == nullptr) 
+    if (s_host == nullptr)
     {
-        s_host = new Host();
+        s_host = new Host(debuggerServices);
     }
     s_host->AddRef();
     return s_host;
@@ -99,6 +102,6 @@ HRESULT Host::GetCurrentTarget(ITarget** ppTarget)
     {
         return E_INVALIDARG;
     }
-    *ppTarget = Target::GetInstance();
+    *ppTarget = Target::GetInstance(m_debuggerServices);
     return S_OK;
 }

--- a/src/SOS/Strike/platform/hostimpl.h
+++ b/src/SOS/Strike/platform/hostimpl.h
@@ -12,14 +12,15 @@ class Host : public IHost
 {
 private:
     LONG m_ref;
+    IDebuggerServices* m_debuggerServices;
 
     static Host* s_host;
 
-    Host();
+    Host(IDebuggerServices* debuggerServices);
     virtual ~Host();
 
 public:
-    static IHost* GetInstance();
+    static IHost* GetInstance(IDebuggerServices* debuggerServices);
 
     //----------------------------------------------------------------------------
     // IUnknown

--- a/src/SOS/Strike/platform/runtimeimpl.cpp
+++ b/src/SOS/Strike/platform/runtimeimpl.cpp
@@ -65,8 +65,13 @@ extern "C" bool TryGetSymbolWithCallback(
 
 bool ReaderReadMemory(void* address, void* buffer, size_t size)
 {
+    IDebuggerServices* debuggerServices = GetDebuggerServices();
+    if (debuggerServices == nullptr)
+    {
+        return false;
+    }
     ULONG read = 0;
-    return SUCCEEDED(g_ExtData->ReadVirtual((ULONG64)address, buffer, (ULONG)size, &read));
+    return SUCCEEDED(debuggerServices->ReadVirtual((ULONG64)address, buffer, (ULONG)size, &read));
 }
 
 /**********************************************************************\
@@ -85,7 +90,7 @@ static HRESULT GetSingleFileInfo(ITarget* target, PULONG pModuleIndex, PULONG64 
     }
 
     ULONG loaded, unloaded;
-    HRESULT hr = g_ExtSymbols->GetNumberModules(&loaded, &unloaded);
+    HRESULT hr = debuggerServices->GetNumberModules(&loaded, &unloaded);
     if (FAILED(hr)) {
         return hr;
     }
@@ -94,7 +99,7 @@ static HRESULT GetSingleFileInfo(ITarget* target, PULONG pModuleIndex, PULONG64 
     for (ULONG index = 0; index < loaded; index++)
     {
         ULONG64 baseAddress;
-        hr = g_ExtSymbols->GetModuleByIndex(index, &baseAddress);
+        hr = debuggerServices->GetModuleByIndex(index, &baseAddress);
         if (FAILED(hr)) {
             return hr;
         }
@@ -115,7 +120,7 @@ static HRESULT GetSingleFileInfo(ITarget* target, PULONG pModuleIndex, PULONG64 
         }
         ULONG read = 0;
         ArrayHolder<BYTE> buffer = new BYTE[sizeof(RuntimeInfo)];
-        hr = g_ExtData->ReadVirtual(symbolAddress, buffer, sizeof(RuntimeInfo), &read);
+        hr = debuggerServices->ReadVirtual(symbolAddress, buffer, sizeof(RuntimeInfo), &read);
         if (FAILED(hr)) {
             return hr;
         }
@@ -148,8 +153,13 @@ HRESULT Runtime::CreateInstance(ITarget* target, RuntimeConfiguration configurat
 
     if (*ppRuntime == nullptr)
     {
+        IDebuggerServices* debuggerServices = GetDebuggerServices();
+        if (debuggerServices == nullptr)
+        {
+            return E_NOINTERFACE;
+        }
         // Check if the normal runtime module (coreclr.dll, libcoreclr.so, etc.) is loaded
-        hr = g_ExtSymbols->GetModuleByModuleName(runtimeModuleName, 0, &moduleIndex, &moduleAddress);
+        hr = debuggerServices->GetModuleByModuleName(runtimeModuleName, 0, &moduleIndex, &moduleAddress);
         if (FAILED(hr))
         {
             // If the standard runtime module isn't loaded, try looking for a single-file program
@@ -166,12 +176,7 @@ HRESULT Runtime::CreateInstance(ITarget* target, RuntimeConfiguration configurat
             hr = g_ExtServices2->GetModuleInfo(moduleIndex, nullptr, &moduleSize, nullptr, nullptr);
 #else
             _ASSERTE(moduleAddress != 0);
-            DEBUG_MODULE_PARAMETERS params;
-            hr = g_ExtSymbols->GetModuleParameters(1, &moduleAddress, 0, &params);
-            if (SUCCEEDED(hr))
-            {
-                moduleSize = params.Size;
-            }
+            hr = debuggerServices->GetModuleInfo(moduleIndex, nullptr, &moduleSize, nullptr, nullptr);
 #endif
         }
 
@@ -217,7 +222,10 @@ Runtime::Runtime(ITarget* target, RuntimeConfiguration configuration, ULONG inde
     _ASSERTE(size != 0);
 
     ArrayHolder<char> szModuleName = new char[MAX_LONGPATH + 1];
-    HRESULT hr = g_ExtSymbols->GetModuleNames(index, 0, szModuleName, MAX_LONGPATH, NULL, NULL, 0, NULL, NULL, 0, NULL);
+    IDebuggerServices* debuggerServices = GetDebuggerServices();
+    HRESULT hr = debuggerServices != nullptr
+        ? debuggerServices->GetModuleNames(index, 0, szModuleName, MAX_LONGPATH, NULL, NULL, 0, NULL, NULL, 0, NULL)
+        : E_NOINTERFACE;
     if (SUCCEEDED(hr))
     {
         m_name = szModuleName.Detach();
@@ -836,9 +844,13 @@ HRESULT Runtime::GetCorDebugInterface(ICorDebugProcess** ppCorDebugProcess)
 HRESULT Runtime::GetEEVersion(VS_FIXEDFILEINFO* pFileInfo, char* fileVersionBuffer, int fileVersionBufferSizeInBytes)
 {
     _ASSERTE(pFileInfo);
-    _ASSERTE(g_ExtSymbols2 != nullptr);
+    IDebuggerServices* debuggerServices = GetDebuggerServices();
+    if (debuggerServices == nullptr)
+    {
+        return E_NOINTERFACE;
+    }
 
-    HRESULT hr = g_ExtSymbols2->GetModuleVersionInformation(
+    HRESULT hr = debuggerServices->GetModuleVersionInformation(
         m_index, 0, "\\", pFileInfo, sizeof(VS_FIXEDFILEINFO), NULL);
 
     // 0.0.0.0 is not a valid version. This is sometime returned by windbg for Linux core dumps
@@ -853,7 +865,7 @@ HRESULT Runtime::GetEEVersion(VS_FIXEDFILEINFO* pFileInfo, char* fileVersionBuff
             fileVersionBuffer[0] = '\0';
         }
         // We can assume the English/CP_UNICODE lang/code page for the runtime modules
-        g_ExtSymbols2->GetModuleVersionInformation(
+        debuggerServices->GetModuleVersionInformation(
             m_index, 0, "\\StringFileInfo\\040904B0\\FileVersion", fileVersionBuffer, fileVersionBufferSizeInBytes, NULL);
     }
 

--- a/src/SOS/Strike/platform/targetimpl.cpp
+++ b/src/SOS/Strike/platform/targetimpl.cpp
@@ -13,14 +13,16 @@ Target* Target::s_target = nullptr;
 // Target
 //----------------------------------------------------------------------------
 
-Target::Target() :
+Target::Target(IDebuggerServices* debuggerServices) :
     m_ref(1),
+    m_debuggerServices(debuggerServices),
     m_tmpPath(nullptr),
 #ifndef FEATURE_PAL
     m_desktop(nullptr),
 #endif
     m_netcore(nullptr)
-{ 
+{
+    m_debuggerServices->AddRef();
 }
 
 Target::~Target()
@@ -69,17 +71,23 @@ Target::~Target()
     }
 #endif
     g_pRuntime = nullptr;
+    m_debuggerServices->Release();
     s_target = nullptr;
 }
 
 /**********************************************************************\
 * Creates a local target instance or returns the existing one
 \**********************************************************************/
-ITarget* Target::GetInstance()
+ITarget* Target::GetInstance(IDebuggerServices* debuggerServices)
 {
-    if (s_target == nullptr) 
+    if (s_target == nullptr)
     {
-        s_target = new Target();
+        _ASSERTE(debuggerServices != nullptr);
+        if (debuggerServices == nullptr)
+        {
+            return nullptr;
+        }
+        s_target = new Target(debuggerServices);
         OnUnloadTask::Register(CleanupTarget);
     }
     s_target->AddRef();
@@ -215,8 +223,6 @@ ULONG Target::Release()
 // ITarget
 //----------------------------------------------------------------------------
 
-#define VER_PLATFORM_UNIX 10 
-
 ITarget::OperatingSystem Target::GetOperatingSystem()
 {
 #ifdef FEATURE_PAL
@@ -228,15 +234,25 @@ ITarget::OperatingSystem Target::GetOperatingSystem()
     return OperatingSystem::Unknown;
 #endif
 #else
-    ULONG platformId, major, minor, servicePack;
-    if (SUCCEEDED(g_ExtControl->GetSystemVersion(&platformId, &major, &minor, nullptr, 0, nullptr, &servicePack, nullptr, 0, nullptr)))
+    if (m_debuggerServices != nullptr)
     {
-        if (platformId == VER_PLATFORM_UNIX)
+        IDebuggerServices::OperatingSystem operatingSystem;
+        if (SUCCEEDED(m_debuggerServices->GetOperatingSystem(&operatingSystem)))
         {
-            return OperatingSystem::Linux;
+            switch (operatingSystem)
+            {
+                case IDebuggerServices::OperatingSystem::Windows:
+                    return OperatingSystem::Windows;
+                case IDebuggerServices::OperatingSystem::Linux:
+                    return OperatingSystem::Linux;
+                case IDebuggerServices::OperatingSystem::OSX:
+                    return OperatingSystem::OSX;
+                default:
+                    return OperatingSystem::Unknown;
+            }
         }
     }
-    return OperatingSystem::Windows;
+    return OperatingSystem::Unknown;
 #endif
 }
 
@@ -257,7 +273,7 @@ LPCSTR Target::GetTempDirectory()
             strcat_s(tmpPath, MAX_LONGPATH, DIRECTORY_SEPARATOR_STR_A);
         }
         ULONG pid = 0;
-        if (g_ExtSystem->GetCurrentProcessSystemId(&pid) != 0)
+        if (m_debuggerServices == nullptr || m_debuggerServices->GetCurrentProcessSystemId(&pid) != S_OK)
         {
             // Use the SOS process id if can't get target's
             pid = ::GetCurrentProcessId();

--- a/src/SOS/Strike/platform/targetimpl.h
+++ b/src/SOS/Strike/platform/targetimpl.h
@@ -15,6 +15,7 @@ class Target : public ITarget
 {
 private:
     LONG m_ref;
+    IDebuggerServices* m_debuggerServices;
     LPCSTR m_tmpPath;
 #ifndef FEATURE_PAL
     Runtime* m_desktop;
@@ -28,20 +29,19 @@ private:
 #endif
     void DisplayStatusInstance();
 
-    Target();
+    Target(IDebuggerServices* debuggerServices);
     virtual ~Target();
 
 public:
-    static ITarget* GetInstance();
+    static ITarget* GetInstance(IDebuggerServices* debuggerServices);
 
     HRESULT CreateInstance(IRuntime** ppRuntime);
 
 #ifndef FEATURE_PAL
     static bool SwitchRuntime(bool desktop)
     {
-        GetInstance();
         _ASSERTE(s_target != nullptr);
-        return s_target->SwitchRuntimeInstance(desktop);
+        return s_target != nullptr && s_target->SwitchRuntimeInstance(desktop);
     }
 #endif
 

--- a/src/SOS/Strike/platform/targetimpl.h
+++ b/src/SOS/Strike/platform/targetimpl.h
@@ -40,8 +40,15 @@ public:
 #ifndef FEATURE_PAL
     static bool SwitchRuntime(bool desktop)
     {
-        _ASSERTE(s_target != nullptr);
-        return s_target != nullptr && s_target->SwitchRuntimeInstance(desktop);
+        // Lazily create the local target with the session-lifetime debugger services so
+        // -netfx/-netcore switching works even when no command has created a target yet.
+        ITarget* target = GetInstance(GetDebuggerServices());
+        bool switched = s_target != nullptr && s_target->SwitchRuntimeInstance(desktop);
+        if (target != nullptr)
+        {
+            target->Release();
+        }
+        return switched;
     }
 #endif
 

--- a/src/SOS/Strike/sosextensions.cpp
+++ b/src/SOS/Strike/sosextensions.cpp
@@ -81,7 +81,7 @@ SOSExtensions::GetHost()
         // Otherwise, use the local host instance (hostimpl.*) that creates a local target instance (targetimpl.*)
         if (m_pHost == nullptr)
         {
-            m_pHost = Host::GetInstance();
+            m_pHost = Host::GetInstance(m_pDebuggerServices);
         }
     }
     return m_pHost;

--- a/src/tests/SOS.UnitTests/Scripts/StackAndOtherTests.script
+++ b/src/tests/SOS.UnitTests/Scripts/StackAndOtherTests.script
@@ -297,14 +297,17 @@ VERIFY:\s+<DECVAL>\s+<DECVAL>\s+<HEXVAL>\s+<HEXVAL>.*\s+
 
 # Exercise the native (non-hosted) CLRMA path under cdb. With no managed host, clrma associates
 # through the DAC CLRMA provider, which drives the SOS native Target/DataTarget/Runtime objects.
-# Those must resolve the target OS (for the module path separator) and thread context through the
-# session-lifetime IDebuggerServices; the exported CLRMACreateInstance path runs outside command
-# scope where the command-scoped debugger client globals are null, so relying on them faults there.
+# Association runs AssociateClient -> QueryDebugClient -> IsWindowsTarget -> Target::GetOperatingSystem,
+# which must resolve the target OS through the session-lifetime IDebuggerServices. The exported
+# CLRMACreateInstance path (dbgeng !analyze) runs outside command scope where the command-scoped
+# debugger client globals are null, so relying on them faults there. Printing the provider line and
+# OSThreadId proves association and the OS query completed without faulting. The managed frame output
+# is intentionally not verified: which exception clrma reports and the module-name format it prints
+# are not stable across runs, so asserting a specific frame would be flaky.
 IFDEF:HOST_RUNTIME_NONE
 IFDEF:WINDOWS
 SOSCOMMAND:clrma
 VERIFY:Managed analysis provider:\s+SOSCLRMA\s+
 VERIFY:OSThreadId:\s+<HEXVAL>\s+
-VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp!SymbolTestApp\.Program\.Main\+0x<HEXVAL>
 ENDIF:WINDOWS
 ENDIF:HOST_RUNTIME_NONE

--- a/src/tests/SOS.UnitTests/Scripts/StackAndOtherTests.script
+++ b/src/tests/SOS.UnitTests/Scripts/StackAndOtherTests.script
@@ -294,3 +294,17 @@ VERIFY:\s+DeadThread:\s+<DECVAL>\s+
 VERIFY:\s+Hosted Runtime:\s+no\s+
 VERIFY:\s+ID\s+OSID\s+ThreadOBJ\s+State.*\s+
 VERIFY:\s+<DECVAL>\s+<DECVAL>\s+<HEXVAL>\s+<HEXVAL>.*\s+
+
+# Exercise the native (non-hosted) CLRMA path under cdb. With no managed host, clrma associates
+# through the DAC CLRMA provider, which drives the SOS native Target/DataTarget/Runtime objects.
+# Those must resolve the target OS (for the module path separator) and thread context through the
+# session-lifetime IDebuggerServices; the exported CLRMACreateInstance path runs outside command
+# scope where the command-scoped debugger client globals are null, so relying on them faults there.
+IFDEF:HOST_RUNTIME_NONE
+IFDEF:WINDOWS
+SOSCOMMAND:clrma
+VERIFY:Managed analysis provider:\s+SOSCLRMA\s+
+VERIFY:OSThreadId:\s+<HEXVAL>\s+
+VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp!SymbolTestApp\.Program\.Main\(.*\).*
+ENDIF:WINDOWS
+ENDIF:HOST_RUNTIME_NONE

--- a/src/tests/SOS.UnitTests/Scripts/StackAndOtherTests.script
+++ b/src/tests/SOS.UnitTests/Scripts/StackAndOtherTests.script
@@ -305,6 +305,6 @@ IFDEF:WINDOWS
 SOSCOMMAND:clrma
 VERIFY:Managed analysis provider:\s+SOSCLRMA\s+
 VERIFY:OSThreadId:\s+<HEXVAL>\s+
-VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp!SymbolTestApp\.Program\.Main\(.*\).*
+VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.(dll|exe)!SymbolTestApp\.Program\.Main\(.*\).*
 ENDIF:WINDOWS
 ENDIF:HOST_RUNTIME_NONE

--- a/src/tests/SOS.UnitTests/Scripts/StackAndOtherTests.script
+++ b/src/tests/SOS.UnitTests/Scripts/StackAndOtherTests.script
@@ -305,6 +305,6 @@ IFDEF:WINDOWS
 SOSCOMMAND:clrma
 VERIFY:Managed analysis provider:\s+SOSCLRMA\s+
 VERIFY:OSThreadId:\s+<HEXVAL>\s+
-VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp\.(dll|exe)!SymbolTestApp\.Program\.Main\(.*\).*
+VERIFY:\s+<HEXVAL>\s+<HEXVAL>\s+SymbolTestApp!SymbolTestApp\.Program\.Main\+0x<HEXVAL>
 ENDIF:WINDOWS
 ENDIF:HOST_RUNTIME_NONE


### PR DESCRIPTION
The exported `CLRMACreateInstance` entrypoint runs outside any SOS command, but the native `Target`/`Runtime`/`DataTarget`/`Host` fallback objects read the command-scoped `g_Ext*` globals, which are null outside a command. `!analyze` hit this and crashed in `Target::GetOperatingSystem`.

These objects now use the session-lifetime `IDebuggerServices` (backed by `DbgEngServices`/`LLDBServices`) instead of `g_Ext*`, so they are valid regardless of command scope. OS-dependent choices, including the CLRMA module-name separator, now come from `ITarget::GetOperatingSystem()`.

Rejected repopulating `g_Ext*` for the exported path: it preserves the command-scoped-global coupling instead of fixing the lifetime mismatch.

**Behavior change:** `DataTarget::GetMachineType` now normalizes `ARM64EC` to `AMD64` (via `DbgEngServices::GetProcessorType`), matching the rest of SOS; AMD64/ARM64 are unaffected.