### PR TITLE
Fix SOS.Tests musl apphost

### DIFF
--- a/src/tests/SOS.Tests/SOS.Tests.csproj
+++ b/src/tests/SOS.Tests/SOS.Tests.csproj
@@ -5,6 +5,7 @@
          net10.0-only, so the test project must target net10.0 (overriding the repo's net8.0 default). -->
     <TargetFrameworks>$(NetCoreAppTestTargetFramework)</TargetFrameworks>
     <OutputType>Exe</OutputType>
+    <RuntimeIdentifier>$(TargetRid)</RuntimeIdentifier>
     <IsPackable>false</IsPackable>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
## Summary
- build the SOS.Tests executable for the configured target RID
- produce a musl-compatible apphost for Alpine test legs

## Testing
- Built SOS.Tests for linux-musl-x64
- Verified the generated apphost uses /lib/ld-musl-x86_64.so.1