### PR TITLE
Preserve dumpasync continuation order

### DIFF
--- a/src/Microsoft.Diagnostics.ExtensionCommands/DumpAsyncCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/DumpAsyncCommand.cs
@@ -240,7 +240,7 @@ namespace Microsoft.Diagnostics.ExtensionCommands
             // <summary>Render each stack of frames.</summary>
             void RenderStacks()
             {
-                Stack<(AsyncObject AsyncObject, int Depth)> stack = new();
+                Stack<(ClrObject Object, AsyncObject? AsyncObject, int Depth)> stack = new();
 
                 // Find every top-level object (ones that nothing else has as a continuation) and output
                 // a stack starting from each.
@@ -369,39 +369,40 @@ namespace Microsoft.Diagnostics.ExtensionCommands
                     // Push the root node onto the stack to start the iteration.  Then as long as there are nodes left
                     // on the stack, pop the next, render it, and push any continuations it may have back onto the stack.
                     Debug.Assert(stack.Count == 0);
-                    stack.Push((top, depth));
+                    stack.Push((top.Object, top, depth));
                     while (stack.Count > 0)
                     {
-                        (AsyncObject frame, depth) = stack.Pop();
-
-                        Write($"{Tabs(depth)}");
-                        WriteAddress(frame.Object.Address, asyncObject: true);
-                        Write(" ");
-                        WriteMethodTable(frame.Object.Type?.MethodTable ?? 0, asyncObject: true);
-                        Write($" {(frame.IsStateMachine ? $"({frame.AwaitState})" : $"({DescribeTaskFlags(frame.TaskStateFlags)})")} {Describe(frame.Object)}");
-                        WriteCodeLink(frame.NativeCode);
-                        WriteLine("");
-
-                        if (DisplayFields)
+                        (ClrObject frameObject, AsyncObject? frame, depth) = stack.Pop();
+                        if (frame is not null)
                         {
-                            RenderFields(frame.StateMachine ?? frame.Object, depth + 4); // +4 for extra indent for fields
+                            Write($"{Tabs(depth)}");
+                            WriteAddress(frameObject.Address, asyncObject: true);
+                            Write(" ");
+                            WriteMethodTable(frameObject.Type?.MethodTable ?? 0, asyncObject: true);
+                            Write($" {(frame.IsStateMachine ? $"({frame.AwaitState})" : $"({DescribeTaskFlags(frame.TaskStateFlags)})")} {Describe(frameObject)}");
+                            WriteCodeLink(frame.NativeCode);
+                            WriteLine("");
+
+                            if (DisplayFields)
+                            {
+                                RenderFields(frame.StateMachine ?? frameObject, depth + 4); // +4 for extra indent for fields
+                            }
+
+                            for (int i = frame.Continuations.Count - 1; i >= 0; i--)
+                            {
+                                ClrObject continuation = frame.Continuations[i];
+                                objects.TryGetValue(continuation, out AsyncObject? asyncContinuation);
+                                stack.Push((continuation, asyncContinuation, depth + 1));
+                            }
                         }
-
-                        foreach (ClrObject continuation in frame.Continuations)
+                        else
                         {
-                            if (objects.TryGetValue(continuation, out AsyncObject asyncContinuation))
-                            {
-                                stack.Push((asyncContinuation, depth + 1));
-                            }
-                            else
-                            {
-                                string state = TryGetTaskStateFlags(continuation, out int flags) ? DescribeTaskFlags(flags) : "";
-                                Write($"{Tabs(depth + 1)}");
-                                WriteAddress(continuation.Address, asyncObject: true);
-                                Write(" ");
-                                WriteMethodTable(continuation.Type?.MethodTable ?? 0, asyncObject: true);
-                                WriteLine($" ({state}) {Describe(continuation)}");
-                            }
+                            string state = TryGetTaskStateFlags(frameObject, out int flags) ? DescribeTaskFlags(flags) : "";
+                            Write($"{Tabs(depth)}");
+                            WriteAddress(frameObject.Address, asyncObject: true);
+                            Write(" ");
+                            WriteMethodTable(frameObject.Type?.MethodTable ?? 0, asyncObject: true);
+                            WriteLine($" ({state}) {Describe(frameObject)}");
                         }
                     }
 

--- a/src/tests/SOS.UnitTests/Debuggees/DotnetDumpCommands/Program.cs
+++ b/src/tests/SOS.UnitTests/Debuggees/DotnetDumpCommands/Program.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO.Pipes;
+using System.Threading.Tasks;
 
 namespace DotnetDumpCommands
 {
@@ -45,6 +46,10 @@ namespace DotnetDumpCommands
             else if ("dumpgen".Equals(args[1]))
             {
                 _objectsToKeepInMemory.AddRange(CreateObjectsInDifferentGenerations());
+            }
+            else if ("dumpasyncorder".Equals(args[1]))
+            {
+                _objectsToKeepInMemory.AddRange(CreateDumpAsyncContinuationOrder());
             }
             else
             {
@@ -151,6 +156,37 @@ namespace DotnetDumpCommands
             {
                 yield return new DumpSampleClass();
             }
+        }
+
+        private static IEnumerable<object> CreateDumpAsyncContinuationOrder()
+        {
+            TaskCompletionSource<int> source = new TaskCompletionSource<int>();
+            Task whenAll = AwaitContinuationsInOrderAsync(source.Task);
+
+            return new object[] { source, source.Task, whenAll };
+        }
+
+        private static async Task AwaitContinuationsInOrderAsync(Task<int> task)
+        {
+            await Task.WhenAll(
+                ContinuationOrderFirstAsync(task),
+                ContinuationOrderSecondAsync(task),
+                ContinuationOrderThirdAsync(task));
+        }
+
+        private static async Task<int> ContinuationOrderFirstAsync(Task<int> task)
+        {
+            return await task + 1;
+        }
+
+        private static async Task<int> ContinuationOrderSecondAsync(Task<int> task)
+        {
+            return await task + 2;
+        }
+
+        private static async Task<int> ContinuationOrderThirdAsync(Task<int> task)
+        {
+            return await task + 3;
         }
 
         public class DumpSampleClass

--- a/src/tests/SOS.UnitTests/SOS.cs
+++ b/src/tests/SOS.UnitTests/SOS.cs
@@ -770,6 +770,25 @@ public class SOSAsyncTests
     {
         await SOSTestHelpers.RunTest(config, debuggeeName: "AsyncMain", scriptName: "AsyncMain.script", Output, testTriage: true);
     }
+
+    [SkippableTheory, MemberData(nameof(SOSTestHelpers.Configurations), MemberType = typeof(SOSTestHelpers))]
+    public async Task DumpAsyncContinuationOrder(TestConfiguration config)
+    {
+        await SOSTestHelpers.RunTest(
+            scriptName: "DumpAsyncContinuationOrder.script",
+            new SOSRunner.TestInformation
+            {
+                TestConfiguration = config,
+                TestLive = false,
+                TestName = "SOS.DumpAsyncContinuationOrder",
+                DebuggeeName = "DotnetDumpCommands",
+                DebuggeeArguments = "dumpasyncorder",
+                DumpNameSuffix = "dumpasyncorder",
+                UsePipeSync = true,
+                DumpGenerator = SOSRunner.DumpGenerator.DotNetDump,
+            },
+            Output);
+    }
 }
 
 public class SOSScenarioTests

--- a/src/tests/SOS.UnitTests/Scripts/DumpAsyncContinuationOrder.script
+++ b/src/tests/SOS.UnitTests/Scripts/DumpAsyncContinuationOrder.script
@@ -1,0 +1,6 @@
+# Verify that dumpasync preserves the order of continuations in a task's continuation array.
+
+LOADSOS
+
+SOSCOMMAND:DumpAsync --tasks
+VERIFY:(?s)System\.Threading\.Tasks\.Task<System\.Int32>.*\r?\n\s+.*ContinuationOrderFirstAsync.*\r?\n\s+.*ContinuationOrderSecondAsync.*\r?\n\s+.*ContinuationOrderThirdAsync


### PR DESCRIPTION
## Summary

- preserve the order of child tasks stored in a task continuation array when rendering `dumpasync` stacks
- represent both tracked async objects and plain task continuations in the iterative depth-first traversal
- add an end-to-end `Task.WhenAll` scenario that verifies first, second, and third continuations are displayed in registration order

## Validation

- `Build.cmd`
- `SOSAsyncTests.DumpAsyncContinuationOrder`: 8 passed
- baseline verification without the command change: 8 failed