### PR TITLE
Prefer public symbols for SOS name resolution

### DIFF
--- a/src/SOS/SOS.Extensions/DebuggerServices.cs
+++ b/src/SOS/SOS.Extensions/DebuggerServices.cs
@@ -33,6 +33,7 @@ namespace SOS.Extensions
         private ref readonly IDebuggerServicesVTable VTable => ref Unsafe.AsRef<IDebuggerServicesVTable>(_vtable);
 
         private readonly HostType _hostType;
+        private readonly HResult _symbolOptionsResult = HResult.S_OK;
 
         /// <summary>
         /// A pointer to the underlying IDebugClient interface if the host is DbgEng.
@@ -51,6 +52,12 @@ namespace SOS.Extensions
                 if (obj is IDebugClient5 client)
                 {
                     DebugClient = client;
+                    if (client is IDebugSymbols5 symbols)
+                    {
+                        // Use stable public symbol names instead of CodeView display names.
+                        // See https://github.com/dotnet/runtime/pull/132735.
+                        _symbolOptionsResult = symbols.AddSymbolOptions(SYMOPT.PUBLICS_ONLY);
+                    }
                 }
             }
         }
@@ -330,6 +337,13 @@ namespace SOS.Extensions
 
         public HResult GetSymbolByOffset(int moduleIndex, ulong address, out string symbol, out ulong displacement)
         {
+            if (!_symbolOptionsResult.IsOK)
+            {
+                symbol = null;
+                displacement = 0;
+                return _symbolOptionsResult;
+            }
+
             symbol = null;
 
             // Get the symbol length first

--- a/src/SOS/SOS.Extensions/DebuggerServices.cs
+++ b/src/SOS/SOS.Extensions/DebuggerServices.cs
@@ -54,7 +54,8 @@ namespace SOS.Extensions
                     DebugClient = client;
                     if (client is IDebugSymbols5 symbols)
                     {
-                        // Use stable public symbol names instead of CodeView display names.
+                        // NativeAOT emits debugger-friendly CodeView display names while retaining stable, reversible
+                        // COFF public names used by diagnostic tooling. Prefer the public names for SOS lookups.
                         // See https://github.com/dotnet/runtime/pull/132735.
                         _symbolOptionsResult = symbols.AddSymbolOptions(SYMOPT.PUBLICS_ONLY);
                     }


### PR DESCRIPTION
## Summary

- Configure DbgEng to prefer public symbols for SOS name-by-address lookups.
- Return stable public/linker names instead of CodeView display names.
- Surface an error from symbol lookup if the option could not be enabled.

## Motivation

NativeAOT now emits debugger-friendly names in CodeView procedure records while retaining the existing COFF public symbol names. DbgEng prefers the CodeView display names, but diagnostic tooling relies on the stable, reversible public names.

See dotnet/runtime#132735.

## Testing

- Ran internal diagnostics testing.