### PR TITLE
Build SOS interpreter test assets when enabled

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -67,6 +67,10 @@ if ($bundletools) {
     $test = $False
 }
 
+if ($testInterpreter) {
+    $env:SOS_TEST_INTERPRETER="true"
+}
+
 # Build native components
 if (-not $skipnative) {
     Invoke-Expression "& `"$engroot\Build-Native.cmd`" -architecture $architecture -configuration $configuration -verbosity $verbosity $remainingargs"
@@ -117,10 +121,6 @@ if ($test) {
     if (-not $crossbuild) {
         if ($dacMode -ne '') {
             $env:SOS_TEST_DAC_MODE=$dacMode
-        }
-
-        if ($testInterpreter) {
-            $env:SOS_TEST_INTERPRETER="true"
         }
 
         # Build the test filter argument if provided

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -153,6 +153,10 @@ if [[ -n "$__CDacPath" && "$__DacMode" != "cdac" ]]; then
     exit 1
 fi
 
+if [[ "$__TestInterpreter" == 1 ]]; then
+    export SOS_TEST_INTERPRETER="true"
+fi
+
 __LogsDir="$__RootBinDir/log/$__BuildType"
 __ConfigTriplet="$__TargetOS.$__TargetArch.$__BuildType"
 __BinDir="$__RootBinDir/bin/$__ConfigTriplet"
@@ -350,10 +354,6 @@ if [[ "$__Test" == 1 ]]; then
 
       if [[ -n "$__DacMode" ]]; then
           export SOS_TEST_DAC_MODE="$__DacMode"
-      fi
-
-      if [[ "$__TestInterpreter" == 1 ]]; then
-          export SOS_TEST_INTERPRETER="true"
       fi
 
       # Build the test filter argument if provided


### PR DESCRIPTION
## Summary

Make `-testInterpreter` set `SOS_TEST_INTERPRETER` before the managed build as well as during test execution.

The runtime-diagnostics pipeline separates diagnostics build and test into different processes. Previously, `-testInterpreter` was passed only to the test invocation, so the tests were enabled but the interpreter debuggee projects had already been skipped during the build.

The companion runtime pipeline commit passes `-testInterpreter` to the diagnostics build step: https://github.com/dotnet/runtime/commit/e3dc2ea6a39

This addresses the interpreter failures in: https://dev.azure.com/dnceng-public/public/_build/results?buildId=1587921

## Validation

Removed the generated interpreter outputs and confirmed that a managed build with `-testInterpreter` recreated `InterpreterStackTest`, `InterpreterStackInterleavedTest`, and `Trampoline` for `net11.0`.

> [!NOTE]
> This pull request description was generated with GitHub Copilot.