### PR TITLE
Stabilize the SOS test harness across platforms

### DIFF
--- a/src/SOS/Strike/util.cpp
+++ b/src/SOS/Strike/util.cpp
@@ -3148,7 +3148,7 @@ BOOL GetSOSVersion(VS_FIXEDFILEINFO *pFileInfo)
                 UINT uLen = 0;
                 if (VerQueryValueA(pVersionInfo, "\\", (LPVOID *) &pTmpFileInfo, &uLen))
                 {
-                    if (pFileInfo->dwFileVersionMS == (DWORD)-1) {
+                    if (pTmpFileInfo->dwFileVersionMS == (DWORD)-1) {
                         return FALSE;
                     }
                     *pFileInfo = *pTmpFileInfo; // Copy the info

--- a/src/tests/Debuggees.proj
+++ b/src/tests/Debuggees.proj
@@ -19,6 +19,8 @@
     <SOSSingleFileDebuggee Include="SOS.UnitTests/Debuggees/SimpleThrow/SimpleThrow.csproj" />
     <SOSSingleFileDebuggee Include="SOS.UnitTests/Debuggees/ReflectionTest/ReflectionTest.csproj" />
     <SOSSingleFileDebuggee Include="SOS.UnitTests/Debuggees/SosHarnessScenarios/SosHarnessScenarios.csproj" />
+    <SOSFrameworkDebuggee Include="@(SOSSingleFileDebuggee)" />
+    <SOSFrameworkDebuggee Remove="SOS.UnitTests/Debuggees/DynamicMethod/DynamicMethod.csproj" />
   </ItemGroup>
 
   <Target Name="PublishSOSSingleFileDebuggees"
@@ -40,6 +42,18 @@
              Targets="Restore;Publish"
              BuildInParallel="true"
              Properties="Configuration=$(Configuration);BuildProjectFramework=%(_SOSSingleFileRuntime.TargetFramework);RuntimeIdentifier=$(TargetRid);RuntimeFrameworkVersion=%(_SOSSingleFileRuntime.Runtime);SelfContained=true;PublishSingleFile=true;SOSSingleFileRuntimeVersion=%(_SOSSingleFileRuntime.Runtime);ArtifactsObjDir=$(ArtifactsObjDir)SOSSingleFile/%(_SOSSingleFileRuntime.TargetFramework)/$(TargetRid)/" />
+  </Target>
+
+  <Target Name="BuildSOSFrameworkDebuggees"
+          AfterTargets="Build"
+          Condition="'$(OS)' == 'Windows_NT' and '$(SkipSOSFrameworkDebuggees)' != 'true'">
+    <PropertyGroup>
+      <_SOSFrameworkPlatformProperty Condition="'$(TargetArch)' == 'x86'">PlatformTarget=x86;</_SOSFrameworkPlatformProperty>
+    </PropertyGroup>
+    <MSBuild Projects="@(SOSFrameworkDebuggee)"
+             Targets="Restore;Build"
+             BuildInParallel="true"
+             Properties="Configuration=$(Configuration);BuildProjectFramework=net462;$(_SOSFrameworkPlatformProperty)DebugType=full;DebugSymbols=true;ArtifactsObjDir=$(ArtifactsObjDir)SOSFramework/$(TargetArch)/%(Filename)/" />
   </Target>
 
 </Project>

--- a/src/tests/SOS.TestHarness/BoundedProcess.cs
+++ b/src/tests/SOS.TestHarness/BoundedProcess.cs
@@ -1,0 +1,139 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+
+namespace SOS.TestHarness;
+
+internal sealed record BoundedProcessResult(int ExitCode, string StandardOutput, string StandardError);
+
+internal static partial class BoundedProcess
+{
+    private const int KillSignal = 9;
+    private static readonly TimeSpan s_terminationTimeout = TimeSpan.FromSeconds(5);
+
+    public static BoundedProcessResult Run(
+        ProcessStartInfo startInfo,
+        TimeSpan timeout,
+        bool isolateLinuxProcessGroup = false,
+        TimeSpan? outputDrainTimeout = null)
+    {
+        if (!startInfo.RedirectStandardOutput || !startInfo.RedirectStandardError)
+        {
+            throw new ArgumentException("Standard output and standard error must both be redirected.", nameof(startInfo));
+        }
+
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(timeout, TimeSpan.Zero);
+
+        string command = $"{startInfo.FileName} {string.Join(' ', startInfo.ArgumentList)}".Trim();
+        bool hasLinuxProcessGroup = isolateLinuxProcessGroup && OperatingSystem.IsLinux();
+        if (hasLinuxProcessGroup)
+        {
+            WrapWithSetSid(startInfo);
+        }
+
+        using Process process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException($"Failed to start '{command}'.");
+        int processGroupId = process.Id;
+        Task<string> stdoutTask = process.StandardOutput.ReadToEndAsync();
+        Task<string> stderrTask = process.StandardError.ReadToEndAsync();
+
+        if (!process.WaitForExit(TimeoutMilliseconds(timeout)))
+        {
+            Terminate(process, hasLinuxProcessGroup, processGroupId);
+            BoundedProcessResult output = DrainOutput(
+                process,
+                stdoutTask,
+                stderrTask,
+                command,
+                s_terminationTimeout);
+            throw new TimeoutException(
+                $"'{command}' did not exit within {timeout}.{Environment.NewLine}" +
+                $"stdout:{Environment.NewLine}{output.StandardOutput}{Environment.NewLine}" +
+                $"stderr:{Environment.NewLine}{output.StandardError}");
+        }
+
+        // Linux single-file dump helpers can survive the target while retaining its redirected handles.
+        // End the isolated group before waiting for stream EOF so those descendants cannot wedge drainage.
+        if (hasLinuxProcessGroup)
+        {
+            KillProcessGroup(processGroupId);
+        }
+
+        return DrainOutput(
+            process,
+            stdoutTask,
+            stderrTask,
+            command,
+            outputDrainTimeout ?? s_terminationTimeout);
+    }
+
+    private static BoundedProcessResult DrainOutput(
+        Process process,
+        Task<string> stdoutTask,
+        Task<string> stderrTask,
+        string command,
+        TimeSpan timeout)
+    {
+        Task outputTask = Task.WhenAll(stdoutTask, stderrTask);
+        if (!outputTask.Wait(timeout))
+        {
+            throw new TimeoutException(
+                $"'{command}' exited with code {process.ExitCode}, but its redirected output did not close " +
+                $"within {timeout}.");
+        }
+
+        return new BoundedProcessResult(
+            process.ExitCode,
+            stdoutTask.GetAwaiter().GetResult(),
+            stderrTask.GetAwaiter().GetResult());
+    }
+
+    private static void Terminate(Process process, bool hasLinuxProcessGroup, int processGroupId)
+    {
+        if (hasLinuxProcessGroup)
+        {
+            KillProcessGroup(processGroupId);
+        }
+
+        if (!process.HasExited)
+        {
+            process.Kill(entireProcessTree: true);
+        }
+
+        process.WaitForExit(TimeoutMilliseconds(s_terminationTimeout));
+    }
+
+    private static void WrapWithSetSid(ProcessStartInfo startInfo)
+    {
+        string setSid = File.Exists("/usr/bin/setsid") ? "/usr/bin/setsid" :
+            File.Exists("/bin/setsid") ? "/bin/setsid" :
+            throw new FileNotFoundException("Could not locate setsid for Linux process-group isolation.");
+
+        string executable = startInfo.FileName;
+        string[] arguments = startInfo.ArgumentList.ToArray();
+        startInfo.FileName = setSid;
+        startInfo.ArgumentList.Clear();
+        startInfo.ArgumentList.Add(executable);
+        foreach (string argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+    }
+
+    private static void KillProcessGroup(int processGroupId)
+    {
+        _ = KillUnix(-processGroupId, KillSignal);
+    }
+
+    private static int TimeoutMilliseconds(TimeSpan timeout) =>
+        (int)Math.Min(timeout.TotalMilliseconds, int.MaxValue);
+
+    [LibraryImport("libc", EntryPoint = "kill", SetLastError = true)]
+    private static partial int KillUnix(int processId, int signal);
+}

--- a/src/tests/SOS.TestHarness/ChildEngineClient.cs
+++ b/src/tests/SOS.TestHarness/ChildEngineClient.cs
@@ -23,6 +23,7 @@ public sealed class ChildEngineClient : ILiveDebuggerHost
     private readonly StreamWriter _stdin;
     private readonly BlockingCollection<string> _lines = new();
     private readonly Thread _reader;
+    private readonly Task<string> _stderr;
 
     public string Name { get; }
 
@@ -92,6 +93,7 @@ public sealed class ChildEngineClient : ILiveDebuggerHost
 
         _process = Process.Start(psi) ?? throw new InvalidOperationException("Failed to start EngineHost");
         _stdin = _process.StandardInput;
+        _stderr = _process.StandardError.ReadToEndAsync();
 
         _reader = new Thread(ReadLoop) { IsBackground = true, Name = $"enginehost-reader-{name}" };
         _reader.Start();
@@ -144,10 +146,10 @@ public sealed class ChildEngineClient : ILiveDebuggerHost
     {
         while (true)
         {
-            if (!_lines.TryTake(out string? line, (int)timeout.TotalMilliseconds, HarnessCancellation.Token))
-            {
-                throw new TimeoutException("EngineHost did not become ready in time.");
-            }
+            string line = ReadLine(
+                timeout,
+                "EngineHost did not become ready in time.",
+                "before becoming ready");
 
             if (line == EngineProtocol.Ready)
             {
@@ -161,10 +163,10 @@ public sealed class ChildEngineClient : ILiveDebuggerHost
         StringBuilder sb = new();
         while (true)
         {
-            if (!_lines.TryTake(out string? line, (int)timeout.TotalMilliseconds, HarnessCancellation.Token))
-            {
-                throw new TimeoutException($"EngineHost did not return output for '{command}' within {timeout}.");
-            }
+            string line = ReadLine(
+                timeout,
+                $"EngineHost did not return output for '{command}' within {timeout}.",
+                $"while running '{command}'");
 
             if (line == EngineProtocol.End)
             {
@@ -186,12 +188,48 @@ public sealed class ChildEngineClient : ILiveDebuggerHost
         return sb.ToString();
     }
 
+    private string ReadLine(TimeSpan timeout, string timeoutMessage, string exitContext)
+    {
+        if (_lines.TryTake(out string? line, (int)timeout.TotalMilliseconds, HarnessCancellation.Token))
+        {
+            return line;
+        }
+
+        if (_lines.IsCompleted || _process.HasExited)
+        {
+            throw CreateEngineHostExitException(exitContext);
+        }
+
+        throw new TimeoutException(timeoutMessage);
+    }
+
+    private InvalidOperationException CreateEngineHostExitException(string context)
+    {
+        bool exited = _process.HasExited || _process.WaitForExit(1000);
+        string exitDescription = exited
+            ? $"exited with code {_process.ExitCode}"
+            : "closed its standard output";
+        string stderr = exited && _stderr.Wait(TimeSpan.FromSeconds(2))
+            ? _stderr.GetAwaiter().GetResult().Trim()
+            : string.Empty;
+        string details = stderr.Length == 0 ? string.Empty : $"{Environment.NewLine}{stderr}";
+
+        return new InvalidOperationException($"EngineHost {exitDescription} {context}.{details}");
+    }
+
     private void ReadLoop()
     {
-        string? line;
-        while ((line = _process.StandardOutput.ReadLine()) is not null)
+        try
         {
-            _lines.Add(line);
+            string? line;
+            while ((line = _process.StandardOutput.ReadLine()) is not null)
+            {
+                _lines.Add(line);
+            }
+        }
+        finally
+        {
+            _lines.CompleteAdding();
         }
     }
 

--- a/src/tests/SOS.TestHarness/DbgEngCapturer.cs
+++ b/src/tests/SOS.TestHarness/DbgEngCapturer.cs
@@ -71,7 +71,7 @@ public static class DbgEngCapturer
                 }
                 else // Crash
                 {
-                    RunToBreak(control, "second-chance crash");
+                    RunToBreak(control, "second-chance crash", requireSecondChanceException: true);
                 }
 
                 Run($".dump /o {DbgEngDumpOption(dumpKind)} \"{dumpPath}\"");
@@ -102,7 +102,7 @@ public static class DbgEngCapturer
         _ => throw new ArgumentOutOfRangeException(nameof(dumpKind), dumpKind, "Unsupported dump kind"),
     };
 
-    private static void RunToBreak(IDebugControl control, string what)
+    private static void RunToBreak(IDebugControl control, string what, bool requireSecondChanceException = false)
     {
         const int MaxResumes = 40;
         for (int i = 0; i < MaxResumes; i++)
@@ -111,7 +111,10 @@ public static class DbgEngCapturer
             control.WaitForEvent(TimeSpan.FromSeconds(60));
             control.GetExecutionStatus(out DEBUG_STATUS status);
 
-            if (status == DEBUG_STATUS.BREAK)
+            if (status == DEBUG_STATUS.BREAK
+                && (!requireSecondChanceException
+                    || (control.GetLastEvent(out DEBUG_LAST_EVENT_INFO_EXCEPTION exception, out _, out _)
+                        && exception.FirstChance == 0)))
             {
                 return;
             }

--- a/src/tests/SOS.TestHarness/DbgEngLiveHost.cs
+++ b/src/tests/SOS.TestHarness/DbgEngLiveHost.cs
@@ -114,7 +114,9 @@ public sealed class DbgEngLiveHost : DbgEngHostBase
                 Control.WaitForEvent(TimeSpan.FromSeconds(60));
                 Control.GetExecutionStatus(out DEBUG_STATUS status);
 
-                if (status == DEBUG_STATUS.BREAK)
+                if (status == DEBUG_STATUS.BREAK
+                    && Control.GetLastEvent(out DEBUG_LAST_EVENT_INFO_EXCEPTION exception, out _, out _)
+                    && exception.FirstChance == 0)
                 {
                     return; // second-chance crash break
                 }

--- a/src/tests/SOS.TestHarness/DumpGenerationRequirements.cs
+++ b/src/tests/SOS.TestHarness/DumpGenerationRequirements.cs
@@ -34,8 +34,7 @@ namespace SOS.TestHarness;
 /// </summary>
 internal static class DumpGenerationRequirements
 {
-    private static readonly string s_root = RuntimeInformation.ProcessArchitecture == Architecture.X86 ? @"SOFTWARE\WOW6432Node\" : @"SOFTWARE\";
-    private static readonly string s_settingsNode = s_root + @"Microsoft\Windows NT\CurrentVersion\MiniDumpSettings";
+    private const string SettingsNode = @"SOFTWARE\Microsoft\Windows NT\CurrentVersion\MiniDumpSettings";
     private const string DisableCheckValue = "DisableAuxProviderSignatureCheck";
 
     // Read the registry value at most once per process (cheap, read-only; reading HKLM needs no elevation).
@@ -68,7 +67,7 @@ internal static class DumpGenerationRequirements
         if (dumpKind == DumpKind.Mini)
         {
             HarnessSkipException.Now(
-                $@"Mini dump capture requires HKLM\{s_settingsNode}\{DisableCheckValue}=1 so dbghelp can " +
+                $@"Mini dump capture requires HKLM\{SettingsNode}\{DisableCheckValue}=1 so dbghelp can " +
                 "load the unsigned test DAC");
         }
 
@@ -90,7 +89,10 @@ internal static class DumpGenerationRequirements
     {
         try
         {
-            using RegistryKey? key = Registry.LocalMachine.OpenSubKey(s_settingsNode);
+            using RegistryKey localMachine = RegistryKey.OpenBaseKey(
+                RegistryHive.LocalMachine,
+                RegistryViewForProcess(Environment.Is64BitProcess));
+            using RegistryKey? key = localMachine.OpenSubKey(SettingsNode);
             return key?.GetValue(DisableCheckValue) is int value && value == 1;
         }
         catch (Exception ex) when (ex is SecurityException or UnauthorizedAccessException or IOException)
@@ -98,4 +100,8 @@ internal static class DumpGenerationRequirements
             return false;
         }
     }
+
+    [SupportedOSPlatform("windows")]
+    internal static RegistryView RegistryViewForProcess(bool is64BitProcess) =>
+        is64BitProcess ? RegistryView.Registry64 : RegistryView.Registry32;
 }

--- a/src/tests/SOS.TestHarness/DumpSession.cs
+++ b/src/tests/SOS.TestHarness/DumpSession.cs
@@ -21,18 +21,20 @@ namespace SOS.TestHarness;
 ///   <item><b>dotnet-dump</b> children busy-wait on stdin at ~100% CPU, so keeping many alive would
 ///   saturate the machine. They route through a capacity-1 <see cref="HostSlot"/> (most-recently-used
 ///   stays open, reopened on demand).</item>
+///   <item><b>lldb</b> children retain their loaded core and hosted SOS runtime. They use a separate
+///   capacity-1 slot so memoized sessions cannot accumulate enough processes to exhaust memory.</item>
 /// </list>
 /// </summary>
 internal sealed class DumpSession : IPooledHost, IDisposable
 {
     private readonly Host _hostKind;
-    private readonly bool _pooled;       // dotnet-dump: route through the single slot
+    private readonly bool _pooled;
     private readonly HostSlot? _slot;
     private readonly object _gate = new(); // serializes concurrent commands on this shared child
     private IDebuggerHost? _host;        // kept-alive host for non-pooled (cdb child) targets
 
-    // One diagnostics collector for the life of this session (survives the pooled dotnet-dump host being
-    // closed and reopened), for the child-process hosts that support capture. Null for the cdb child host.
+    // One diagnostics collector for the life of this session (survives a pooled host being closed and
+    // reopened), for the child-process hosts that support capture. Null for the cdb child host.
     private readonly HostDiagnostics? _diagnostics;
 
     public Host Host { get; }
@@ -59,10 +61,10 @@ internal sealed class DumpSession : IPooledHost, IDisposable
         CoreVersion = coreVersion;
         Dac = dac;
 
-        // dotnet-dump children spin on stdin -> bound to one via the slot. cdb children block
-        // when idle -> keep alive concurrently (no slot), which is the subprocess-backend payoff.
-        _pooled = hostKind == Host.DotnetDump;
-        _slot = _pooled ? HostSlot.DotNetDump : null;
+        // Bound resource-heavy LLDB and dotnet-dump children independently. cdb children block when
+        // idle and remain cheap enough to keep per session.
+        _slot = HostSlotFor(hostKind);
+        _pooled = _slot is not null;
 
         // The child-process hosts (lldb, dotnet-dump) capture their stdout/stderr and crash dumps; the cdb
         // child host runs dbgeng out-of-process and is not wired for capture.
@@ -80,8 +82,8 @@ internal sealed class DumpSession : IPooledHost, IDisposable
     /// Run a SOS command against this target (host prefixing handled by the host). A shared target
     /// may be handed to several tests at once (it is memoized by host/target/stop/flavor), and the
     /// cdb backend is a single child process whose stdin/stdout pipe is not safe for concurrent
-    /// callers — so non-pooled commands are serialized on a per-target gate. The dotnet-dump path
-    /// serializes itself on the slot lock.
+    /// callers — so non-pooled commands are serialized on a per-target gate. Pooled paths serialize
+    /// themselves on their slot locks.
     /// </summary>
     public SosOutput Sos(string command) =>
         RunCommand("SOS", command, h => h.Sos(command));
@@ -121,7 +123,14 @@ internal sealed class DumpSession : IPooledHost, IDisposable
         }
     }
 
-    // IPooledHost — used only for the pooled (dotnet-dump) path.
+    internal static HostSlot? HostSlotFor(Host hostKind) => hostKind switch
+    {
+        Host.Lldb => HostSlot.Lldb,
+        Host.DotnetDump => HostSlot.DotNetDump,
+        _ => null,
+    };
+
+    // IPooledHost — used only for the pooled LLDB and dotnet-dump paths.
 
     IDebuggerHost IPooledHost.Host => _host!;
 

--- a/src/tests/SOS.TestHarness/HostSlot.cs
+++ b/src/tests/SOS.TestHarness/HostSlot.cs
@@ -18,12 +18,14 @@ internal interface IPooledHost
 /// <summary>
 /// Governs how many live host instances of one kind may exist at once — here, exactly one.
 ///
-/// Two kinds need this for different reasons:
+/// Debugger backends need this for different reasons:
 /// <list type="bullet">
 ///   <item><b>cdb (in-process dbgeng)</b> is genuinely one-instance-per-process (a second client
 ///   throws).</item>
 ///   <item><b>dotnet-dump</b> children each busy-wait on stdin at ~100% CPU; keeping many alive
 ///   saturates the machine, so we keep at most one.</item>
+///   <item><b>lldb</b> children retain every loaded core and hosted SOS runtime. Keeping one per
+///   memoized dump session can exhaust memory during a large run, so dump sessions share one.</item>
 /// </list>
 /// The most-recently-used host stays open and is evicted (disposed) only when a different target
 /// of the same kind is needed — so a run of assertions against one dump reuses the open host, and
@@ -38,6 +40,9 @@ internal sealed class HostSlot
 
     /// <summary>The dotnet-dump slot (one analyze child alive at a time).</summary>
     public static readonly HostSlot DotNetDump = new();
+
+    /// <summary>The LLDB dump slot (one core-loaded child alive at a time).</summary>
+    public static readonly HostSlot Lldb = new();
 
     private readonly object _lock = new();
     private IPooledHost? _open;
@@ -58,8 +63,30 @@ internal sealed class HostSlot
 
             if (!ReferenceEquals(_open, owner))
             {
-                _open?.CloseHost();
-                owner.OpenHost();
+                IPooledHost? previous = _open;
+                _open = null;
+                previous?.CloseHost();
+                try
+                {
+                    owner.OpenHost();
+                }
+                catch (Exception openException)
+                {
+                    try
+                    {
+                        owner.CloseHost();
+                    }
+                    catch (Exception closeException)
+                    {
+                        throw new AggregateException(
+                            "Opening the pooled host failed, and cleaning up the partial host also failed.",
+                            openException,
+                            closeException);
+                    }
+
+                    throw;
+                }
+
                 _open = owner;
             }
 
@@ -80,8 +107,9 @@ internal sealed class HostSlot
                 System.Threading.Monitor.Wait(_lock);
             }
 
-            _open?.CloseHost();
+            IPooledHost? open = _open;
             _open = null;
+            open?.CloseHost();
             _exclusiveHeld = true;
         }
 
@@ -93,8 +121,9 @@ internal sealed class HostSlot
     {
         lock (_lock)
         {
-            _open?.CloseHost();
+            IPooledHost? open = _open;
             _open = null;
+            open?.CloseHost();
         }
     }
 

--- a/src/tests/SOS.TestHarness/LldbHostBase.cs
+++ b/src/tests/SOS.TestHarness/LldbHostBase.cs
@@ -110,6 +110,24 @@ public abstract class LldbHostBase : IDebuggerHost, IDiagnosticHost
         // that on-disk resolution working.
         psi.Environment.Remove("_NT_SYMBOL_PATH");
 
+        if (OperatingSystem.IsMacOS())
+        {
+            // Apple LLDB guards its Mach exception ports. The SOS hosting runtime must not replace them
+            // or macOS terminates LLDB with EXC_GUARD (dotnet/diagnostics#4551).
+            psi.Environment["PAL_MachExceptionMode"] = "7";
+
+            // sos-lldb links LLDB.framework through @rpath. Resolve it from the selected Xcode at launch
+            // rather than embedding the build machine's /Applications/Xcode*.app path in the driver.
+            string? sharedFrameworks = ToolPaths.ResolveXcodeSharedFrameworksDirectory();
+            if (sharedFrameworks is not null)
+            {
+                string? inherited = Environment.GetEnvironmentVariable("DYLD_FRAMEWORK_PATH");
+                psi.Environment["DYLD_FRAMEWORK_PATH"] = string.IsNullOrEmpty(inherited)
+                    ? sharedFrameworks
+                    : sharedFrameworks + Path.PathSeparator + inherited;
+            }
+        }
+
         // Run the host with the .NET crash-dump environment so a fatal fault in the SOS managed runtime
         // hosted inside lldb writes a full dump we can surface as an artifact. Do this before configure so
         // a derived host could still override it if needed.
@@ -124,7 +142,8 @@ public abstract class LldbHostBase : IDebuggerHost, IDiagnosticHost
         _stdin = _process.StandardInput;
         _diagnostics?.RecordProcess(_process);
 
-        _reader = new Thread(ReadLoop) { IsBackground = true, Name = "lldb-reader" };
+        StreamReader stdout = _process.StandardOutput;
+        _reader = new Thread(() => ReadLoop(stdout)) { IsBackground = true, Name = "lldb-reader" };
         _reader.Start();
 
         // Drain stderr on its own thread: lldb prints crash diagnostics, python errors, and unhandled
@@ -132,7 +151,8 @@ public abstract class LldbHostBase : IDebuggerHost, IDiagnosticHost
         // pipe could even block the host — and, more importantly, the evidence for a crash was discarded.
         if (_diagnostics is not null)
         {
-            _stderrReader = new Thread(StderrLoop) { IsBackground = true, Name = "lldb-stderr" };
+            StreamReader stderr = _process.StandardError;
+            _stderrReader = new Thread(() => StderrLoop(stderr)) { IsBackground = true, Name = "lldb-stderr" };
             _stderrReader.Start();
         }
 
@@ -216,16 +236,20 @@ public abstract class LldbHostBase : IDebuggerHost, IDiagnosticHost
         return sb.ToString();
     }
 
-    private void ReadLoop()
+    private void ReadLoop(StreamReader stdout)
     {
         try
         {
             string? line;
-            while ((line = _process.StandardOutput.ReadLine()) is not null)
+            while ((line = stdout.ReadLine()) is not null)
             {
                 _diagnostics?.AppendStdout(line);
                 _lines.Add(line);
             }
+        }
+        catch (Exception ex) when (ex is IOException or ObjectDisposedException)
+        {
+            AppendTrace($"--- lldb stdout read failed ---{Environment.NewLine}{ex}{Environment.NewLine}");
         }
         finally
         {
@@ -234,12 +258,12 @@ public abstract class LldbHostBase : IDebuggerHost, IDiagnosticHost
         }
     }
 
-    private void StderrLoop()
+    private void StderrLoop(StreamReader stderr)
     {
         try
         {
             string? line;
-            while ((line = _process.StandardError.ReadLine()) is not null)
+            while ((line = stderr.ReadLine()) is not null)
             {
                 _diagnostics?.AppendStderr(line);
             }
@@ -392,6 +416,10 @@ public abstract class LldbHostBase : IDebuggerHost, IDiagnosticHost
                 // best effort
             }
 
+            // The readers can still be inside StreamReader after the process exits. Join them before
+            // disposing Process so teardown cannot invalidate StandardOutput/StandardError mid-read.
+            _reader.Join(10000);
+            _stderrReader?.Join(10000);
             _process.Dispose();
         }
     }

