### PR TITLE
Update System.CommandLine to 2.0.10

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -45,6 +45,7 @@
     <SystemReflectionMetadataVersion>8.0.0</SystemReflectionMetadataVersion>
     <SystemCollectionsImmutableVersion>9.0.11</SystemCollectionsImmutableVersion>
     <!-- Other libs -->
+    <SystemCommandLineVersion>2.0.10</SystemCommandLineVersion>
     <MicrosoftBclAsyncInterfacesVersion>9.0.8</MicrosoftBclAsyncInterfacesVersion>
     <MicrosoftDiaSymReaderNativeVersion>17.10.0-beta1.24272.1</MicrosoftDiaSymReaderNativeVersion>
     <MicrosoftDiagnosticsTracingTraceEventVersion>3.1.23</MicrosoftDiagnosticsTracingTraceEventVersion>

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/CommandService.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/CommandService.cs
@@ -276,7 +276,6 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
         {
             private Command _rootCommand;
             private readonly Dictionary<string, CommandHandler> _commandHandlers = new();
-            private readonly ParseResult _emptyParseResult;
 
             /// <summary>
             /// Create an instance of the command processor;
@@ -285,10 +284,6 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
             public CommandGroup(string commandPrompt = null)
             {
                 _rootCommand = new Command(commandPrompt);
-
-                // The actual ParseResult.Empty() has a bug in it where it tries to get the executable name
-                // and nothing is returned under lldb on Linux causing an index out of range exception.
-                _emptyParseResult = _rootCommand.Parse(Array.Empty<string>());
             }
 
             /// <summary>
@@ -300,15 +295,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
             /// <exception cref="DiagnosticsException">parsing error</exception>
             internal bool Execute(IReadOnlyList<string> commandLine, IServiceProvider services)
             {
-                IConsoleService consoleService = services.GetService<IConsoleService>();
-                CommandLineConfiguration configuration = new(_rootCommand)
-                {
-                    Output = new ConsoleServiceWrapper(consoleService.Write),
-                    Error = new ConsoleServiceWrapper(consoleService.WriteError)
-                };
-
-                // Parse the command line and invoke the command
-                ParseResult parseResult = configuration.Parse(commandLine);
+                ParseResult parseResult = _rootCommand.Parse(commandLine);
 
                 if (parseResult.Errors.Count > 0)
                 {
@@ -437,10 +424,26 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
             {
                 StringWriter console = new();
 
-                // Get the command help
-                HelpBuilder helpBuilder = new(maxWidth: windowWidth);
-                HelpContext helpContext = new(helpBuilder, command, console, _emptyParseResult);
-                helpBuilder.Write(helpContext);
+                HelpOption helpOption = new()
+                {
+                    Hidden = true,
+                    Action = new HelpAction
+                    {
+                        MaxWidth = windowWidth
+                    }
+                };
+                command.Options.Add(helpOption);
+                try
+                {
+                    command.Parse(["--help"]).Invoke(new InvocationConfiguration
+                    {
+                        Output = console
+                    });
+                }
+                finally
+                {
+                    command.Options.Remove(helpOption);
+                }
 
                 // Get the detailed help if any
                 if (TryGetCommandHandler(command.Name, out CommandHandler handler))
@@ -725,15 +728,5 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
             }
         }
 
-        internal sealed class ConsoleServiceWrapper : TextWriter
-        {
-            private Action<string> _write;
-
-            public ConsoleServiceWrapper(Action<string> write) => _write = write;
-
-            public override void Write(string value) => _write.Invoke(value);
-
-            public override Encoding Encoding => throw new NotImplementedException();
-        }
     }
 }

--- a/src/Tools/Common/Commands/ProcessStatus.cs
+++ b/src/Tools/Common/Commands/ProcessStatus.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Internal.Common.Commands
         public static Command ProcessStatusCommand(string description)
         {
             Command statusCommand = new(name: "ps", description);
-            statusCommand.SetAction((parseResult, ct) => Task.FromResult(ProcessStatus(parseResult.Configuration.Output, parseResult.Configuration.Error)));
+            statusCommand.SetAction((parseResult, ct) => Task.FromResult(ProcessStatus(parseResult.InvocationConfiguration.Output, parseResult.InvocationConfiguration.Error)));
             return statusCommand;
         }
 

