### PR TITLE
Support test filters across xUnit runners

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -127,10 +127,10 @@ if ($test) {
         # Use backslash-escaped quotes so they survive the additional quoting in tools.ps1
         $testFilterArg = ''
         if ($methodfilter -ne '') {
-            $testFilterArg = "/p:TestRunnerAdditionalArguments=\`"-method $methodfilter\`""
+            $testFilterArg = "/p:DiagnosticsTestMethodFilter=\`"$methodfilter\`""
         }
         elseif ($classfilter -ne '') {
-            $testFilterArg = "/p:TestRunnerAdditionalArguments=\`"-class $classfilter\`""
+            $testFilterArg = "/p:DiagnosticsTestClassFilter=\`"$classfilter\`""
         }
 
         # When the managed build was skipped (e.g. the test-only CI legs that download prebuilt

--- a/src/tests/Directory.Build.targets
+++ b/src/tests/Directory.Build.targets
@@ -1,6 +1,17 @@
 <Project>
   <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.targets"/>
 
+  <!-- xUnit v3 uses Microsoft Testing Platform filter options while legacy xUnit uses console-runner options. -->
+  <PropertyGroup Condition="'$(DiagnosticsTestMethodFilter)' != ''">
+    <TestRunnerAdditionalArguments Condition="'$(TestRunnerName)' == 'XUnitV3' and '$(UseMicrosoftTestingPlatformRunner)' == 'true'">$(TestRunnerAdditionalArguments) --filter-method $(DiagnosticsTestMethodFilter)</TestRunnerAdditionalArguments>
+    <TestRunnerAdditionalArguments Condition="'$(TestRunnerName)' != 'XUnitV3' or '$(UseMicrosoftTestingPlatformRunner)' != 'true'">$(TestRunnerAdditionalArguments) -method $(DiagnosticsTestMethodFilter)</TestRunnerAdditionalArguments>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(DiagnosticsTestClassFilter)' != ''">
+    <TestRunnerAdditionalArguments Condition="'$(TestRunnerName)' == 'XUnitV3' and '$(UseMicrosoftTestingPlatformRunner)' == 'true'">$(TestRunnerAdditionalArguments) --filter-class $(DiagnosticsTestClassFilter)</TestRunnerAdditionalArguments>
+    <TestRunnerAdditionalArguments Condition="'$(TestRunnerName)' != 'XUnitV3' or '$(UseMicrosoftTestingPlatformRunner)' != 'true'">$(TestRunnerAdditionalArguments) -class $(DiagnosticsTestClassFilter)</TestRunnerAdditionalArguments>
+  </PropertyGroup>
+
   <!-- Projects that use debuggees/tracees depend on the test runtime installation.
        Using ProjectReference ensures the install runs exactly once via MSBuild's
        result cache, even when multiple test projects reference it in parallel. -->


### PR DESCRIPTION
## Summary

- Preserve the existing `eng/build.ps1` `-methodfilter` and `-classfilter` interface.
- Pass neutral filter properties into the test traversal.
- Translate filters to `-method`/`-class` for the legacy xUnit runner and `--filter-method`/`--filter-class` for xUnit v3 using Microsoft Testing Platform.

This allows legacy `SOS.UnitTests` and the new `SOS.Tests` project to run in the same test invocation while using their respective command-line syntax.

## Testing

- Ran a filtered legacy `SOS.UnitTests` method through `eng/build.ps1`.
- Ran one filtered xUnit v3 method through `eng/build.ps1`.
- Ran four filtered xUnit v3 class tests through `eng/build.ps1`.

> [!NOTE]
> This pull request description was generated with GitHub Copilot.