### PR TITLE
Restore dbgshim-only package layout

### DIFF
--- a/src/dbgshim/pkg/Microsoft.Diagnostics.DbgShim.props
+++ b/src/dbgshim/pkg/Microsoft.Diagnostics.DbgShim.props
@@ -18,21 +18,6 @@
       <None Include="$(NativeBinDir)$(LibPrefix)dbgshim$(LibSuffix)"
             PackagePath="runtimes/$(PackageRID)/native"
             Pack="true" />
-      <!--
-        Include the cDAC native binary (mscordaccore_universal[.dll/.so/.dylib]) alongside
-        dbgshim when PackageWithCDac is set. The file is staged into $(NativeBinDir) by the
-        InstallNativePackages target which downloads it from the runtime's cDAC transport
-        package. Avoid pulling in any SOS-related assets here — dbgshim is a standalone
-        native package consumed independently of SOS.
-      -->
-      <None Condition="'$(PackageWithCDac)' == 'true'"
-            Include="$(NativeBinDir)$(LibPrefix)mscordaccore_universal$(LibSuffix)"
-            PackagePath="runtimes/$(PackageRID)/native"
-            Pack="true" />
-      <None Condition="'$(PackageWithCDac)' == 'true'"
-            Include="$(NativeBinDir)$(LibPrefix)mscordbi_universal$(LibSuffix)"
-            PackagePath="runtimes/$(PackageRID)/native"
-            Pack="true" />
     </ItemGroup>
 
     <Target Name="AddRuntimeSpecificNativeSymbolToPackage">


### PR DESCRIPTION
## Description

Return `Microsoft.Diagnostics.DbgShim` to its original dbgshim-only package layout by removing the universal cDAC and DBI assets. Diagnostic tools continue using the assets from the cDAC transport package.