### PR TITLE
SOS: control runtime candidate enumeration

### DIFF
--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/Microsoft.Diagnostics.DebugServices.Implementation.csproj
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/Microsoft.Diagnostics.DebugServices.Implementation.csproj
@@ -30,4 +30,8 @@
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\Microsoft.Diagnostics.DebugServices\Microsoft.Diagnostics.DebugServices.csproj" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\Microsoft.SymbolStore\Microsoft.SymbolStore.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Microsoft.Diagnostics.DebugServices.UnitTests" />
+  </ItemGroup>
 </Project>

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/Runtime.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/Runtime.cs
@@ -55,9 +55,8 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
 
         void IDisposable.Dispose()
         {
-            // The DataTarget created in the RuntimeProvider is disposed here. The ClrRuntime
-            // instance is disposed below in DisposeServices().
-            _clrRuntime?.DataTarget.Dispose();
+            // The ClrRuntime instance is disposed below in DisposeServices().
+            _clrInfo.DataTarget.Dispose();
             _clrRuntime = null;
             _serviceContainer.RemoveService(typeof(IRuntime));
             _serviceContainer.DisposeServices();

--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/RuntimeProvider.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/RuntimeProvider.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using Microsoft.Diagnostics.Runtime;
 
@@ -15,6 +16,9 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
     [ProviderExport(Type = typeof(IRuntimeProvider))]
     public class RuntimeProvider : IRuntimeProvider
     {
+        private const string RuntimeInfoExport = "DotNetRuntimeInfo";
+        private const string ContractDescriptorExport = "DotNetRuntimeContractDescriptor";
+
         private readonly IServiceProvider _services;
 
         public RuntimeProvider(IServiceProvider services)
@@ -36,6 +40,13 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
             // all re-created the next time the IRuntime or ClrRuntime instance is queried.
             ISettingsService settingsService = _services.GetService<ISettingsService>();
             bool verifyDac = settingsService?.DacSignatureVerificationEnabled ?? true;
+            IDataReader dataReader = _services.GetService<IDataReader>();
+            IModule entryPoint = _services.GetService<IModuleService>()?.EntryPointModule;
+            IReadOnlyList<ModuleInfo> runtimeModules = EnumerateRuntimeModules(
+                dataReader,
+                flags,
+                entryPoint?.ImageBase,
+                entryPoint?.FileName);
 
             // The cDAC (mscordaccore_universal) ships inside the (signed) diagnostics tool package and
             // carries no individual DAC signature, so it cannot satisfy ClrMD's signature check. Trust it
@@ -47,9 +58,12 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
             string normalizedTrustedCDacPath = string.IsNullOrEmpty(trustedCDacPath) ? null : Path.GetFullPath(trustedCDacPath);
             StringComparison pathComparison = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
 
-            DataTarget dataTarget = new(_services.GetService<IDataReader>(), new DataTargetOptions()
+            DataTargetOptions CreateDataTargetOptions(
+                bool skipRuntimeEnumeration,
+                bool forceCompleteRuntimeEnumeration) => new()
             {
-                ForceCompleteRuntimeEnumeration = (flags & RuntimeEnumerationFlags.All) != 0,
+                ForceCompleteRuntimeEnumeration = forceCompleteRuntimeEnumeration,
+                SkipRuntimeEnumeration = skipRuntimeEnumeration,
                 VerifyDacOnWindows = verifyDac,
                 // Takes priority over VerifyDacOnWindows: skip verification only for the exact bundled cDAC.
                 DacSignatureVerificationOverride = (dacFilePath) =>
@@ -63,11 +77,162 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
                     return verifyDac;
                 },
                 SymbolProvider = _services.GetService<IClrSymbolProvider>(),
-            });
-            for (int i = 0; i < dataTarget.ClrVersions.Length; i++)
+            };
+
+            List<ClrInfo> runtimes;
+            using (DataTarget discoveryTarget = new(
+                new RuntimeModuleDataReader(dataReader, runtimeModules),
+                CreateDataTargetOptions(
+                    skipRuntimeEnumeration: false,
+                    forceCompleteRuntimeEnumeration: true)))
             {
-                yield return new Runtime(_services, startingRuntimeId + i, dataTarget.ClrVersions[i]);
+                List<ClrInfo> discoveredRuntimes = discoveryTarget.ClrVersions.ToList();
+                runtimes = discoveredRuntimes
+                    .Select(clrInfo => CloneClrInfo(
+                        clrInfo,
+                        // ClrMD's legacy DAC loader currently requires DataTarget.ClrVersions to be
+                        // populated. Keep enumeration enabled on the full-reader target until ClrMD
+                        // supports registering host-discovered metadata without a loaded interface.
+                        new DataTarget(
+                            dataReader,
+                            CreateDataTargetOptions(
+                                skipRuntimeEnumeration: false,
+                                forceCompleteRuntimeEnumeration:
+                                    (flags & RuntimeEnumerationFlags.All) != 0))))
+                    .ToList();
             }
