### PR TITLE
Add collect-linux buffersize option

### DIFF
--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectLinuxCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectLinuxCommand.cs
@@ -23,6 +23,10 @@ namespace Microsoft.Diagnostics.Tools.Trace
         private ProgressWriter progressWriter;
         private Version minRuntimeSupportingUserEventsIPCCommand = new(10, 0, 0);
         private readonly bool cancelOnEnter;
+        private const int ScNProcessorsOnln = 84;
+
+        [LibraryImport("libc", EntryPoint = "sysconf")]
+        private static partial long SysConf(int name);
 
         internal sealed record CollectLinuxArgs(
             CancellationToken Ct,
@@ -31,7 +35,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
             string ClrEvents,
             string[] PerfEvents,
             string[] Profiles,
-            uint? EventBufferSizeInMB,
+            uint? BufferSizeInMB,
             FileInfo Output,
             TimeSpan Duration,
             string Name,
@@ -176,7 +180,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 CommonOptions.CLREventLevelOption,
                 CommonOptions.CLREventsOption,
                 PerfEventsOption,
-                EventBufferSizeInMBOption,
+                BufferSizeInMBOption,
                 ProbeOption,
                 CommonOptions.ProfileOption,
                 CommonOptions.OutputPathOption,
@@ -200,7 +204,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                     ClrEvents: parseResult.GetValue(CommonOptions.CLREventsOption) ?? string.Empty,
                     PerfEvents: perfEventsValue.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries),
                     Profiles: profilesValue.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries),
-                    EventBufferSizeInMB: parseResult.GetValue(EventBufferSizeInMBOption),
+                    BufferSizeInMB: parseResult.GetValue(BufferSizeInMBOption),
                     Output: parseResult.GetValue(CommonOptions.OutputPathOption) ?? new FileInfo(CommonOptions.DefaultTraceName),
                     Duration: parseResult.GetValue(CommonOptions.DurationOption),
                     Name: parseResult.GetValue(CommonOptions.NameOption) ?? string.Empty,
@@ -430,6 +434,14 @@ namespace Microsoft.Diagnostics.Tools.Trace
             scriptPath = null;
             List<string> recordTraceArgs = new();
 
+            if (args.BufferSizeInMB.HasValue)
+            {
+                if (args.BufferSizeInMB.Value == 0)
+                {
+                    throw new DiagnosticToolException("Buffer size must be at least 1 MB.");
+                }
+            }
+
             string[] profiles = args.Profiles;
             if (args.Profiles.Length == 0 && args.Providers.Length == 0 && string.IsNullOrEmpty(args.ClrEvents) && args.PerfEvents.Length == 0)
             {
@@ -438,15 +450,12 @@ namespace Microsoft.Diagnostics.Tools.Trace
             }
 
             StringBuilder scriptBuilder = new();
-            if (args.EventBufferSizeInMB.HasValue)
+            if (args.BufferSizeInMB.HasValue)
             {
-                if (args.EventBufferSizeInMB.Value == 0)
-                {
-                    throw new DiagnosticToolException("Event buffer size must be at least 1 MB.");
-                }
-
-                ulong eventBufferSizeBytes = args.EventBufferSizeInMB.Value * 1024UL * 1024UL;
-                scriptBuilder.AppendLine($"with_per_cpu_buffer_bytes({eventBufferSizeBytes});");
+                ulong cpuCount = GetOnlineProcessorCount();
+                ulong totalBufferSizeBytes = args.BufferSizeInMB.Value * 1024UL * 1024UL;
+                ulong perCpuBufferSizeBytes = (totalBufferSizeBytes + cpuCount - 1) / cpuCount;
+                scriptBuilder.AppendLine($"with_per_cpu_buffer_bytes({perCpuBufferSizeBytes});");
                 scriptBuilder.AppendLine();
             }
 
@@ -540,6 +549,17 @@ namespace Microsoft.Diagnostics.Tools.Trace
             return Encoding.UTF8.GetBytes(options);
         }
 