--- a/src/Tools/Common/ProcessTerminationHandler.cs
+++ b/src/Tools/Common/ProcessTerminationHandler.cs
@@ -24,15 +24,13 @@ namespace Microsoft.Internal.Common.Utils
 
         internal static async Task<int> InvokeAsync(ParseResult parseResult, string blockedSignals = "")
         {
-            using ProcessTerminationHandler terminationHandler = ConfigureTerminationHandler(parseResult, blockedSignals);
-            return await parseResult.InvokeAsync(terminationHandler.GetToken).ConfigureAwait(false);
-        }
-
-        private static ProcessTerminationHandler ConfigureTerminationHandler(ParseResult parseResult, string blockedSignals)
-        {
-            // Use custom process terminate handler for the command line tool parse result.
-            parseResult.Configuration.ProcessTerminationTimeout = null;
-            return new ProcessTerminationHandler(blockedSignals);
+            using ProcessTerminationHandler terminationHandler = new(blockedSignals);
+            return await parseResult.InvokeAsync(
+                configuration: new InvocationConfiguration
+                {
+                    ProcessTerminationTimeout = null
+                },
+                cancellationToken: terminationHandler.GetToken).ConfigureAwait(false);
         }
 
         private ProcessTerminationHandler(string blockedSignals)

--- a/src/Tools/dotnet-dump/Program.cs
+++ b/src/Tools/dotnet-dump/Program.cs
@@ -32,8 +32,8 @@ namespace Microsoft.Diagnostics.Tools.Dump
             };
 
             command.SetAction((parseResult) => new Dumper().Collect(
-                stdOutput: parseResult.Configuration.Output,
-                stdError: parseResult.Configuration.Error,
+                stdOutput: parseResult.InvocationConfiguration.Output,
+                stdError: parseResult.InvocationConfiguration.Error,
                 processId: parseResult.GetValue(ProcessIdOption),
                 output: parseResult.GetValue(OutputOption),
                 diag: parseResult.GetValue(DiagnosticLoggingOption),

--- a/src/Tools/dotnet-sos/Program.cs
+++ b/src/Tools/dotnet-sos/Program.cs
@@ -32,8 +32,8 @@ namespace Microsoft.Diagnostics.Tools.SOS
             };
 
             installCommand.SetAction(parseResult => Invoke(
-                parseResult.Configuration.Output,
-                parseResult.Configuration.Error,
+                parseResult.InvocationConfiguration.Output,
+                parseResult.InvocationConfiguration.Error,
                 architecture: parseResult.GetValue(ArchitectureOption),
                 install: true));
 
@@ -53,8 +53,8 @@ namespace Microsoft.Diagnostics.Tools.SOS
                 description: "Uninstalls SOS and reverts any configuration changes to LLDB.");
 
             uninstallCommand.SetAction(parseResult => Invoke(
-                parseResult.Configuration.Output,
-                parseResult.Configuration.Error,
+                parseResult.InvocationConfiguration.Output,
+                parseResult.InvocationConfiguration.Error,
                 architecture: null,
                 install: false));
 

--- a/src/Tools/dotnet-stack/ReportCommand.cs
+++ b/src/Tools/dotnet-stack/ReportCommand.cs
@@ -174,8 +174,8 @@ namespace Microsoft.Diagnostics.Tools.Stack
             };
 
             reportCommand.SetAction((parseResult, ct) => Report(ct,
-                stdOutput: parseResult.Configuration.Output,
-                stdError: parseResult.Configuration.Error,
+                stdOutput: parseResult.InvocationConfiguration.Output,
+                stdError: parseResult.InvocationConfiguration.Error,
                 processId: parseResult.GetValue(ProcessIdOption),
                 name: parseResult.GetValue(NameOption),
                 duration: parseResult.GetValue(DurationOption)));

