### PR TITLE
Allow DAC fallback for non-CoreCLR runtimes

### DIFF
--- a/src/Microsoft.Diagnostics.DebugServices.Implementation/Runtime.cs
+++ b/src/Microsoft.Diagnostics.DebugServices.Implementation/Runtime.cs
@@ -143,6 +143,12 @@ namespace Microsoft.Diagnostics.DebugServices.Implementation
         private ClrRuntime CreateRuntime()
         {
             CDacLoadPolicy policy = _settingsService.CDacLoadPolicy;
+            if (policy == CDacLoadPolicy.OnlyUseCDacForCoreClr)
+            {
+                policy = RuntimeType is RuntimeType.NetCore or RuntimeType.SingleFile
+                    ? CDacLoadPolicy.OnlyUseCDac
+                    : CDacLoadPolicy.PreferCDac;
+            }
             Trace.TraceInformation($"Runtime #{Id} data-access: begin (cDAC policy={policy})");
 
             if (policy != CDacLoadPolicy.UseLegacyDac)

--- a/src/Microsoft.Diagnostics.DebugServices/CDacLoadPolicy.cs
+++ b/src/Microsoft.Diagnostics.DebugServices/CDacLoadPolicy.cs
@@ -23,4 +23,9 @@ public enum CDacLoadPolicy
     /// </summary>
     UseLegacyDac = 2,
 
+    /// <summary>
+    /// Require cDAC activation for CoreCLR runtimes and allow DAC fallback for other runtimes.
+    /// </summary>
+    OnlyUseCDacForCoreClr = 3,
+
 }

--- a/src/Microsoft.Diagnostics.ExtensionCommands/Host/CommandFormatHelpers.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/Host/CommandFormatHelpers.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Diagnostics.ExtensionCommands
         {
             ISettingsService settingsService = command.Services.GetService<ISettingsService>() ?? throw new DiagnosticsException("Settings service required");
             command.Console.WriteLine("Settings:");
-            command.Console.WriteLine($"-> Use cDAC: {settingsService.CDacLoadPolicy switch { CDacLoadPolicy.OnlyUseCDac => "true", CDacLoadPolicy.UseLegacyDac => "false", _ => "prefer" }}");
+            command.Console.WriteLine($"-> Use cDAC: {settingsService.CDacLoadPolicy switch { CDacLoadPolicy.OnlyUseCDac => "true", CDacLoadPolicy.UseLegacyDac => "false", CDacLoadPolicy.OnlyUseCDacForCoreClr => "coreclr", _ => "prefer" }}");
             command.Console.WriteLine($"-> DAC signature verification check enabled: {settingsService.DacSignatureVerificationEnabled}");
         }
 

--- a/src/Microsoft.Diagnostics.ExtensionCommands/Host/RuntimesCommand.cs
+++ b/src/Microsoft.Diagnostics.ExtensionCommands/Host/RuntimesCommand.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Diagnostics.ExtensionCommands
         [Option(Name = "--all", Aliases = new string[] { "-a" }, Help = "Forces all runtimes to be enumerated.")]
         public bool All { get; set; }
 
-        [Option(Name = "--usecdac", Help = "Controls cDAC usage: true (required), false (disabled), prefer (allow DAC fallback).")]
+        [Option(Name = "--usecdac", Help = "Controls cDAC usage: true (required), false (disabled), prefer (allow DAC fallback), coreclr (required for CoreCLR, allow DAC fallback otherwise).")]
         public string UseCDac { get; set; }
 
         [Option(Name = "--DacSignatureVerification", Aliases = new string[] { "-v" }, Help = "Enforce the proper DAC certificate signing when loaded (true/false).")]
@@ -57,7 +57,8 @@ namespace Microsoft.Diagnostics.ExtensionCommands
                     "true" => CDacLoadPolicy.OnlyUseCDac,
                     "false" => CDacLoadPolicy.UseLegacyDac,
                     "prefer" => CDacLoadPolicy.PreferCDac,
-                    _ => throw new DiagnosticsException($"Invalid --usecdac value '{UseCDac}'. Expected true, false, or prefer."),
+                    "coreclr" => CDacLoadPolicy.OnlyUseCDacForCoreClr,
+                    _ => throw new DiagnosticsException($"Invalid --usecdac value '{UseCDac}'. Expected true, false, prefer, or coreclr."),
                 };
                 flush = true;
             }