+        internal static ulong GetOnlineProcessorCount()
+        {
+            long cpuCount = SysConf(ScNProcessorsOnln);
+            if (cpuCount <= 0)
+            {
+                throw new DiagnosticToolException("Unable to determine the number of online processors.");
+            }
+
+            return (ulong)cpuCount;
+        }
+
         private static FileInfo ResolveOutputPath(FileInfo output, string processName)
         {
             if (!string.Equals(output.Name, CommonOptions.DefaultTraceName, StringComparison.OrdinalIgnoreCase))
@@ -597,10 +617,10 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 Description = @"Comma-separated list of perf events (e.g. syscalls:sys_enter_execve,sched:sched_switch)."
             };
 
-        private static readonly Option<uint?> EventBufferSizeInMBOption =
-            new("--event-buffer-size-mb")
+        private static readonly Option<uint?> BufferSizeInMBOption =
+            new("--buffersize")
             {
-                Description = "Size of each per-CPU event buffer, in megabytes. Larger buffers can accommodate event bursts but use more memory. When omitted, the recorder chooses a default based on the enabled features."
+                Description = "Requested total size of the event buffers, in megabytes. The size is divided across the available CPUs. When omitted, the recorder chooses a default based on the enabled features."
             };
 
         private static readonly Option<bool> ProbeOption =

--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectLinuxCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectLinuxCommand.cs
@@ -23,10 +23,6 @@ namespace Microsoft.Diagnostics.Tools.Trace
         private ProgressWriter progressWriter;
         private Version minRuntimeSupportingUserEventsIPCCommand = new(10, 0, 0);
         private readonly bool cancelOnEnter;
-        private const int ScNProcessorsOnln = 84;
-
-        [LibraryImport("libc", EntryPoint = "sysconf")]
-        private static partial long SysConf(int name);
 
         internal sealed record CollectLinuxArgs(
             CancellationToken Ct,
@@ -551,13 +547,55 @@ namespace Microsoft.Diagnostics.Tools.Trace
 
         internal static ulong GetOnlineProcessorCount()
         {
-            long cpuCount = SysConf(ScNProcessorsOnln);
-            if (cpuCount <= 0)
+            const string OnlineCpusPath = "/sys/devices/system/cpu/online";
+            string onlineCpus;
+            try
             {
-                throw new DiagnosticToolException("Unable to determine the number of online processors.");
+                onlineCpus = File.ReadAllText(OnlineCpusPath);
+            }
+            catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException or IOException or UnauthorizedAccessException)
+            {
+                throw new DiagnosticToolException($"Unable to read online processors from '{OnlineCpusPath}': {ex.Message}");
             }
 
-            return (ulong)cpuCount;
+            return ParseOnlineProcessorCount(onlineCpus);
+        }
+
+        internal static ulong ParseOnlineProcessorCount(string onlineCpus)
+        {
+            ulong cpuCount = 0;
+
+            foreach (string range in onlineCpus.Trim().Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                string[] bounds = range.Split('-', 2, StringSplitOptions.TrimEntries);
+                if (!ulong.TryParse(bounds[0], out ulong first))
+                {
+                    throw new DiagnosticToolException($"Invalid online processor range '{range}'.");
+                }
+
+                ulong last = first;
+                if (bounds.Length == 2 &&
+                    (!ulong.TryParse(bounds[1], out last) || last < first))
+                {
+                    throw new DiagnosticToolException($"Invalid online processor range '{range}'.");
+                }
+
+                try
+                {
+                    cpuCount = checked(cpuCount + checked(last - first + 1));
+                }
+                catch (OverflowException)
+                {
+                    throw new DiagnosticToolException("Online processor count is too large.");
+                }
+            }
+
+            if (cpuCount == 0)
+            {
+                throw new DiagnosticToolException("No online processors were reported.");
+            }
+
+            return cpuCount;
         }
 
         private static FileInfo ResolveOutputPath(FileInfo output, string processName)

--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectLinuxCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectLinuxCommand.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
             string ClrEvents,
             string[] PerfEvents,
             string[] Profiles,