--- a/src/tests/SOS.TestHarness/LldbLiveHost.cs
+++ b/src/tests/SOS.TestHarness/LldbLiveHost.cs
@@ -68,6 +68,13 @@ public sealed class LldbLiveHost : LldbHostBase, ILiveDebuggerHost
 
         Run($"target create \"{exePath}\"");
 
+        if (OperatingSystem.IsMacOS())
+        {
+            // Keep the debuggee at CoreCLR's normal native-debugger mode. Mode 7 is only for the separate
+            // runtime hosted inside Apple LLDB and must not change the target's managed exception behavior.
+            Run("settings set target.env-vars PAL_MachExceptionMode=2");
+        }
+
         // Stop at the program entry so we can load SOS and arm bpmd before the app runs.
         Run("process launch -s");
 

--- a/src/tests/SOS.TestHarness/RepoLayout.cs
+++ b/src/tests/SOS.TestHarness/RepoLayout.cs
@@ -88,6 +88,10 @@ public static class RepoLayout
     public static string SingleFileDebuggeeDir(string name, string tfm) =>
         Path.Combine(ArtifactsBin, name, ArtifactsConfiguration, tfm, Rid, "publish");
 
+    /// <summary>The pre-built desktop .NET Framework output directory for a debuggee.</summary>
+    public static string FrameworkDebuggeeDir(string name) =>
+        Path.Combine(ArtifactsBin, name, ArtifactsConfiguration, "net462");
+
     /// <summary>
     /// The repo's locally-acquired multi-version test .NET install (<c>artifacts/dotnet-test</c>), which
     /// <c>eng/InstallRuntimes.proj</c> populates with every <c>RuntimeTestVersions</c> runtime (8/9/10/11).