--- a/src/Tools/dotnet-stack/Symbolicate.cs
+++ b/src/Tools/dotnet-stack/Symbolicate.cs
@@ -306,8 +306,8 @@ namespace Microsoft.Diagnostics.Tools.Stack
             };
 
             symbolicateCommand.SetAction((parseResult, ct) => Task.FromResult(Symbolicate(
-                stdOutput: parseResult.Configuration.Output,
-                stdError: parseResult.Configuration.Error,
+                stdOutput: parseResult.InvocationConfiguration.Output,
+                stdError: parseResult.InvocationConfiguration.Error,
                 inputPath: parseResult.GetValue(InputFileArgument),
                 searchDir: parseResult.GetValue(SearchDirectoryOption),
                 output: parseResult.GetValue(OutputFileOption),

--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectCommand.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
         /// <param name="rundown">Collect rundown events.</param>
         /// <param name="bufferingMode">The session buffering mode; Block requests non-lossy collection (requires a .NET 11+ target).</param>
         /// <returns></returns>
-        internal async Task<int> Collect(CancellationToken ct, CommandLineConfiguration cliConfig, int processId, FileInfo output, uint buffersize, string[] providers, string[] profile, TraceFileFormat format, TimeSpan duration, string clrevents, string clreventlevel, string name, string diagnosticPort, bool showchildio, bool resumeRuntime, string stoppingEventProviderName, string stoppingEventEventName, string stoppingEventPayloadFilter, bool? rundown, string dsrouter, EventPipeBufferingMode bufferingMode)
+        internal async Task<int> Collect(CancellationToken ct, InvocationConfiguration cliConfig, int processId, FileInfo output, uint buffersize, string[] providers, string[] profile, TraceFileFormat format, TimeSpan duration, string clrevents, string clreventlevel, string name, string diagnosticPort, bool showchildio, bool resumeRuntime, string stoppingEventProviderName, string stoppingEventEventName, string stoppingEventPayloadFilter, bool? rundown, string dsrouter, EventPipeBufferingMode bufferingMode)
         {
             bool collectionStopped = false;
             bool cancelOnEnter = true;
@@ -572,7 +572,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 string profileValue = parseResult.GetValue(CommonOptions.ProfileOption) ?? string.Empty;
 
                 return handler.Collect(ct,
-                                       cliConfig: parseResult.Configuration,
+                                       cliConfig: parseResult.InvocationConfiguration,
                                        processId: parseResult.GetValue(CommonOptions.ProcessIdOption),
                                        output: parseResult.GetValue(CommonOptions.OutputPathOption),
                                        buffersize: parseResult.GetValue(CircularBufferOption),

--- a/src/Tools/dotnet-trace/CommandLine/Commands/ConvertCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/ConvertCommand.cs
@@ -104,8 +104,8 @@ namespace Microsoft.Diagnostics.Tools.Trace
             };
 
             convertCommand.SetAction((parseResult, ct) => Task.FromResult(ConvertFile(
-                stdOut: parseResult.Configuration.Output,
-                stdError: parseResult.Configuration.Error,
+                stdOut: parseResult.InvocationConfiguration.Output,
+                stdError: parseResult.InvocationConfiguration.Error,
                 inputFilename: parseResult.GetValue(InputFileArgument),
                 format: parseResult.GetValue(CommonOptions.ConvertFormatOption),
                 output: parseResult.GetValue(OutputOption

--- a/src/tests/EventPipeStress/Common/Common.csproj
+++ b/src/tests/EventPipeStress/Common/Common.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
+    <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/tests/EventPipeStress/Common/Options.cs
+++ b/src/tests/EventPipeStress/Common/Options.cs
@@ -6,26 +6,23 @@ namespace Common
 {
     public static class CommandLineOptions
     {
-        static public ValidateSymbol<OptionResult> GreaterThanZeroValidator = (OptionResult result) =>
+        static public Action<OptionResult> GreaterThanZeroValidator = (OptionResult result) =>
         {
             if (result.GetValueOrDefault<int>() <= 0)
-                return $"{result.Option.Name} must be greater than or equal to 0";
-            return null;
+                result.AddError($"{result.Option.Name} must be greater than or equal to 0");
         };
 
-        static public ValidateSymbol<OptionResult> GreaterThanOrEqualZeroValidator = (OptionResult result) =>
+        static public Action<OptionResult> GreaterThanOrEqualZeroValidator = (OptionResult result) =>
         {
             if (result.GetValueOrDefault<int>() < 0)
-                return $"{result.Option.Name} must be greater than 0";
-            return null;
+                result.AddError($"{result.Option.Name} must be greater than 0");
         };
 
-        static public ValidateSymbol<OptionResult> MustBeNegOneOrPositiveValidator = (OptionResult result) =>
+        static public Action<OptionResult> MustBeNegOneOrPositiveValidator = (OptionResult result) =>
         {
             int val = result.GetValueOrDefault<int>();
             if (val < -1 || val == 0)
-                return $"{result.Option.Name} must be -1 or greater than 0";
-            return null;
+                result.AddError($"{result.Option.Name} must be -1 or greater than 0");
         };
 
         static private Option<int> _eventSizeOption = null;
@@ -36,11 +33,12 @@ namespace Common
                 if (_eventSizeOption != null)
                     return _eventSizeOption;
 
-                _eventSizeOption = new Option<int>(
-                                        alias: "--event-size",
-                                        getDefaultValue: () => 100,
-                                        description: "The size of the event payload.  The payload is a string, so the actual size will be eventSize * sizeof(char) where sizeof(char) is 2 Bytes due to Unicode in C#.");
-                _eventSizeOption.AddValidator(GreaterThanZeroValidator);
+                _eventSizeOption = new Option<int>("--event-size")
+                {
+                    DefaultValueFactory = _ => 100,
+                    Description = "The size of the event payload.  The payload is a string, so the actual size will be eventSize * sizeof(char) where sizeof(char) is 2 Bytes due to Unicode in C#."
+                };
+                _eventSizeOption.Validators.Add(GreaterThanZeroValidator);
                 return _eventSizeOption;
             }
             private set {}
@@ -54,21 +52,23 @@ namespace Common
                 if (_eventRateOption != null)
                     return _eventRateOption;
 
-                _eventRateOption = new Option<int>(
-                                        alias: "--event-rate",
-                                        getDefaultValue: () => -1,
-                                        description: "The rate of events in events/sec.  -1 means 'as fast as possible'.");
-                _eventRateOption.AddValidator(MustBeNegOneOrPositiveValidator);
+                _eventRateOption = new Option<int>("--event-rate")
+                {
+                    DefaultValueFactory = _ => -1,
+                    Description = "The rate of events in events/sec.  -1 means 'as fast as possible'."
+                };
+                _eventRateOption.Validators.Add(MustBeNegOneOrPositiveValidator);
                 return _eventRateOption;
             }
             private set {}
         }
 
         static public Option<BurstPattern> BurstPatternOption =
-            new Option<BurstPattern>(
-                alias: "--burst-pattern",
-                getDefaultValue: () => BurstPattern.NONE,
-                description: "The burst pattern to send events in.");
+            new Option<BurstPattern>("--burst-pattern")
+            {
+                DefaultValueFactory = _ => BurstPattern.NONE,
+                Description = "The burst pattern to send events in."
+            };
 
         static private Option<int> _durationOption = null;
         static public Option<int> DurationOption
@@ -78,11 +78,12 @@ namespace Common
                 if (_durationOption != null)
                     return _durationOption;
 
-                _durationOption = new Option<int>(
-                                        alias: "--duration",
-                                        getDefaultValue: () => 60,
-                                        description: "The number of seconds to send events for.");
-                _durationOption.AddValidator(GreaterThanZeroValidator);
+                _durationOption = new Option<int>("--duration")
+                {
+                    DefaultValueFactory = _ => 60,
+                    Description = "The number of seconds to send events for."
+                };
+                _durationOption.Validators.Add(GreaterThanZeroValidator);
                 return _durationOption;
             }
             private set {}
@@ -97,11 +98,12 @@ namespace Common
                 if (_threadsOption != null)
                     return _threadsOption;
 
-                _threadsOption = new Option<int>(
-                                        alias: "--threads",
-                                        getDefaultValue: () => 1,
-                                        description: "The number of threads writing events.");
-                _threadsOption.AddValidator(GreaterThanZeroValidator);
+                _threadsOption = new Option<int>("--threads")
+                {
+                    DefaultValueFactory = _ => 1,
+                    Description = "The number of threads writing events."
+                };
+                _threadsOption.Validators.Add(GreaterThanZeroValidator);
                 return _threadsOption;
             }
             private set {}
@@ -116,11 +118,12 @@ namespace Common
                 if (_eventCountOption != null)
                     return _eventCountOption;
 
-                _eventCountOption = new Option<int>(
-                                            alias: "--event-count",
-                                            getDefaultValue: () => -1,
-                                            description: "The total number of events to write per thread.  -1 means no limit");
-                _eventCountOption.AddValidator(MustBeNegOneOrPositiveValidator);
+                _eventCountOption = new Option<int>("--event-count")
+                {
+                    DefaultValueFactory = _ => -1,
+                    Description = "The total number of events to write per thread.  -1 means no limit"
+                };
+                _eventCountOption.Validators.Add(MustBeNegOneOrPositiveValidator);
                 return _eventCountOption;
             }
             private set {}

--- a/src/tests/EventPipeStress/Orchestrator/CommandLine.cs
+++ b/src/tests/EventPipeStress/Orchestrator/CommandLine.cs
@@ -8,22 +8,25 @@ namespace Orchestrator
     public static class OrchestrateCommandLine
     {
         static public Option<ReaderType> ReaderTypeOption = 
-            new Option<ReaderType>(
-                alias: "--reader-type",
-                getDefaultValue: () => ReaderType.Stream,
-                description: "The method to read the stream of events.");
+            new Option<ReaderType>("--reader-type")
+            {
+                DefaultValueFactory = _ => ReaderType.Stream,
+                Description = "The method to read the stream of events."
+            };
 
         static public Option<bool> PauseOption = 
-            new Option<bool>(
-                alias: "--pause",
-                getDefaultValue: () => false,
-                description: "Should the orchestrator pause before starting each test phase for a debugger to attach?");
+            new Option<bool>("--pause")
+            {
+                DefaultValueFactory = _ => false,
+                Description = "Should the orchestrator pause before starting each test phase for a debugger to attach?"
+            };
 
         static public Option<bool> RundownOption = 
-            new Option<bool>(
-                alias: "--rundown",
-                getDefaultValue: () => true,
-                description: "Should the EventPipe session request rundown events?");
+            new Option<bool>("--rundown")
+            {
+                DefaultValueFactory = _ => true,
+                Description = "Should the EventPipe session request rundown events?"
+            };
 
         static private Option<int> _bufferSizeOption = null;
         static public Option<int> BufferSizeOption 
@@ -33,11 +36,12 @@ namespace Orchestrator
                 if (_bufferSizeOption != null)
                     return _bufferSizeOption;
 
-                _bufferSizeOption = new Option<int>(
-                                            alias: "--buffer-size",
-                                            getDefaultValue: () => 256,
-                                            description: "The size of the buffer requested in the EventPipe session");
-                _bufferSizeOption.AddValidator(CommandLineOptions.GreaterThanZeroValidator);
+                _bufferSizeOption = new Option<int>("--buffer-size")
+                {
+                    DefaultValueFactory = _ => 256,
+                    Description = "The size of the buffer requested in the EventPipe session"
+                };
+                _bufferSizeOption.Validators.Add(CommandLineOptions.GreaterThanZeroValidator);
                 return _bufferSizeOption;
             }
             private set {}
@@ -51,11 +55,12 @@ namespace Orchestrator
                 if (_slowReaderOption != null)
                     return _slowReaderOption;
 
-                _slowReaderOption = new Option<int>(
-                                            alias: "--slow-reader",
-                                            getDefaultValue: () => 0,
-                                            description: "<Only valid for EventPipeEventSource reader> Delay every read by this many milliseconds.");
-                _slowReaderOption.AddValidator(CommandLineOptions.GreaterThanOrEqualZeroValidator);
+                _slowReaderOption = new Option<int>("--slow-reader")
+                {
+                    DefaultValueFactory = _ => 0,
+                    Description = "<Only valid for EventPipeEventSource reader> Delay every read by this many milliseconds."
+                };
+                _slowReaderOption.Validators.Add(CommandLineOptions.GreaterThanOrEqualZeroValidator);
                 return _slowReaderOption;
             }
             private set {}
@@ -69,11 +74,12 @@ namespace Orchestrator
                 if (_coresOption != null)
                     return _coresOption;
 
-                _coresOption = new Option<int>(
-                                        alias: "--cores",
-                                        getDefaultValue: () => Environment.ProcessorCount,
-                                        description: "The number of logical cores to restrict the writing process to.");
-                _coresOption.AddValidator(CoreValueMustBeFeasibleValidator);
+                _coresOption = new Option<int>("--cores")
+                {
+                    DefaultValueFactory = _ => Environment.ProcessorCount,
+                    Description = "The number of logical cores to restrict the writing process to."
+                };
+                _coresOption.Validators.Add(CoreValueMustBeFeasibleValidator);
                 return _coresOption;
             }
             private set {}
@@ -87,22 +93,22 @@ namespace Orchestrator
                 if (_iterationsOption != null)
                     return _iterationsOption;
 
-                _iterationsOption = new Option<int>(
-                                        alias: "--iterations",
-                                        getDefaultValue: () => 1,
-                                        description: "The number of times to run the test.");
-                _iterationsOption.AddValidator(CommandLineOptions.GreaterThanZeroValidator);
+                _iterationsOption = new Option<int>("--iterations")
+                {
+                    DefaultValueFactory = _ => 1,
+                    Description = "The number of times to run the test."
+                };
+                _iterationsOption.Validators.Add(CommandLineOptions.GreaterThanZeroValidator);
                 return _iterationsOption;
             }
             private set {}
         }
 