+            uint? EventBufferSizeInMB,
             FileInfo Output,
             TimeSpan Duration,
             string Name,
@@ -175,6 +176,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 CommonOptions.CLREventLevelOption,
                 CommonOptions.CLREventsOption,
                 PerfEventsOption,
+                EventBufferSizeInMBOption,
                 ProbeOption,
                 CommonOptions.ProfileOption,
                 CommonOptions.OutputPathOption,
@@ -198,6 +200,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                     ClrEvents: parseResult.GetValue(CommonOptions.CLREventsOption) ?? string.Empty,
                     PerfEvents: perfEventsValue.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries),
                     Profiles: profilesValue.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries),
+                    EventBufferSizeInMB: parseResult.GetValue(EventBufferSizeInMBOption),
                     Output: parseResult.GetValue(CommonOptions.OutputPathOption) ?? new FileInfo(CommonOptions.DefaultTraceName),
                     Duration: parseResult.GetValue(CommonOptions.DurationOption),
                     Name: parseResult.GetValue(CommonOptions.NameOption) ?? string.Empty,
@@ -435,6 +438,18 @@ namespace Microsoft.Diagnostics.Tools.Trace
             }
 
             StringBuilder scriptBuilder = new();
+            if (args.EventBufferSizeInMB.HasValue)
+            {
+                if (args.EventBufferSizeInMB.Value == 0)
+                {
+                    throw new DiagnosticToolException("Event buffer size must be at least 1 MB.");
+                }
+
+                ulong eventBufferSizeBytes = args.EventBufferSizeInMB.Value * 1024UL * 1024UL;
+                scriptBuilder.AppendLine($"with_per_cpu_buffer_bytes({eventBufferSizeBytes});");
+                scriptBuilder.AppendLine();
+            }
+
             List<EventPipeProvider> providerCollection = ProviderUtils.ComputeProviderConfig(args.Providers, args.ClrEvents, args.ClrEventLevel, profiles, true, "collect-linux", Console);
             foreach (EventPipeProvider provider in providerCollection)
             {
@@ -580,6 +595,12 @@ namespace Microsoft.Diagnostics.Tools.Trace
             new("--perf-events")
             {
                 Description = @"Comma-separated list of perf events (e.g. syscalls:sys_enter_execve,sched:sched_switch)."
+            };
+
+        private static readonly Option<uint?> EventBufferSizeInMBOption =
+            new("--event-buffer-size-mb")
+            {
+                Description = "Size of each per-CPU event buffer, in megabytes. Larger buffers can accommodate event bursts but use more memory. When omitted, the recorder chooses a default based on the enabled features."
             };
 
         private static readonly Option<bool> ProbeOption =

--- a/src/Tools/dotnet-trace/CommandLine/Commands/CollectLinuxCommand.cs
+++ b/src/Tools/dotnet-trace/CommandLine/Commands/CollectLinuxCommand.cs
@@ -448,10 +448,8 @@ namespace Microsoft.Diagnostics.Tools.Trace
             StringBuilder scriptBuilder = new();
             if (args.BufferSizeInMB.HasValue)
             {
-                ulong cpuCount = GetOnlineProcessorCount();
                 ulong totalBufferSizeBytes = args.BufferSizeInMB.Value * 1024UL * 1024UL;
-                ulong perCpuBufferSizeBytes = (totalBufferSizeBytes + cpuCount - 1) / cpuCount;
-                scriptBuilder.AppendLine($"with_per_cpu_buffer_bytes({perCpuBufferSizeBytes});");
+                scriptBuilder.AppendLine($"with_buffer_size_bytes({totalBufferSizeBytes});");
                 scriptBuilder.AppendLine();
             }
 
@@ -545,59 +543,6 @@ namespace Microsoft.Diagnostics.Tools.Trace
             return Encoding.UTF8.GetBytes(options);
         }
 
