### PR TITLE
Harden dotnet-trace process probe test

### DIFF
--- a/src/tests/dotnet-trace/CollectLinuxCommandFunctionalTests.cs
+++ b/src/tests/dotnet-trace/CollectLinuxCommandFunctionalTests.cs
@@ -415,8 +415,11 @@ namespace Microsoft.Diagnostics.Tools.Trace
             List<string> result = new();
             foreach (string line in lines)
             {
-                // Filter out possible pid lines
-                if (Regex.IsMatch(line, @"^\d"))
+                if (// Filter out possible pid lines
+                    Regex.IsMatch(line, @"^\d") ||
+                    // Process enumeration and probing are not atomic, so this optional section can
+                    // appear whenever an enumerated process exits before its diagnostic port is probed.
+                    string.Equals(line, ".NET processes that could not be probed:", StringComparison.Ordinal))
                 {
                     continue;
                 }


### PR DESCRIPTION
Make `CollectLinuxCommand_Probe_ListsProcesses_WhenNoArgs` tolerate the optional unprobeable-process section emitted when an enumerated .NET process exits before diagnostic-port probing.

The sanitizer continues validating the stable probe output while filtering only process rows and the exact optional section heading. There are no product behavior changes.