--- a/src/tests/SOS.TestHarness/SOS.TestHarness.csproj
+++ b/src/tests/SOS.TestHarness/SOS.TestHarness.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="SOS.TestHarness.EngineHost" />
+    <InternalsVisibleTo Include="SOS.Tests" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/tests/SOS.TestHarness/SnapshotStore.cs
+++ b/src/tests/SOS.TestHarness/SnapshotStore.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 
 namespace SOS.TestHarness;
 
@@ -22,8 +23,8 @@ namespace SOS.TestHarness;
 ///   runtime.</item>
 ///   <item><b>SingleFile</b> is pre-published by <c>Debuggees.proj</c> once per tested runtime, RID, and
 ///   configuration. Tests only locate and consume that immutable output.</item>
-///   <item><b>Framework (net462)</b> is produced on the fly in the harness scratch tree, matching the
-///   legacy harness's <c>cli</c> build process.</item>
+///   <item><b>Framework (net462)</b> is pre-built on Windows by <c>Debuggees.proj</c>; local development
+///   falls back to an on-demand build when that output is absent.</item>
 /// </list>
 ///
 /// Capture mechanism depends on the flavor and stop kind:
@@ -37,6 +38,8 @@ namespace SOS.TestHarness;
 /// </summary>
 public static class SnapshotStore
 {
+    private static readonly TimeSpan s_captureTimeout = TimeSpan.FromMinutes(5);
+
     // One acquisition per (flavor, target, coreVersion); thread-safe via Lazy.
     private static readonly ConcurrentDictionary<(Flavor Flavor, string Target, CoreVersion CoreVersion), Lazy<string>> s_targetExe = new();
 
@@ -215,16 +218,49 @@ public static class SnapshotStore
         ApplyMacOsDumpConfig(psi);
         ApplyGcType(psi, gcType);
 
-        using Process p = Process.Start(psi) ?? throw new InvalidOperationException("Failed to launch target");
-        string stdout = p.StandardOutput.ReadToEnd();
-        string stderr = p.StandardError.ReadToEnd();
-        p.WaitForExit();
+        // Windows createdump can outlive the crashing target while retaining its redirected handles.
+        BoundedProcessResult result = BoundedProcess.Run(
+            psi,
+            s_captureTimeout,
+            isolateLinuxProcessGroup: true,
+            outputDrainTimeout: s_captureTimeout);
 
         if (!File.Exists(dumpPath))
         {
+            if (IsKnownCreatedumpPermissionFailure(
+                coreVersion,
+                RuntimeInformation.ProcessArchitecture,
+                OperatingSystem.IsLinux(),
+                result.StandardOutput,
+                result.StandardError))
+            {
+                HarnessSkipException.Now(
+                    ".NET 8 createdump cannot read /proc/<pid>/mem on this Linux ARM64 host; " +
+                    "this runtime issue is fixed in later .NET versions.");
+            }
+
             throw new InvalidOperationException(
-                $"createdump did not produce '{dumpPath}' for {target.Project} ({flavor}); exit {p.ExitCode}.\n{stdout}\n{stderr}");
+                $"createdump did not produce '{dumpPath}' for {target.Project} ({flavor}); exit {result.ExitCode}.\n" +
+                $"stdout:\n{result.StandardOutput}\n" +
+                $"stderr:\n{result.StandardError}");
         }
