### PR TITLE
Host SOS in a standalone LLDB driver

### DIFF
--- a/src/SOS/Strike/clrma/managedanalysis.cpp
+++ b/src/SOS/Strike/clrma/managedanalysis.cpp
@@ -413,6 +413,12 @@ ClrmaManagedAnalysis::GetThread(
 #endif
     }
 
+    if (osThreadId == 0 || osThreadId == (ULONG)-1)
+    {
+        TraceError("GetThread resolved an invalid OS thread ID %08x\n", osThreadId);
+        return E_INVALIDARG;
+    }
+
     if (m_clrmaService != nullptr)
     {
         if (FAILED(hr = m_clrmaService->GetThread(osThreadId, ppClrThread)))

--- a/src/SOS/lldbplugin/CMakeLists.txt
+++ b/src/SOS/lldbplugin/CMakeLists.txt
@@ -135,5 +135,13 @@ add_library_clr(sosplugin SHARED ${SOURCES})
 
 target_link_libraries(sosplugin ${LIBRARIES})
 
+if(CLR_CMAKE_HOST_OSX)
+    add_executable_clr(sos-lldb driver.cpp)
+    target_link_libraries(sos-lldb ${LLDB_LIB})
+endif()
+
 # add the install targets
 install_clr(TARGETS sosplugin DESTINATIONS .)
+if(CLR_CMAKE_HOST_OSX)
+    install_clr(TARGETS sos-lldb DESTINATIONS .)
+endif()

--- a/src/SOS/lldbplugin/driver.cpp
+++ b/src/SOS/lldbplugin/driver.cpp
@@ -1,0 +1,102 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include <cstdio>
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <vector>
+#include <lldb/API/LLDB.h>
+
+namespace
+{
+    void PrintUsage(const char* program)
+    {
+        std::fprintf(stderr, "Usage: %s [--no-lldbinit] [--batch] [-o command]...\n", program);
+    }
+
+    bool ExecuteCommand(lldb::SBCommandInterpreter& interpreter, const std::string& command)
+    {
+        lldb::SBCommandReturnObject result;
+        result.SetImmediateOutputFile(stdout, false);
+        result.SetImmediateErrorFile(stderr, false);
+        interpreter.HandleCommand(command.c_str(), result, false);
+        std::fflush(stdout);
+        std::fflush(stderr);
+
+        return result.GetStatus() != lldb::eReturnStatusQuit;
+    }
+}
+
+int main(int argc, char** argv)
+{
+    bool batch = false;
+    bool sourceInitFiles = true;
+    std::vector<std::string> startupCommands;
+
+    for (int index = 1; index < argc; index++)
+    {
+        if (std::strcmp(argv[index], "--no-lldbinit") == 0)
+        {
+            sourceInitFiles = false;
+        }
+        else if (std::strcmp(argv[index], "--batch") == 0)
+        {
+            batch = true;
+        }
+        else if (std::strcmp(argv[index], "-o") == 0)
+        {
+            if (++index == argc)
+            {
+                std::fprintf(stderr, "Missing command after -o.\n");
+                PrintUsage(argv[0]);
+                return 2;
+            }
+            startupCommands.emplace_back(argv[index]);
+        }
+        else
+        {
+            std::fprintf(stderr, "Unsupported argument: %s\n", argv[index]);
+            PrintUsage(argv[0]);
+            return 2;
+        }
+    }
+
+    lldb::SBDebugger::Initialize();
+    lldb::SBDebugger debugger = lldb::SBDebugger::Create(sourceInitFiles);
+    if (!debugger.IsValid())
+    {
+        std::fprintf(stderr, "Failed to initialize LLDB.\n");
+        lldb::SBDebugger::Terminate();
+        return 1;
+    }
+
+    debugger.SetAsync(false);
+    debugger.SetInputFileHandle(stdin, false);
+    debugger.SetOutputFileHandle(stdout, false);
+    debugger.SetErrorFileHandle(stderr, false);
+
+    lldb::SBCommandInterpreter interpreter = debugger.GetCommandInterpreter();
+    bool keepRunning = true;
+    for (const std::string& command : startupCommands)
+    {
+        if (!ExecuteCommand(interpreter, command))
+        {
+            keepRunning = false;
+            break;
+        }
+    }
+
+    if (!batch)
+    {
+        std::string command;
+        while (keepRunning && std::getline(std::cin, command))
+        {
+            keepRunning = ExecuteCommand(interpreter, command);
+        }
+    }
+
+    lldb::SBDebugger::Destroy(debugger);
+    lldb::SBDebugger::Terminate();
+    return 0;
+}

--- a/src/SOS/lldbplugin/services.cpp
+++ b/src/SOS/lldbplugin/services.cpp
@@ -2293,6 +2293,7 @@ public:
                char** arguments,
                lldb::SBCommandReturnObject &result)
     {
+        LLDBServices::CurrentResultScope resultScope(g_services, &result);
         IHostServices* hostservices = GetHostServices();
         if (hostservices == nullptr)
         {
@@ -3154,6 +3155,8 @@ LLDBServices::ExecuteCommand(
     char** arguments,
     lldb::SBCommandReturnObject &result)
 {
+    CurrentResultScope resultScope(this, &result);
+
     // Build all the possible arguments into a string
     std::string commandArguments;
     for (const char* arg = *arguments; arg != nullptr; arg = *(++arguments))

--- a/src/SOS/lldbplugin/services.h
+++ b/src/SOS/lldbplugin/services.h
@@ -72,6 +72,28 @@ private:
     lldb::SBFrame GetCurrentFrame();
 
 public:
+    class CurrentResultScope
+    {
+        LLDBServices* m_services;
+        lldb::SBCommandReturnObject* m_previousResult;
+
+    public:
+        CurrentResultScope(LLDBServices* services, lldb::SBCommandReturnObject* result) :
+            m_services(services),
+            m_previousResult(services->m_currentResult)
+        {
+            m_services->m_currentResult = result;
+        }
+
+        ~CurrentResultScope()
+        {
+            m_services->m_currentResult = m_previousResult;
+        }
+
+        CurrentResultScope(const CurrentResultScope&) = delete;
+        CurrentResultScope& operator=(const CurrentResultScope&) = delete;
+    };
+
     LLDBServices(lldb::SBDebugger debugger);
     ~LLDBServices();
 
@@ -454,9 +476,6 @@ public:
     void AddManagedCommand(const char* name, const char* help);
 
     bool ExecuteCommand( const char* commandName, char** arguments, lldb::SBCommandReturnObject &result);
-
-    void SetCurrentResult(lldb::SBCommandReturnObject *result) { m_currentResult = result; }
-    void ClearCurrentResult() { m_currentResult = nullptr; }
 
     HRESULT InternalOutputVaList(ULONG mask, PCSTR format, va_list args);
 };

--- a/src/SOS/lldbplugin/soscommand.cpp
+++ b/src/SOS/lldbplugin/soscommand.cpp
@@ -35,6 +35,7 @@ public:
                char** arguments,
                lldb::SBCommandReturnObject &result)
     {
+        LLDBServices::CurrentResultScope resultScope(g_services, &result);
         result.SetStatus(lldb::eReturnStatusSuccessFinishResult);
 
         const char* sosCommand = m_command;
@@ -76,10 +77,8 @@ public:
                     }
                 }
                 g_services->FlushCheck();
-                g_services->SetCurrentResult(&result);
                 const char* sosArgs = str.c_str();
                 HRESULT hr = commandFunc(g_services, sosArgs);
-                g_services->ClearCurrentResult();
                 if (hr != S_OK)
                 {
                     result.SetStatus(lldb::eReturnStatusFailed);


### PR DESCRIPTION
## Summary

- add a temporary `sos-lldb` executable on macOS to host SOS through Apple LLDB reliably
- scope LLDB command-result routing with a reentrant RAII guard that restores the previous result
- reject CLRMA thread lookups that resolve to invalid OS thread IDs (`0` or `-1`)

## Why this layer is separate

This PR contains only the standalone product-facing LLDB hosting layer from #5981. Keeping it separate from Helix sharding, harness, test, documentation, and dependency work makes the temporary host independently reviewable and provides a clean bottom layer for subsequent changes. The executable is intentionally temporary while SOS needs a reliable Apple LLDB command host.

## Validation

- `./build.sh -skipmanaged` (macOS arm64 Debug)
- `sos-lldb --no-lldbinit --batch -o version`
- invalid and missing argument exit-code checks
- loaded `libsosplugin.dylib` through `sos-lldb` and ran `soshelp`, confirming plugin command output is routed through the scoped result