-        static public ValidateSymbol<OptionResult> CoreValueMustBeFeasibleValidator = (OptionResult result) =>
+        static public Action<OptionResult> CoreValueMustBeFeasibleValidator = (OptionResult result) =>
         {
             int val = result.GetValueOrDefault<int>();
             if (val < 1 || val > Environment.ProcessorCount)
-                return $"Core count must be between 1 and {Environment.ProcessorCount}";
-            return null;
+                result.AddError($"Core count must be between 1 and {Environment.ProcessorCount}");
         };
     }
 }

--- a/src/tests/EventPipeStress/Orchestrator/Orchestrator.csproj
+++ b/src/tests/EventPipeStress/Orchestrator/Orchestrator.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.137102" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="$(MicrosoftDiagnosticsTracingTraceEventVersion)" />
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
+    <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
     <PackageReference Include="System.Security.Principal.Windows" Version="4.7.0" />
   </ItemGroup>
 

--- a/src/tests/EventPipeStress/Orchestrator/Program.cs
+++ b/src/tests/EventPipeStress/Orchestrator/Program.cs
@@ -7,9 +7,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Runtime.InteropServices;
 using System.CommandLine;
-using System.CommandLine.Invocation;
-using System.CommandLine.Builder;
-using System.CommandLine.Parsing;
 
 using Common;
 using Microsoft.Diagnostics.NETCore.Client;