+    }
+
+    internal static bool IsKnownCreatedumpPermissionFailure(
+        CoreVersion coreVersion,
+        Architecture architecture,
+        bool isLinux,
+        string stdout,
+        string stderr)
+    {
+        if (!isLinux || architecture != Architecture.Arm64 || coreVersion != CoreVersion.Net8)
+        {
+            return false;
+        }
+
+        string output = stdout + "\n" + stderr;
+        return output.Contains("open(/proc/", StringComparison.Ordinal) &&
+            output.Contains("/mem) FAILED Permission denied (13)", StringComparison.Ordinal);
     }
 
     /// <summary>Core/SingleFile snapshot capture: run the target once; its markers self-snapshot mid-run.</summary>
@@ -323,19 +359,25 @@ public static class SnapshotStore
         ApplyMacOsDumpConfig(psi);
         ApplyGcType(psi, gcType);
 
-        using Process p = Process.Start(psi) ?? throw new InvalidOperationException("Failed to launch target");
-        string stderr = p.StandardError.ReadToEnd();
-        p.WaitForExit();
+        // Windows dump helpers can outlive the target while retaining its redirected handles.
+        BoundedProcessResult result = BoundedProcess.Run(
+            psi,
+            s_captureTimeout,
+            isolateLinuxProcessGroup: true,
+            outputDrainTimeout: s_captureTimeout);
 
