### PR TITLE
Handle unavailable module image metadata

### DIFF
--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/Module.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/Module.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
     /// <summary>
     /// Module base implementation
     /// </summary>
-    public abstract class Module : IModule, IExportSymbols, IDisposable
+    public abstract class Module : IModule, IModuleImageInfo, IExportSymbols, IDisposable
     {
         [Flags]
         public enum Flags : byte
@@ -34,6 +34,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
         }
 
         private Flags _flags;
+        private bool _isImageInfoAvailable;
         private IEnumerable<PdbFileInfo> _pdbFileInfos;
         private string _symbolFileName;
 
@@ -43,15 +44,17 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
         public Module(IServiceProvider services)
         {
             ServiceContainerFactory containerFactory = services.GetService<IServiceManager>().CreateServiceContainerFactory(ServiceScope.Module, services);
-            containerFactory.AddServiceFactory<PEFile>((services) => ModuleService.GetPEInfo(ImageBase, ImageSize, out _pdbFileInfos, ref _flags));
+            containerFactory.AddServiceFactory<PEFile>((services) => GetPEInfo());
             _serviceContainer = containerFactory.Build();
             _serviceContainer.AddService<IModule>(this);
+            _serviceContainer.AddService<IModuleImageInfo>(this);
             _serviceContainer.AddService<IExportSymbols>(this);
         }
 
         public virtual void Dispose()
         {
             _serviceContainer.RemoveService(typeof(IModule));
+            _serviceContainer.RemoveService(typeof(IModuleImageInfo));
             _serviceContainer.RemoveService(typeof(IExportSymbols));
             _serviceContainer.DisposeServices();
         }
@@ -212,6 +215,19 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
 
         #endregion
 
+        #region IModuleImageInfo
+
+        bool IModuleImageInfo.IsImageInfoAvailable
+        {
+            get
+            {
+                Services.GetService<PEFile>();
+                return _isImageInfoAvailable;
+            }
+        }
+
+        #endregion
+
         #region IExportSymbols
 
         bool IExportSymbols.TryGetSymbolAddress(string name, out ulong address)
@@ -299,6 +315,18 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
                 return true;
             }
             return false;
+        }
+
+        private PEFile GetPEInfo()
+        {
+            PEFile peFile = ModuleService.GetPEInfo(ImageBase, ImageSize, out _pdbFileInfos, out bool imageInfoAvailable, ref _flags);
+            _isImageInfoAvailable = imageInfoAvailable &&
+                (peFile is not null || Target.OperatingSystem != OSPlatform.Windows);
+            if (!_isImageInfoAvailable && ImageSize > 0)
+            {
+                ModuleService.ReportImageInfoUnavailable(ModuleIndex, ImageBase);
+            }
+            return peFile;
         }
 
         protected abstract ModuleService ModuleService { get; }

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/ModuleService.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/ModuleService.cs
@@ -32,12 +32,14 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
 
         // MachO writable segment attribute
         private const uint VmProtWrite = 0x02;
+        private const ushort ImageDosSignature = 0x5A4D;
 
         private IMemoryService _memoryService;
         private ISymbolService _symbolService;
         private ReadVirtualCache _versionCache;
         private Dictionary<ulong, IModule> _modules;
         private IModule[] _sortedByBaseAddress;
+        private bool _reportedImageInfoUnavailable;
 
         private static readonly byte[] s_versionString = Encoding.ASCII.GetBytes("@(#)Version ");
         private static readonly int s_versionLength = s_versionString.Length;