@@ -28,24 +25,6 @@ namespace Orchestrator
 
     class Program
     {
-        delegate Task<int> RootCommandHandler(
-            IConsole console,
-            CancellationToken ct,
-            FileInfo stressPath,
-            int eventSize,
-            int eventRate,
-            BurstPattern burstPattern,
-            ReaderType readerType,
-            int slowReader,
-            int duration,
-            int cores,
-            int threads,
-            int eventCount,
-            bool rundown,
-            int bufferSize,
-            int iterations,
-            bool pause);
-
         // TODO: Collect CPU % of reader and writer while running test and add to stats
         // TODO: Standardize and clean up logging from orchestrator and corescaletest
         // TODO: Improve error handling
@@ -69,20 +48,18 @@ namespace Orchestrator
                 } 
             }
 
-            return await BuildCommandLine()
-                            .UseDefaults()
-                            .Build()
-                            .InvokeAsync(args);
+            return await BuildCommandLine().Parse(args).InvokeAsync();
         }
 
-        static CommandLineBuilder BuildCommandLine()
+        static RootCommand BuildCommandLine()
         {
-            var rootCommand = new RootCommand("EventPipe Stress Tester - Orchestrator")
+            Argument<FileInfo> stressPathArgument = new("stress-path")
             {
-                new Argument<FileInfo>(
-                    name: "stress-path",
-                    description: "The location of the Stress executable."
-                ),
+                Description = "The location of the Stress executable."
+            };
+            RootCommand rootCommand = new("EventPipe Stress Tester - Orchestrator")
+            {
+                stressPathArgument,
                 CommandLineOptions.EventSizeOption,
                 CommandLineOptions.EventRateOption,
                 CommandLineOptions.BurstPatternOption,
@@ -99,8 +76,23 @@ namespace Orchestrator
             };
 
 
-            rootCommand.Handler = CommandHandler.Create((RootCommandHandler)Orchestrate);
-            return new CommandLineBuilder(rootCommand);
+            rootCommand.SetAction((parseResult, ct) => Orchestrate(
+                ct,
+                parseResult.GetValue(stressPathArgument),
+                parseResult.GetValue(CommandLineOptions.EventSizeOption),
+                parseResult.GetValue(CommandLineOptions.EventRateOption),
+                parseResult.GetValue(CommandLineOptions.BurstPatternOption),
+                parseResult.GetValue(OrchestrateCommandLine.ReaderTypeOption),
+                parseResult.GetValue(OrchestrateCommandLine.SlowReaderOption),
+                parseResult.GetValue(CommandLineOptions.DurationOption),
+                parseResult.GetValue(OrchestrateCommandLine.CoresOption),
+                parseResult.GetValue(CommandLineOptions.ThreadsOption),
+                parseResult.GetValue(CommandLineOptions.EventCountOption),
+                parseResult.GetValue(OrchestrateCommandLine.RundownOption),
+                parseResult.GetValue(OrchestrateCommandLine.BufferSizeOption),
+                parseResult.GetValue(OrchestrateCommandLine.IterationsOption),
+                parseResult.GetValue(OrchestrateCommandLine.PauseOption)));
+            return rootCommand;
         }
 
         private static EventPipeSession GetSession(int pid, bool rundown, int bufferSize)