-        if (p.ExitCode != 0)
+        if (result.ExitCode != 0)
         {
-            throw new InvalidOperationException($"Target '{target.Project}' ({flavor}) failed ({p.ExitCode}):\n{stderr}");
+            throw new InvalidOperationException(
+                $"Target '{target.Project}' ({flavor}) failed ({result.ExitCode}):\n" +
+                $"stdout:\n{result.StandardOutput}\n" +
+                $"stderr:\n{result.StandardError}");
         }
     }
 
     /// <summary>
-    /// Resolve the runnable debuggee for a flavor. Core and SingleFile are repo build outputs; Framework
-    /// is built on demand from the repo debuggee csproj.
+    /// Resolve the runnable debuggee for a flavor. All flavors prefer repo build outputs; Framework falls
+    /// back to an on-demand build from the repo debuggee csproj for local development.
     /// </summary>
     private static string AcquireTarget(Flavor flavor, TargetDefinition target, CoreVersion coreVersion) => flavor switch
     {
@@ -365,7 +407,8 @@ public static class SnapshotStore
             if (!IsUpToDate(exe, NewestSourceWriteTime(project)))
             {
                 RunToCompletion(RepoLayout.DotnetTestExe,
-                    $"build \"{project}\" -p:BuildProjectFramework={tfm} -c {RepoLayout.ArtifactsConfiguration}");
+                    $"build \"{project}\" -p:BuildProjectFramework={tfm} -p:TargetRid={RepoLayout.Rid} " +
+                    $"-p:TargetArch={RepoLayout.TargetArch} -c {RepoLayout.ArtifactsConfiguration}");
             }
         }
 
@@ -413,6 +456,12 @@ public static class SnapshotStore
     /// than the debuggee source.</summary>
     private static string BuildFramework(TargetDefinition target)
     {
+        string prebuilt = Path.Combine(RepoLayout.FrameworkDebuggeeDir(target.Project), target.Project + RepoLayout.ExeSuffix);
+        if (File.Exists(prebuilt))
+        {
+            return prebuilt;
+        }
+
         string project = RepoLayout.DebuggeeProject(target.Project);
         string outDir = Path.Combine(RepoLayout.Scratch, "targets", "framework", target.Name);
         string exe = Path.Combine(outDir, target.Project + RepoLayout.ExeSuffix);
@@ -424,11 +473,14 @@ public static class SnapshotStore
         }
 
         string config = RepoLayout.ArtifactsConfiguration;
+        string platform = RepoLayout.TargetArch == "x86" ? " -p:PlatformTarget=x86" : string.Empty;
         // Desktop SOS resolves source lines from a classic Windows PDB (read via DIA), not a
         // portable/embedded one — the repo's global props default DebugType to embedded, so force
         // a full (Windows) PDB next to the exe for the source-line tests.
         string args =
-            $"build \"{project}\" -p:BuildProjectFramework=net462 -p:DebugType=full -p:DebugSymbols=true -c {config} -o \"{outDir}\"";
+            $"build \"{project}\" -p:BuildProjectFramework=net462 -p:TargetRid={RepoLayout.Rid} " +
+            $"-p:TargetArch={RepoLayout.TargetArch}{platform} -p:DebugType=full -p:DebugSymbols=true " +
+            $"-c {config} -o \"{outDir}\"";
 
         // Rebuild only when stale (above). Different frameworks of one csproj share its obj/ (and
         // project.assets.json), so serialize fallback builds per project.

--- a/src/tests/SOS.TestHarness/Targets.cs
+++ b/src/tests/SOS.TestHarness/Targets.cs
@@ -83,7 +83,7 @@ public static class Targets
         return session;
     }
 
-    /// <summary>Dispose every memoized dump session (kills dotnet-dump children, closes dbgeng hosts).</summary>
+    /// <summary>Dispose every memoized dump session and close pooled debugger children.</summary>
     public static void DisposeAll()
     {
         while (s_created.TryTake(out DumpSession? session))
@@ -98,8 +98,8 @@ public static class Targets
             }
         }
 
-        // Close any pooled (dotnet-dump) host still open. cdb children were disposed above via
-        // each SharedTarget.Dispose().
+        // Close any pooled host still open. cdb children were disposed with their sessions above.
+        HostSlot.Lldb.CloseCurrent();
         HostSlot.DotNetDump.CloseCurrent();
     }
 }

--- a/src/tests/SOS.TestHarness/TestConfig.cs
+++ b/src/tests/SOS.TestHarness/TestConfig.cs
@@ -187,7 +187,7 @@ public sealed record TestConfig : IXunitSerializable
     /// Whether a configuration is valid on the current platform. Centralizes every constraint that the old
     /// nested-loop <c>BuildMatrix</c> scattered across per-axis <c>continue</c>s.
     /// </summary>
-    private static bool IsValid(TestConfig c)
+    internal static bool IsValid(TestConfig c)
     {
         // Host platform constraints: cdb is Windows-only, lldb is non-Windows-only.
         if (c.Host == Host.Cdb && !OperatingSystem.IsWindows())
@@ -206,6 +206,13 @@ public sealed record TestConfig : IXunitSerializable
             return false;
         }
 
+        // SOS hosts cannot discover the statically linked CoreCLR module in musl single-file processes
+        // or dumps. Keep Core coverage on Alpine while excluding unsupported single-file rows.
+        if (!IsFlavorSupportedOnRid(c.Flavor, RepoLayout.Rid))
+        {
+            return false;
+        }
+
         // dotnet-dump is post-mortem only; it has no live host.
         if (c.IsLive && c.Host == Host.DotnetDump)
         {
@@ -218,6 +225,18 @@ public sealed record TestConfig : IXunitSerializable
         // works there). Prune the (lldb, single-file, live) row for targets navigated via a managed stop
         // point; crash targets, which just run to the fault, keep their live single-file coverage.
         if (c.IsLive && c.Host == Host.Lldb && c.Flavor == Flavor.SingleFile && TargetCatalog.NavigatesViaBpmd(c.Target))
+        {
+            return false;
+        }
+
+        // A single-file snapshot requires a Full dump because createdump cannot enumerate reduced-dump
+        // regions for a statically linked runtime. On constrained test machines, marker targets produce
+        // several multi-gigabyte dumps and cannot complete reliably. Callers can exclude only those
+        // snapshot rows while preserving single-file crash coverage.
+        if (!c.IsLive &&
+            c.Flavor == Flavor.SingleFile &&
+            TargetCatalog.NavigatesViaBpmd(c.Target) &&
+            ExcludeSingleFileSnapshots(Environment.GetEnvironmentVariable("SOSHARNESS_EXCLUDE_SINGLEFILE_SNAPSHOTS")))
         {
             return false;
         }
@@ -249,34 +268,33 @@ public sealed record TestConfig : IXunitSerializable
             return false;
         }
 
-        // The cDAC (managed contract DAC) is a .NET Core concept; desktop .NET Framework has no cDAC, so
-        // `runtimes --usecdac true` fails on clr.dll ("no matching cDAC is available for this runtime").
-        // Prune the CDac axis for the Framework flavor (its CoreVersion label is meaningless anyway).
-        if (c.Dac == Dac.CDac && c.Flavor == Flavor.Framework)
-        {
-            return false;
-        }
-
-        // The cDAC (managed contract DAC) only exists on .NET 11+; on earlier runtimes only the legacy
-        // native DAC is available, so prune the CDac axis there. The same dump is reused across DAC values
-        // (only `runtimes --usecdac` differs at debug time), so this just removes the invalid debug-time
-        // variant, never a capture.
-        if (c.Dac == Dac.CDac && (uint)c.CoreVersion < (uint)CoreVersion.Net11)
-        {
-            return false;
-        }
-
-        // The universal cDAC can identify a single-file runtime and inspect its GC heap, but it cannot
-        // currently expose the managed execution metadata that SOS commands require (AppDomain/module
-        // details, MethodDescs, exception stack traces, or stack walks). Keep cDAC coverage on Core,
-        // where the full command surface is supported, and test SingleFile with its matching legacy DAC.
-        if (c.Dac == Dac.CDac && c.Flavor == Flavor.SingleFile)
+        if (!IsDacSupported(c))
         {
             return false;
         }
 
         return true;
     }