-        internal static ulong GetOnlineProcessorCount()
-        {
-            const string OnlineCpusPath = "/sys/devices/system/cpu/online";
-            string onlineCpus;
-            try
-            {
-                onlineCpus = File.ReadAllText(OnlineCpusPath);
-            }
-            catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException or IOException or UnauthorizedAccessException)
-            {
-                throw new DiagnosticToolException($"Unable to read online processors from '{OnlineCpusPath}': {ex.Message}");
-            }
-
-            return ParseOnlineProcessorCount(onlineCpus);
-        }
-
-        internal static ulong ParseOnlineProcessorCount(string onlineCpus)
-        {
-            ulong cpuCount = 0;
-
-            foreach (string range in onlineCpus.Trim().Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
-            {
-                string[] bounds = range.Split('-', 2, StringSplitOptions.TrimEntries);
-                if (!ulong.TryParse(bounds[0], out ulong first))
-                {
-                    throw new DiagnosticToolException($"Invalid online processor range '{range}'.");
-                }
-
-                ulong last = first;
-                if (bounds.Length == 2 &&
-                    (!ulong.TryParse(bounds[1], out last) || last < first))
-                {
-                    throw new DiagnosticToolException($"Invalid online processor range '{range}'.");
-                }
-
-                try
-                {
-                    cpuCount = checked(cpuCount + checked(last - first + 1));
-                }
-                catch (OverflowException)
-                {
-                    throw new DiagnosticToolException("Online processor count is too large.");
-                }
-            }
-
-            if (cpuCount == 0)
-            {
-                throw new DiagnosticToolException("No online processors were reported.");
-            }
-
-            return cpuCount;
-        }
-
         private static FileInfo ResolveOutputPath(FileInfo output, string processName)
         {
             if (!string.Equals(output.Name, CommonOptions.DefaultTraceName, StringComparison.OrdinalIgnoreCase))
@@ -658,7 +603,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
         private static readonly Option<uint?> BufferSizeInMBOption =
             new("--buffersize")
             {
-                Description = "Requested total size of the event buffers, in megabytes. The size is divided across the available CPUs. When omitted, the recorder chooses a default based on the enabled features."
+                Description = "Requested total size of the event buffers, in megabytes. When omitted, the recorder chooses a default based on the enabled features."
             };
 
         private static readonly Option<bool> ProbeOption =

--- a/src/tests/dotnet-trace/CollectLinuxCommandFunctionalTests.cs
+++ b/src/tests/dotnet-trace/CollectLinuxCommandFunctionalTests.cs
@@ -402,6 +402,27 @@ namespace Microsoft.Diagnostics.Tools.Trace
                 FormatException("Buffer size must be at least 1 MB."));
         }
 
