### PR TITLE
Stabilize distributed trace pipeline tests

### DIFF
--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/DistributedTraces/DistributedTracesPipeline.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/DistributedTraces/DistributedTracesPipeline.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
 
         protected override async Task OnEventSourceAvailable(EventPipeEventSource eventSource, Func<Task> stopSessionAsync, CancellationToken token)
         {
+            // Register callbacks before the first await because an incomplete asynchronous return allows event processing to begin.
             eventSource.Dynamic.All += traceEvent => {
                 try
                 {

--- a/src/Microsoft.Diagnostics.Monitoring.EventPipe/DistributedTraces/DistributedTracesPipeline.cs
+++ b/src/Microsoft.Diagnostics.Monitoring.EventPipe/DistributedTraces/DistributedTracesPipeline.cs
@@ -29,8 +29,6 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
 
         protected override async Task OnEventSourceAvailable(EventPipeEventSource eventSource, Func<Task> stopSessionAsync, CancellationToken token)
         {
-            await ExecuteActivityLoggerActionAsync((logger) => logger.PipelineStarted(token)).ConfigureAwait(false);
-
             eventSource.Dynamic.All += traceEvent => {
                 try
                 {
@@ -54,6 +52,8 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe
                 {
                 }
             };
+
+            await ExecuteActivityLoggerActionAsync((logger) => logger.PipelineStarted(token)).ConfigureAwait(false);
 
             using EventTaskSource<Action> sourceCompletedTaskSource = new(
                 taskComplete => taskComplete,

--- a/src/tests/CommonTestRunner/Debuggees/EventPipeTracee/Program.cs
+++ b/src/tests/CommonTestRunner/Debuggees/EventPipeTracee/Program.cs
@@ -34,8 +34,9 @@ namespace EventPipeTracee
             bool diagMetrics = args.Any("DiagMetrics".Equals);
             bool duplicateNameMetrics = args.Any("DuplicateNameMetrics".Equals);
             bool useActivitySource = args.Any("UseActivitySource".Equals);
+            bool waitForActivitySourceListener = args.Any("WaitForActivitySourceListener".Equals);
 
-            Console.WriteLine($"{pid} EventPipeTracee: DiagMetrics {diagMetrics} UseActivitySource {useActivitySource}");
+            Console.WriteLine($"{pid} EventPipeTracee: DiagMetrics {diagMetrics} UseActivitySource {useActivitySource} WaitForActivitySourceListener {waitForActivitySourceListener}");
             Console.WriteLine($"{pid} EventPipeTracee: DuplicateNameMetrics {duplicateNameMetrics}");
 
             Console.WriteLine($"{pid} EventPipeTracee: start process");
@@ -75,6 +76,11 @@ namespace EventPipeTracee
 
             // Wait for server to send something
             int input = pipeStream.ReadByte();
+
+            if (waitForActivitySourceListener)
+            {
+                await WaitForActivitySourceListener(activitySource, pid).ConfigureAwait(false);
+            }
 
             Console.WriteLine($"{pid} {DateTime.UtcNow} Starting test body '{input}'");
             Console.Out.Flush();
@@ -139,6 +145,33 @@ namespace EventPipeTracee
 
             Console.WriteLine($"{pid} EventPipeTracee {DateTime.UtcNow} Ending remote test process '{input}'");
             return 0;
+        }
+
+        private static async Task WaitForActivitySourceListener(ActivitySource activitySource, int pid)
+        {
+            if (activitySource == null)
+            {
+                throw new InvalidOperationException("WaitForActivitySourceListener requires UseActivitySource.");
+            }
+
+            TimeSpan timeout = TimeSpan.FromSeconds(30);
+            Stopwatch stopwatch = Stopwatch.StartNew();
+
+            Console.WriteLine($"{pid} EventPipeTracee: waiting for ActivitySource listener");
+            Console.Out.Flush();
+
+            while (!activitySource.HasListeners() && stopwatch.Elapsed < timeout)
+            {
+                await Task.Delay(10).ConfigureAwait(false);
+            }
+
+            if (!activitySource.HasListeners())
+            {
+                throw new TimeoutException($"ActivitySource listener was not installed within {timeout}.");
+            }
+
+            Console.WriteLine($"{pid} EventPipeTracee: ActivitySource listener ready after {stopwatch.Elapsed}");
+            Console.Out.Flush();
         }
 
         // TODO At some point we may want parameters to choose different test bodies.

--- a/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/DistributedTracesPipelineUnitTests.cs
+++ b/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/DistributedTracesPipelineUnitTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
             TaskCompletionSource<object?> activityLoggedSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
             TestActivityLogger logger = new(pipelineStartedSource, activityLoggedSource);
 
-            await using (TestRunner testRunner = await PipelineTestUtilities.StartProcess(config, "TracesRemoteTest UseActivitySource", _output))
+            await using (TestRunner testRunner = await PipelineTestUtilities.StartProcess(config, "TracesRemoteTest UseActivitySource WaitForActivitySourceListener", _output))
             {
                 DiagnosticsClient client = new(testRunner.Pid);
 
@@ -91,7 +91,7 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
             TaskCompletionSource<object?> activityLoggedSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
             TestActivityLogger logger = new(pipelineStartedSource, activityLoggedSource);
 
-            await using (TestRunner testRunner = await PipelineTestUtilities.StartProcess(config, "TracesRemoteTest UseActivitySource", _output))
+            await using (TestRunner testRunner = await PipelineTestUtilities.StartProcess(config, "TracesRemoteTest UseActivitySource WaitForActivitySourceListener", _output))
             {
                 DiagnosticsClient client = new(testRunner.Pid);
 

--- a/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/DistributedTracesPipelineUnitTests.cs
+++ b/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/DistributedTracesPipelineUnitTests.cs
@@ -32,7 +32,9 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
         [SkippableTheory, MemberData(nameof(Configurations))]
         public async Task TestTracesPipeline(TestConfiguration config)
         {
-            TestActivityLogger logger = new();
+            TaskCompletionSource<object?> pipelineStartedSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource<object?> activityLoggedSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            TestActivityLogger logger = new(pipelineStartedSource, activityLoggedSource);
 
             await using (TestRunner testRunner = await PipelineTestUtilities.StartProcess(config, "TracesRemoteTest UseActivitySource", _output))
             {
@@ -47,7 +49,9 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
 
                 await PipelineTestUtilities.ExecutePipelineWithTracee(
                     pipeline,
-                    testRunner);
+                    testRunner,
+                    activityLoggedSource,
+                    pipelineStartedSource.Task);
             }
 
             Assert.Single(logger.LoggedActivities);
@@ -83,7 +87,9 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
         [SkippableTheory, MemberData(nameof(Configurations))]
         public async Task TestTracesPipelineWithSamplingRatio(TestConfiguration config)
         {
-            TestActivityLogger logger = new();
+            TaskCompletionSource<object?> pipelineStartedSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource<object?> activityLoggedSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            TestActivityLogger logger = new(pipelineStartedSource, activityLoggedSource);
 
             await using (TestRunner testRunner = await PipelineTestUtilities.StartProcess(config, "TracesRemoteTest UseActivitySource", _output))
             {
@@ -98,14 +104,11 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
 
                 await PipelineTestUtilities.ExecutePipelineWithTracee(
                     pipeline,
-                    testRunner);
+                    testRunner,
+                    activityLoggedSource,
+                    pipelineStartedSource.Task);
             }
 
-            // ParentRatioSampler used to be unavailable on DiagnosticSource < 9,
-            // which caused the sampler portion of the FilterAndPayloadSpec to be
-            // ignored and no activities to flow. Newer net 8 servicing runtimes
-            // honor it, so all supported TFMs now produce a single (un-recorded)
-            // activity here.
             Assert.Single(logger.LoggedActivities);
 
             var activityData = logger.LoggedActivities[0];
@@ -134,6 +137,17 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
 
         private sealed class TestActivityLogger : IActivityLogger
         {
+            private readonly TaskCompletionSource<object?> _pipelineStartedSource;
+            private readonly TaskCompletionSource<object?> _activityLoggedSource;
+
+            public TestActivityLogger(
+                TaskCompletionSource<object?> pipelineStartedSource,
+                TaskCompletionSource<object?> activityLoggedSource)
+            {
+                _pipelineStartedSource = pipelineStartedSource;
+                _activityLoggedSource = activityLoggedSource;
+            }
+
             public List<(ActivityData, KeyValuePair<string, object?>[])> LoggedActivities { get; } = new();
 
             public void Log(
@@ -141,9 +155,14 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
                 ReadOnlySpan<KeyValuePair<string, object?>> tags)
             {
                 LoggedActivities.Add((activity, tags.ToArray()));
+                _activityLoggedSource.TrySetResult(null);
             }
 
-            public Task PipelineStarted(CancellationToken token) => Task.CompletedTask;
+            public Task PipelineStarted(CancellationToken token)
+            {
+                _pipelineStartedSource.TrySetResult(null);
+                return Task.CompletedTask;
+            }
 
             public Task PipelineStopped(CancellationToken token) => Task.CompletedTask;
         }

--- a/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/PipelineTestUtilities.cs
+++ b/src/tests/Microsoft.Diagnostics.Monitoring.EventPipe/PipelineTestUtilities.cs
@@ -37,7 +37,8 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
         public static async Task ExecutePipelineWithTracee<T>(
             EventSourcePipeline<T> pipeline,
             TestRunner testRunner,
-            TaskCompletionSource<object> waitTaskSource = null)
+            TaskCompletionSource<object> waitTaskSource = null,
+            Task pipelineStartedTask = null)
             where T : EventSourcePipelineSettings
         {
             using CancellationTokenSource cancellation = new(DefaultPipelineRunTimeout);
@@ -47,7 +48,8 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
                 (p, t) => p.StartAsync(t),
                 testRunner,
                 cancellation.Token,
-                waitTaskSource);
+                waitTaskSource,
+                pipelineStartedTask);
         }
 
         public static Task ExecutePipelineWithTracee(
@@ -69,7 +71,8 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
             Func<TPipeline, CancellationToken, Task<Task>> startPipelineAsync,
             TestRunner testRunner,
             CancellationToken token,
-            TaskCompletionSource<object> waitTaskSource = null)
+            TaskCompletionSource<object> waitTaskSource = null,
+            Task pipelineStartedTask = null)
             where TPipeline : Pipeline
         {
             Task runTask;
@@ -81,6 +84,20 @@ namespace Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests
             {
                 await TestRunnerUtilities.ExecuteCollection(Task.CompletedTask, testRunner, token);
                 throw;
+            }
+
+            if (pipelineStartedTask != null)
+            {
+                // The startup callback only completes on successful initialization, so also
+                // observe pipeline failure and the test timeout while waiting for readiness.
+                Task cancellationTask = Task.Delay(Timeout.InfiniteTimeSpan, token);
+                Task completedTask = await Task.WhenAny(pipelineStartedTask, runTask, cancellationTask).ConfigureAwait(false);
+                await completedTask.ConfigureAwait(false);
+
+                if (completedTask == runTask)
+                {
+                    throw new InvalidOperationException("Pipeline completed before signaling startup.");
+                }
             }
 
             Func<CancellationToken, Task> waitForPipeline = async (cancellationToken) => {


### PR DESCRIPTION
Fix a race in `DistributedTracesPipeline` where EventPipe processing could begin while `OnEventSourceAvailable` was suspended in an asynchronous `PipelineStarted` callback, before the activity event handler was registered. Register the handler before the first await so activities emitted during logger startup are captured instead of dropped.

The tests now also wait for the target runtime to install its `ActivitySource` listener and keep the pipeline open until the expected activity is consumed.

No API breaking changes. Observable lifecycle behavior changes: `Log` may overlap an asynchronous `PipelineStarted` callback, and startup events are no longer dropped.