+
+    /// <summary>
+    /// The cDAC is available only for .NET Core 11+; desktop Framework and single-file command coverage
+    /// continue to use the legacy DAC.
+    /// </summary>
+    internal static bool IsDacSupported(TestConfig config) =>
+        config.Dac != Dac.CDac ||
+        (config.Flavor is not Flavor.Framework and not Flavor.SingleFile &&
+            (uint)config.CoreVersion >= (uint)CoreVersion.Net11);
+
+    internal static bool IsFlavorSupportedOnRid(Flavor flavor, string rid) =>
+        flavor != Flavor.SingleFile || !rid.StartsWith("linux-musl-", StringComparison.Ordinal);
+
+    internal static bool ExcludeSingleFileSnapshots(string? value) => value switch
+    {
+        null or "" or "0" => false,
+        "1" => true,
+        _ => throw new InvalidOperationException(
+            "SOSHARNESS_EXCLUDE_SINGLEFILE_SNAPSHOTS must be unset, 0, or 1."),
+    };
 
     private static IEnumerable<T> SingleFlags<T>(T value) where T : struct, Enum
     {

--- a/src/tests/SOS.TestHarness/ToolPaths.cs
+++ b/src/tests/SOS.TestHarness/ToolPaths.cs
@@ -38,17 +38,18 @@ public static class ToolPaths
     public static string LldbPluginPath => s_lldbPluginPath.Value;
 
     /// <summary>
-    /// The <c>lldb</c> executable the harness drives. Resolution mirrors <c>eng/build.sh</c>: the
-    /// <c>LLDB_PATH</c> env var first, then (on macOS) Xcode's lldb at
-    /// <c>$(xcode-select -p)/usr/bin/lldb</c> (it carries the debugging entitlements), then a plain
-    /// <c>lldb</c> on <c>PATH</c>. Non-Windows; resolved lazily.
+    /// The <c>lldb</c> executable the harness drives. On macOS the repo-built <c>sos-lldb</c> driver is
+    /// preferred because it embeds Xcode's LLDB framework without inheriting the system executable's
+    /// CoreCLR-hosting restriction. <c>SOSHARNESS_LLDB_PATH</c> is the explicit harness override;
+    /// <c>LLDB_PATH</c> and system LLDB remain fallbacks. Non-Windows; resolved lazily.
     /// </summary>
     public static string LldbExe => s_lldbExe.Value;
 
     /// <summary>
     /// The .NET runtime directory SOS hosts its managed extension on (the <c>sethostruntime</c> target).
-    /// Points at the repo's locally-acquired <c>.dotnet</c> shared runtime (highest net10 present), so the
-    /// host runtime is deterministic and hermetic rather than auto-detected from <c>PATH</c>.
+    /// Defaults to the repo's locally-acquired <c>.dotnet</c> shared runtime (highest net10 present), so the
+    /// host runtime is deterministic and hermetic rather than auto-detected from <c>PATH</c>. Set
+    /// <c>SOSHARNESS_HOST_RUNTIME_DIR</c> to validate SOS against another complete runtime layout.
     /// </summary>
     public static string HostRuntimeDirectory => s_hostRuntimeDirectory.Value;
 
@@ -174,15 +175,32 @@ public static class ToolPaths
 
     private static string ResolveLldbExe()
     {
-        // 1) Explicit override (what eng/build.sh exports), if it points at a real file.
-        string? env = Environment.GetEnvironmentVariable("LLDB_PATH");
+        // 1) Explicit harness override.
+        string? env = Environment.GetEnvironmentVariable("SOSHARNESS_LLDB_PATH");
         if (!string.IsNullOrEmpty(env) && File.Exists(env))
         {
             return env;
         }
 
-        // 2) macOS: Xcode's lldb is signed with the debugging entitlements needed to drive a process and
-        //    to load core dumps, so prefer it over anything else.
+        // 2) The repo-built macOS driver uses the selected Xcode's LLDB framework without running inside
+        //    Apple's restricted LLDB executable.
+        if (OperatingSystem.IsMacOS())
+        {
+            string driver = Path.Combine(RepoLayout.ArtifactsBinNative, "sos-lldb");
+            if (File.Exists(driver))
+            {
+                return driver;
+            }
+        }
+
+        // 3) Existing build-script override.
+        env = Environment.GetEnvironmentVariable("LLDB_PATH");
+        if (!string.IsNullOrEmpty(env) && File.Exists(env))
+        {
+            return env;
+        }
+
+        // 4) Xcode's LLDB.
         if (OperatingSystem.IsMacOS())
         {
             string? developerDir = TryRun("xcode-select", "-p");
@@ -196,7 +214,7 @@ public static class ToolPaths
             }
         }
 
-        // 3) A plain `lldb` on PATH.
+        // 5) A plain `lldb` on PATH.
         string? onPath = FindOnPath("lldb");
         if (onPath is not null)
         {
@@ -204,12 +222,48 @@ public static class ToolPaths
         }
 
         throw new FileNotFoundException(
-            "Could not locate an 'lldb' executable. Set LLDB_PATH, install lldb on PATH, or (on macOS) " +
-            "install Xcode.");
+            "Could not locate an 'lldb' executable. Set SOSHARNESS_LLDB_PATH or LLDB_PATH, install lldb " +
+            "on PATH, or (on macOS) install Xcode.");
+    }
+
+    internal static string? ResolveXcodeSharedFrameworksDirectory()
+    {
+        string? developerDir = Environment.GetEnvironmentVariable("DEVELOPER_DIR");
+        if (string.IsNullOrWhiteSpace(developerDir))
+        {
+            developerDir = TryRun("xcode-select", "-p");
+        }
+
+        if (string.IsNullOrWhiteSpace(developerDir))
+        {
+            return null;
+        }
+
+        string sharedFrameworks = Path.GetFullPath(Path.Combine(developerDir.Trim(), "..", "SharedFrameworks"));
+        return Directory.Exists(sharedFrameworks) ? sharedFrameworks : null;
     }
 
     private static string ResolveHostRuntimeDirectory()
     {
+        string? configuredDirectory = Environment.GetEnvironmentVariable("SOSHARNESS_HOST_RUNTIME_DIR");
+        if (!string.IsNullOrEmpty(configuredDirectory))
+        {
+            string directory = Path.GetFullPath(configuredDirectory);
+            string coreClrName = OperatingSystem.IsWindows()
+                ? "coreclr.dll"
+                : OperatingSystem.IsMacOS() ? "libcoreclr.dylib" : "libcoreclr.so";
+            string coreClrPath = Path.Combine(directory, coreClrName);
+            string coreLibPath = Path.Combine(directory, "System.Private.CoreLib.dll");
+            if (File.Exists(coreClrPath) && File.Exists(coreLibPath))
+            {
+                return directory;
+            }
+
+            throw new DirectoryNotFoundException(
+                $"The configured SOS harness host runtime directory '{directory}' must contain " +
+                $"{coreClrName} and System.Private.CoreLib.dll.");
+        }
+
         // SOS hosts its managed extension on a .NET runtime; point it at the repo's locally-acquired
         // .dotnet shared runtime so it's deterministic. Any recent runtime works as a host (it need not
         // match the target's runtime), so pick the highest net10 present.

--- a/src/tests/SOS.Tests/BoundedProcessTests.cs
+++ b/src/tests/SOS.Tests/BoundedProcessTests.cs
@@ -1,0 +1,133 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using SOS.TestHarness;
+using Xunit;
+
+namespace SOS.Tests;
+
+public sealed class BoundedProcessTests
+{
+    [Fact]
+    public void DrainsLargeOutputConcurrently()
+    {
+        if (!OperatingSystem.IsLinux())
+        {
+            return;
+        }
+
+        ProcessStartInfo startInfo = Shell(
+            "i=0; while [ $i -lt 10000 ]; do echo stdout-$i; echo stderr-$i >&2; i=$((i+1)); done");
+
+        BoundedProcessResult result = BoundedProcess.Run(startInfo, TimeSpan.FromSeconds(30));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.True(result.StandardOutput.Length > 64 * 1024);
+        Assert.True(result.StandardError.Length > 64 * 1024);
+    }
+
+    [Fact]
+    public void KillsLinuxProcessGroupOnTimeout()
+    {
+        if (!OperatingSystem.IsLinux())
+        {
+            return;
+        }
+
+        ProcessStartInfo startInfo = Shell("sleep 30 & echo $!; wait");
+
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        TimeoutException error = Assert.Throws<TimeoutException>(
+            () => BoundedProcess.Run(
+                startInfo,
+                TimeSpan.FromMilliseconds(250),
+                isolateLinuxProcessGroup: true));
+        stopwatch.Stop();
+
+        string childPid = error.Message
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .First(line => int.TryParse(line, out _));
+
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(10));
+        Assert.False(IsRunning(childPid));
+    }
+
+    [Fact]
+    public void ClosesInheritedOutputAfterParentExit()
+    {
+        if (!OperatingSystem.IsLinux())
+        {
+            return;
+        }
+
+        ProcessStartInfo startInfo = Shell("sleep 30 & echo $!; exit 0");
+
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        BoundedProcessResult result = BoundedProcess.Run(
+            startInfo,
+            TimeSpan.FromSeconds(10),
+            isolateLinuxProcessGroup: true);
+        stopwatch.Stop();
+
+        string childPid = result.StandardOutput.Trim();
+        Assert.Equal(0, result.ExitCode);
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(10));
+        Assert.False(IsRunning(childPid));
+    }
+
+    [Fact]
+    public void WaitsForInheritedOutputWithinConfiguredDeadline()
+    {
+        if (!OperatingSystem.IsLinux())
+        {
+            return;
+        }
+
+        ProcessStartInfo startInfo = Shell("sleep 1 & echo inherited-output; exit 0");
+
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        BoundedProcessResult result = BoundedProcess.Run(
+            startInfo,
+            TimeSpan.FromSeconds(2),
+            outputDrainTimeout: TimeSpan.FromSeconds(3));
+        stopwatch.Stop();
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("inherited-output", result.StandardOutput);
+        Assert.True(stopwatch.Elapsed >= TimeSpan.FromMilliseconds(500));
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(3));
+    }
+
+    private static ProcessStartInfo Shell(string command)
+    {
+        ProcessStartInfo startInfo = new("/bin/sh")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        startInfo.ArgumentList.Add("-c");
+        startInfo.ArgumentList.Add(command);
+        return startInfo;
+    }
+
+    private static bool IsRunning(string processId)
+    {
+        string processPath = $"/proc/{processId}";
+        string statPath = Path.Combine(processPath, "stat");
+        string stat;
+        try
+        {
+            stat = File.ReadAllText(statPath);
+        }
+        catch (IOException) when (!Directory.Exists(processPath))
+        {
+            return false;
+        }
+
+        int commandEnd = stat.LastIndexOf(')');
+        return commandEnd < 0 || commandEnd + 2 >= stat.Length || stat[commandEnd + 2] != 'Z';
+    }
+}

