### PR TITLE
SOS: read macOS arm64 thread metadata from a valid address

### DIFF
--- a/src/SOS/inc/specialthreadinfo.h
+++ b/src/SOS/inc/specialthreadinfo.h
@@ -13,7 +13,7 @@
 
 #define SPECIAL_THREADINFO_SIGNATURE "THREADINFO"
 
-#if defined(__APPLE__) && (defined(HOST_ARM64) || defined(__arm64__) || defined(__aarch64__))
+#if defined(HOST_ARM64) || defined(__arm64__) || defined(__aarch64__)
 // Apple Silicon (arm64) macOS user-space VM is 47 bits. lldb's core reader
 // rejects segments above 0x7FFF_FFFF_FFFF, so use a 47-bit-valid address.
 // The legacy address is still probed for dumps produced by older createdump binaries.

--- a/src/SOS/inc/specialthreadinfo.h
+++ b/src/SOS/inc/specialthreadinfo.h
@@ -17,7 +17,7 @@
 // Apple Silicon (arm64) macOS user-space VM is 47 bits. lldb's core reader
 // rejects segments above 0x7FFF_FFFF_FFFF, so use a 47-bit-valid address.
 // The legacy address is still probed for dumps produced by older createdump binaries.
-const uint64_t SpecialThreadInfoAddress = 0x00007ffffff20000;
+const uint64_t SpecialThreadInfoAddress = 0x00007ffffff00000;
 const uint64_t SpecialThreadInfoLegacyAddress = 0x7fffffff00000000;
 #else
 const uint64_t SpecialThreadInfoAddress = 0x7fffffff00000000;

--- a/src/SOS/inc/specialthreadinfo.h
+++ b/src/SOS/inc/specialthreadinfo.h
@@ -13,7 +13,16 @@
 
 #define SPECIAL_THREADINFO_SIGNATURE "THREADINFO"
 
+#if defined(__APPLE__) && (defined(HOST_ARM64) || defined(__arm64__) || defined(__aarch64__))
+// Apple Silicon (arm64) macOS user-space VM is 47 bits. lldb's core reader
+// rejects segments above 0x7FFF_FFFF_FFFF, so use a 47-bit-valid address.
+// The legacy address is still probed for dumps produced by older createdump binaries.
+const uint64_t SpecialThreadInfoAddress = 0x00007ffffff20000;
+const uint64_t SpecialThreadInfoLegacyAddress = 0x7fffffff00000000;
+#else
 const uint64_t SpecialThreadInfoAddress = 0x7fffffff00000000;
+const uint64_t SpecialThreadInfoLegacyAddress = 0x7fffffff00000000;
+#endif
 
 struct SpecialThreadInfoHeader
 {

--- a/src/SOS/lldbplugin/services.cpp
+++ b/src/SOS/lldbplugin/services.cpp
@@ -2756,7 +2756,17 @@ LLDBServices::InitializeThreadInfo(lldb::SBProcess process)
     }
     SpecialThreadInfoHeader header;
     lldb::SBError error;
-    size_t read = process.ReadMemory(SpecialThreadInfoAddress, &header, sizeof(SpecialThreadInfoHeader), error);
+    uint64_t threadInfoAddress = SpecialThreadInfoAddress;
+    size_t read = process.ReadMemory(threadInfoAddress, &header, sizeof(SpecialThreadInfoHeader), error);
+    if ((error.Fail() || read != sizeof(header) ||
+         strncmp(header.signature, SPECIAL_THREADINFO_SIGNATURE, sizeof(SPECIAL_THREADINFO_SIGNATURE)) != 0)
+        && SpecialThreadInfoAddress != SpecialThreadInfoLegacyAddress)
+    {
+        // Fall back to the legacy address for dumps produced by older createdump binaries.
+        error.Clear();
+        threadInfoAddress = SpecialThreadInfoLegacyAddress;
+        read = process.ReadMemory(threadInfoAddress, &header, sizeof(SpecialThreadInfoHeader), error);
+    }
     if (error.Fail() || read != sizeof(header))
     {
         return;
@@ -2775,7 +2785,7 @@ LLDBServices::InitializeThreadInfo(lldb::SBProcess process)
     m_processId = header.pid;
     m_threadInfos.clear();
 
-    uint64_t address = SpecialThreadInfoAddress + sizeof(header);
+    uint64_t address = threadInfoAddress + sizeof(header);
     for (int index = 0; index < number; index++)
     {
         SpecialThreadInfoEntry entry;


### PR DESCRIPTION
## Summary

- read macOS arm64 createdump thread metadata from the new 47-bit-valid address
- fall back to the legacy address for compatibility with existing createdump output
- use the selected address for all subsequent thread-info entries

## Motivation

Apple Silicon LLDB rejects the legacy `0x7fffffff00000000` synthetic segment and assigns sequential thread IDs beginning at zero. SOS cannot then correlate LLDB threads with runtime OS thread IDs or retrieve the selected thread context.

Coordinated writer change: https://github.com/dotnet/runtime/pull/131962

## Related precedent

This follows @steveisok's coordinated Apple Silicon fix for `SpecialDiagInfoAddress`:

- runtime writer: https://github.com/dotnet/runtime/pull/130443
- diagnostics readers: https://github.com/dotnet/diagnostics/pull/5823

## Testing

Draft pending coordinated macOS arm64 validation with the runtime writer change.