### PR TITLE
Host SOS in a standalone LLDB driver

### DIFF
--- a/diagnostics.yml
+++ b/diagnostics.yml
@@ -26,9 +26,7 @@ pr:
   autoCancel: true
   branches:
     include:
-    - main
-    - release/*
-    - internal/*
+    - '*'
   paths:
     exclude:
     - documentation/*

--- a/src/SOS/Strike/clrma/managedanalysis.cpp
+++ b/src/SOS/Strike/clrma/managedanalysis.cpp
@@ -416,7 +416,7 @@ ClrmaManagedAnalysis::GetThread(
     if (osThreadId == 0 || osThreadId == (ULONG)-1)
     {
         TraceError("GetThread resolved an invalid OS thread ID %08x\n", osThreadId);
-        return E_INVALIDARG;
+        return E_UNEXPECTED;
     }
 
     if (m_clrmaService != nullptr)

--- a/src/SOS/Strike/clrma/managedanalysis.cpp
+++ b/src/SOS/Strike/clrma/managedanalysis.cpp
@@ -413,6 +413,12 @@ ClrmaManagedAnalysis::GetThread(
 #endif
     }
 
+    if (osThreadId == 0 || osThreadId == (ULONG)-1)
+    {
+        TraceError("GetThread resolved an invalid OS thread ID %08x\n", osThreadId);
+        return E_INVALIDARG;
+    }
+
     if (m_clrmaService != nullptr)
     {
         if (FAILED(hr = m_clrmaService->GetThread(osThreadId, ppClrThread)))

--- a/src/SOS/lldbplugin/CMakeLists.txt
+++ b/src/SOS/lldbplugin/CMakeLists.txt
@@ -135,5 +135,13 @@ add_library_clr(sosplugin SHARED ${SOURCES})
 
 target_link_libraries(sosplugin ${LIBRARIES})
 
+if(CLR_CMAKE_HOST_OSX)
+    add_executable_clr(sos-lldb driver.cpp)
+    target_link_libraries(sos-lldb ${LLDB_LIB})
+endif()
+
 # add the install targets
 install_clr(TARGETS sosplugin DESTINATIONS .)
+if(CLR_CMAKE_HOST_OSX)
+    install_clr(TARGETS sos-lldb DESTINATIONS .)
+endif()

--- a/src/SOS/lldbplugin/CMakeLists.txt
+++ b/src/SOS/lldbplugin/CMakeLists.txt
@@ -113,8 +113,6 @@ add_compile_options(-Wno-delete-non-virtual-dtor)
 
 include_directories(${ROOT_DIR}/src/SOS/inc)
 include_directories(${ROOT_DIR}/src/SOS/extensions)
-include_directories("${LLDB_H}")
-
 set(SOURCES
     sosplugin.cpp
     soscommand.cpp
@@ -125,23 +123,19 @@ set(SOURCES
 
 set(LIBRARIES
     extensions
+    sos_lldb_dependencies
 )
 
+add_library(sos_lldb_dependencies INTERFACE)
+target_include_directories(sos_lldb_dependencies INTERFACE "${LLDB_H}")
+
 if(NOT ${LLDB_LIB} STREQUAL "")
-    list(APPEND LIBRARIES ${LLDB_LIB})
+    target_link_libraries(sos_lldb_dependencies INTERFACE ${LLDB_LIB})
 endif()
 
 add_library_clr(sosplugin SHARED ${SOURCES})
 
 target_link_libraries(sosplugin ${LIBRARIES})
 
-if(CLR_CMAKE_HOST_OSX)
-    add_executable_clr(sos-lldb driver.cpp)
-    target_link_libraries(sos-lldb ${LLDB_LIB})
-endif()
-
 # add the install targets
 install_clr(TARGETS sosplugin DESTINATIONS .)
-if(CLR_CMAKE_HOST_OSX)
-    install_clr(TARGETS sos-lldb DESTINATIONS .)
-endif()

--- a/src/SOS/lldbplugin/driver.cpp
+++ b/src/SOS/lldbplugin/driver.cpp
@@ -1,0 +1,102 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include <cstdio>
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <vector>
+#include <lldb/API/LLDB.h>
+
+namespace
+{
+    void PrintUsage(const char* program)
+    {
+        std::fprintf(stderr, "Usage: %s [--no-lldbinit] [--batch] [-o command]...\n", program);
+    }
+
+    bool ExecuteCommand(lldb::SBCommandInterpreter& interpreter, const std::string& command)
+    {
+        lldb::SBCommandReturnObject result;
+        result.SetImmediateOutputFile(stdout, false);
+        result.SetImmediateErrorFile(stderr, false);
+        interpreter.HandleCommand(command.c_str(), result, false);
+        std::fflush(stdout);
+        std::fflush(stderr);
+
+        return result.GetStatus() != lldb::eReturnStatusQuit;
+    }
+}
+
+int main(int argc, char** argv)
+{
+    bool batch = false;
+    bool sourceInitFiles = true;
+    std::vector<std::string> startupCommands;
+
+    for (int index = 1; index < argc; index++)
+    {
+        if (std::strcmp(argv[index], "--no-lldbinit") == 0)
+        {
+            sourceInitFiles = false;
+        }
+        else if (std::strcmp(argv[index], "--batch") == 0)
+        {
+            batch = true;
+        }
+        else if (std::strcmp(argv[index], "-o") == 0)
+        {
+            if (++index == argc)
+            {
+                std::fprintf(stderr, "Missing command after -o.\n");
+                PrintUsage(argv[0]);
+                return 2;
+            }
+            startupCommands.emplace_back(argv[index]);
+        }
+        else
+        {
+            std::fprintf(stderr, "Unsupported argument: %s\n", argv[index]);
+            PrintUsage(argv[0]);
+            return 2;
+        }
+    }
+
+    lldb::SBDebugger::Initialize();
+    lldb::SBDebugger debugger = lldb::SBDebugger::Create(sourceInitFiles);
+    if (!debugger.IsValid())
+    {
+        std::fprintf(stderr, "Failed to initialize LLDB.\n");
+        lldb::SBDebugger::Terminate();
+        return 1;
+    }
+
+    debugger.SetAsync(false);
+    debugger.SetInputFileHandle(stdin, false);
+    debugger.SetOutputFileHandle(stdout, false);
+    debugger.SetErrorFileHandle(stderr, false);
+
+    lldb::SBCommandInterpreter interpreter = debugger.GetCommandInterpreter();
+    bool keepRunning = true;
+    for (const std::string& command : startupCommands)
+    {
+        if (!ExecuteCommand(interpreter, command))
+        {
+            keepRunning = false;
+            break;
+        }
+    }
+
+    if (!batch)
+    {
+        std::string command;
+        while (keepRunning && std::getline(std::cin, command))
+        {
+            keepRunning = ExecuteCommand(interpreter, command);
+        }
+    }
+
+    lldb::SBDebugger::Destroy(debugger);
+    lldb::SBDebugger::Terminate();
+    return 0;
+}

--- a/src/SOS/lldbplugin/services.cpp
+++ b/src/SOS/lldbplugin/services.cpp
@@ -2293,6 +2293,7 @@ public:
                char** arguments,
                lldb::SBCommandReturnObject &result)
     {
+        LLDBServices::CurrentResultScope resultScope(g_services, &result);
         IHostServices* hostservices = GetHostServices();
         if (hostservices == nullptr)
         {
@@ -3154,6 +3155,8 @@ LLDBServices::ExecuteCommand(
     char** arguments,
     lldb::SBCommandReturnObject &result)
 {
+    CurrentResultScope resultScope(this, &result);
+
     // Build all the possible arguments into a string
     std::string commandArguments;
     for (const char* arg = *arguments; arg != nullptr; arg = *(++arguments))

--- a/src/SOS/lldbplugin/services.cpp
+++ b/src/SOS/lldbplugin/services.cpp
@@ -535,7 +535,11 @@ LLDBServices::GetLastEventInformation(
     InitializeThreadInfo(process);
 
     *processId = GetProcessId(process);
-    *threadId = GetThreadId(thread);
+    HRESULT hr = GetThreadId(thread, threadId);
+    if (FAILED(hr))
+    {
+        return hr;
+    }
 
     SpecialDiagInfoHeader header;
     size_t read = process.ReadMemory(SpecialDiagInfoAddress, &header, sizeof(header), error);
@@ -1656,8 +1660,7 @@ LLDBServices::GetCurrentThreadSystemId(
         return E_FAIL;
     }
 
-    *sysId = GetThreadId(thread);
-    return S_OK;
+    return GetThreadId(thread, sysId);
 }
 
 HRESULT
@@ -2443,7 +2446,11 @@ LLDBServices::GetThreadIdsByIndex(
         }
         if (sysIds != nullptr)
         {
-            sysIds[index] = GetThreadId(thread);
+            HRESULT hr = GetThreadId(thread, &sysIds[index]);
+            if (FAILED(hr))
+            {
+                return hr;
+            }
         }
     }
     return S_OK;
@@ -2879,18 +2886,37 @@ LLDBServices::GetProcessId(lldb::SBProcess process)
     return m_processId != 0 ? m_processId : process.GetProcessID();
 }
 
-uint32_t
-LLDBServices::GetThreadId(lldb::SBThread thread)
+HRESULT
+LLDBServices::GetThreadId(lldb::SBThread thread, PULONG threadId)
 {
+    if (threadId == nullptr)
+    {
+        return E_INVALIDARG;
+    }
+
     uint32_t index = thread.GetIndexID() - 1;
+    ULONG id;
     if (m_threadInfos.size() > index && m_threadInfos[index].tid != 0)
     {
-        return m_threadInfos[index].tid;
+        id = m_threadInfos[index].tid;
     }
     else
     {
-        return thread.GetThreadID();
+        lldb::tid_t lldbId = thread.GetThreadID();
+        if (lldbId == LLDB_INVALID_THREAD_ID || lldbId > UINT32_MAX)
+        {
+            *threadId = 0;
+            return E_UNEXPECTED;
+        }
+        id = static_cast<ULONG>(lldbId);
     }
+    if (id == 0 || id == UINT32_MAX)
+    {
+        *threadId = 0;
+        return E_UNEXPECTED;
+    }
+    *threadId = id;
+    return S_OK;
 }
 
 lldb::SBProcess

--- a/src/SOS/lldbplugin/services.h
+++ b/src/SOS/lldbplugin/services.h
@@ -65,7 +65,7 @@ private:
 
     void InitializeThreadInfo(lldb::SBProcess process);
     uint32_t GetProcessId(lldb::SBProcess process);
-    uint32_t GetThreadId(lldb::SBThread thread);
+    HRESULT GetThreadId(lldb::SBThread thread, PULONG threadId);
     lldb::SBThread GetThreadBySystemId(ULONG sysId);
     lldb::SBProcess GetCurrentProcess();
     lldb::SBThread GetCurrentThread();

--- a/src/SOS/lldbplugin/services.h
+++ b/src/SOS/lldbplugin/services.h
@@ -72,6 +72,28 @@ private:
     lldb::SBFrame GetCurrentFrame();
 
 public:
+    class CurrentResultScope
+    {
+        LLDBServices* m_services;
+        lldb::SBCommandReturnObject* m_previousResult;
+
+    public:
+        CurrentResultScope(LLDBServices* services, lldb::SBCommandReturnObject* result) :
+            m_services(services),
+            m_previousResult(services->m_currentResult)
+        {
+            m_services->m_currentResult = result;
+        }
+
+        ~CurrentResultScope()
+        {
+            m_services->m_currentResult = m_previousResult;
+        }
+
+        CurrentResultScope(const CurrentResultScope&) = delete;
+        CurrentResultScope& operator=(const CurrentResultScope&) = delete;
+    };
+
     LLDBServices(lldb::SBDebugger debugger);
     ~LLDBServices();
 
@@ -454,9 +476,6 @@ public:
     void AddManagedCommand(const char* name, const char* help);
 
     bool ExecuteCommand( const char* commandName, char** arguments, lldb::SBCommandReturnObject &result);
-
-    void SetCurrentResult(lldb::SBCommandReturnObject *result) { m_currentResult = result; }
-    void ClearCurrentResult() { m_currentResult = nullptr; }
 
     HRESULT InternalOutputVaList(ULONG mask, PCSTR format, va_list args);
 };

--- a/src/SOS/lldbplugin/soscommand.cpp
+++ b/src/SOS/lldbplugin/soscommand.cpp
@@ -35,6 +35,7 @@ public:
                char** arguments,
                lldb::SBCommandReturnObject &result)
     {
+        LLDBServices::CurrentResultScope resultScope(g_services, &result);
         result.SetStatus(lldb::eReturnStatusSuccessFinishResult);
 
         const char* sosCommand = m_command;
@@ -76,10 +77,8 @@ public:
                     }
                 }
                 g_services->FlushCheck();
-                g_services->SetCurrentResult(&result);
                 const char* sosArgs = str.c_str();
                 HRESULT hr = commandFunc(g_services, sosArgs);
-                g_services->ClearCurrentResult();
                 if (hr != S_OK)
                 {
                     result.SetStatus(lldb::eReturnStatusFailed);

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -7,3 +7,7 @@ if(CLR_CMAKE_HOST_WIN32)
     add_subdirectory(DesktopClrHost)
   endif(NOT CLR_CMAKE_TARGET_ARCH_ARM)
 endif(CLR_CMAKE_HOST_WIN32)
+
+if(CLR_CMAKE_HOST_OSX AND TARGET sos_lldb_dependencies)
+  add_subdirectory(sos-lldb)
+endif()

--- a/src/tests/sos-lldb/CMakeLists.txt
+++ b/src/tests/sos-lldb/CMakeLists.txt
@@ -1,0 +1,6 @@
+project(sos-lldb)
+
+add_executable_clr(sos-lldb driver.cpp)
+target_link_libraries(sos-lldb sos_lldb_dependencies)
+
+install_clr(TARGETS sos-lldb DESTINATIONS .)

--- a/src/tests/sos-lldb/driver.cpp
+++ b/src/tests/sos-lldb/driver.cpp
@@ -10,12 +10,18 @@
 
 namespace
 {
+    struct CommandOutcome
+    {
+        bool shouldContinue;
+        bool succeeded;
+    };
+
     void PrintUsage(const char* program)
     {
         std::fprintf(stderr, "Usage: %s [--no-lldbinit] [--batch] [-o command]...\n", program);
     }
 
-    bool ExecuteCommand(lldb::SBCommandInterpreter& interpreter, const std::string& command)
+    CommandOutcome ExecuteCommand(lldb::SBCommandInterpreter& interpreter, const std::string& command)
     {
         lldb::SBCommandReturnObject result;
         result.SetImmediateOutputFile(stdout, false);
@@ -24,7 +30,7 @@ namespace
         std::fflush(stdout);
         std::fflush(stderr);
 
-        return result.GetStatus() != lldb::eReturnStatusQuit;
+        return { result.GetStatus() != lldb::eReturnStatusQuit, result.Succeeded() };
     }
 }
 
@@ -78,10 +84,18 @@ int main(int argc, char** argv)
 
     lldb::SBCommandInterpreter interpreter = debugger.GetCommandInterpreter();
     bool keepRunning = true;
+    int exitCode = 0;
     for (const std::string& command : startupCommands)
     {
-        if (!ExecuteCommand(interpreter, command))
+        CommandOutcome outcome = ExecuteCommand(interpreter, command);
+        if (!outcome.shouldContinue)
         {
+            keepRunning = false;
+            break;
+        }
+        if (batch && !outcome.succeeded)
+        {
+            exitCode = 1;
             keepRunning = false;
             break;
         }
@@ -92,11 +106,11 @@ int main(int argc, char** argv)
         std::string command;
         while (keepRunning && std::getline(std::cin, command))
         {
-            keepRunning = ExecuteCommand(interpreter, command);
+            keepRunning = ExecuteCommand(interpreter, command).shouldContinue;
         }
     }
 
     lldb::SBDebugger::Destroy(debugger);
     lldb::SBDebugger::Terminate();
-    return 0;
+    return exitCode;
 }


### PR DESCRIPTION
## Summary

- add a temporary test-only `sos-lldb` executable on macOS to host SOS through Apple LLDB reliably
- keep the driver source and build target with native test helpers while staging the executable for SOS Helix tests
- scope LLDB command-result routing with a reentrant RAII guard that restores the previous result
- reject invalid LLDB thread IDs at the debugger-service boundary and retain an `E_UNEXPECTED` CLRMA backstop
- stop batch execution and return a non-zero exit code when an LLDB command fails

## Why this layer is separate

This PR contains only the standalone LLDB test-host layer from #5981. Keeping it separate from Helix sharding, harness, documentation, and dependency work makes the temporary host independently reviewable and provides the bottom layer for subsequent stacked changes.

The executable is test infrastructure, is not included in SOS packages, and is temporary until the .NET 11 SDK contains the runtime fix that makes this Apple LLDB workaround unnecessary.

## Validation

- `./build.sh -skipmanaged` (macOS arm64 Debug)
- successful `sos-lldb --no-lldbinit --batch -o version` returns `0`
- failed batch command returns `1` and prevents later `-o` commands from running
- an interactive command failure remains nonfatal and later commands still run
- invalid and missing argument checks return `2`
- loaded `libsosplugin.dylib` through `sos-lldb` and ran `soshelp`, confirming plugin command output is routed through the scoped result