--- a/src/tests/SOS.Tests/HostSlotTests.cs
+++ b/src/tests/SOS.Tests/HostSlotTests.cs
@@ -1,0 +1,104 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using SOS.TestHarness;
+using Xunit;
+
+namespace SOS.Tests;
+
+public sealed class HostSlotTests
+{
+    [Fact]
+    public void DumpSessionsUseSeparateBoundedSlots()
+    {
+        Assert.Same(HostSlot.Lldb, DumpSession.HostSlotFor(Host.Lldb));
+        Assert.Same(HostSlot.DotNetDump, DumpSession.HostSlotFor(Host.DotnetDump));
+        Assert.Null(DumpSession.HostSlotFor(Host.Cdb));
+    }
+
+    [Fact]
+    public void SwitchingOwnersEvictsTheOpenHost()
+    {
+        HostSlot slot = new();
+        FakePooledHost first = new();
+        FakePooledHost second = new();
+
+        slot.Run(first, host => host.Sos("first"));
+        slot.Run(first, host => host.Sos("again"));
+
+        Assert.Equal(1, first.OpenCount);
+        Assert.Equal(0, first.CloseCount);
+
+        slot.Run(second, host => host.Sos("second"));
+
+        Assert.Equal(1, first.CloseCount);
+        Assert.Equal(1, second.OpenCount);
+
+        slot.CloseCurrent();
+
+        Assert.Equal(1, second.CloseCount);
+    }
+
+    [Fact]
+    public void FailedReplacementDoesNotPoisonTheSlot()
+    {
+        HostSlot slot = new();
+        FakePooledHost first = new();
+        FakePooledHost failing = new() { ThrowOnOpen = true };
+
+        slot.Run(first, host => host.Sos("first"));
+
+        Assert.Throws<InvalidOperationException>(
+            () => slot.Run(failing, host => host.Sos("unreachable")));
+        Assert.Equal(1, first.CloseCount);
+        Assert.Equal(1, failing.CloseCount);
+
+        slot.Run(first, host => host.Sos("reopened"));
+
+        Assert.Equal(2, first.OpenCount);
+    }
+
+    private sealed class FakePooledHost : IPooledHost
+    {
+        private FakeDebuggerHost? _host;
+
+        public int OpenCount { get; private set; }
+        public int CloseCount { get; private set; }
+        public bool ThrowOnOpen { get; init; }
+        public IDebuggerHost Host => _host ?? throw new InvalidOperationException("The host is not open.");
+
+        public void OpenHost()
+        {
+            OpenCount++;
+            _host = new FakeDebuggerHost();
+            if (ThrowOnOpen)
+            {
+                throw new InvalidOperationException("Open failed.");
+            }
+        }
+
+        public void CloseHost()
+        {
+            CloseCount++;
+            _host?.Dispose();
+            _host = null;
+        }
+    }
+
+    private sealed class FakeDebuggerHost : IDebuggerHost
+    {
+        public string Name => "fake";
+
+        public void Dispose()
+        {
+        }
+
+        public void LoadSos()
+        {
+        }
+
+        public SosOutput Execute(string command) => new(Name, command, string.Empty);
+
+        public SosOutput Sos(string command) => new(Name, command, string.Empty);
+    }
+}

--- a/src/tests/SOS.Tests/TestConfigValidityTests.cs
+++ b/src/tests/SOS.Tests/TestConfigValidityTests.cs
@@ -1,0 +1,81 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+using SOS.TestHarness;
+using Xunit;
+
+namespace SOS.Tests;
+
+public sealed class TestConfigValidityTests
+{
+    [Theory]
+    [InlineData(null, false)]
+    [InlineData("", false)]
+    [InlineData("0", false)]
+    [InlineData("1", true)]
+    public void SingleFileSnapshotExclusionIsStrict(string? value, bool expected)
+    {
+        Assert.Equal(expected, TestConfig.ExcludeSingleFileSnapshots(value));
+    }
+
+    [Theory]
+    [InlineData("true")]
+    [InlineData(" 1")]
+    [InlineData("yes")]
+    public void SingleFileSnapshotExclusionRejectsInvalidValues(string value)
+    {
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(
+            () => TestConfig.ExcludeSingleFileSnapshots(value));
+
+        Assert.Contains("SOSHARNESS_EXCLUDE_SINGLEFILE_SNAPSHOTS", error.Message);
+    }
+
+    [Fact]
+    public void CDacRequiresSupportedCoreConfiguration()
+    {
+        TestConfig config = Config() with { Dac = Dac.CDac, CoreVersion = CoreVersion.Net11 };
+
+        Assert.True(TestConfig.IsDacSupported(config));
+        Assert.False(TestConfig.IsDacSupported(config with { CoreVersion = CoreVersion.Net10 }));
+        Assert.False(TestConfig.IsDacSupported(config with { Flavor = Flavor.Framework }));
+        Assert.False(TestConfig.IsDacSupported(config with { Flavor = Flavor.SingleFile }));
+        Assert.False(TestConfig.IsValid(config with { Flavor = Flavor.SingleFile }));
+    }
+
+    [Theory]
+    [InlineData(Flavor.Core, "linux-musl-x64", true)]
+    [InlineData(Flavor.SingleFile, "linux-x64", true)]
+    [InlineData(Flavor.SingleFile, "linux-musl-x64", false)]
+    [InlineData(Flavor.SingleFile, "linux-musl-arm64", false)]
+    public void MuslExcludesOnlySingleFile(Flavor flavor, string rid, bool expected)
+    {
+        Assert.Equal(expected, TestConfig.IsFlavorSupportedOnRid(flavor, rid));
+    }
+
+    [Fact]
+    public void Net8LinuxArm64CreatedumpPermissionFailureIsKnown()
+    {
+        const string error = "open(/proc/123/mem) FAILED Permission denied (13)";
+
+        Assert.True(SnapshotStore.IsKnownCreatedumpPermissionFailure(
+            CoreVersion.Net8, Architecture.Arm64, isLinux: true, error, string.Empty));
+        Assert.False(SnapshotStore.IsKnownCreatedumpPermissionFailure(
+            CoreVersion.Net11, Architecture.Arm64, isLinux: true, error, string.Empty));
+        Assert.False(SnapshotStore.IsKnownCreatedumpPermissionFailure(
+            CoreVersion.Net8, Architecture.X64, isLinux: true, error, string.Empty));
+        Assert.False(SnapshotStore.IsKnownCreatedumpPermissionFailure(
+            CoreVersion.Net8, Architecture.Arm64, isLinux: true, "unrelated failure", string.Empty));
+    }
+
+    private static TestConfig Config() =>
+        new(
+            TargetCatalog.DivZero,
+            OperatingSystem.IsWindows() ? Host.Cdb : Host.Lldb,
+            Flavor.Core,
+            Liveness.Dump,
+            GcType.Workstation,
+            DumpKind.Heap,
+            CoreVersion.Net10,
+            Dac.Legacy);
+}