@@ -197,7 +189,6 @@ namespace Orchestrator
         static bool IsWindowsOrLinux => OperatingSystem.IsLinux() || OperatingSystem.IsWindows();
 
         static async Task<int> Orchestrate(
-            IConsole console,
             CancellationToken ct,
             FileInfo stressPath,
             int eventSize,

--- a/src/tests/EventPipeStress/Stress/Program.cs
+++ b/src/tests/EventPipeStress/Stress/Program.cs
@@ -1,8 +1,5 @@
-﻿using System;
+using System;
 using System.CommandLine;
-using System.CommandLine.Builder;
-using System.CommandLine.Invocation;
-using System.CommandLine.Parsing;
 using System.Diagnostics.Tracing;
 using System.Linq;
 using System.Threading;
@@ -44,11 +41,9 @@ namespace Stress
                 return () => { while (!finished) { burst(); } };
         }
 
-        private delegate Task<int> RootCommandHandler(IConsole console, CancellationToken ct, int eventSize, int eventRate, BurstPattern burstPattern, int threads, int duration, int eventCount);
-
-        private static CommandLineBuilder BuildCommandLine()
+        private static RootCommand BuildCommandLine()
         {
-            var rootCommand = new RootCommand("EventPipe Stress Tester - Stress")
+            RootCommand rootCommand = new("EventPipe Stress Tester - Stress")
             {
                 CommandLineOptions.EventSizeOption,
                 CommandLineOptions.EventRateOption,
@@ -59,19 +54,23 @@ namespace Stress
             };
 
 
-            rootCommand.Handler = CommandHandler.Create((RootCommandHandler)Run);
-            return new CommandLineBuilder(rootCommand);
+            rootCommand.SetAction((parseResult, ct) => Run(
+                ct,
+                parseResult.GetValue(CommandLineOptions.EventSizeOption),
+                parseResult.GetValue(CommandLineOptions.EventRateOption),
+                parseResult.GetValue(CommandLineOptions.BurstPatternOption),
+                parseResult.GetValue(CommandLineOptions.ThreadsOption),
+                parseResult.GetValue(CommandLineOptions.DurationOption),
+                parseResult.GetValue(CommandLineOptions.EventCountOption)));
+            return rootCommand;
         }
 
         static async Task<int> Main(string[] args)
         {
-            return await BuildCommandLine()
-                .UseDefaults()
-                .Build()
-                .InvokeAsync(args);
+            return await BuildCommandLine().Parse(args).InvokeAsync();
         }
 