@@ -57,6 +59,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
         private void Flush()
         {
             _versionCache?.Clear();
+            _reportedImageInfoUnavailable = false;
             if (_modules is not null)
             {
                 foreach (IModule module in _modules.Values)
@@ -240,21 +243,39 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
         /// <param name="address">module base address</param>
         /// <param name="size">module size</param>
         /// <param name="pdbFileInfos">the pdb records or null</param>
+        /// <param name="imageInfoAvailable">whether the module image was read sufficiently to determine its type</param>
         /// <param name="moduleFlags">module flags</param>
         /// <returns>PEImage instance or null</returns>
-        internal PEFile GetPEInfo(ulong address, ulong size, out IEnumerable<PdbFileInfo> pdbFileInfos, ref Module.Flags moduleFlags)
+        internal PEFile GetPEInfo(
+            ulong address,
+            ulong size,
+            out IEnumerable<PdbFileInfo> pdbFileInfos,
+            out bool imageInfoAvailable,
+            ref Module.Flags moduleFlags)
         {
             PEFile peFile = null;
+            imageInfoAvailable = false;
 
             // Start off with no pdb infos and as a native non-PE non-managed module
             pdbFileInfos = Array.Empty<PdbFileInfo>();
             moduleFlags &= ~(Module.Flags.IsPEImage | Module.Flags.IsManaged | Module.Flags.IsLoadedLayout | Module.Flags.IsFileLayout);
 
             // None of the modules that lldb (on either Linux/MacOS) provides are PEs
-            if (size > 0 && Target.Host.HostType != HostType.Lldb)
+            if (Target.Host.HostType == HostType.Lldb)
+            {
+                imageInfoAvailable = true;
+            }
+            else if (size > 0)
             {
                 // First try getting the PE info as loaded layout (native Windows DLLs and most managed PEs).
-                peFile = GetPEInfo(isVirtual: true, address, size, out List<PdbFileInfo> pdbs, out Module.Flags flags);
+                peFile = GetPEInfo(
+                    isVirtual: true,
+                    address,
+                    size,
+                    out List<PdbFileInfo> pdbs,
+                    out bool loadedImageInfoAvailable,
+                    out Module.Flags flags);
+                imageInfoAvailable = loadedImageInfoAvailable;
 
                 // Continue only if marked as a PE. This bit is set regardless of the layout if the module has a PE header/signature.
                 if ((flags & Module.Flags.IsPEImage) != 0)
@@ -264,7 +285,14 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
                         // If PE file is invalid or there are no PDB records, try getting the PE info as file layout. No PDB records can mean
                         // that either the layout is wrong or that there really no PDB records. If file layout doesn't have any pdb records
                         // either default to loaded layout PEFile.
-                        PEFile peFileLayout = GetPEInfo(isVirtual: false, address, size, out List<PdbFileInfo> pdbsFileLayout, out Module.Flags flagsFileLayout);
+                        PEFile peFileLayout = GetPEInfo(
+                            isVirtual: false,
+                            address,
+                            size,
+                            out List<PdbFileInfo> pdbsFileLayout,
+                            out bool fileImageInfoAvailable,
+                            out Module.Flags flagsFileLayout);
+                        imageInfoAvailable |= fileImageInfoAvailable;
                         Debug.Assert((flagsFileLayout & Module.Flags.IsPEImage) != 0);
                         if (peFileLayout is not null && (peFile is null || pdbsFileLayout.Count > 0))
                         {
@@ -284,6 +312,18 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
             return peFile;
         }
 
+        internal void ReportImageInfoUnavailable(int moduleIndex, ulong imageBase)
+        {
+            if (!_reportedImageInfoUnavailable)
+            {
+                _reportedImageInfoUnavailable = true;
+                Trace.TraceWarning(
+                    "Module image information is unavailable for module index {0} at {1:X16}; the image could not be read from target memory or acquired from configured symbol sources. Additional failures for this target are suppressed.",
+                    moduleIndex,
+                    imageBase);
+            }
+        }
+
         /// <summary>
         /// Returns information about the PE file for a specific layout.
         /// </summary>
@@ -291,18 +331,32 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
         /// <param name="address">module base address</param>
         /// <param name="size">module size</param>
         /// <param name="pdbs">pdb infos</param>
+        /// <param name="imageInfoAvailable">whether the image was read sufficiently to determine its type</param>
         /// <param name="flags">module flags</param>
         /// <returns>PEFile instance or null</returns>
-        private PEFile GetPEInfo(bool isVirtual, ulong address, ulong size, out List<PdbFileInfo> pdbs, out Module.Flags flags)
+        private PEFile GetPEInfo(
+            bool isVirtual,
+            ulong address,
+            ulong size,
+            out List<PdbFileInfo> pdbs,
+            out bool imageInfoAvailable,
+            out Module.Flags flags)
         {
-            pdbs = null;
+            PEFile peFile = null;
+            pdbs = new List<PdbFileInfo>();
+            imageInfoAvailable = false;
             flags = 0;
             try
             {
                 Stream stream = MemoryService.CreateMemoryStream(address, size);
-                PEFile peFile = new(new StreamAddressSpace(stream), isVirtual);
+                peFile = new PEFile(new StreamAddressSpace(stream), isVirtual);
+                if (peFile.DosHeaderMagic != ImageDosSignature)
+                {
+                    imageInfoAvailable = true;
+                }
                 if (peFile.IsValid())
                 {
+                    imageInfoAvailable = true;
                     flags |= Module.Flags.IsPEImage;
                     flags |= peFile.IsILImage ? Module.Flags.IsManaged : Module.Flags.None;
                     pdbs = peFile.Pdbs.Select((pdb) => pdb.ToPdbFileInfo()).ToList();
@@ -314,6 +368,7 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
             {
                 Trace.TraceError($"GetPEInfo: {address:X16} isVirtual {isVirtual} exception {ex.Message}");
             }
+            peFile?.Dispose();
             return null;
         }
 

--- a/src/Microsoft.Diagnostics.DebugServices/IModuleImageInfo.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/IModuleImageInfo.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.DebugServices
+{
+    /// <summary>
+    /// Provides the availability of image metadata for a module.
+    /// </summary>
+    public interface IModuleImageInfo
+    {
+        /// <summary>
+        /// Gets whether the image metadata needed to determine module characteristics is available.
+        /// When false, properties such as <see cref="IModule.IsManaged"/> and
+        /// <see cref="IModule.IsFileLayout"/> may contain fallback values.
+        /// </summary>
+        bool IsImageInfoAvailable { get; }
+    }
+}

--- a/src/Microsoft.Diagnostics.ExtensionCommands/Host/ModulesCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/Host/ModulesCommand.cs
@@ -76,12 +76,14 @@ namespace Microsoft.Diagnostics.ExtensionCommands
         {
             if (Verbose)
             {
+                IModuleImageInfo imageInfo = module.Services.GetService<IModuleImageInfo>();
+                bool imageInfoAvailable = imageInfo?.IsImageInfoAvailable ?? true;
                 WriteLine("{0} {1}", module.ModuleIndex, module.FileName);
                 WriteLine("    Address:         {0:X16}", module.ImageBase);
                 WriteLine("    ImageSize:       {0:X8}", module.ImageSize);
                 WriteLine("    IsPEImage:       {0}", module.IsPEImage);
-                WriteLine("    IsManaged:       {0}", module.IsManaged);
-                WriteLine("    IsFileLayout:    {0}", module.IsFileLayout?.ToString() ?? "<unknown>");
+                WriteLine("    IsManaged:       {0}", imageInfoAvailable ? module.IsManaged.ToString() : "<unknown>");
+                WriteLine("    IsFileLayout:    {0}", imageInfoAvailable ? module.IsFileLayout?.ToString() ?? "<unknown>" : "<unknown>");
                 WriteLine("    IndexFileSize:   {0}", module.IndexFileSize?.ToString("X8") ?? "<none>");
                 WriteLine("    IndexTimeStamp:  {0}", module.IndexTimeStamp?.ToString("X8") ?? "<none>");
                 WriteLine("    Version:         {0}", module.GetVersionData()?.ToString() ?? "<none>");

--- a/src/Microsoft.Diagnostics.TestHelpers/TestHost/TestDataReader.cs
+++ b/src/Microsoft.Diagnostics.TestHelpers/TestHost/TestDataReader.cs
@@ -204,9 +204,27 @@ namespace Microsoft.Diagnostics.TestHelpers
         /// <param name="instance">object to compare</param>
         public void CompareMembers(ImmutableDictionary<string, Value> values, object instance)
         {
+            CompareMembers(values, instance, excludedMemberNames: null);
+        }
+
+        /// <summary>
+        /// Compares the test data values with the properties in the instance with the same name.
+        /// </summary>
+        /// <param name="values">test data for the item</param>
+        /// <param name="instance">object to compare</param>
+        /// <param name="excludedMemberNames">member names to exclude from comparison</param>
+        public void CompareMembers(
+            ImmutableDictionary<string, Value> values,
+            object instance,
+            ISet<string> excludedMemberNames)
+        {
             foreach (KeyValuePair<string, Value> testData in values)
             {
                 string testDataKey = testData.Key;
+                if (excludedMemberNames?.Contains(testDataKey) == true)
+                {
+                    continue;
+                }
                 if (Version <= Version100 && testDataKey == "VersionData")
                 {
                     testDataKey = "GetVersionData";
@@ -245,7 +263,7 @@ namespace Microsoft.Diagnostics.TestHelpers
                         if (testData.Value.IsSubValue)
                         {
                             Trace.TraceInformation($"CompareMembers {testDataKey} sub value:");
-                            CompareMembers(testData.Value.Values.Single(), memberValue);
+                            CompareMembers(testData.Value.Values.Single(), memberValue, excludedMemberNames);
                         }
                         else
                         {

--- a/src/Microsoft.Diagnostics.TestHelpers/TestHost/TestDump.cs
+++ b/src/Microsoft.Diagnostics.TestHelpers/TestHost/TestDump.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.Diagnostics.DebugServices;
@@ -36,9 +37,15 @@ namespace Microsoft.Diagnostics.TestHelpers
             _dumpTargetFactory = new DumpTargetFactory(_host);
             serviceContainer.AddService<IDumpTargetFactory>(_dumpTargetFactory);
 
-            // Automatically enable symbol server support
-            _symbolService.AddSymbolServer(timeoutInMinutes: 6, retryCount: 5);
-            _symbolService.AddCachePath(_symbolService.DefaultSymbolCache);
+            // Remote symbol acquisition is opt-in so dump tests do not depend on network or machine cache state.
+            if (string.Equals(
+                Environment.GetEnvironmentVariable("DOTNET_DIAGNOSTICS_TEST_ENABLE_SYMBOL_SERVER"),
+                "true",
+                StringComparison.OrdinalIgnoreCase))
+            {
+                _symbolService.AddSymbolServer(timeoutInMinutes: 6, retryCount: 5);
+                _symbolService.AddCachePath(_symbolService.DefaultSymbolCache);
+            }
         }
 
         public ServiceContainer ServiceContainer => _host.ServiceContainer;

--- a/src/tests/Microsoft.Diagnostics.DebugServices.UnitTests/DebugServicesTests.cs
+++ b/src/tests/Microsoft.Diagnostics.DebugServices.UnitTests/DebugServicesTests.cs
@@ -25,6 +25,11 @@ namespace Microsoft.Diagnostics.DebugServices.UnitTests
         private const string ListenerName = "DebugServicesTests";
 
         private static readonly string[] s_excludedModules = new string[] { "MpClient.dll", "MpOAV.dll" };
+        private static readonly ISet<string> s_imageInfoMembers = new HashSet<string>(StringComparer.Ordinal)
+        {
+            nameof(IModule.IsManaged),
+            nameof(IModule.IsFileLayout)
+        };
 
         private static IEnumerable<object[]> _configurations;
 
@@ -78,6 +83,7 @@ namespace Microsoft.Diagnostics.DebugServices.UnitTests
         {
             IModuleService moduleService = host.Target.Services.GetService<IModuleService>();
             Assert.NotNull(moduleService);
+            int modulesWithAvailableImageInfo = 0;
 
             foreach (ImmutableDictionary<string, TestDataReader.Value> moduleData in host.TestData.Modules)
             {
@@ -122,10 +128,22 @@ namespace Microsoft.Diagnostics.DebugServices.UnitTests
                     }
                 }
 
+                IModuleImageInfo moduleImageInfo = module.Services.GetService<IModuleImageInfo>();
+                Assert.NotNull(moduleImageInfo);
+                ISet<string> excludedMemberNames = null;
+                if (moduleImageInfo.IsImageInfoAvailable)
+                {
+                    modulesWithAvailableImageInfo++;
+                }
+                else
+                {
+                    excludedMemberNames = s_imageInfoMembers;
+                }
+
                 if (host.Target.Host.HostType != HostType.Lldb)
                 {
                     // Check that the resulting module matches the test data
-                    host.TestData.CompareMembers(moduleData, module);
+                    host.TestData.CompareMembers(moduleData, module, excludedMemberNames);
                 }
 
                 IModule module1 = moduleService.GetModuleFromIndex(module.ModuleIndex);
@@ -167,7 +185,7 @@ namespace Microsoft.Diagnostics.DebugServices.UnitTests
                             if (mod.ImageBase == imageBase)
                             {
                                 // Check that the resulting module matches the test data
-                                host.TestData.CompareMembers(moduleData, mod);
+                                host.TestData.CompareMembers(moduleData, mod, excludedMemberNames);
                             }
                         }
                     }
@@ -216,6 +234,10 @@ namespace Microsoft.Diagnostics.DebugServices.UnitTests
                         }
                     }
                 }
+            }
+            if (host.Target.Host.HostType != HostType.Lldb)
+            {
+                Assert.True(modulesWithAvailableImageInfo > 0, "No module image information was available.");
             }
         }
 


### PR DESCRIPTION
## Summary

- Distinguish unavailable module image metadata from valid native modules through an additive `IModuleImageInfo` module service.
- Keep `DebugServicesTests.ModuleTests` deterministic and offline by default while retaining dump-directory image resolution.
- Skip only metadata-dependent comparisons when image acquisition is unavailable, and render unavailable module classification as `<unknown>`.

This addresses intermittent `DebugServicesTests.ModuleTests` failures where a failed PE image acquisition was cached and surfaced as `IsManaged=false`.

## Compatibility

`IModule` is unchanged. The new service is additive and introduces no breaking API changes for external module implementations.

## Manual validation

Ran ModuleTests five times behind a failing local proxy with remote symbol acquisition disabled: 45/45 passed. The captured results still include hard `IsManaged=true` comparisons for locally resolved managed modules.