--- a/src/tests/SOS.Tests/TestConfigValidityTests.cs
+++ b/src/tests/SOS.Tests/TestConfigValidityTests.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using Microsoft.Win32;
 using SOS.TestHarness;
 using Xunit;
 
@@ -66,6 +68,15 @@ public sealed class TestConfigValidityTests
             CoreVersion.Net8, Architecture.X64, isLinux: true, error, string.Empty));
         Assert.False(SnapshotStore.IsKnownCreatedumpPermissionFailure(
             CoreVersion.Net8, Architecture.Arm64, isLinux: true, "unrelated failure", string.Empty));
+    }
+
+    [Theory]
+    [InlineData(false, RegistryView.Registry32)]
+    [InlineData(true, RegistryView.Registry64)]
+    [SupportedOSPlatform("windows")]
+    public void DumpGenerationRegistryViewMatchesProcessBitness(bool is64BitProcess, RegistryView expected)
+    {
+        Assert.Equal(expected, DumpGenerationRequirements.RegistryViewForProcess(is64BitProcess));
     }
 
     private static TestConfig Config() =>

--- a/src/tests/SOS.UnitTests/Debuggees/Directory.Build.props
+++ b/src/tests/SOS.UnitTests/Debuggees/Directory.Build.props
@@ -7,6 +7,9 @@
     <DebugType Condition="'$(TargetFramework)' == '$(DesktopTargetFramework)'">full</DebugType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Optimize>false</Optimize>
+    <!-- Framework-dependent apphosts default to the build SDK's host platform. Keep their output
+         RID-neutral while selecting an apphost that can execute on cross-target test legs. -->
+    <DefaultAppHostRuntimeIdentifier Condition="'$(TargetRid)' == 'win-x86' or $(TargetRid.EndsWith('-arm64')) or $(TargetRid.StartsWith('linux-musl-'))">$(TargetRid)</DefaultAppHostRuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/SOS.UnitTests/Debuggees/SosHarnessScenarios/SosHarnessScenarios.csproj
+++ b/src/tests/SOS.UnitTests/Debuggees/SosHarnessScenarios/SosHarnessScenarios.csproj
@@ -9,4 +9,8 @@
     <TargetFrameworks Condition="'$(BuildProjectFramework)' == ''">$(SupportedSubProcessTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' != '$(DesktopTargetFramework)'">
+    <Compile Include="..\..\..\SOS.TestHarness\BoundedProcess.cs" Link="BoundedProcess.cs" />
+  </ItemGroup>
+
 </Project>

--- a/src/tests/SOS.UnitTests/Debuggees/SosHarnessScenarios/TestHarness.cs
+++ b/src/tests/SOS.UnitTests/Debuggees/SosHarnessScenarios/TestHarness.cs
@@ -5,7 +5,9 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
-using System.Threading.Tasks;
+#if !NETFRAMEWORK
+using SOS.TestHarness;
+#endif
 
 /// <summary>
 /// The one piece of shared machinery the marker debuggee uses. A call to <see cref="Stop"/> marks a
@@ -65,17 +67,16 @@ public static class TestHarness
         psi.ArgumentList.Add("-o");
         psi.ArgumentList.Add(outPath);
 
-        using Process p = Process.Start(psi) ??
-            throw new InvalidOperationException("Failed to start dotnet-dump.");
-        Task<string> stdoutTask = p.StandardOutput.ReadToEndAsync();
-        Task<string> stderrTask = p.StandardError.ReadToEndAsync();
-        p.WaitForExit();
-        string stdout = stdoutTask.GetAwaiter().GetResult();
-        string stderr = stderrTask.GetAwaiter().GetResult();
-        if (p.ExitCode != 0 || !File.Exists(outPath))
+        BoundedProcessResult result = BoundedProcess.Run(
+            psi,
+            TimeSpan.FromMinutes(2),
+            isolateLinuxProcessGroup: true);
+        if (result.ExitCode != 0 || !File.Exists(outPath))
         {
             throw new InvalidOperationException(
-                $"Snapshot '{name}' failed (exit {p.ExitCode}):\n{stdout}\n{stderr}");
+                $"Snapshot '{name}' failed (exit {result.ExitCode}):\n" +
+                $"stdout:\n{result.StandardOutput}\n" +
+                $"stderr:\n{result.StandardError}");
         }
 #endif
     }

--- a/src/tests/dirs.proj
+++ b/src/tests/dirs.proj
@@ -64,7 +64,7 @@
       <DebuggeeBuildEnv Include="MSBuildSDKsPath=$(_BuildSdkVersionDir)$([System.IO.Path]::DirectorySeparatorChar)Sdks" />
       <DebuggeeBuildEnv Include="MSBuildExtensionsPath=$(_BuildSdkVersionDir)" />
     </ItemGroup>
-    <Exec Command="$(DebuggeeBuildDotNetPath) build $(MSBuildThisFileDirectory)Debuggees.proj -c $(Configuration) -bl:$(ArtifactsLogDir)Debuggees.binlog /p:TargetOS=$(TargetOS) /p:TargetArch=$(TargetArch) /p:RepoRoot=$(RepoRoot)"
+    <Exec Command="$(DebuggeeBuildDotNetPath) build $(MSBuildThisFileDirectory)Debuggees.proj -c $(Configuration) -bl:$(ArtifactsLogDir)Debuggees.binlog /p:TargetOS=$(TargetOS) /p:TargetArch=$(TargetArch) /p:TargetRid=$(TargetRid) /p:RepoRoot=$(RepoRoot)"
           WorkingDirectory="$(DebuggeeBuildDotNetDir)"
           EnvironmentVariables="@(DebuggeeBuildEnv)" />
   </Target>


### PR DESCRIPTION
Stack layer 2 of the native decomposition for dotnet/diagnostics#5981.

Depends on #5999

This layer stabilizes the reusable SOS harness across hosts and architectures: bounded child-process capture and stream drainage, clearer child-host failures, bounded LLDB dump hosts, second-chance DbgEng crash handling, macOS `sos-lldb` integration, RID-aware debuggee builds, and focused platform/configuration validity checks.

It intentionally excludes Helix submission and pipeline wiring, payload overlays, sharding, command-coverage migration, and legacy test deletion.

Validation:
- `dotnet build src/tests/SOS.Tests/SOS.Tests.csproj -c Debug -p:TargetArch=arm64 -p:TargetRid=osx-arm64 --no-restore`
- focused `BoundedProcessTests`, `HostSlotTests`, and `TestConfigValidityTests` (20 passed)
- `dotnet publish` for the `SosHarnessScenarios` single-file `osx-arm64` debuggee
- `./build.sh -skipmanaged -configuration Debug -architecture arm64`