+        [Theory]
+        [InlineData("0", 1)]
+        [InlineData("0-3", 4)]
+        [InlineData("0-3,8,10-11", 7)]
+        public void CollectLinuxCommand_ParsesOnlineProcessorRanges(string onlineCpus, ulong expectedCount)
+        {
+            Assert.Equal(
+                expectedCount,
+                CollectLinuxCommandHandler.ParseOnlineProcessorCount(onlineCpus));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("3-1")]
+        [InlineData("invalid")]
+        public void CollectLinuxCommand_RejectsInvalidOnlineProcessorRanges(string onlineCpus)
+        {
+            Assert.Throws<DiagnosticToolException>(
+                () => CollectLinuxCommandHandler.ParseOnlineProcessorCount(onlineCpus));
+        }
+
         [ConditionalFact(nameof(IsCollectLinuxSupported))]
         public void CollectLinuxCommand_PrintsStatusOnce_WhenCursorRepositioningUnsupported()
         {

--- a/src/tests/dotnet-trace/CollectLinuxCommandFunctionalTests.cs
+++ b/src/tests/dotnet-trace/CollectLinuxCommandFunctionalTests.cs
@@ -38,6 +38,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
             string clrEvents = "",
             string[] perfEvents = null,
             string[] profile = null,
+            uint? eventBufferSizeInMB = null,
             FileInfo output = null,
             TimeSpan duration = default,
             string name = "",
@@ -50,6 +51,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                                                                    clrEvents,
                                                                    perfEvents ?? Array.Empty<string>(),
                                                                    profile ?? Array.Empty<string>(),
+                                                                   eventBufferSizeInMB,
                                                                    output ?? new FileInfo("trace.nettrace"),
                                                                    duration,
                                                                    name,
@@ -357,6 +359,28 @@ namespace Microsoft.Diagnostics.Tools.Trace
 
             // The important assertion is in the callback so make sure it was called.
             Assert.True(callbackInvoked);
+        }
+
+        [ConditionalFact(nameof(IsCollectLinuxSupported))]
+        public void CollectLinuxCommand_AddsEventBufferSizeInMBToScript()
+        {
+            string outputPath = Path.Combine(Path.GetTempPath(), $"collect-linux-{Guid.NewGuid():N}.nettrace");
+            string scriptPath = Path.ChangeExtension(outputPath, ".script");
+            MockConsole console = new(200, 30, _outputHelper);
+            var handler = new CollectLinuxCommandHandler(console);
+            handler.RecordTraceInvoker = (cmd, len, cb) => {
+                Assert.Contains(
+                    "with_per_cpu_buffer_bytes(8388608);",
+                    File.ReadAllText(scriptPath));
+                return 0;
+            };
+
+            int exitCode = handler.CollectLinux(TestArgs(
+                eventBufferSizeInMB: 8,
+                output: new FileInfo(outputPath)));
+
+            Assert.Equal((int)ReturnCode.Ok, exitCode);
+            Assert.False(File.Exists(scriptPath));
         }
 
         [ConditionalFact(nameof(IsCollectLinuxSupported))]

--- a/src/tests/dotnet-trace/CollectLinuxCommandFunctionalTests.cs
+++ b/src/tests/dotnet-trace/CollectLinuxCommandFunctionalTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
             string clrEvents = "",
             string[] perfEvents = null,
             string[] profile = null,
-            uint? eventBufferSizeInMB = null,
+            uint? bufferSizeInMB = null,
             FileInfo output = null,
             TimeSpan duration = default,
             string name = "",
@@ -51,7 +51,7 @@ namespace Microsoft.Diagnostics.Tools.Trace
                                                                    clrEvents,
                                                                    perfEvents ?? Array.Empty<string>(),
                                                                    profile ?? Array.Empty<string>(),
-                                                                   eventBufferSizeInMB,
+                                                                   bufferSizeInMB,
                                                                    output ?? new FileInfo("trace.nettrace"),
                                                                    duration,
                                                                    name,
@@ -362,25 +362,44 @@ namespace Microsoft.Diagnostics.Tools.Trace
         }
 
         [ConditionalFact(nameof(IsCollectLinuxSupported))]
-        public void CollectLinuxCommand_AddsEventBufferSizeInMBToScript()
+        public void CollectLinuxCommand_AddsPerCpuBufferSizeToScript()
         {
             string outputPath = Path.Combine(Path.GetTempPath(), $"collect-linux-{Guid.NewGuid():N}.nettrace");
             string scriptPath = Path.ChangeExtension(outputPath, ".script");
+            ulong cpuCount = CollectLinuxCommandHandler.GetOnlineProcessorCount();
+            ulong expectedPerCpuBufferSize = (256UL * 1024UL * 1024UL + cpuCount - 1) / cpuCount;
             MockConsole console = new(200, 30, _outputHelper);
             var handler = new CollectLinuxCommandHandler(console);
             handler.RecordTraceInvoker = (cmd, len, cb) => {
                 Assert.Contains(
-                    "with_per_cpu_buffer_bytes(8388608);",
+                    $"with_per_cpu_buffer_bytes({expectedPerCpuBufferSize});",
                     File.ReadAllText(scriptPath));
                 return 0;
             };
 
             int exitCode = handler.CollectLinux(TestArgs(
-                eventBufferSizeInMB: 8,
+                bufferSizeInMB: 256,
                 output: new FileInfo(outputPath)));
 
             Assert.Equal((int)ReturnCode.Ok, exitCode);
-            Assert.False(File.Exists(scriptPath));
+        }
+
+        [ConditionalFact(nameof(IsCollectLinuxSupported))]
+        public void CollectLinuxCommand_RejectsZeroBufferSize()
+        {
+            MockConsole console = new(200, 30, _outputHelper);
+            var handler = new CollectLinuxCommandHandler(console);
+            handler.RecordTraceInvoker = (cmd, len, cb) => {
+                Assert.Fail("RecordTrace should not be invoked for an invalid buffer size.");
+                return 0;
+            };
+
+            int exitCode = handler.CollectLinux(TestArgs(bufferSizeInMB: 0));
+
+            Assert.Equal((int)ReturnCode.ArgumentError, exitCode);
+            console.AssertSanitizedLinesEqual(
+                null,
+                FormatException("Buffer size must be at least 1 MB."));
         }
 
         [ConditionalFact(nameof(IsCollectLinuxSupported))]