--- a/src/SOS/SOS.Hosting/RuntimeWrapper.cs
+++ b/src/SOS/SOS.Hosting/RuntimeWrapper.cs
@@ -264,7 +264,7 @@ namespace SOS.Hosting
 
         private CDacLoadPolicy GetCDacLoadPolicy(IntPtr self)
         {
-            return _services.GetService<ISettingsService>()?.CDacLoadPolicy ?? CDacLoadPolicy.PreferCDac;
+            return EffectiveCDacLoadPolicy;
         }
 
         private int GetCorDebugInterface(
@@ -377,8 +377,7 @@ namespace SOS.Hosting
         private int CreateCorDebugProcess(out IntPtr corDebugProcess)
         {
             corDebugProcess = IntPtr.Zero;
-            CDacLoadPolicy policy =
-                _services.GetService<ISettingsService>()?.CDacLoadPolicy ?? CDacLoadPolicy.PreferCDac;
+            CDacLoadPolicy policy = EffectiveCDacLoadPolicy;
             if (_runtime.RuntimeType == RuntimeType.Desktop)
             {
                 return policy == CDacLoadPolicy.OnlyUseCDac
@@ -403,6 +402,14 @@ namespace SOS.Hosting
                 policy,
                 out corDebugProcess);
         }
+
+        private CDacLoadPolicy EffectiveCDacLoadPolicy =>
+            (_services.GetService<ISettingsService>()?.CDacLoadPolicy ?? CDacLoadPolicy.PreferCDac) switch
+            {
+                CDacLoadPolicy.OnlyUseCDacForCoreClr when _runtime.RuntimeType is RuntimeType.NetCore or RuntimeType.SingleFile => CDacLoadPolicy.OnlyUseCDac,
+                CDacLoadPolicy.OnlyUseCDacForCoreClr => CDacLoadPolicy.PreferCDac,
+                CDacLoadPolicy policy => policy,
+            };
 
         private int CreateDesktopCorDebugProcess(out IntPtr corDebugProcess)
         {

--- a/src/SOS/Strike/platform/runtimeimpl.cpp
+++ b/src/SOS/Strike/platform/runtimeimpl.cpp
@@ -595,7 +595,14 @@ CDacLoadPolicy Runtime::GetConfiguredCDacLoadPolicy()
 
 CDacLoadPolicy Runtime::GetCDacLoadPolicy() const
 {
-    return GetConfiguredCDacLoadPolicy();
+    CDacLoadPolicy policy = GetConfiguredCDacLoadPolicy();
+    if (policy == CDacLoadPolicy::OnlyUseCDacForCoreClr)
+    {
+        return GetRuntimeConfiguration() == IRuntime::WindowsDesktop
+            ? CDacLoadPolicy::PreferCDac
+            : CDacLoadPolicy::OnlyUseCDac;
+    }
+    return policy;
 }
 
 void Runtime::SetCDacLoadPolicy(CDacLoadPolicy policy)

--- a/src/SOS/Strike/strike.cpp
+++ b/src/SOS/Strike/strike.cpp
@@ -13501,6 +13501,9 @@ static void DisplayCDacLoadPolicy()
         case CDacLoadPolicy::PreferCDac:
             cdacPolicy = "prefer";
             break;
+        case CDacLoadPolicy::OnlyUseCDacForCoreClr:
+            cdacPolicy = "coreclr";
+            break;
         default:
             break;
     }
@@ -13540,9 +13543,13 @@ DECLARE_API(runtimes)
         {
             policy = CDacLoadPolicy::PreferCDac;
         }
+        else if (_stricmp(useCDac.data, "coreclr") == 0)
+        {
+            policy = CDacLoadPolicy::OnlyUseCDacForCoreClr;
+        }
         else
         {
-            ExtErr("Invalid --usecdac value '%s'. Expected true, false, or prefer.\n", useCDac.data);
+            ExtErr("Invalid --usecdac value '%s'. Expected true, false, prefer, or coreclr.\n", useCDac.data);
             return E_INVALIDARG;
         }
         Runtime::SetCDacLoadPolicy(policy);

--- a/src/SOS/inc/runtime.h
+++ b/src/SOS/inc/runtime.h
@@ -43,6 +43,7 @@ public:
         PreferCDac = 0,
         OnlyUseCDac = 1,
         UseLegacyDac = 2,
+        OnlyUseCDacForCoreClr = 3,
     };
 
     /// <summary>

--- a/src/tests/SOS.UnitTests/SOSRunner.cs
+++ b/src/tests/SOS.UnitTests/SOSRunner.cs
@@ -1159,7 +1159,7 @@ public class SOSRunner : IDisposable
         // selects the legacy DAC so DOTNET_ENABLE_CDAC affects only the DAC-hosted contract reader.
         string cdacPolicyCommand = _config.DacMode switch
         {
-            DacMode.CDac => "runtimes --usecdac true",    // Force the standalone cDAC next to sos.dll.
+            DacMode.CDac => "runtimes --usecdac coreclr", // Require the standalone cDAC for CoreCLR and allow DAC fallback for other runtimes.
             DacMode.CDacVerify or DacMode.Dac => "runtimes --usecdac false", // Force the legacy in-box DAC.
             _ => null,
         };


### PR DESCRIPTION
## Summary

Add a `coreclr` cDAC load policy that:

- requires cDAC activation for CoreCLR runtimes
- allows DAC fallback for other runtimes, including desktop .NET Framework
- preserves the existing `true`, `false`, and `prefer` policy behavior

The policy is implemented consistently in the managed and native SOS hosting paths. The SOS `cdac` test mode now selects `runtimes --usecdac coreclr` instead of globally requiring cDAC.

## Motivation

A process may contain both CoreCLR and desktop .NET Framework runtimes. Requiring standalone cDAC globally prevents SOS from inspecting Framework after switching runtimes because Framework does not support cDAC.

This was exposed by `SOSScenarioTests.DualRuntimes` in: https://dev.azure.com/dnceng-public/public/_build/results?buildId=1587921

The unrelated interpreter build fix is isolated in #6015.

## Validation

- built the affected managed and native SOS components
- confirmed `SOSScenarioTests.DualRuntimes` passes in `cdac` mode without a test-specific policy change or runtime-path override

> [!NOTE]
> This pull request description was generated with GitHub Copilot.