-        private static async Task<int> Run(IConsole console, CancellationToken ct, int eventSize, int eventRate, BurstPattern burstPattern, int threads, int duration, int eventCount)
+        private static async Task<int> Run(CancellationToken ct, int eventSize, int eventRate, BurstPattern burstPattern, int threads, int duration, int eventCount)
         {
             TimeSpan durationTimeSpan = TimeSpan.FromSeconds(duration);
 

--- a/src/tests/EventPipeStress/Stress/Stress.csproj
+++ b/src/tests/EventPipeStress/Stress/Stress.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../Common/Common.csproj" />
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
+    <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/tests/dotnet-stack/StackTests.cs
+++ b/src/tests/dotnet-stack/StackTests.cs
@@ -4,8 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.CommandLine;
-using System.CommandLine.IO;
-using System.CommandLine.Parsing;
+using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Diagnostics.TestHelpers;
 using Xunit;
@@ -61,8 +60,7 @@ namespace Microsoft.Diagnostics.Tools.Stack
         {
             Command reportCommand = ReportCommandHandler.ReportCommand();
 
-            TestConsole console = new();
-            Parser parser = new(reportCommand);
+            StringWriter stdOut = new();
 
             await using TestRunner runner = await TestRunner.Create(config, _output, "StackTracee", usePipe: false);
             await runner.Start();
@@ -70,9 +68,12 @@ namespace Microsoft.Diagnostics.Tools.Stack
             // Wait for tracee to get to readkey call
             await Task.Delay(TimeSpan.FromSeconds(1));
 
-            await parser.InvokeAsync($"report -p {runner.Pid}", console);
+            await reportCommand.Parse(["-p", runner.Pid.ToString()]).InvokeAsync(new InvocationConfiguration
+            {
+                Output = stdOut
+            });
 
-            string report = console.Out.ToString();
+            string report = stdOut.ToString();
 
             runner.WriteLine($"REPORT_START\n{report}REPORT_END");
             Assert.True(!string.IsNullOrEmpty(report));

--- a/src/tests/dotnet-trace/CollectCommandFunctionalTests.cs
+++ b/src/tests/dotnet-trace/CollectCommandFunctionalTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
 
         public sealed record CollectArgs(
             CancellationToken ct = default,
-            CommandLineConfiguration cliConfig = null,
+            InvocationConfiguration cliConfig = null,
             int processId = -1,
             uint buffersize = 1,
             string[] providers = null,


### PR DESCRIPTION
Updates System.CommandLine from a pre-GA build to the latest stable 2.0.10 release and migrates affected tools and tests to the finalized APIs.

Also updates the EventPipeStress command-line handling and preserves debugger help rendering, output redirection, and termination behavior.

No user-facing breaking changes.

Manually verified dotnet-dump heap collection and managed SOS commands, including heap inspection, object inspection, GC roots, stacks, handles, domains, and async state.

Fixes #5676