+
+            for (int i = 0; i < runtimes.Count; i++)
+            {
+                yield return new Runtime(_services, startingRuntimeId + i, runtimes[i]);
+            }
+        }
+
+        internal static IReadOnlyList<ModuleInfo> EnumerateRuntimeModules(
+            IDataReader dataReader,
+            RuntimeEnumerationFlags flags,
+            ulong? entryPointBase,
+            string entryPointFileName)
+        {
+            if (dataReader is null)
+            {
+                throw new ArgumentNullException(nameof(dataReader));
+            }
+
+            List<ModuleInfo> modules = dataReader.EnumerateModules().ToList();
+            if ((flags & RuntimeEnumerationFlags.All) != 0)
+            {
+                return modules;
+            }
+
+            HashSet<ulong> candidates = new();
+            foreach (ModuleInfo module in modules)
+            {
+                if (IsNamedRuntimeModule(module.FileName))
+                {
+                    candidates.Add(module.ImageBase);
+                }
+            }
+
+            if (entryPointBase.HasValue && !string.IsNullOrEmpty(entryPointFileName))
+            {
+                string entryPointName = GetFileNameWithoutExtension(entryPointFileName);
+                foreach (ModuleInfo module in modules)
+                {
+                    bool isEntryPoint = module.ImageBase == entryPointBase.Value;
+                    bool isEntryPointDll =
+                        dataReader.TargetPlatform == OSPlatform.Windows &&
+                        GetExtension(module.FileName).Equals(".dll", StringComparison.OrdinalIgnoreCase) &&
+                        GetFileNameWithoutExtension(module.FileName).Equals(entryPointName, StringComparison.OrdinalIgnoreCase);
+                    if ((isEntryPoint || isEntryPointDll) && HasRuntimeExport(module))
+                    {
+                        candidates.Add(module.ImageBase);
+                    }
+                }
+            }
+
+            return modules.Where(module => candidates.Contains(module.ImageBase)).ToList();
+        }
+
+        private static bool IsNamedRuntimeModule(string fileName)
+        {
+            string moduleName = GetFileName(fileName);
+            return moduleName.Equals("clr.dll", StringComparison.OrdinalIgnoreCase)
+                || moduleName.Equals("coreclr.dll", StringComparison.OrdinalIgnoreCase)
+                || moduleName.Equals("libcoreclr.so", StringComparison.Ordinal)
+                || moduleName.Equals("libcoreclr.dylib", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool HasRuntimeExport(ModuleInfo module)
+        {
+            return GetExportAddress(module, RuntimeInfoExport) != 0
+                || GetExportAddress(module, ContractDescriptorExport) != 0;
+        }
+
+        private static ulong GetExportAddress(ModuleInfo module, string export)
+        {
+            try
+            {
+                return module.GetExportSymbolAddress(export);
+            }
+            catch (Exception ex) when
+                (ex is IOException or
+                 InvalidDataException or
+                 ArgumentException or
+                 OverflowException or
+                 DiagnosticsException)
+            {
+                return 0;
+            }
+        }
+
+        private static ClrInfo CloneClrInfo(ClrInfo source, DataTarget dataTarget) =>
+            new(dataTarget, source.ModuleInfo, source.Version)
+            {
+                BuildId = source.BuildId,
+                ContractDescriptorAddress = source.ContractDescriptorAddress,
+                DebuggingLibraries = source.DebuggingLibraries,
+                Flavor = source.Flavor,
+                IndexFileSize = source.IndexFileSize,
+                IndexTimeStamp = source.IndexTimeStamp,
+                IsSingleFile = source.IsSingleFile,
+            };
+
+        private static string GetFileName(string path) =>
+            Path.GetFileName(path.Replace('\\', '/'));
+
+        private static string GetFileNameWithoutExtension(string path) =>
+            Path.GetFileNameWithoutExtension(path.Replace('\\', '/'));
+
+        private static string GetExtension(string path) =>
+            Path.GetExtension(path.Replace('\\', '/'));
+
+        private sealed class RuntimeModuleDataReader : IDataReader
+        {
+            private readonly IDataReader _reader;
+            private readonly IReadOnlyList<ModuleInfo> _modules;
+
+            public RuntimeModuleDataReader(IDataReader reader, IReadOnlyList<ModuleInfo> modules)
+            {
+                _reader = reader ?? throw new ArgumentNullException(nameof(reader));
+                _modules = modules ?? throw new ArgumentNullException(nameof(modules));
+            }
+
+            public string DisplayName => _reader.DisplayName;
+            public bool IsThreadSafe => _reader.IsThreadSafe;
+            public OSPlatform TargetPlatform => _reader.TargetPlatform;
+            public Architecture Architecture => _reader.Architecture;
+            public int ProcessId => _reader.ProcessId;
+            public int PointerSize => _reader.PointerSize;
+            public IEnumerable<ModuleInfo> EnumerateModules() => _modules;
+            public bool GetThreadContext(uint threadID, uint contextFlags, Span<byte> context) =>
+                _reader.GetThreadContext(threadID, contextFlags, context);
+            public void FlushCachedData() => _reader.FlushCachedData();
+            public int Read(ulong address, Span<byte> buffer) => _reader.Read(address, buffer);
+            public bool Read<T>(ulong address, out T value) where T : unmanaged => _reader.Read(address, out value);
+            public T Read<T>(ulong address) where T : unmanaged => _reader.Read<T>(address);
+            public bool ReadPointer(ulong address, out ulong value) => _reader.ReadPointer(address, out value);
+            public ulong ReadPointer(ulong address) => _reader.ReadPointer(address);
         }
 
         #endregion

--- a/src/tests/Microsoft.Diagnostics.DebugServices.UnitTests/RuntimeProviderTests.cs
+++ b/src/tests/Microsoft.Diagnostics.DebugServices.UnitTests/RuntimeProviderTests.cs
@@ -1,0 +1,152 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Microsoft.Diagnostics.DebugServices;
+using Microsoft.Diagnostics.DebugServices.Implementation;
+using Microsoft.Diagnostics.Runtime;
+using Xunit;
+
+public class RuntimeProviderTests
+{
+    [Fact]
+    public void NamedRuntimeModulesAreSelected()
+    {
+        TestModuleInfo[] modules =
+        [
+            new(0x1000, @"C:\app\app.exe"),
+            new(0x2000, @"C:\runtime\coreclr.dll"),
+            new(0x3000, @"C:\runtime\clr.dll"),
+            new(0x4000, "/runtime/libcoreclr.so"),
+            new(0x5000, "/runtime/libcoreclr.dylib"),
+            new(0x6000, @"C:\app\other.dll"),
+        ];
+
+        IReadOnlyList<ModuleInfo> result = RuntimeProvider.EnumerateRuntimeModules(
+            new TestDataReader(OSPlatform.Windows, modules),
+            RuntimeEnumerationFlags.Default,
+            entryPointBase: 0x1000,
+            entryPointFileName: modules[0].FileName);
+
+        Assert.Equal([0x2000UL, 0x3000UL, 0x4000UL, 0x5000UL], result.Select(module => module.ImageBase));
+    }
+
+    [Fact]
+    public void EntrypointRuntimeExportsAreSelected()
+    {
+        TestModuleInfo[] modules =
+        [
+            new(0x1000, @"C:\app\sample.exe", "DotNetRuntimeInfo"),
+            new(0x2000, @"C:\app\sample.dll", "DotNetRuntimeContractDescriptor"),
+            new(0x3000, @"C:\other\other.dll", "DotNetRuntimeContractDescriptor"),
+            new(0x4000, @"C:\runtime\coreclr.dll"),
+        ];
+
+        IReadOnlyList<ModuleInfo> result = RuntimeProvider.EnumerateRuntimeModules(
+            new TestDataReader(OSPlatform.Windows, modules),
+            RuntimeEnumerationFlags.Default,
+            entryPointBase: 0x1000,
+            entryPointFileName: modules[0].FileName);
+
+        Assert.Equal([0x1000UL, 0x2000UL, 0x4000UL], result.Select(module => module.ImageBase));
+    }
+
+    [Fact]
+    public void AllReturnsEveryModule()
+    {
+        TestModuleInfo[] modules =
+        [
+            new(0x1000, "app"),
+            new(0x2000, "other"),
+        ];
+
+        IReadOnlyList<ModuleInfo> result = RuntimeProvider.EnumerateRuntimeModules(
+            new TestDataReader(OSPlatform.Linux, modules),
+            RuntimeEnumerationFlags.All,
+            entryPointBase: null,
+            entryPointFileName: null);
+
+        Assert.Same(modules[0], result[0]);
+        Assert.Same(modules[1], result[1]);
+    }
+
+    [Fact]
+    public void ExportProbeFailureDoesNotSelectEntrypoint()
+    {
+        TestModuleInfo entryPoint = new(0x1000, @"C:\app\sample.exe", throwOnExport: true);
+
+        IReadOnlyList<ModuleInfo> result = RuntimeProvider.EnumerateRuntimeModules(
+            new TestDataReader(OSPlatform.Windows, [entryPoint]),
+            RuntimeEnumerationFlags.Default,
+            entryPoint.ImageBase,
+            entryPoint.FileName);
+
+        Assert.Empty(result);
+    }
+
+    private sealed class TestModuleInfo : ModuleInfo
+    {
+        private readonly HashSet<string> _exports;
+        private readonly bool _throwOnExport;
+
+        public TestModuleInfo(
+            ulong imageBase,
+            string fileName,
+            string export = null,
+            bool throwOnExport = false)
+            : base(imageBase, fileName)
+        {
+            _exports = export is null ? [] : [export];
+            _throwOnExport = throwOnExport;
+        }
+
+        public override ModuleKind Kind => ModuleKind.Unknown;
+
+        public override ulong GetExportSymbolAddress(string symbol)
+        {
+            if (_throwOnExport)
+            {
+                throw new InvalidDataException();
+            }
+            return _exports.Contains(symbol) ? ImageBase + 0x100 : 0;
+        }
+    }
+
+    private sealed class TestDataReader : IDataReader
+    {
+        private readonly IReadOnlyList<ModuleInfo> _modules;
+
+        public TestDataReader(OSPlatform targetPlatform, IReadOnlyList<ModuleInfo> modules)
+        {
+            TargetPlatform = targetPlatform;
+            _modules = modules;
+        }
+
+        public string DisplayName => nameof(TestDataReader);
+        public bool IsThreadSafe => true;
+        public OSPlatform TargetPlatform { get; }
+        public Architecture Architecture => Architecture.X64;
+        public int ProcessId => 1;
+        public int PointerSize => sizeof(long);
+        public IEnumerable<ModuleInfo> EnumerateModules() => _modules;
+        public bool GetThreadContext(uint threadID, uint contextFlags, Span<byte> context) => false;
+        public void FlushCachedData() { }
+        public int Read(ulong address, Span<byte> buffer) => 0;
+        public bool Read<T>(ulong address, out T value) where T : unmanaged
+        {
+            value = default;
+            return false;
+        }
+        public T Read<T>(ulong address) where T : unmanaged => default;
+        public bool ReadPointer(ulong address, out ulong value)
+        {
+            value = 0;
+            return false;
+        }
+        public ulong ReadPointer(ulong address) => 0;
+    }
+}


### PR DESCRIPTION
## Summary

Move runtime candidate selection into SOS while retaining ClrMD providers for exact `ClrInfo` metadata construction and legacy Desktop DAC activation.

Default enumeration considers:
- `clr.dll`, `coreclr.dll`, `libcoreclr.so`, and `libcoreclr.dylib`
- the entrypoint module and same-named Windows DLL when they export `DotNetRuntimeInfo` or `DotNetRuntimeContractDescriptor`

`runtimes --all` passes every module to the registered ClrMD providers. Additional `IRuntimeProvider` implementations can append runtimes to the runtime service without changing the public candidate provider.

A short-lived filtered `IDataReader` is used only for `ClrInfo` discovery. Production DataTargets retain the complete module list, so debugger module enumeration, DAC `GetImageBase`, image-backed reads, and stress-log resolution are unchanged.

## Acceptance applications

Two standalone applications and dumps were created outside the repository:
- CoreCLR + Desktop CLR in one process
- self-contained single-file CoreCLR

## Results

- Dual runtime: default enumeration finds CoreCLR and Desktop CLR; both can be selected; heap commands work for each.
- Native-only dual-runtime coverage: with managed SOS hosting disabled, native `eeversion` and `threads` succeed after switching to CoreCLR and then Desktop CLR. CoreCLR reports version `11.0.26.41219` and four threads; Desktop CLR reports version `4.8.9337.0` and three threads.
- Single-file: default and `--all` find the same runtime; `clrstack` and `dumpheap` work. Existing `clrstack -i` limitation remains.

## Transitional ClrMD behavior

ClrMD enumeration remains enabled internally on each production DataTarget because the current legacy `DacLibrary` rejects activation when `DataTarget.ClrVersions` is empty. SOS ignores that internal list and exposes only its candidate-controlled RuntimeService list. A future metadata-only ClrMD `AddRuntime(ClrInfo)` API can remove this duplicate internal enumeration and enable `SkipRuntimeEnumeration=true` end to end.
