### PR TITLE
Fix pattern bugs caught by new Roslyn diagnostic

### DIFF
--- a/src/Microsoft.Diagnostics.ExtensionCommands/DumpHeapService.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/DumpHeapService.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Diagnostics.ExtensionCommands
                             // Also, don't report fragmentation for Large/Pinned/Frozen segments.  This check
                             // is a little slow, so we do this last.
                             ClrSegment seg = obj.Type.Heap.GetSegmentByAddress(obj);
-                            if (seg is not null && seg.Kind is not GCSegmentKind.Large or GCSegmentKind.Pinned or GCSegmentKind.Frozen)
+                            if (seg is not null && seg.Kind is not (GCSegmentKind.Large or GCSegmentKind.Pinned or GCSegmentKind.Frozen))
                             {
                                 fragmentation ??= new();
                                 fragmentation.Add((lastFreeObject, obj));

--- a/src/Microsoft.Diagnostics.ExtensionCommands/FindEphemeralReferencesToLOHCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/FindEphemeralReferencesToLOHCommand.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Diagnostics.ExtensionCommands
 
         public override void Invoke()
         {
-            int segments = Runtime.Heap.Segments.Count(seg => seg.Kind is not GCSegmentKind.Frozen or GCSegmentKind.Pinned);
+            int segments = Runtime.Heap.Segments.Count(seg => seg.Kind is not (GCSegmentKind.Frozen or GCSegmentKind.Pinned));
             if (segments > 50)
             {
                 string gcSegKind = Runtime.Heap.SubHeaps[0].HasRegions ? "regions" : "segments";
@@ -121,7 +121,7 @@ namespace Microsoft.Diagnostics.ExtensionCommands
 
                     // This handles both regions and segments
                     Generation gen = seg.GetGeneration(obj);
-                    if (gen is not Generation.Generation0 or Generation.Generation1)
+                    if (gen is not (Generation.Generation0 or Generation.Generation1))
                     {
                         continue;
                     }


### PR DESCRIPTION
## Summary

A newer Roslyn diagnostic exposed three existing negated-pattern bugs:

- Pinned segments were incorrectly included in the segment count.
- Generation 1 objects were incorrectly skipped when finding ephemeral references.
- Pinned and frozen segments incorrectly contributed to fragmentation reporting.

Parenthesizing each disjunctive pattern makes `not` apply to the complete set of excluded values. This fixes the behavior and resolves the four CS9336 diagnostics.

## Testing

- `eng\build.ps1 -restore -build -ci -configuration Release -architecture x64 -privatebuild`

> [!NOTE]
> This pull request description was generated with GitHub Copilot.