--- a/src/tests/dotnet-trace/CollectLinuxCommandFunctionalTests.cs
+++ b/src/tests/dotnet-trace/CollectLinuxCommandFunctionalTests.cs
@@ -362,17 +362,15 @@ namespace Microsoft.Diagnostics.Tools.Trace
         }
 
         [ConditionalFact(nameof(IsCollectLinuxSupported))]
-        public void CollectLinuxCommand_AddsPerCpuBufferSizeToScript()
+        public void CollectLinuxCommand_AddsBufferSizeToScript()
         {
             string outputPath = Path.Combine(Path.GetTempPath(), $"collect-linux-{Guid.NewGuid():N}.nettrace");
             string scriptPath = Path.ChangeExtension(outputPath, ".script");
-            ulong cpuCount = CollectLinuxCommandHandler.GetOnlineProcessorCount();
-            ulong expectedPerCpuBufferSize = (256UL * 1024UL * 1024UL + cpuCount - 1) / cpuCount;
             MockConsole console = new(200, 30, _outputHelper);
             var handler = new CollectLinuxCommandHandler(console);
             handler.RecordTraceInvoker = (cmd, len, cb) => {
                 Assert.Contains(
-                    $"with_per_cpu_buffer_bytes({expectedPerCpuBufferSize});",
+                    "with_buffer_size_bytes(268435456);",
                     File.ReadAllText(scriptPath));
                 return 0;
             };
@@ -400,27 +398,6 @@ namespace Microsoft.Diagnostics.Tools.Trace
             console.AssertSanitizedLinesEqual(
                 null,
                 FormatException("Buffer size must be at least 1 MB."));
-        }
-
-        [Theory]
-        [InlineData("0", 1)]
-        [InlineData("0-3", 4)]
-        [InlineData("0-3,8,10-11", 7)]
-        public void CollectLinuxCommand_ParsesOnlineProcessorRanges(string onlineCpus, ulong expectedCount)
-        {
-            Assert.Equal(
-                expectedCount,
-                CollectLinuxCommandHandler.ParseOnlineProcessorCount(onlineCpus));
-        }
-
-        [Theory]
-        [InlineData("")]
-        [InlineData("3-1")]
-        [InlineData("invalid")]
-        public void CollectLinuxCommand_RejectsInvalidOnlineProcessorRanges(string onlineCpus)
-        {
-            Assert.Throws<DiagnosticToolException>(
-                () => CollectLinuxCommandHandler.ParseOnlineProcessorCount(onlineCpus));
         }
 
         [ConditionalFact(nameof(IsCollectLinuxSupported))]


### PR DESCRIPTION
Adds `--buffersize` to `dotnet-trace collect-linux`, matching the existing `dotnet-trace collect` option name. The value is a requested total event-buffer size in megabytes and is forwarded unchanged to one-collect through the generated script. One-collect owns platform-specific normalization.

When omitted, one-collect continues to choose its adaptive default. Zero is rejected before record-trace is invoked. This PR depends on the new Universal script setting in microsoft/one-collect#332 and should consume a package containing that change before merge.

Breaking changes: None.