### PR TITLE
Run SOS test harness on Helix

### DIFF
--- a/diagnostics.yml
+++ b/diagnostics.yml
@@ -50,7 +50,7 @@ extends:
   parameters:
     stages:
     - stage: build
-      displayName: Build Diagnostics
+      displayName: Build / Test Diagnostics
       jobs:
 
         ############################
@@ -135,31 +135,46 @@ extends:
       - template: /eng/pipelines/build.yml
         parameters:
           jobTemplate: ${{ variables.jobTemplate }}
-          osGroup: MacOS
+          osGroup: Linux
+          container: linux_arm64
+          crossBuild: true
           buildOnly: true
-          publishTestArtifacts: true
+          publishTestArtifacts: ${{ eq(variables['System.TeamProject'], 'public') }}
+          publishTestRuntimeArtifacts: ${{ eq(variables['System.TeamProject'], 'public') }}
           buildConfigs:
           - configuration: Release
-            architecture: x64
-            artifactUploadPath: bin/osx.x64.Release
+            architecture: arm64
+            artifactUploadPath: bin/linux.arm64.Release
           - ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
             - configuration: Debug
-              architecture: x64
-              artifactUploadPath: bin/osx.x64.Debug
+              architecture: arm64
+              artifactUploadPath: bin/linux.arm64.Debug
 
+      # Reuse one macOS agent per configuration: build/test x64 first, then cross-build arm64.
+      # PRs submit only arm64 SOS.Tests; non-PR builds submit both architectures.
       - template: /eng/pipelines/build.yml
         parameters:
           jobTemplate: ${{ variables.jobTemplate }}
           osGroup: MacOS
-          crossBuild: true
-          buildOnly: true
+          timeoutInMinutes: 360
+          buildOnly: ${{ parameters.buildOnly }}
+          runSOSHelix: ${{ and(eq(parameters.buildOnly, false), eq(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}
+          sosHelixTargetOS: osx
+          sosHelixRidPrefix: osx
+          sosHelixQueue: OSX.15.Amd64.Open
+          additionalArchitecture: arm64
+          additionalCrossBuild: true
+          runAdditionalSOSHelix: ${{ and(eq(parameters.buildOnly, false), eq(variables['System.TeamProject'], 'public')) }}
+          additionalSOSHelixQueue: OSX.15.Arm64.Open
           buildConfigs:
           - configuration: Release
-            architecture: arm64
-            artifactUploadPath: bin/osx.arm64.Release
+            architecture: x64
+            artifactUploadPath: bin/osx.x64.Release
+            additionalArtifactUploadPath: bin/osx.arm64.Release
           - ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
             - configuration: Debug
-              architecture: arm64
+              architecture: x64
+              artifactUploadPath: bin/osx.x64.Debug
 
       - ${{ if ne(variables['System.TeamProject'], 'public') }}:
         - template: /eng/pipelines/build.yml
@@ -173,18 +188,6 @@ extends:
             - configuration: Release
               architecture: arm
               artifactUploadPath: bin/linux.arm.Release
-
-        - template: /eng/pipelines/build.yml
-          parameters:
-            jobTemplate: ${{ variables.jobTemplate }}
-            osGroup: Linux
-            container: linux_arm64
-            crossBuild: true
-            buildOnly: true
-            buildConfigs:
-            - configuration: Release
-              architecture: arm64
-              artifactUploadPath: bin/linux.arm64.Release
 
         - template: /eng/pipelines/build.yml
           parameters:
@@ -216,18 +219,13 @@ extends:
               artifactUploadPath: bin/linux.arm64.Release
               artifactTargetPath: bin/linux-musl.arm64.Release
 
-    ############################
-    #                          #
-    #        Test stage        #
-    #                          #
-    ############################
+      ############################
+      #                          #
+      #        Test legs         #
+      #                          #
+      ############################
 
-    - ${{ if ne(parameters.buildOnly, true) }}:
-      - stage: test
-        displayName: Test Diagnostics
-        dependsOn: build
-        jobs:
-
+      - ${{ if ne(parameters.buildOnly, true) }}:
         - template: /eng/pipelines/build.yml
           parameters:
             jobTemplate: ${{ variables.jobTemplate }}
@@ -235,6 +233,10 @@ extends:
             osGroup: Windows_NT
             dependsOn: Windows
             testOnly: true
+            runSOSHelix: ${{ eq(variables['System.TeamProject'], 'public') }}
+            sosHelixTargetOS: Windows_NT
+            sosHelixRidPrefix: win
+            sosHelixQueue: Windows.Amd64.Server2022.Open
             buildConfigs:
             - configuration: Debug
               architecture: x64
@@ -246,10 +248,15 @@ extends:
         - template: /eng/pipelines/build.yml
           parameters:
             jobTemplate: ${{ variables.jobTemplate }}
-            name: MacOS_Test
-            osGroup: MacOS
-            dependsOn: MacOS
+            name: Ubuntu_22_04
+            osGroup: Linux
+            container: test_ubuntu_22_04
+            dependsOn: Linux
             testOnly: true
+            runSOSHelix: ${{ eq(variables['System.TeamProject'], 'public') }}
+            sosHelixTargetOS: linux
+            sosHelixRidPrefix: linux
+            sosHelixQueue: Ubuntu.2204.Amd64.Open
             buildConfigs:
             - configuration: Release
               architecture: x64
@@ -257,20 +264,27 @@ extends:
               - configuration: Debug
                 architecture: x64
 
-        - template: /eng/pipelines/build.yml
-          parameters:
-            jobTemplate: ${{ variables.jobTemplate }}
-            name: Ubuntu_22_04
-            osGroup: Linux
-            container: test_ubuntu_22_04
-            dependsOn: Linux
-            testOnly: true
-            buildConfigs:
-            - configuration: Release
-              architecture: x64
-            - ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
-              - configuration: Debug
-                architecture: x64
+        # Cross-built arm64 artifacts are submitted from an x64 Linux agent and execute only on Helix.
+        - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+          - template: /eng/pipelines/build.yml
+            parameters:
+              jobTemplate: ${{ variables.jobTemplate }}
+              name: Ubuntu_22_04
+              osGroup: Linux
+              container: test_ubuntu_22_04
+              dependsOn: Linux
+              testOnly: true
+              helixOnly: true
+              runSOSHelix: true
+              sosHelixTargetOS: linux
+              sosHelixRidPrefix: linux
+              sosHelixQueue: Ubuntu.2204.ArmArch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-helix-arm64v8
+              buildConfigs:
+              - configuration: Release
+                architecture: arm64
+              - ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
+                - configuration: Debug
+                  architecture: arm64
 
         - template: /eng/pipelines/build.yml
           parameters:
@@ -282,6 +296,10 @@ extends:
             dependsOn: Linux_musl
             testOnly: true
             disableComponentGovernance: true
+            runSOSHelix: ${{ eq(variables['System.TeamProject'], 'public') }}
+            sosHelixTargetOS: linux
+            sosHelixRidPrefix: linux-musl
+            sosHelixQueue: '(Alpine.323.Amd64.Open)azurelinux.3.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.23-helix-amd64'
             buildConfigs:
             - configuration: Release
               architecture: x64

--- a/eng/helix/SOS.Tests.Helix.proj
+++ b/eng/helix/SOS.Tests.Helix.proj
@@ -25,9 +25,10 @@
                      Version="[$(cdbsosversion)]"
                      Condition="'$(TargetOS)' == 'Windows_NT'" />
 
-    <HelixCorrelationPayload Include="$(CorrelationPayloadDirectory)">
+    <_SOSHelixCorrelationPayload Include="$(CorrelationPayloadDirectory)">
       <PayloadDirectory>%(Identity)</PayloadDirectory>
-    </HelixCorrelationPayload>
+    </_SOSHelixCorrelationPayload>
+    <HelixCorrelationPayload Include="@(_SOSHelixCorrelationPayload)" />
 
     <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_0_of_8" ShardIndex="0" ShardCount="8" Liveness="Dump" Condition="'$(TargetOS)' != 'osx'" />
     <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_1_of_8" ShardIndex="1" ShardCount="8" Liveness="Dump" Condition="'$(TargetOS)' != 'osx'" />
@@ -97,13 +98,17 @@
         <Command Condition="'$(TargetOS)' != 'Windows_NT' and '%(_SOSShard.MaxParallelThreads)' != ''">$(SOSHelixTestEnvironment)bash $HELIX_CORRELATION_PAYLOAD/eng/helix/sos/run-sos-tests.sh $(Configuration) $(TargetRid) %(_SOSShard.ShardIndex) %(_SOSShard.ShardCount) %(_SOSShard.Liveness) $(NetCoreAppTestTargetFramework) %(_SOSShard.MaxParallelThreads)</Command>
         <Timeout>$(WorkItemTimeout)</Timeout>
       </HelixWorkItem>
+      <_AzurePipelinesReporterPayload Include="@(HelixCorrelationPayload)"
+                                      Condition="'$(HelixTargetQueue)' != '' and '%(HelixCorrelationPayload.IncludeDirectoryName)' == 'true'" />
     </ItemGroup>
     <Error Condition="'$(SOSHelixLiveness)' == '' and '@(HelixWorkItem->Count())' != '$(SOSExpectedWorkItemCount)'"
            Text="SOS Helix graph must contain exactly $(SOSExpectedWorkItemCount) work items; found @(HelixWorkItem->Count())." />
     <Error Condition="'$(SOSHelixLiveness)' != '' and '@(HelixWorkItem->Count())' != '1'"
            Text="SOS Helix smoke selection must match exactly one work item; found @(HelixWorkItem->Count())." />
-    <Error Condition="'@(HelixCorrelationPayload->Count())' != '1'"
-           Text="SOS Helix must use exactly one shared correlation payload; found @(HelixCorrelationPayload->Count())." />
+    <Error Condition="'@(_SOSHelixCorrelationPayload->Count())' != '1'"
+           Text="SOS Helix must define exactly one shared SOS correlation payload; found @(_SOSHelixCorrelationPayload->Count())." />
+    <Error Condition="'$(EnableAzurePipelinesReporter)' == 'true' and '$(HelixTargetQueue)' != '' and '@(_AzurePipelinesReporterPayload)' == ''"
+           Text="The Azure Pipelines reporter is enabled, but its correlation payload was not retained." />
   </Target>
 
   <Target Name="PrepareSOSHelixPayload"
@@ -206,6 +211,8 @@
 
   <Target Name="PrintSOSHelixWorkItems"
           DependsOnTargets="CreateSOSHelixWorkItems">
+    <Message Importance="High"
+             Text="SOSCorrelationPayload|@(_SOSHelixCorrelationPayload->'%(Identity)|%(PayloadDirectory)')" />
     <Message Importance="High"
              Text="CorrelationPayload|@(HelixCorrelationPayload->'%(Identity)|%(PayloadDirectory)')" />
     <Message Importance="High"

--- a/eng/helix/SOS.Tests.Helix.proj
+++ b/eng/helix/SOS.Tests.Helix.proj
@@ -1,0 +1,215 @@
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
+<Project Sdk="Microsoft.DotNet.Helix.Sdk" DefaultTargets="Test">
+
+  <PropertyGroup>
+    <Language>msbuild</Language>
+    <TargetFramework>$(NetCoreAppTestTargetFramework)</TargetFramework>
+    <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
+    <EnableAzurePipelinesReporter Condition="'$(SYSTEM_ACCESSTOKEN)' != ''">true</EnableAzurePipelinesReporter>
+    <EnableAzurePipelinesReporter Condition="'$(SYSTEM_ACCESSTOKEN)' == ''">false</EnableAzurePipelinesReporter>
+    <EnableXUnitReporter>true</EnableXUnitReporter>
+    <WaitForWorkItemCompletion>true</WaitForWorkItemCompletion>
+    <FailOnTestFailure>true</FailOnTestFailure>
+    <WorkItemTimeout>02:00:00</WorkItemTimeout>
+    <CorrelationPayloadDirectory Condition="'$(CorrelationPayloadDirectory)' == ''">$(ArtifactsDir)helix/SOS.Tests/$(TargetRid)/$(Configuration)/payload</CorrelationPayloadDirectory>
+    <DotNetHostName Condition="'$(TargetOS)' == 'Windows_NT'">dotnet.exe</DotNetHostName>
+    <DotNetHostName Condition="'$(TargetOS)' != 'Windows_NT'">dotnet</DotNetHostName>
+    <PayloadNativeSourceDir>$(ArtifactsBinNativeDir)</PayloadNativeSourceDir>
+    <SOSHelixTestEnvironment Condition="'$(TargetOS)' == 'osx'">SOSHARNESS_TEST_RUNTIME_MAJOR=11 SOSHARNESS_ONLY_COREVERSIONS=Net11 </SOSHelixTestEnvironment>
+    <SOSExpectedWorkItemCount Condition="'$(TargetOS)' == 'osx'">34</SOSExpectedWorkItemCount>
+    <SOSExpectedWorkItemCount Condition="'$(SOSExpectedWorkItemCount)' == ''">10</SOSExpectedWorkItemCount>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageDownload Include="cdb-sos"
+                     Version="[$(cdbsosversion)]"
+                     Condition="'$(TargetOS)' == 'Windows_NT'" />
+
+    <HelixCorrelationPayload Include="$(CorrelationPayloadDirectory)">
+      <PayloadDirectory>%(Identity)</PayloadDirectory>
+    </HelixCorrelationPayload>
+
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_0_of_8" ShardIndex="0" ShardCount="8" Liveness="Dump" Condition="'$(TargetOS)' != 'osx'" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_1_of_8" ShardIndex="1" ShardCount="8" Liveness="Dump" Condition="'$(TargetOS)' != 'osx'" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_2_of_8" ShardIndex="2" ShardCount="8" Liveness="Dump" Condition="'$(TargetOS)' != 'osx'" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_3_of_8" ShardIndex="3" ShardCount="8" Liveness="Dump" Condition="'$(TargetOS)' != 'osx'" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_4_of_8" ShardIndex="4" ShardCount="8" Liveness="Dump" Condition="'$(TargetOS)' != 'osx'" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_5_of_8" ShardIndex="5" ShardCount="8" Liveness="Dump" Condition="'$(TargetOS)' != 'osx'" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_6_of_8" ShardIndex="6" ShardCount="8" Liveness="Dump" Condition="'$(TargetOS)' != 'osx'" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_7_of_8" ShardIndex="7" ShardCount="8" Liveness="Dump" Condition="'$(TargetOS)' != 'osx'" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_0_of_32" ShardIndex="0" ShardCount="32" Liveness="Dump" MaxParallelThreads="4" Condition="'$(TargetOS)' == 'osx'" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_1_of_32" ShardIndex="1" ShardCount="32" Liveness="Dump" MaxParallelThreads="4" Condition="'$(TargetOS)' == 'osx'" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_2_of_32" ShardIndex="2" ShardCount="32" Liveness="Dump" MaxParallelThreads="4" Condition="'$(TargetOS)' == 'osx'" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_3_of_32" ShardIndex="3" ShardCount="32" Liveness="Dump" MaxParallelThreads="4" Condition="'$(TargetOS)' == 'osx'" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_4_of_32" ShardIndex="4" ShardCount="32" Liveness="Dump" MaxParallelThreads="4" Condition="'$(TargetOS)' == 'osx'" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_5_of_32" ShardIndex="5" ShardCount="32" Liveness="Dump" MaxParallelThreads="4" Condition="'$(TargetOS)' == 'osx'" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_6_of_32" ShardIndex="6" ShardCount="32" Liveness="Dump" MaxParallelThreads="4" Condition="'$(TargetOS)' == 'osx'" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_7_of_32" ShardIndex="7" ShardCount="32" Liveness="Dump" MaxParallelThreads="4" Condition="'$(TargetOS)' == 'osx'" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_8_of_32" ShardIndex="8" ShardCount="32" Liveness="Dump" MaxParallelThreads="4" Condition="'$(TargetOS)' == 'osx'" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_9_of_32" ShardIndex="9" ShardCount="32" Liveness="Dump" MaxParallelThreads="4" Condition="'$(TargetOS)' == 'osx'" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_10_of_32" ShardIndex="10" ShardCount="32" Liveness="Dump" MaxParallelThreads="4" Condition="'$(TargetOS)' == 'osx'" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_11_of_32" ShardIndex="11" ShardCount="32" Liveness="Dump" MaxParallelThreads="4" Condition="'$(TargetOS)' == 'osx'" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_12_of_32" ShardIndex="12" ShardCount="32" Liveness="Dump" MaxParallelThreads="4" Condition="'$(TargetOS)' == 'osx'" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_13_of_32" ShardIndex="13" ShardCount="32" Liveness="Dump" MaxParallelThreads="4" Condition="'$(TargetOS)' == 'osx'" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_14_of_32" ShardIndex="14" ShardCount="32" Liveness="Dump" MaxParallelThreads="4" Condition="'$(TargetOS)' == 'osx'" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_15_of_32" ShardIndex="15" ShardCount="32" Liveness="Dump" MaxParallelThreads="4" Condition="'$(TargetOS)' == 'osx'" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_16_of_32" ShardIndex="16" ShardCount="32" Liveness="Dump" MaxParallelThreads="4" Condition="'$(TargetOS)' == 'osx'" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_17_of_32" ShardIndex="17" ShardCount="32" Liveness="Dump" MaxParallelThreads="4" Condition="'$(TargetOS)' == 'osx'" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_18_of_32" ShardIndex="18" ShardCount="32" Liveness="Dump" MaxParallelThreads="4" Condition="'$(TargetOS)' == 'osx'" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_19_of_32" ShardIndex="19" ShardCount="32" Liveness="Dump" MaxParallelThreads="4" Condition="'$(TargetOS)' == 'osx'" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_20_of_32" ShardIndex="20" ShardCount="32" Liveness="Dump" MaxParallelThreads="4" Condition="'$(TargetOS)' == 'osx'" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_21_of_32" ShardIndex="21" ShardCount="32" Liveness="Dump" MaxParallelThreads="4" Condition="'$(TargetOS)' == 'osx'" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_22_of_32" ShardIndex="22" ShardCount="32" Liveness="Dump" MaxParallelThreads="4" Condition="'$(TargetOS)' == 'osx'" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_23_of_32" ShardIndex="23" ShardCount="32" Liveness="Dump" MaxParallelThreads="4" Condition="'$(TargetOS)' == 'osx'" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_24_of_32" ShardIndex="24" ShardCount="32" Liveness="Dump" MaxParallelThreads="4" Condition="'$(TargetOS)' == 'osx'" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_25_of_32" ShardIndex="25" ShardCount="32" Liveness="Dump" MaxParallelThreads="4" Condition="'$(TargetOS)' == 'osx'" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_26_of_32" ShardIndex="26" ShardCount="32" Liveness="Dump" MaxParallelThreads="4" Condition="'$(TargetOS)' == 'osx'" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_27_of_32" ShardIndex="27" ShardCount="32" Liveness="Dump" MaxParallelThreads="4" Condition="'$(TargetOS)' == 'osx'" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_28_of_32" ShardIndex="28" ShardCount="32" Liveness="Dump" MaxParallelThreads="4" Condition="'$(TargetOS)' == 'osx'" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_29_of_32" ShardIndex="29" ShardCount="32" Liveness="Dump" MaxParallelThreads="4" Condition="'$(TargetOS)' == 'osx'" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_30_of_32" ShardIndex="30" ShardCount="32" Liveness="Dump" MaxParallelThreads="4" Condition="'$(TargetOS)' == 'osx'" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_31_of_32" ShardIndex="31" ShardCount="32" Liveness="Dump" MaxParallelThreads="4" Condition="'$(TargetOS)' == 'osx'" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_live_0_of_2" ShardIndex="0" ShardCount="2" Liveness="Live" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_live_1_of_2" ShardIndex="1" ShardCount="2" Liveness="Live" />
+  </ItemGroup>
+
+  <Target Name="ValidateSOSHelixConfiguration">
+    <Error Condition="'$(Configuration)' == ''" Text="Configuration is required." />
+    <Error Condition="'$(TargetArch)' == ''" Text="TargetArch is required." />
+    <Error Condition="'$(TargetOS)' == ''" Text="TargetOS is required." />
+    <Error Condition="'$(TargetRid)' == ''" Text="TargetRid is required." />
+    <Error Condition="'$(SOSHelixLiveness)' == '' and '$(SOSHelixShardIndex)' != ''"
+           Text="SOSHelixLiveness and SOSHelixShardIndex must either both be set or both be unset." />
+    <Error Condition="'$(SOSHelixLiveness)' != '' and '$(SOSHelixShardIndex)' == ''"
+           Text="SOSHelixLiveness and SOSHelixShardIndex must either both be set or both be unset." />
+    <Error Condition="'$(SOSHelixLiveness)' != '' and '$(SOSHelixLiveness)' != 'Dump' and '$(SOSHelixLiveness)' != 'Live'"
+           Text="SOSHelixLiveness must be Dump or Live." />
+  </Target>
+
+  <Target Name="CreateSOSHelixWorkItems"
+          DependsOnTargets="ValidateSOSHelixConfiguration"
+          BeforeTargets="CoreTest">
+    <ItemGroup>
+      <HelixWorkItem Include="@(_SOSShard)"
+                     Condition="'$(SOSHelixLiveness)' == '' or ('%(_SOSShard.Liveness)' == '$(SOSHelixLiveness)' and '%(_SOSShard.ShardIndex)' == '$(SOSHelixShardIndex)')">
+        <Command Condition="'$(TargetOS)' == 'Windows_NT'">%25HELIX_CORRELATION_PAYLOAD%25\eng\helix\sos\run-sos-tests.cmd $(Configuration) $(TargetRid) %(_SOSShard.ShardIndex) %(_SOSShard.ShardCount) %(_SOSShard.Liveness) $(NetCoreAppTestTargetFramework)</Command>
+        <Command Condition="'$(TargetOS)' != 'Windows_NT' and '%(_SOSShard.MaxParallelThreads)' == ''">$(SOSHelixTestEnvironment)bash $HELIX_CORRELATION_PAYLOAD/eng/helix/sos/run-sos-tests.sh $(Configuration) $(TargetRid) %(_SOSShard.ShardIndex) %(_SOSShard.ShardCount) %(_SOSShard.Liveness) $(NetCoreAppTestTargetFramework)</Command>
+        <Command Condition="'$(TargetOS)' != 'Windows_NT' and '%(_SOSShard.MaxParallelThreads)' != ''">$(SOSHelixTestEnvironment)bash $HELIX_CORRELATION_PAYLOAD/eng/helix/sos/run-sos-tests.sh $(Configuration) $(TargetRid) %(_SOSShard.ShardIndex) %(_SOSShard.ShardCount) %(_SOSShard.Liveness) $(NetCoreAppTestTargetFramework) %(_SOSShard.MaxParallelThreads)</Command>
+        <Timeout>$(WorkItemTimeout)</Timeout>
+      </HelixWorkItem>
+    </ItemGroup>
+    <Error Condition="'$(SOSHelixLiveness)' == '' and '@(HelixWorkItem->Count())' != '$(SOSExpectedWorkItemCount)'"
+           Text="SOS Helix graph must contain exactly $(SOSExpectedWorkItemCount) work items; found @(HelixWorkItem->Count())." />
+    <Error Condition="'$(SOSHelixLiveness)' != '' and '@(HelixWorkItem->Count())' != '1'"
+           Text="SOS Helix smoke selection must match exactly one work item; found @(HelixWorkItem->Count())." />
+    <Error Condition="'@(HelixCorrelationPayload->Count())' != '1'"
+           Text="SOS Helix must use exactly one shared correlation payload; found @(HelixCorrelationPayload->Count())." />
+  </Target>
+
+  <Target Name="PrepareSOSHelixPayload"
+          DependsOnTargets="ValidateSOSHelixConfiguration"
+          BeforeTargets="CoreTest"
+          Condition="'$(HelixTargetQueue)' == ''">
+    <ItemGroup>
+      <_PayloadRootFile Include="$(RepoRoot)global.json;$(RepoRoot)Build.cmd" />
+      <_PayloadEngineeringFile Include="$(RepoRoot)eng/DisableSignatureCheck.ps1" />
+      <_PayloadLauncherFile Include="$(RepoRoot)eng/helix/sos/**/*" />
+
+      <_PayloadBinFile Include="$(ArtifactsBinDir)SOS.Tests/$(Configuration)/**/*;
+                                $(ArtifactsBinDir)SOS.TestHarness.EngineHost/$(Configuration)/**/*;
+                                $(ArtifactsBinDir)SOS.TestHarness.Capturer/$(Configuration)/**/*;
+                                $(ArtifactsBinDir)dotnet-dump/$(Configuration)/**/*;
+                                $(ArtifactsBinDir)NestedExceptionTest/$(Configuration)/*/*;
+                                $(ArtifactsBinDir)NestedExceptionTest/$(Configuration)/*/$(TargetRid)/publish/*;
+                                $(ArtifactsBinDir)DivZero/$(Configuration)/*/*;
+                                $(ArtifactsBinDir)DivZero/$(Configuration)/*/$(TargetRid)/publish/*;
+                                $(ArtifactsBinDir)AsyncMain/$(Configuration)/*/*;
+                                $(ArtifactsBinDir)AsyncMain/$(Configuration)/*/$(TargetRid)/publish/*;
+                                $(ArtifactsBinDir)DynamicMethod/$(Configuration)/*/*;
+                                $(ArtifactsBinDir)DynamicMethod/$(Configuration)/*/$(TargetRid)/publish/*;
+                                $(ArtifactsBinDir)Overflow/$(Configuration)/*/*;
+                                $(ArtifactsBinDir)Overflow/$(Configuration)/*/$(TargetRid)/publish/*;
+                                $(ArtifactsBinDir)LineNums/$(Configuration)/*/*;
+                                $(ArtifactsBinDir)LineNums/$(Configuration)/*/$(TargetRid)/publish/*;
+                                $(ArtifactsBinDir)SimpleThrow/$(Configuration)/*/*;
+                                $(ArtifactsBinDir)SimpleThrow/$(Configuration)/*/$(TargetRid)/publish/*;
+                                $(ArtifactsBinDir)ReflectionTest/$(Configuration)/*/*;
+                                $(ArtifactsBinDir)ReflectionTest/$(Configuration)/*/$(TargetRid)/publish/*;
+                                $(ArtifactsBinDir)SosHarnessScenarios/$(Configuration)/*/*;
+                                $(ArtifactsBinDir)SosHarnessScenarios/$(Configuration)/*/$(TargetRid)/publish/*" />
+      <_PayloadNativeFile Include="$(PayloadNativeSourceDir)**/*" />
+      <_PayloadDotNetTestFile Include="$(ArtifactsDotnetTestDir)$(DotNetHostName);
+                                          $(ArtifactsDotnetTestDir)LICENSE.txt;
+                                          $(ArtifactsDotnetTestDir)ThirdPartyNotices.txt;
+                                          $(ArtifactsDotnetTestDir)Debugger.Tests.Versions.txt;
+                                          $(ArtifactsDotnetTestDir)host/fxr/**/*;
+                                          $(ArtifactsDotnetTestDir)shared/Microsoft.NETCore.App/**/*" />
+      <_PayloadCDacFile Include="$(ArtifactsDir)cdac-override/$(Configuration)/**/*"
+                        Condition="Exists('$(ArtifactsDir)cdac-override/$(Configuration)')" />
+
+      <_PayloadCdbFile Include="$(NuGetPackageRoot)cdb-sos/$(cdbsosversion)/runtimes/$(TargetRid)/native/*"
+                       Condition="'$(TargetOS)' == 'Windows_NT'" />
+
+      <_PayloadFile Include="@(_PayloadRootFile)">
+        <DestinationRelative>%(_PayloadRootFile.Filename)%(_PayloadRootFile.Extension)</DestinationRelative>
+      </_PayloadFile>
+      <_PayloadFile Include="@(_PayloadEngineeringFile)">
+        <DestinationRelative>eng/%(_PayloadEngineeringFile.Filename)%(_PayloadEngineeringFile.Extension)</DestinationRelative>
+      </_PayloadFile>
+      <_PayloadFile Include="@(_PayloadLauncherFile)">
+        <DestinationRelative>eng/helix/sos/%(_PayloadLauncherFile.RecursiveDir)%(_PayloadLauncherFile.Filename)%(_PayloadLauncherFile.Extension)</DestinationRelative>
+      </_PayloadFile>
+      <_PayloadFile Include="@(_PayloadBinFile)">
+        <DestinationRelative>artifacts/bin/$([MSBuild]::MakeRelative('$(ArtifactsBinDir)', '%(_PayloadBinFile.Identity)'))</DestinationRelative>
+      </_PayloadFile>
+      <_PayloadFile Include="@(_PayloadNativeFile)">
+        <DestinationRelative>artifacts/bin/$(TargetOS).$(TargetArch).$(Configuration)/%(_PayloadNativeFile.RecursiveDir)%(_PayloadNativeFile.Filename)%(_PayloadNativeFile.Extension)</DestinationRelative>
+      </_PayloadFile>
+      <_PayloadFile Include="@(_PayloadDotNetTestFile)">
+        <DestinationRelative>artifacts/dotnet-test/$([MSBuild]::MakeRelative('$(ArtifactsDotnetTestDir)', '%(_PayloadDotNetTestFile.Identity)'))</DestinationRelative>
+      </_PayloadFile>
+      <_PayloadFile Include="@(_PayloadCDacFile)">
+        <DestinationRelative>artifacts/cdac-override/$(Configuration)/%(_PayloadCDacFile.RecursiveDir)%(_PayloadCDacFile.Filename)%(_PayloadCDacFile.Extension)</DestinationRelative>
+      </_PayloadFile>
+      <_PayloadFile Include="@(_PayloadCdbFile)">
+        <DestinationRelative>artifacts/cdb-sos/%(_PayloadCdbFile.Filename)%(_PayloadCdbFile.Extension)</DestinationRelative>
+      </_PayloadFile>
+    </ItemGroup>
+
+    <Error Condition="'@(_PayloadFile)' == ''" Text="The SOS Helix correlation payload is empty." />
+    <Error Condition="!Exists('$(ArtifactsBinDir)SOS.Tests/$(Configuration)/$(NetCoreAppTestTargetFramework)/SOS.Tests.dll')"
+           Text="SOS.Tests was not found under '$(ArtifactsBinDir)SOS.Tests/$(Configuration)'." />
+    <Error Condition="!Exists('$(ArtifactsBinDir)dotnet-dump/$(Configuration)/net8.0/dotnet-dump.dll') and !Exists('$(ArtifactsBinDir)dotnet-dump/$(Configuration)/net8.0/publish/dotnet-dump.dll')"
+           Text="dotnet-dump was not found under '$(ArtifactsBinDir)dotnet-dump/$(Configuration)'." />
+    <Error Condition="!Exists('$(ArtifactsDotnetTestDir)$(DotNetHostName)')"
+           Text="The test runtime host was not found at '$(ArtifactsDotnetTestDir)$(DotNetHostName)'." />
+    <Error Condition="!Exists('$(PayloadNativeSourceDir)sos.dll') and '$(TargetOS)' == 'Windows_NT'"
+           Text="Native SOS was not found at '$(PayloadNativeSourceDir)sos.dll'." />
+    <Error Condition="!Exists('$(NuGetPackageRoot)cdb-sos/$(cdbsosversion)/runtimes/$(TargetRid)/native/dbgeng.dll') and '$(TargetOS)' == 'Windows_NT'"
+           Text="DbgEng was not found in the cdb-sos package for '$(TargetRid)'." />
+    <Error Condition="!Exists('$(PayloadNativeSourceDir)libsosplugin.so') and '$(TargetOS)' == 'linux'"
+           Text="The SOS lldb plugin was not found at '$(PayloadNativeSourceDir)libsosplugin.so'." />
+    <Error Condition="!Exists('$(PayloadNativeSourceDir)libsosplugin.dylib') and '$(TargetOS)' == 'osx'"
+           Text="The SOS lldb plugin was not found at '$(PayloadNativeSourceDir)libsosplugin.dylib'." />
+    <Error Condition="!Exists('$(PayloadNativeSourceDir)sos-lldb') and '$(TargetOS)' == 'osx'"
+           Text="The SOS lldb driver was not found at '$(PayloadNativeSourceDir)sos-lldb'." />
+
+    <RemoveDir Directories="$(CorrelationPayloadDirectory)" />
+    <MakeDir Directories="$(CorrelationPayloadDirectory)" />
+    <Copy SourceFiles="@(_PayloadFile)"
+          DestinationFiles="@(_PayloadFile->'$(CorrelationPayloadDirectory)/%(DestinationRelative)')"
+          SkipUnchangedFiles="true"
+          UseHardlinksIfPossible="true" />
+    <Error Condition="'$(TargetOS)' == 'Windows_NT' and !Exists('$(CorrelationPayloadDirectory)/artifacts/cdb-sos/dbgeng.dll')"
+           Text="DbgEng was not staged in the SOS Helix correlation payload." />
+  </Target>
+
+  <Target Name="PrintSOSHelixWorkItems"
+          DependsOnTargets="CreateSOSHelixWorkItems">
+    <Message Importance="High"
+             Text="CorrelationPayload|@(HelixCorrelationPayload->'%(Identity)|%(PayloadDirectory)')" />
+    <Message Importance="High"
+             Text="@(HelixWorkItem->'%(Identity)|%(Command)|%(Timeout)', '%0A')" />
+  </Target>
+
+</Project>

--- a/eng/helix/SOS.Tests.Helix.proj
+++ b/eng/helix/SOS.Tests.Helix.proj
@@ -16,6 +16,8 @@
     <DotNetHostName Condition="'$(TargetOS)' != 'Windows_NT'">dotnet</DotNetHostName>
     <PayloadNativeSourceDir>$(ArtifactsBinNativeDir)</PayloadNativeSourceDir>
     <SOSHelixTestEnvironment Condition="'$(TargetOS)' == 'osx'">SOSHARNESS_TEST_RUNTIME_MAJOR=11 SOSHARNESS_ONLY_COREVERSIONS=Net11 </SOSHelixTestEnvironment>
+    <!-- The unprivileged Helix Alpine container exposes a .NET 8 createdump PR_SET_PTRACER race for Mini captures. -->
+    <SOSHelixPlatformTestEnvironment Condition="$([System.String]::Copy('$(TargetRid)').StartsWith('linux-musl-'))">SOSHARNESS_ONLY_DUMPKIND=Heap,Full </SOSHelixPlatformTestEnvironment>
     <!-- ARM64 native dump hosts are unstable under concurrent SOS commands. -->
     <SOSHelixDumpMaxParallelThreads Condition="'$(TargetOS)' == 'linux' and '$(TargetArch)' == 'arm64'">1</SOSHelixDumpMaxParallelThreads>
     <SOSExpectedWorkItemCount Condition="'$(TargetOS)' == 'osx'">34</SOSExpectedWorkItemCount>
@@ -87,6 +89,10 @@
            Text="SOSHelixLiveness and SOSHelixShardIndex must either both be set or both be unset." />
     <Error Condition="'$(SOSHelixLiveness)' != '' and '$(SOSHelixLiveness)' != 'Dump' and '$(SOSHelixLiveness)' != 'Live'"
            Text="SOSHelixLiveness must be Dump or Live." />
+    <Error Condition="$([System.String]::Copy('$(TargetRid)').StartsWith('linux-musl-')) and '$(SOSHelixPlatformTestEnvironment)' != 'SOSHARNESS_ONLY_DUMPKIND=Heap,Full '"
+           Text="Linux musl Helix work items must select exactly the Heap and Full dump kinds." />
+    <Error Condition="!$([System.String]::Copy('$(TargetRid)').StartsWith('linux-musl-')) and '$(SOSHelixPlatformTestEnvironment)' != ''"
+           Text="Non-musl Helix work items must not inherit Linux musl platform restrictions." />
   </Target>
 
   <Target Name="CreateSOSHelixWorkItems"
@@ -96,8 +102,8 @@
       <HelixWorkItem Include="@(_SOSShard)"
                      Condition="'$(SOSHelixLiveness)' == '' or ('%(_SOSShard.Liveness)' == '$(SOSHelixLiveness)' and '%(_SOSShard.ShardIndex)' == '$(SOSHelixShardIndex)')">
         <Command Condition="'$(TargetOS)' == 'Windows_NT'">%25HELIX_CORRELATION_PAYLOAD%25\eng\helix\sos\run-sos-tests.cmd $(Configuration) $(TargetRid) %(_SOSShard.ShardIndex) %(_SOSShard.ShardCount) %(_SOSShard.Liveness) $(NetCoreAppTestTargetFramework)</Command>
-        <Command Condition="'$(TargetOS)' != 'Windows_NT' and '%(_SOSShard.MaxParallelThreads)' == ''">$(SOSHelixTestEnvironment)bash $HELIX_CORRELATION_PAYLOAD/eng/helix/sos/run-sos-tests.sh $(Configuration) $(TargetRid) %(_SOSShard.ShardIndex) %(_SOSShard.ShardCount) %(_SOSShard.Liveness) $(NetCoreAppTestTargetFramework)</Command>
-        <Command Condition="'$(TargetOS)' != 'Windows_NT' and '%(_SOSShard.MaxParallelThreads)' != ''">$(SOSHelixTestEnvironment)bash $HELIX_CORRELATION_PAYLOAD/eng/helix/sos/run-sos-tests.sh $(Configuration) $(TargetRid) %(_SOSShard.ShardIndex) %(_SOSShard.ShardCount) %(_SOSShard.Liveness) $(NetCoreAppTestTargetFramework) %(_SOSShard.MaxParallelThreads)</Command>
+        <Command Condition="'$(TargetOS)' != 'Windows_NT' and '%(_SOSShard.MaxParallelThreads)' == ''">$(SOSHelixPlatformTestEnvironment)$(SOSHelixTestEnvironment)bash $HELIX_CORRELATION_PAYLOAD/eng/helix/sos/run-sos-tests.sh $(Configuration) $(TargetRid) %(_SOSShard.ShardIndex) %(_SOSShard.ShardCount) %(_SOSShard.Liveness) $(NetCoreAppTestTargetFramework)</Command>
+        <Command Condition="'$(TargetOS)' != 'Windows_NT' and '%(_SOSShard.MaxParallelThreads)' != ''">$(SOSHelixPlatformTestEnvironment)$(SOSHelixTestEnvironment)bash $HELIX_CORRELATION_PAYLOAD/eng/helix/sos/run-sos-tests.sh $(Configuration) $(TargetRid) %(_SOSShard.ShardIndex) %(_SOSShard.ShardCount) %(_SOSShard.Liveness) $(NetCoreAppTestTargetFramework) %(_SOSShard.MaxParallelThreads)</Command>
         <Timeout>$(WorkItemTimeout)</Timeout>
       </HelixWorkItem>
       <_AzurePipelinesReporterPayload Include="@(HelixCorrelationPayload)"

--- a/eng/helix/SOS.Tests.Helix.proj
+++ b/eng/helix/SOS.Tests.Helix.proj
@@ -16,6 +16,8 @@
     <DotNetHostName Condition="'$(TargetOS)' != 'Windows_NT'">dotnet</DotNetHostName>
     <PayloadNativeSourceDir>$(ArtifactsBinNativeDir)</PayloadNativeSourceDir>
     <SOSHelixTestEnvironment Condition="'$(TargetOS)' == 'osx'">SOSHARNESS_TEST_RUNTIME_MAJOR=11 SOSHARNESS_ONLY_COREVERSIONS=Net11 </SOSHelixTestEnvironment>
+    <!-- ARM64 native dump hosts are unstable under concurrent SOS commands. -->
+    <SOSHelixDumpMaxParallelThreads Condition="'$(TargetOS)' == 'linux' and '$(TargetArch)' == 'arm64'">1</SOSHelixDumpMaxParallelThreads>
     <SOSExpectedWorkItemCount Condition="'$(TargetOS)' == 'osx'">34</SOSExpectedWorkItemCount>
     <SOSExpectedWorkItemCount Condition="'$(SOSExpectedWorkItemCount)' == ''">10</SOSExpectedWorkItemCount>
   </PropertyGroup>
@@ -30,14 +32,14 @@
     </_SOSHelixCorrelationPayload>
     <HelixCorrelationPayload Include="@(_SOSHelixCorrelationPayload)" />
 
-    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_0_of_8" ShardIndex="0" ShardCount="8" Liveness="Dump" Condition="'$(TargetOS)' != 'osx'" />
-    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_1_of_8" ShardIndex="1" ShardCount="8" Liveness="Dump" Condition="'$(TargetOS)' != 'osx'" />
-    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_2_of_8" ShardIndex="2" ShardCount="8" Liveness="Dump" Condition="'$(TargetOS)' != 'osx'" />
-    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_3_of_8" ShardIndex="3" ShardCount="8" Liveness="Dump" Condition="'$(TargetOS)' != 'osx'" />
-    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_4_of_8" ShardIndex="4" ShardCount="8" Liveness="Dump" Condition="'$(TargetOS)' != 'osx'" />
-    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_5_of_8" ShardIndex="5" ShardCount="8" Liveness="Dump" Condition="'$(TargetOS)' != 'osx'" />
-    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_6_of_8" ShardIndex="6" ShardCount="8" Liveness="Dump" Condition="'$(TargetOS)' != 'osx'" />
-    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_7_of_8" ShardIndex="7" ShardCount="8" Liveness="Dump" Condition="'$(TargetOS)' != 'osx'" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_0_of_8" ShardIndex="0" ShardCount="8" Liveness="Dump" MaxParallelThreads="$(SOSHelixDumpMaxParallelThreads)" Condition="'$(TargetOS)' != 'osx'" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_1_of_8" ShardIndex="1" ShardCount="8" Liveness="Dump" MaxParallelThreads="$(SOSHelixDumpMaxParallelThreads)" Condition="'$(TargetOS)' != 'osx'" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_2_of_8" ShardIndex="2" ShardCount="8" Liveness="Dump" MaxParallelThreads="$(SOSHelixDumpMaxParallelThreads)" Condition="'$(TargetOS)' != 'osx'" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_3_of_8" ShardIndex="3" ShardCount="8" Liveness="Dump" MaxParallelThreads="$(SOSHelixDumpMaxParallelThreads)" Condition="'$(TargetOS)' != 'osx'" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_4_of_8" ShardIndex="4" ShardCount="8" Liveness="Dump" MaxParallelThreads="$(SOSHelixDumpMaxParallelThreads)" Condition="'$(TargetOS)' != 'osx'" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_5_of_8" ShardIndex="5" ShardCount="8" Liveness="Dump" MaxParallelThreads="$(SOSHelixDumpMaxParallelThreads)" Condition="'$(TargetOS)' != 'osx'" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_6_of_8" ShardIndex="6" ShardCount="8" Liveness="Dump" MaxParallelThreads="$(SOSHelixDumpMaxParallelThreads)" Condition="'$(TargetOS)' != 'osx'" />
+    <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_7_of_8" ShardIndex="7" ShardCount="8" Liveness="Dump" MaxParallelThreads="$(SOSHelixDumpMaxParallelThreads)" Condition="'$(TargetOS)' != 'osx'" />
     <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_0_of_32" ShardIndex="0" ShardCount="32" Liveness="Dump" MaxParallelThreads="4" Condition="'$(TargetOS)' == 'osx'" />
     <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_1_of_32" ShardIndex="1" ShardCount="32" Liveness="Dump" MaxParallelThreads="4" Condition="'$(TargetOS)' == 'osx'" />
     <_SOSShard Include="SOS_$(TargetRid)_$(Configuration)_dump_2_of_32" ShardIndex="2" ShardCount="32" Liveness="Dump" MaxParallelThreads="4" Condition="'$(TargetOS)' == 'osx'" />

--- a/eng/helix/SOS.Tests.Helix.proj
+++ b/eng/helix/SOS.Tests.Helix.proj
@@ -16,10 +16,10 @@
     <DotNetHostName Condition="'$(TargetOS)' != 'Windows_NT'">dotnet</DotNetHostName>
     <PayloadNativeSourceDir>$(ArtifactsBinNativeDir)</PayloadNativeSourceDir>
     <SOSHelixTestEnvironment Condition="'$(TargetOS)' == 'osx'">SOSHARNESS_TEST_RUNTIME_MAJOR=11 SOSHARNESS_ONLY_COREVERSIONS=Net11 </SOSHelixTestEnvironment>
-    <!-- The unprivileged Helix Alpine container exposes a .NET 8 createdump PR_SET_PTRACER race for Mini captures. -->
+    <!-- The unprivileged Helix Alpine container exposes a .NET 8 createdump PR_SET_PTRACER race during snapshot capture. -->
     <SOSHelixPlatformTestEnvironment Condition="$([System.String]::Copy('$(TargetRid)').StartsWith('linux-musl-'))">SOSHARNESS_ONLY_DUMPKIND=Heap,Full </SOSHelixPlatformTestEnvironment>
-    <!-- ARM64 native dump hosts are unstable under concurrent SOS commands. -->
-    <SOSHelixDumpMaxParallelThreads Condition="'$(TargetOS)' == 'linux' and '$(TargetArch)' == 'arm64'">1</SOSHelixDumpMaxParallelThreads>
+    <!-- ARM64 native dump hosts and unprivileged Alpine snapshot capture are unstable under concurrent tests. -->
+    <SOSHelixDumpMaxParallelThreads Condition="('$(TargetOS)' == 'linux' and '$(TargetArch)' == 'arm64') or $([System.String]::Copy('$(TargetRid)').StartsWith('linux-musl-'))">1</SOSHelixDumpMaxParallelThreads>
     <SOSExpectedWorkItemCount Condition="'$(TargetOS)' == 'osx'">34</SOSExpectedWorkItemCount>
     <SOSExpectedWorkItemCount Condition="'$(SOSExpectedWorkItemCount)' == ''">10</SOSExpectedWorkItemCount>
   </PropertyGroup>
@@ -91,6 +91,8 @@
            Text="SOSHelixLiveness must be Dump or Live." />
     <Error Condition="$([System.String]::Copy('$(TargetRid)').StartsWith('linux-musl-')) and '$(SOSHelixPlatformTestEnvironment)' != 'SOSHARNESS_ONLY_DUMPKIND=Heap,Full '"
            Text="Linux musl Helix work items must select exactly the Heap and Full dump kinds." />
+    <Error Condition="$([System.String]::Copy('$(TargetRid)').StartsWith('linux-musl-')) and '$(SOSHelixDumpMaxParallelThreads)' != '1'"
+           Text="Linux musl Helix dump work items must run one test at a time." />
     <Error Condition="!$([System.String]::Copy('$(TargetRid)').StartsWith('linux-musl-')) and '$(SOSHelixPlatformTestEnvironment)' != ''"
            Text="Non-musl Helix work items must not inherit Linux musl platform restrictions." />
   </Target>

--- a/eng/helix/sos/debuggee-entitlements.plist
+++ b/eng/helix/sos/debuggee-entitlements.plist
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.get-task-allow</key>
+  <true/>
+</dict>
+</plist>

--- a/eng/helix/sos/run-sos-tests.cmd
+++ b/eng/helix/sos/run-sos-tests.cmd
@@ -1,0 +1,104 @@
+@echo off
+setlocal EnableExtensions
+
+if "%~6"=="" (
+  echo usage: %~nx0 ^<configuration^> ^<rid^> ^<shard-index^> ^<shard-count^> ^<Dump^|Live^> ^<test-tfm^>
+  exit /b 2
+)
+
+if "%HELIX_CORRELATION_PAYLOAD%"=="" (
+  echo HELIX_CORRELATION_PAYLOAD is required.
+  exit /b 2
+)
+
+if "%HELIX_WORKITEM_UPLOAD_ROOT%"=="" (
+  echo HELIX_WORKITEM_UPLOAD_ROOT is required.
+  exit /b 2
+)
+
+if "%HELIX_WORKITEM_ROOT%"=="" (
+  echo HELIX_WORKITEM_ROOT is required.
+  exit /b 2
+)
+
+set "CONFIGURATION=%~1"
+set "RID=%~2"
+set "SHARD_INDEX=%~3"
+set "SHARD_COUNT=%~4"
+set "LIVENESS=%~5"
+set "TEST_TFM=%~6"
+set "ROOT=%HELIX_CORRELATION_PAYLOAD%"
+set "UPLOAD=%HELIX_WORKITEM_UPLOAD_ROOT%"
+set "TARGET_ARCH=%RID:win-=%"
+set "PAYLOAD_DOTNET_ROOT=%ROOT%\artifacts\dotnet-test"
+set "DOTNET_MULTILEVEL_LOOKUP=0"
+set "NUGET_PACKAGES=%ROOT%\.packages"
+set "SOSHARNESS_REPO_ROOT=%ROOT%"
+set "SOSHARNESS_ARTIFACTS_CONFIG=%CONFIGURATION%"
+set "SOSHARNESS_DBGENG_ROOT=%ROOT%\artifacts\cdb-sos"
+set "SOSHARNESS_USE_PREBUILT_TARGETS=1"
+set "SOSHARNESS_SHARD_INDEX=%SHARD_INDEX%"
+set "SOSHARNESS_SHARD_COUNT=%SHARD_COUNT%"
+set "SOSHARNESS_ONLY_LIVENESS=%LIVENESS%"
+set "SOSHARNESS_UPLOAD_ROOT=%UPLOAD%"
+
+if not exist "%UPLOAD%" mkdir "%UPLOAD%"
+
+set "TEST_DLL=%ROOT%\artifacts\bin\SOS.Tests\%CONFIGURATION%\%TEST_TFM%\SOS.Tests.dll"
+set "SIGNATURE_SCRIPT=%ROOT%\eng\DisableSignatureCheck.ps1"
+set "SIGNATURE_REPO=%HELIX_WORKITEM_ROOT%\sos-signature-repo"
+set "SIGNATURE_RUNTIME=%SIGNATURE_REPO%\artifacts\dotnet-test"
+set "POWERSHELL_EXE=powershell.exe"
+if /I "%TARGET_ARCH%"=="x86" set "POWERSHELL_EXE=%SystemRoot%\SysWOW64\WindowsPowerShell\v1.0\powershell.exe"
+
+if not exist "%TEST_DLL%" (
+  echo SOS.Tests.dll was not found at "%TEST_DLL%".
+  exit /b 3
+)
+
+if not exist "%SIGNATURE_SCRIPT%" (
+  echo DisableSignatureCheck.ps1 was not found at "%SIGNATURE_SCRIPT%".
+  exit /b 3
+)
+
+if not exist "%SIGNATURE_REPO%\artifacts" mkdir "%SIGNATURE_REPO%\artifacts"
+if not exist "%SIGNATURE_RUNTIME%\." (
+  mklink /J "%SIGNATURE_RUNTIME%" "%PAYLOAD_DOTNET_ROOT%"
+  if errorlevel 1 exit /b 3
+)
+
+set "DOTNET_ROOT=%SIGNATURE_RUNTIME%"
+set "DOTNET_ROOT_X86=%DOTNET_ROOT%"
+set "SOSHARNESS_DOTNET_ROOT=%DOTNET_ROOT%"
+set "SOSHARNESS_DOTNET_TEST_ROOT=%DOTNET_ROOT%"
+
+set "IDENTITY=%LIVENESS%-%SHARD_INDEX%-of-%SHARD_COUNT%"
+set "LOG=%UPLOAD%\SOS.Tests-%RID%-%CONFIGURATION%-%IDENTITY%.log"
+
+"%POWERSHELL_EXE%" -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass ^
+  -File "%SIGNATURE_SCRIPT%" -RepoRoot "%SIGNATURE_REPO%"
+set "SIGNATURE_EXIT_CODE=%ERRORLEVEL%"
+if not "%SIGNATURE_EXIT_CODE%"=="0" (
+  "%POWERSHELL_EXE%" -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass ^
+    -File "%SIGNATURE_SCRIPT%" -Restore -RepoRoot "%SIGNATURE_REPO%"
+  exit /b %SIGNATURE_EXIT_CODE%
+)
+
+"%DOTNET_ROOT%\dotnet.exe" "%TEST_DLL%" ^
+  --results-directory "%UPLOAD%" ^
+  --report-xunit ^
+  --report-xunit-filename "SOS.Tests-%RID%-%CONFIGURATION%-%IDENTITY%.xml" ^
+  --report-xunit-html ^
+  --report-xunit-html-filename "SOS.Tests-%RID%-%CONFIGURATION%-%IDENTITY%.html" ^
+  --report-trx ^
+  --report-trx-filename "SOS.Tests-%RID%-%CONFIGURATION%-%IDENTITY%.trx" ^
+  --auto-reporters off > "%LOG%" 2>&1
+set "EXIT_CODE=%ERRORLEVEL%"
+
+"%POWERSHELL_EXE%" -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass ^
+  -File "%SIGNATURE_SCRIPT%" -Restore -RepoRoot "%SIGNATURE_REPO%"
+set "RESTORE_EXIT_CODE=%ERRORLEVEL%"
+
+type "%LOG%"
+if not "%RESTORE_EXIT_CODE%"=="0" exit /b %RESTORE_EXIT_CODE%
+exit /b %EXIT_CODE%

--- a/eng/helix/sos/run-sos-tests.sh
+++ b/eng/helix/sos/run-sos-tests.sh
@@ -1,0 +1,278 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -lt 6 || $# -gt 7 ]]; then
+  echo "usage: $0 <configuration> <rid> <shard-index> <shard-count> <Dump|Live> <test-tfm> [max-parallel-threads]" >&2
+  exit 2
+fi
+
+configuration="$1"
+rid="$2"
+shard_index="$3"
+shard_count="$4"
+liveness="$5"
+test_tfm="$6"
+max_parallel_threads="${7:-}"
+test_runtime_major="${SOSHARNESS_TEST_RUNTIME_MAJOR:-}"
+liveness_name="$(printf '%s' "$liveness" | tr '[:upper:]' '[:lower:]')"
+
+if [[ -n "$max_parallel_threads" && (! "$max_parallel_threads" =~ ^[1-9][0-9]*$) ]]; then
+  echo "max-parallel-threads must be a positive integer; got '$max_parallel_threads'." >&2
+  exit 2
+fi
+
+if [[ -n "$test_runtime_major" && (! "$test_runtime_major" =~ ^[1-9][0-9]*$) ]]; then
+  echo "SOSHARNESS_TEST_RUNTIME_MAJOR must be a positive integer; got '$test_runtime_major'." >&2
+  exit 2
+fi
+
+: "${HELIX_CORRELATION_PAYLOAD:?HELIX_CORRELATION_PAYLOAD is required}"
+: "${HELIX_WORKITEM_UPLOAD_ROOT:?HELIX_WORKITEM_UPLOAD_ROOT is required}"
+
+root="$HELIX_CORRELATION_PAYLOAD"
+upload="$HELIX_WORKITEM_UPLOAD_ROOT"
+test_dll="$root/artifacts/bin/SOS.Tests/$configuration/$test_tfm/SOS.Tests.dll"
+identity="${liveness_name}-${shard_index}-of-${shard_count}"
+work="$PWD/.sos-harness"
+
+mkdir -p "$upload" "$work"
+
+if [[ ! -f "$test_dll" ]]; then
+  echo "SOS.Tests.dll was not found at '$test_dll'." >&2
+  exit 3
+fi
+
+mirror_tree()
+{
+  source_root="$1"
+  destination_root="$2"
+
+  rm -rf "$destination_root"
+  mkdir -p "$destination_root"
+
+  while IFS= read -r source_dir; do
+    relative_dir="${source_dir#"$source_root"}"
+    mkdir -p "$destination_root$relative_dir"
+  done < <(find "$source_root" -type d)
+
+  while IFS= read -r source_file; do
+    relative_file="${source_file#"$source_root"/}"
+    ln -s "$source_file" "$destination_root/$relative_file"
+  done < <(find "$source_root" ! -type d)
+}
+
+prepare_dotnet_root()
+{
+  source_root="$root/artifacts/dotnet-test"
+  needs_overlay=0
+
+  if [[ ! -x "$source_root/dotnet" ]]; then
+    needs_overlay=1
+  fi
+
+  while IFS= read -r createdump; do
+    if [[ ! -x "$createdump" ]]; then
+      needs_overlay=1
+      break
+    fi
+  done < <(find "$source_root" -type f -name createdump)
+
+  if [[ "$needs_overlay" == "0" ]]; then
+    printf '%s\n' "$source_root"
+    return
+  fi
+
+  destination_root="$work/dotnet-test"
+  echo "Creating writable executable overlay for dotnet-test." >&2
+  mirror_tree "$source_root" "$destination_root"
+
+  rm "$destination_root/dotnet"
+  cp "$source_root/dotnet" "$destination_root/dotnet"
+  chmod +x "$destination_root/dotnet"
+
+  while IFS= read -r createdump; do
+    relative_createdump="${createdump#"$source_root"/}"
+    rm "$destination_root/$relative_createdump"
+    cp "$createdump" "$destination_root/$relative_createdump"
+    chmod +x "$destination_root/$relative_createdump"
+  done < <(find "$source_root" -type f -name createdump)
+
+  printf '%s\n' "$destination_root"
+}
+
+configure_lldb()
+{
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    target_arch="${rid##*-}"
+    driver_source="$root/artifacts/bin/osx.$target_arch.$configuration/sos-lldb"
+    if [[ ! -f "$driver_source" ]]; then
+      echo "The SOS LLDB driver was not found at '$driver_source'." >&2
+      exit 4
+    fi
+
+    driver="$driver_source"
+    if [[ ! -x "$driver" ]]; then
+      driver="$work/sos-lldb"
+      cp "$driver_source" "$driver"
+      chmod +x "$driver"
+    fi
+
+    developer_dir="${DEVELOPER_DIR:-$(xcode-select -p)}"
+    shared_frameworks="$(cd "$developer_dir/../SharedFrameworks" && pwd)"
+    if [[ ! -d "$shared_frameworks/LLDB.framework" ]]; then
+      echo "LLDB.framework was not found under the selected Xcode at '$shared_frameworks'." >&2
+      exit 4
+    fi
+    export DYLD_FRAMEWORK_PATH="$shared_frameworks${DYLD_FRAMEWORK_PATH:+:$DYLD_FRAMEWORK_PATH}"
+
+    lldb_check="$("$driver" --no-lldbinit --batch \
+      -o 'script print("__SOSHARNESS_LLDB_READY__")' 2>&1 || true)"
+    if [[ "$lldb_check" != *"__SOSHARNESS_LLDB_READY__"* ]]; then
+      echo "The SOS LLDB driver failed its Python interpreter preflight at '$driver'." >&2
+      echo "$lldb_check" >&2
+      exit 4
+    fi
+
+    echo "Using SOS LLDB driver at '$driver'."
+    export SOSHARNESS_LLDB_PATH="$driver"
+    return
+  fi
+
+  if [[ "$(uname -s)" != "Linux" ]]; then
+    return
+  fi
+
+  if [[ -z "${LLDB_PATH:-}" ]]; then
+    for candidate in lldb-16 lldb16 lldb-15 lldb15 lldb-14 lldb14 lldb-13 lldb13 lldb-12 lldb12 lldb; do
+      if command -v "$candidate" > /dev/null 2>&1; then
+        LLDB_PATH="$(command -v "$candidate")"
+        break
+      fi
+    done
+  fi
+
+  if [[ -z "${LLDB_PATH:-}" || ! -x "$LLDB_PATH" ]]; then
+    echo "Could not locate an executable LLDB. Set LLDB_PATH or install LLDB on the Helix image." >&2
+    exit 4
+  fi
+
+  lldb_python_module=""
+  resolved_lldb="$(readlink -f "$LLDB_PATH" 2>/dev/null || printf '%s' "$LLDB_PATH")"
+  lldb_version="${resolved_lldb##*-}"
+  for llvm_root in "/usr/lib/llvm-$lldb_version" "/usr/lib/llvm$lldb_version" /usr/lib/llvm-* /usr/lib/llvm*; do
+    if [[ ! -d "$llvm_root" ]]; then
+      continue
+    fi
+
+    lldb_python_module="$(find "$llvm_root" -type f -path '*/lldb/embedded_interpreter.py' -print 2>/dev/null | head -n 1 || true)"
+    if [[ -n "$lldb_python_module" ]]; then
+      break
+    fi
+  done
+
+  if [[ -n "$lldb_python_module" ]]; then
+    lldb_python_root="$(dirname "$(dirname "$lldb_python_module")")"
+    export PYTHONPATH="$lldb_python_root${PYTHONPATH:+:$PYTHONPATH}"
+  fi
+
+  lldb_check="$("$LLDB_PATH" --no-lldbinit --batch \
+    -o 'script print("__SOSHARNESS_LLDB_READY__")' \
+    -o quit 2>&1 || true)"
+  if [[ "$lldb_check" != *"__SOSHARNESS_LLDB_READY__"* ]]; then
+    echo "LLDB failed its Python interpreter preflight at '$LLDB_PATH'." >&2
+    echo "$lldb_check" >&2
+    exit 4
+  fi
+
+  echo "Using LLDB at '$LLDB_PATH'."
+  export LLDB_PATH
+}
+
+dotnet_root="$(prepare_dotnet_root)"
+dotnet="$dotnet_root/dotnet"
+dotnet_arguments=("$test_dll")
+
+if [[ -n "$test_runtime_major" ]]; then
+  test_runtime_version="$("$dotnet" --list-runtimes | awk -v prefix="$test_runtime_major." \
+    '$1 == "Microsoft.NETCore.App" && index($2, prefix) == 1 { version = $2 } END { print version }')"
+  if [[ -z "$test_runtime_version" ]]; then
+    echo "Microsoft.NETCore.App $test_runtime_major.x was not found under '$dotnet_root'." >&2
+    exit 3
+  fi
+
+  echo "Running SOS.Tests on Microsoft.NETCore.App $test_runtime_version."
+  dotnet_arguments=(--fx-version "$test_runtime_version" "$test_dll")
+fi
+
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  entitlements="$root/eng/helix/sos/debuggee-entitlements.plist"
+  for debuggee in NestedExceptionTest DivZero AsyncMain DynamicMethod Overflow LineNums SimpleThrow ReflectionTest SosHarnessScenarios; do
+    while IFS= read -r source_executable; do
+      relative_executable="${source_executable#"$root"/}"
+      overlay_executable="$work/executables/$relative_executable"
+      mkdir -p "$(dirname "$overlay_executable")"
+      cp "$source_executable" "$overlay_executable"
+      chmod +x "$overlay_executable"
+      codesign --force --sign - --entitlements "$entitlements" "$overlay_executable"
+    done < <(find "$root/artifacts/bin/$debuggee/$configuration" -type f -name "$debuggee")
+  done
+  export SOSHARNESS_EXCLUDE_SINGLEFILE_SNAPSHOTS=1
+fi
+
+if [[ "$rid" == linux-musl-* ]]; then
+  target_arch="${rid##*-}"
+  native_source="$root/artifacts/bin/linux.$target_arch.$configuration"
+  native_overlay="$work/native"
+  mirror_tree "$native_source" "$native_overlay"
+  if [[ -e "$native_source/libmscordaccore_universal.so" ]]; then
+    rm "$native_overlay/libmscordaccore_universal.so"
+    cp "$native_source/libmscordaccore_universal.so" "$native_overlay/libmscordaccore_universal.so"
+  fi
+  export SOSHARNESS_NATIVE_ROOT="$native_overlay"
+fi
+
+configure_lldb
+
+export DOTNET_ROOT="$dotnet_root"
+export DOTNET_ROOT_X64="$DOTNET_ROOT"
+export DOTNET_MULTILEVEL_LOOKUP=0
+export NUGET_PACKAGES="$root/.packages"
+export SOSHARNESS_REPO_ROOT="$root"
+export SOSHARNESS_DOTNET_ROOT="$DOTNET_ROOT"
+export SOSHARNESS_DOTNET_TEST_ROOT="$DOTNET_ROOT"
+export SOSHARNESS_EXECUTABLE_ROOT="$work/executables"
+export SOSHARNESS_SCRATCH_ROOT="$work/scratch"
+export SOSHARNESS_ARTIFACTS_CONFIG="$configuration"
+export SOSHARNESS_USE_PREBUILT_TARGETS=1
+export SOSHARNESS_SHARD_INDEX="$shard_index"
+export SOSHARNESS_SHARD_COUNT="$shard_count"
+export SOSHARNESS_ONLY_LIVENESS="$liveness"
+export SOSHARNESS_UPLOAD_ROOT="$upload"
+export SOSHARNESS_LLDB_TRACE="$upload/SOS.Tests-${rid}-${configuration}-${identity}.lldb.log"
+
+log="$upload/SOS.Tests-${rid}-${configuration}-${identity}.log"
+run_tests()
+{
+  "$dotnet" "${dotnet_arguments[@]}" "$@" \
+    --results-directory "$upload" \
+    --report-xunit \
+    --report-xunit-filename "SOS.Tests-${rid}-${configuration}-${identity}.xml" \
+    --report-xunit-html \
+    --report-xunit-html-filename "SOS.Tests-${rid}-${configuration}-${identity}.html" \
+    --report-trx \
+    --report-trx-filename "SOS.Tests-${rid}-${configuration}-${identity}.trx" \
+    --auto-reporters off
+}
+
+set +e
+if [[ -n "$max_parallel_threads" ]]; then
+  run_tests --max-threads "$max_parallel_threads" 2>&1 | tee "$log"
+  exit_code=${PIPESTATUS[0]}
+else
+  run_tests 2>&1 | tee "$log"
+  exit_code=${PIPESTATUS[0]}
+fi
+set -e
+
+exit "$exit_code"

--- a/eng/pipelines/build.yml
+++ b/eng/pipelines/build.yml
@@ -40,7 +40,7 @@ parameters:
   default: {}
 
 # Build configs. An object with the following properties: configuration, architecture.
-# Optionally it can also contain artifactUploadPath, artifactTargetPath
+# Optionally it can also contain primary and additional architecture artifact upload/target paths.
 - name: buildConfigs
   type: object
   default: {}
@@ -65,6 +65,52 @@ parameters:
 - name: publishTestArtifacts
   type: boolean
   default: false
+
+# Include the target-architecture test runtime in TestArtifacts for a Helix-only
+# test leg that cannot execute target binaries on its submission host.
+- name: publishTestRuntimeArtifacts
+  type: boolean
+  default: false
+
+# Optional: move SOS.Tests from this leg to a sharded Helix submission.
+- name: runSOSHelix
+  type: boolean
+  default: false
+
+# Submit SOS.Tests to Helix without running the repository's local test suite.
+# Used when a cross-built target architecture cannot run on the pipeline agent.
+- name: helixOnly
+  type: boolean
+  default: false
+
+- name: sosHelixTargetOS
+  type: string
+  default: ''
+
+- name: sosHelixRidPrefix
+  type: string
+  default: ''
+
+- name: sosHelixQueue
+  type: string
+  default: ''
+
+# Optional: build a second architecture in the same job after the primary build/test.
+- name: additionalArchitecture
+  type: string
+  default: ''
+
+- name: additionalCrossBuild
+  type: boolean
+  default: false
+
+- name: runAdditionalSOSHelix
+  type: boolean
+  default: false
+
+- name: additionalSOSHelixQueue
+  type: string
+  default: ''
 
 # Optional: architecture cross build if true
 - name: crossBuild
@@ -119,7 +165,8 @@ jobs:
       ${{ if ne(parameters.strategy, '') }}:
         'error, we can no longer support the strategy feature in the new pipeline system. Please remove the strategy from the job template.': error
 
-      ${{ if and(ne(parameters.dependsOn, ''), ne(parameters.testOnly, true)) }}:
+      # Within a stage, test-only jobs can start as soon as their matching build job publishes its artifacts.
+      ${{ if ne(parameters.dependsOn, '') }}:
         dependsOn: ${{ parameters.dependsOn }}_${{ config.architecture }}_${{ config.configuration }}
 
       workspace:
@@ -129,13 +176,26 @@ jobs:
       - ${{ insert }}: ${{ parameters.variables }}
 
       - _PhaseName: ${{ coalesce(parameters.name, parameters.osGroup) }}_${{ config.architecture }}_${{ config.configuration }}
+      - _BuildConfig: ${{ config.configuration }}
       - _Pipeline_StreamDumpDir: $(Build.SourcesDirectory)/artifacts/tmp/${{ config.configuration }}/streams
 
       - _TestArgs: '-test'
       - _Cross: ''
+      - _AdditionalCross: ''
+      - _SkipLocalSOSTests: 'false'
 
       - ${{ if and(eq(parameters.testOnly, 'true'), eq(parameters.buildOnly, 'true')) }}:
         'error, testOnly and buildOnly cannot be true at the same time': error
+      - ${{ if and(eq(parameters.helixOnly, true), or(ne(parameters.testOnly, true), ne(parameters.runSOSHelix, true))) }}:
+        'error, helixOnly requires testOnly and runSOSHelix': error
+      - ${{ if and(eq(parameters.publishTestRuntimeArtifacts, true), ne(parameters.publishTestArtifacts, true)) }}:
+        'error, publishTestRuntimeArtifacts requires publishTestArtifacts': error
+      - ${{ if and(ne(parameters.additionalArchitecture, ''), or(eq(parameters.testOnly, true), ne(parameters.osGroup, 'MacOS'))) }}:
+        'error, additionalArchitecture is only supported by macOS build jobs': error
+      - ${{ if and(eq(parameters.additionalCrossBuild, true), eq(parameters.additionalArchitecture, '')) }}:
+        'error, additionalCrossBuild requires additionalArchitecture': error
+      - ${{ if and(eq(parameters.runAdditionalSOSHelix, true), or(eq(parameters.additionalArchitecture, ''), eq(parameters.additionalSOSHelixQueue, ''))) }}:
+        'error, runAdditionalSOSHelix requires additionalArchitecture and additionalSOSHelixQueue': error
 
       # Test-only legs invoke test.cmd/test.sh, which already encode
       # '-test -skipmanaged -skipnative' and do not prepend '-restore -build'. All other legs
@@ -156,6 +216,9 @@ jobs:
       - ${{ if eq(parameters.buildOnly, 'true') }}:
         - _TestArgs: ''
 
+      - ${{ if or(eq(parameters.runSOSHelix, true), eq(parameters.runAdditionalSOSHelix, true)) }}:
+        - _SkipLocalSOSTests: 'true'
+
       # For testing msrc's and service releases. The RuntimeSourceVersion is either "default" or the service release version to test
       - _InternalInstallArgs: ''
       - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
@@ -168,6 +231,9 @@ jobs:
       # This is only required for cross builds.
       - ${{ if eq(parameters.crossBuild, true) }}:
         - _Cross: -cross
+
+      - ${{ if eq(parameters.additionalCrossBuild, true) }}:
+        - _AdditionalCross: -cross
 
       steps:
       - ${{ if eq(parameters.testOnly, true) }}:
@@ -184,22 +250,95 @@ jobs:
             targetPath: '$(Build.SourcesDirectory)/artifacts'
             checkDownloadedFiles: true
 
-      - script: $(_buildScript)
-          -ci
-          -binaryLog
-          -configuration ${{ config.configuration }}
-          -architecture ${{ config.architecture }}
-          $(_TestArgs)
-          $(_Cross)
-          $(_InternalInstallArgs)
-          /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-        ${{ if eq(parameters.testOnly, 'true') }}:
-          displayName: Test
-        ${{ elseif eq(parameters.buildOnly, 'true') }}:
-          displayName: Build
-        ${{ else }}:
-          displayName: Build / Test
-        condition: succeeded()
+      - ${{ if eq(parameters.helixOnly, false) }}:
+        - script: $(_buildScript)
+            -ci
+            -binaryLog
+            -configuration ${{ config.configuration }}
+            -architecture ${{ config.architecture }}
+            $(_TestArgs)
+            $(_Cross)
+            $(_InternalInstallArgs)
+            /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+          ${{ if eq(parameters.testOnly, 'true') }}:
+            displayName: Test
+          ${{ elseif eq(parameters.buildOnly, 'true') }}:
+            displayName: Build
+          ${{ else }}:
+            displayName: Build / Test
+          condition: succeeded()
+          env:
+            SOSHARNESS_SKIP_LOCAL_TESTS: $(_SkipLocalSOSTests)
+      - ${{ if eq(parameters.runSOSHelix, true) }}:
+        - template: /eng/common/templates/steps/send-to-helix.yml@self
+          parameters:
+            DisplayNamePrefix: Run SOS.Tests on Helix
+            HelixProjectPath: eng/helix/SOS.Tests.Helix.proj
+            HelixProjectArguments: >-
+              /p:Configuration=${{ config.configuration }}
+              /p:TargetArch=${{ config.architecture }}
+              /p:TargetOS=${{ parameters.sosHelixTargetOS }}
+              /p:TargetRid=${{ parameters.sosHelixRidPrefix }}-${{ config.architecture }}
+            HelixSource: pr/dotnet/diagnostics/sos-tests
+            HelixType: tests/sos/harness/
+            HelixConfiguration: ${{ parameters.sosHelixRidPrefix }}-${{ config.architecture }}_${{ config.configuration }}
+            HelixTargetQueues: ${{ parameters.sosHelixQueue }}
+            ${{ if eq(parameters.sosHelixRidPrefix, 'linux-musl') }}:
+              HelixPreCommands: sudo apk add --no-cache py3-lldb
+            ${{ if eq(variables['System.TeamProject'], 'public') }}:
+              Creator: dotnet-bot
+            ${{ else }}:
+              HelixAccessToken: $(HelixApiAccessToken)
+            condition: succeeded()
+
+      - ${{ if ne(parameters.additionalArchitecture, '') }}:
+        # InstallRuntimes.proj uses one shared output directory whose incremental marker is not
+        # architecture-specific. Reset it before switching targets so the second build installs
+        # the correct runtime and apphost closure.
+        - pwsh: |
+            $runtimePaths = @(
+              "$(Build.SourcesDirectory)/artifacts/dotnet-test",
+              "$(Build.SourcesDirectory)/artifacts/dotnet-build"
+            )
+            foreach ($runtimePath in $runtimePaths) {
+              if (Test-Path $runtimePath) {
+                Remove-Item -Recurse -Force $runtimePath
+              }
+            }
+          displayName: Prepare ${{ parameters.additionalArchitecture }} runtime
+          condition: succeeded()
+
+        - script: $(_buildScript)
+            -ci
+            -binaryLog
+            -configuration ${{ config.configuration }}
+            -architecture ${{ parameters.additionalArchitecture }}
+            $(_AdditionalCross)
+            $(_InternalInstallArgs)
+            /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+          displayName: Build ${{ parameters.additionalArchitecture }}
+          condition: succeeded()
+
+      - ${{ if eq(parameters.runAdditionalSOSHelix, true) }}:
+        - template: /eng/common/templates/steps/send-to-helix.yml@self
+          parameters:
+            DisplayNamePrefix: Run ${{ parameters.additionalArchitecture }} SOS.Tests on Helix
+            HelixProjectPath: eng/helix/SOS.Tests.Helix.proj
+            HelixProjectArguments: >-
+              /p:Configuration=${{ config.configuration }}
+              /p:TargetArch=${{ parameters.additionalArchitecture }}
+              /p:TargetOS=${{ parameters.sosHelixTargetOS }}
+              /p:TargetRid=${{ parameters.sosHelixRidPrefix }}-${{ parameters.additionalArchitecture }}
+            HelixSource: pr/dotnet/diagnostics/sos-tests
+            HelixType: tests/sos/harness/
+            HelixConfiguration: ${{ parameters.sosHelixRidPrefix }}-${{ parameters.additionalArchitecture }}_${{ config.configuration }}
+            HelixTargetQueues: ${{ parameters.additionalSOSHelixQueue }}
+            ${{ if eq(variables['System.TeamProject'], 'public') }}:
+              Creator: dotnet-bot
+            ${{ else }}:
+              HelixAccessToken: $(HelixApiAccessToken)
+            condition: succeeded()
+
       - ${{ if ne(config.artifactUploadPath, '') }}:
         - task: CopyFiles@2
           displayName: Gather binaries for publish
@@ -215,6 +354,21 @@ jobs:
               targetPath: '$(Build.ArtifactStagingDirectory)/artifacts'
               artifactName: Build_$(_PhaseName)
 
+      - ${{ if ne(config.additionalArtifactUploadPath, '') }}:
+        - task: CopyFiles@2
+          displayName: Gather ${{ parameters.additionalArchitecture }} binaries for publish
+          inputs:
+            SourceFolder: '$(Build.SourcesDirectory)/artifacts/${{ config.additionalArtifactUploadPath }}'
+            Contents: '**'
+            TargetFolder: $(Build.ArtifactStagingDirectory)/additional-artifacts/${{ coalesce(config.additionalArtifactTargetPath, config.additionalArtifactUploadPath) }}
+
+        - template: /eng/pipelines/publish-pipeline-artifact-shim.yml@self
+          parameters:
+            displayName: Publish ${{ parameters.additionalArchitecture }} Build Artifacts
+            inputs:
+              targetPath: '$(Build.ArtifactStagingDirectory)/additional-artifacts'
+              artifactName: Build_${{ coalesce(parameters.name, parameters.osGroup) }}_${{ parameters.additionalArchitecture }}_${{ config.configuration }}
+
       # Publish the full build outputs for the matching test-only legs to consume. This lets the
       # test legs run with -skipnative -skipmanaged instead of rebuilding the product themselves.
       # Only valid on build-only legs (publishTestArtifacts without buildOnly is a configuration error).
@@ -229,6 +383,20 @@ jobs:
               test/**
             TargetFolder: $(Build.ArtifactStagingDirectory)/testartifacts
 
+        - ${{ if eq(parameters.publishTestRuntimeArtifacts, true) }}:
+          - task: CopyFiles@2
+            displayName: Gather target test runtime for publish
+            inputs:
+              SourceFolder: '$(Build.SourcesDirectory)/artifacts/dotnet-test'
+              Contents: |
+                dotnet
+                LICENSE.txt
+                ThirdPartyNotices.txt
+                Debugger.Tests.Versions.txt
+                host/fxr/**
+                shared/Microsoft.NETCore.App/**
+              TargetFolder: $(Build.ArtifactStagingDirectory)/testartifacts/dotnet-test
+
         - template: /eng/pipelines/publish-pipeline-artifact-shim.yml@self
           parameters:
             displayName: Publish Test Artifacts
@@ -236,7 +404,7 @@ jobs:
               targetPath: '$(Build.ArtifactStagingDirectory)/testartifacts'
               artifactName: TestArtifacts_$(_PhaseName)
 
-      - ${{ if ne(parameters.buildOnly, 'true') }}:
+      - ${{ if and(ne(parameters.buildOnly, 'true'), eq(parameters.helixOnly, false)) }}:
         # Publish test results to Azure Pipelines
         - task: PublishTestResults@2
           inputs:

--- a/global.json
+++ b/global.json
@@ -15,6 +15,7 @@
   "msbuild-sdks": {
     "Microsoft.Build.NoTargets": "3.7.0",
     "Microsoft.Build.Traversal": "3.4.0",
-    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.26431.5"
+    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.26431.5",
+    "Microsoft.DotNet.Helix.Sdk": "10.0.0-beta.26431.5"
   }
 }

--- a/src/tests/SOS.TestHarness/HostDiagnostics.cs
+++ b/src/tests/SOS.TestHarness/HostDiagnostics.cs
@@ -30,8 +30,11 @@ public sealed class HostDiagnostics
     // on a long-lived shared host would grow without limit across the many tests that reuse it.
     private const int MaxStreamChars = 128 * 1024;
 
-    private static readonly string s_crashRoot =
-        Path.Combine(RepoLayout.Root, "artifacts", "replays", "crashdumps");
+    internal const string UploadRootVariable = "SOSHARNESS_UPLOAD_ROOT";
+
+    private static readonly string s_crashRoot = ResolveCrashDumpDirectory(
+        Environment.GetEnvironmentVariable(UploadRootVariable),
+        RepoLayout.Root);
 
     private readonly object _gate = new();
     private readonly StringBuilder _stdout = new();
@@ -48,6 +51,11 @@ public sealed class HostDiagnostics
 
     /// <summary>The shared directory crash dumps are written to (created on demand).</summary>
     public static string CrashDumpDirectory => s_crashRoot;
+
+    internal static string ResolveCrashDumpDirectory(string? uploadRoot, string repoRoot) =>
+        string.IsNullOrEmpty(uploadRoot)
+            ? Path.Combine(repoRoot, "artifacts", "replays", "crashdumps")
+            : Path.Combine(uploadRoot, "failure-diagnostics", "crashdumps");
 
     /// <summary>The launched command line (exe + args), captured for the replay.</summary>
     public string CommandLine

--- a/src/tests/SOS.TestHarness/RepoLayout.cs
+++ b/src/tests/SOS.TestHarness/RepoLayout.cs
@@ -33,14 +33,20 @@ public static class RepoLayout
             .Value!;
 
     /// <summary>The repo root (the directory containing <c>global.json</c> and <c>Build.cmd</c>).</summary>
-    public static string Root { get; } = FindRoot();
+    public static string Root { get; } =
+        Environment.GetEnvironmentVariable("SOSHARNESS_REPO_ROOT") is { Length: > 0 } root
+            ? Path.GetFullPath(root)
+            : FindRoot();
 
     /// <summary><c>artifacts/bin</c> under the repo root.</summary>
     public static string ArtifactsBin => Path.Combine(Root, "artifacts", "bin");
 
-    /// <summary>The native build output directory, e.g. <c>artifacts/bin/Windows_NT.x64.Debug</c>.</summary>
+    /// <summary>The native build output directory, e.g. <c>artifacts/bin/Windows_NT.x64.Debug</c>.
+    /// <c>SOSHARNESS_NATIVE_ROOT</c> redirects it to a writable Helix overlay when necessary.</summary>
     public static string ArtifactsBinNative =>
-        Path.Combine(ArtifactsBin, $"{TargetOS}.{TargetArch}.{ArtifactsConfiguration}");
+        ResolveDirectory(
+            Environment.GetEnvironmentVariable("SOSHARNESS_NATIVE_ROOT"),
+            Path.Combine(ArtifactsBin, $"{TargetOS}.{TargetArch}.{ArtifactsConfiguration}"));
 
     /// <summary>The processor architecture token used in repo artifact paths (<c>x64</c>/<c>x86</c>/<c>arm64</c>).</summary>
     public static string TargetArch { get; } = RuntimeInformation.ProcessArchitecture switch
@@ -69,7 +75,12 @@ public static class RepoLayout
             .Value!;
 
     /// <summary>The repo's locally-acquired .NET host (<c>.dotnet/dotnet.exe</c>) used to shell out builds.</summary>
-    public static string DotNetExe => Path.Combine(Root, ".dotnet", OperatingSystem.IsWindows() ? "dotnet.exe" : "dotnet");
+    public static string DotNetRoot { get; } =
+        Environment.GetEnvironmentVariable("SOSHARNESS_DOTNET_ROOT") is { Length: > 0 } root
+            ? Path.GetFullPath(root)
+            : Path.Combine(Root, ".dotnet");
+
+    public static string DotNetExe => Path.Combine(DotNetRoot, OperatingSystem.IsWindows() ? "dotnet.exe" : "dotnet");
 
     /// <summary>The platform suffix for an apphost executable: <c>.exe</c> on Windows, none elsewhere
     /// (Linux/macOS apphosts have no extension).</summary>
@@ -98,7 +109,12 @@ public static class RepoLayout
     /// Used as <c>DOTNET_ROOT</c> when launching a debuggee so its apphost resolves the matching runtime
     /// version (the repo's <c>.dotnet</c> only carries the build SDK's runtime).
     /// </summary>
-    public static string DotnetTestRoot { get; } = Path.Combine(Root, "artifacts", "dotnet-test");
+    /// <summary>The multi-version test runtime root. <c>SOSHARNESS_DOTNET_TEST_ROOT</c> redirects it to
+    /// a writable executable overlay for read-only Helix payloads.</summary>
+    public static string DotnetTestRoot =>
+        ResolveDirectory(
+            Environment.GetEnvironmentVariable("SOSHARNESS_DOTNET_TEST_ROOT"),
+            Path.Combine(Root, "artifacts", "dotnet-test"));
 
     /// <summary>The multi-version test .NET host (<c>artifacts/dotnet-test/dotnet[.exe]</c>). This is the
     /// net11-capable SDK that <c>Debuggees.proj</c> uses to pre-build the debuggees, so local Core fallback
@@ -106,9 +122,12 @@ public static class RepoLayout
     /// frameworks (<c>NETSDK1045</c>).</summary>
     public static string DotnetTestExe => Path.Combine(DotnetTestRoot, OperatingSystem.IsWindows() ? "dotnet.exe" : "dotnet");
 
-    /// <summary>Scratch directory for harness-produced artifacts (on-the-fly builds, captured dumps).</summary>
-    public static string Scratch { get; } =
-        Path.Combine(Root, "artifacts", "tmp", "sos-harness", ArtifactsConfiguration);
+    /// <summary>Scratch directory for harness-produced artifacts (on-the-fly builds, captured dumps).
+    /// <c>SOSHARNESS_SCRATCH_ROOT</c> redirects writes outside a read-only Helix payload.</summary>
+    public static string Scratch =>
+        ResolveDirectory(
+            Environment.GetEnvironmentVariable("SOSHARNESS_SCRATCH_ROOT"),
+            Path.Combine(Root, "artifacts", "tmp", "sos-harness", ArtifactsConfiguration));
 
     /// <summary>
     /// A hermetic, local-only symbol path for the SOS host child processes. The dev machine's
@@ -118,6 +137,9 @@ public static class RepoLayout
     /// module, so managed source/line resolution still works.
     /// </summary>
     public static string SymbolCache { get; } = Path.Combine(Scratch, "symcache");
+
+    internal static string ResolveDirectory(string? overridePath, string defaultPath) =>
+        Path.GetFullPath(string.IsNullOrEmpty(overridePath) ? defaultPath : overridePath);
 
     private static string FindRoot()
     {

--- a/src/tests/SOS.TestHarness/SnapshotStore.cs
+++ b/src/tests/SOS.TestHarness/SnapshotStore.cs
@@ -86,23 +86,71 @@ public static class SnapshotStore
         string exe = s_targetExe
             .GetOrAdd((flavor, targetName, coreVersion), k => new Lazy<string>(() => AcquireTarget(k.Flavor, TargetCatalog.Get(k.Target), k.CoreVersion)))
             .Value;
-        EnsureExecutable(exe);
-        return exe;
+        return EnsureExecutable(
+            exe,
+            Environment.GetEnvironmentVariable("SOSHARNESS_EXECUTABLE_ROOT"),
+            RepoLayout.Root);
     }
 
-    private static void EnsureExecutable(string path)
+    internal static string EnsureExecutable(string path, string? executableRoot, string repoRoot)
     {
         if (OperatingSystem.IsWindows())
         {
-            return;
+            return path;
         }
 
         UnixFileMode mode = File.GetUnixFileMode(path);
         UnixFileMode execute = UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute;
-        if ((mode & execute) != execute)
+        if (string.IsNullOrEmpty(executableRoot))
         {
-            File.SetUnixFileMode(path, mode | execute);
+            if ((mode & execute) != execute)
+            {
+                File.SetUnixFileMode(path, mode | execute);
+            }
+
+            return path;
         }
+
+        string relative = Path.GetRelativePath(repoRoot, path);
+        if (Path.IsPathRooted(relative) ||
+            relative.Equals("..", StringComparison.Ordinal) ||
+            relative.StartsWith($"..{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Executable '{path}' is outside the repo root '{repoRoot}' and cannot be copied to the writable executable overlay.");
+        }
+
+        string destination = Path.Combine(executableRoot, relative);
+        string sourceDirectory = Path.GetDirectoryName(path)!;
+        string destinationDirectory = Path.GetDirectoryName(destination)!;
+
+        lock (BuildLockFor(destination))
+        {
+            Directory.CreateDirectory(destinationDirectory);
+            foreach (string sibling in Directory.EnumerateFiles(sourceDirectory))
+            {
+                string siblingDestination = Path.Combine(destinationDirectory, Path.GetFileName(sibling));
+                if (string.Equals(sibling, path, StringComparison.Ordinal))
+                {
+                    if (!File.Exists(siblingDestination))
+                    {
+                        File.Copy(sibling, siblingDestination);
+                    }
+                }
+                else if (!File.Exists(siblingDestination))
+                {
+                    File.CreateSymbolicLink(siblingDestination, sibling);
+                }
+            }
+
+            UnixFileMode destinationMode = File.GetUnixFileMode(destination);
+            if ((destinationMode & execute) != execute)
+            {
+                File.SetUnixFileMode(destination, destinationMode | execute);
+            }
+        }
+
+        return destination;
     }
 
     private static string DumpDir(Flavor flavor, string target, GcType gcType, DumpKind dumpKind, CoreVersion coreVersion) =>
@@ -393,6 +441,18 @@ public static class SnapshotStore
     {
         string tfm = CoreVersions.Tfm(coreVersion);
         string exe = Path.Combine(RepoLayout.CoreDebuggeeDir(target.Project, tfm), target.Project + RepoLayout.ExeSuffix);
+        if (UsePrebuiltTargets)
+        {
+            if (File.Exists(exe))
+            {
+                return exe;
+            }
+
+            throw new FileNotFoundException(
+                $"Pre-built Core debuggee '{target.Project}' ({tfm}) was not found at '{exe}'.",
+                exe);
+        }
+
         string project = RepoLayout.DebuggeeProject(target.Project);
         if (IsUpToDate(exe, NewestSourceWriteTime(project)))
         {
@@ -462,6 +522,13 @@ public static class SnapshotStore
             return prebuilt;
         }
 
+        if (UsePrebuiltTargets)
+        {
+            throw new FileNotFoundException(
+                $"Pre-built Framework debuggee '{target.Project}' was not found at '{prebuilt}'.",
+                prebuilt);
+        }
+
         string project = RepoLayout.DebuggeeProject(target.Project);
         string outDir = Path.Combine(RepoLayout.Scratch, "targets", "framework", target.Name);
         string exe = Path.Combine(outDir, target.Project + RepoLayout.ExeSuffix);
@@ -500,6 +567,12 @@ public static class SnapshotStore
         return exe;
     }
 
+    private static bool UsePrebuiltTargets =>
+        string.Equals(
+            Environment.GetEnvironmentVariable("SOSHARNESS_USE_PREBUILT_TARGETS"),
+            "1",
+            StringComparison.Ordinal);
+
     private static readonly ConcurrentDictionary<string, object> s_projectBuildLocks = new(StringComparer.OrdinalIgnoreCase);
 
     private static object BuildLockFor(string projectPath) =>
@@ -536,6 +609,11 @@ public static class SnapshotStore
     {
         string dll = Path.Combine(RepoLayout.ArtifactsBin, name, RepoLayout.ArtifactsConfiguration, RepoLayout.TestTargetFramework, RepoLayout.Rid, name + ".dll");
         string project = Path.Combine(RepoLayout.Root, "src", "tests", name, name + ".csproj");
+
+        if (UsePrebuiltTargets && !File.Exists(dll))
+        {
+            throw new FileNotFoundException($"Pre-built subprocess '{name}' was not found at '{dll}'.", dll);
+        }
 
         if (!File.Exists(dll))
         {

--- a/src/tests/SOS.TestHarness/SnapshotStore.cs
+++ b/src/tests/SOS.TestHarness/SnapshotStore.cs
@@ -4,6 +4,7 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 
 namespace SOS.TestHarness;
 
@@ -132,25 +133,58 @@ public static class SnapshotStore
                 string siblingDestination = Path.Combine(destinationDirectory, Path.GetFileName(sibling));
                 if (string.Equals(sibling, path, StringComparison.Ordinal))
                 {
-                    if (!File.Exists(siblingDestination))
-                    {
-                        File.Copy(sibling, siblingDestination);
-                    }
+                    StageExecutable(sibling, siblingDestination, execute);
                 }
                 else if (!File.Exists(siblingDestination))
                 {
-                    File.CreateSymbolicLink(siblingDestination, sibling);
+                    try
+                    {
+                        File.CreateSymbolicLink(siblingDestination, sibling);
+                    }
+                    catch (IOException) when (File.Exists(siblingDestination))
+                    {
+                        // Another harness process published the same sibling.
+                    }
                 }
-            }
-
-            UnixFileMode destinationMode = File.GetUnixFileMode(destination);
-            if ((destinationMode & execute) != execute)
-            {
-                File.SetUnixFileMode(destination, destinationMode | execute);
             }
         }
 
         return destination;
+    }
+
+    [UnsupportedOSPlatform("windows")]
+    private static void StageExecutable(string source, string destination, UnixFileMode execute)
+    {
+        if (File.Exists(destination) && (File.GetUnixFileMode(destination) & execute) == execute)
+        {
+            return;
+        }
+
+        // Stage beside the destination so the no-overwrite rename publishes a complete executable atomically.
+        string temporary = Path.Combine(
+            Path.GetDirectoryName(destination)!,
+            $".{Path.GetFileName(destination)}.{Guid.NewGuid():N}.tmp");
+        try
+        {
+            File.Copy(source, temporary);
+            UnixFileMode temporaryMode = File.GetUnixFileMode(temporary);
+            File.SetUnixFileMode(temporary, temporaryMode | execute);
+
+            try
+            {
+                File.Move(temporary, destination);
+            }
+            catch (IOException) when (
+                File.Exists(destination) &&
+                (File.GetUnixFileMode(destination) & execute) == execute)
+            {
+                // Another harness process atomically published a complete executable first.
+            }
+        }
+        finally
+        {
+            File.Delete(temporary);
+        }
     }
 
     private static string DumpDir(Flavor flavor, string target, GcType gcType, DumpKind dumpKind, CoreVersion coreVersion) =>

--- a/src/tests/SOS.TestHarness/TestConfig.cs
+++ b/src/tests/SOS.TestHarness/TestConfig.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
+using System.Text;
 using Xunit;
 using Xunit.Sdk;
 
@@ -105,7 +107,8 @@ public sealed record TestConfig : IXunitSerializable
         Dac dac = Dac.All)
     {
         TheoryData<TestConfig> data = new();
-        foreach (TestConfig cfg in Permutations(targets, flavor, host, liveness, gcType, dumpKind, coreVersion, dac))
+        foreach (TestConfig cfg in ApplyShardFilter(
+            UnshardedPermutations(targets, flavor, host, liveness, gcType, dumpKind, coreVersion, dac)))
         {
             data.Add(cfg);
         }
@@ -119,6 +122,17 @@ public sealed record TestConfig : IXunitSerializable
     /// e.g. a stop-point name — into their own <c>TheoryData&lt;TestConfig, ...&gt;</c>.
     /// </summary>
     public static IEnumerable<TestConfig> Permutations(
+        string[] targets,
+        Flavor flavor = Flavor.AllValid,
+        Host host = Host.AllValid,
+        Liveness liveness = Liveness.Dump,
+        GcType gcType = GcType.Workstation,
+        DumpKind dumpKind = DumpKind.Heap,
+        CoreVersion coreVersion = CoreVersion.All,
+        Dac dac = Dac.All) =>
+        ApplyShardFilter(UnshardedPermutations(targets, flavor, host, liveness, gcType, dumpKind, coreVersion, dac));
+
+    internal static IEnumerable<TestConfig> UnshardedPermutations(
         string[] targets,
         Flavor flavor = Flavor.AllValid,
         Host host = Host.AllValid,
@@ -183,6 +197,49 @@ public sealed record TestConfig : IXunitSerializable
         }
     }
 
+    internal static IEnumerable<TestConfig> ApplyShardFilter(IEnumerable<TestConfig> configs)
+        => ApplyShardFilter(
+            configs,
+            ShardSelection.FromEnvironment(Environment.GetEnvironmentVariable));
+
+    internal static IEnumerable<TestConfig> ApplyShardFilter(
+        IEnumerable<TestConfig> configs,
+        ShardSelection? shard)
+    {
+        foreach (TestConfig config in configs)
+        {
+            if (shard is null || config.GetCaptureShard(shard.Value.Count) == shard.Value.Index)
+            {
+                yield return config;
+            }
+        }
+    }
+
+    /// <summary>
+    /// The immutable capture-family key used for sharding. Host and DAC are deliberately absent because
+    /// they replay the same captured dump; keeping them together preserves <see cref="SnapshotStore"/> reuse.
+    /// </summary>
+    internal string CaptureFamilyKey =>
+        $"{Target}|{Flavor}|{CoreVersion}|{GcType}|{DumpKind}|{Liveness}";
+
+    internal int GetCaptureShard(int shardCount) =>
+        (int)(StableHash(CaptureFamilyKey) % (ulong)shardCount);
+
+    internal static ulong StableHash(string value)
+    {
+        const ulong offsetBasis = 14695981039346656037;
+        const ulong prime = 1099511628211;
+
+        ulong hash = offsetBasis;
+        foreach (byte b in Encoding.UTF8.GetBytes(value))
+        {
+            hash ^= b;
+            hash = unchecked(hash * prime);
+        }
+
+        return hash;
+    }
+
     /// <summary>
     /// Whether a configuration is valid on the current platform. Centralizes every constraint that the old
     /// nested-loop <c>BuildMatrix</c> scattered across per-axis <c>continue</c>s.
@@ -231,7 +288,7 @@ public sealed record TestConfig : IXunitSerializable
 
         // A single-file snapshot requires a Full dump because createdump cannot enumerate reduced-dump
         // regions for a statically linked runtime. On constrained test machines, marker targets produce
-        // several multi-gigabyte dumps and cannot complete reliably. Callers can exclude only those
+        // several multi-gigabyte dumps and cannot complete reliably. Helix launchers can exclude only those
         // snapshot rows while preserving single-file crash coverage.
         if (!c.IsLive &&
             c.Flavor == Flavor.SingleFile &&
@@ -294,6 +351,22 @@ public sealed record TestConfig : IXunitSerializable
         _ => throw new InvalidOperationException(
             "SOSHARNESS_EXCLUDE_SINGLEFILE_SNAPSHOTS must be unset, 0, or 1."),
     };
+
+    internal static bool AllowEmptyMatrix(Func<string, string?> getEnvironmentVariable)
+    {
+        if (ShardSelection.FromEnvironment(getEnvironmentVariable) is not null)
+        {
+            return true;
+        }
+
+        return !string.IsNullOrEmpty(getEnvironmentVariable("SOSHARNESS_ONLY_HOSTS")) ||
+            !string.IsNullOrEmpty(getEnvironmentVariable("SOSHARNESS_ONLY_FLAVORS")) ||
+            !string.IsNullOrEmpty(getEnvironmentVariable("SOSHARNESS_ONLY_LIVENESS")) ||
+            !string.IsNullOrEmpty(getEnvironmentVariable("SOSHARNESS_ONLY_GCTYPE")) ||
+            !string.IsNullOrEmpty(getEnvironmentVariable("SOSHARNESS_ONLY_DUMPKIND")) ||
+            !string.IsNullOrEmpty(getEnvironmentVariable("SOSHARNESS_ONLY_COREVERSIONS")) ||
+            !string.IsNullOrEmpty(getEnvironmentVariable("SOSHARNESS_ONLY_DAC"));
+    }
 
     private static IEnumerable<T> SingleFlags<T>(T value) where T : struct, Enum
     {
@@ -367,4 +440,43 @@ public sealed record TestConfig : IXunitSerializable
         return $"{Target}/{Host}/{Flavor}{version}/{Liveness}/{GcType}{dump}{dac}";
     }
 
+}
+
+internal readonly record struct ShardSelection(int Index, int Count)
+{
+    private const string IndexVariable = "SOSHARNESS_SHARD_INDEX";
+    private const string CountVariable = "SOSHARNESS_SHARD_COUNT";
+
+    public static ShardSelection? FromEnvironment(Func<string, string?> getEnvironmentVariable)
+    {
+        string? indexValue = getEnvironmentVariable(IndexVariable);
+        string? countValue = getEnvironmentVariable(CountVariable);
+
+        if (indexValue is null && countValue is null)
+        {
+            return null;
+        }
+
+        if (indexValue is null || countValue is null)
+        {
+            throw new InvalidOperationException(
+                $"{IndexVariable} and {CountVariable} must either both be set or both be unset.");
+        }
+
+        if (!int.TryParse(countValue, NumberStyles.None, CultureInfo.InvariantCulture, out int count) || count <= 0)
+        {
+            throw new InvalidOperationException(
+                $"{CountVariable} must be a positive base-10 integer; received '{countValue}'.");
+        }
+
+        if (!int.TryParse(indexValue, NumberStyles.None, CultureInfo.InvariantCulture, out int index) ||
+            index < 0 ||
+            index >= count)
+        {
+            throw new InvalidOperationException(
+                $"{IndexVariable} must be a base-10 integer in [0, {count}); received '{indexValue}'.");
+        }
+
+        return new ShardSelection(index, count);
+    }
 }

--- a/src/tests/SOS.TestHarness/TestConfig.cs
+++ b/src/tests/SOS.TestHarness/TestConfig.cs
@@ -388,7 +388,11 @@ public sealed record TestConfig : IXunitSerializable
     /// </summary>
     private static IEnumerable<T> SingleFlags<T>(T value, string envVar) where T : struct, Enum
     {
-        string? only = Environment.GetEnvironmentVariable(envVar);
+        return ApplyAllowList(value, Environment.GetEnvironmentVariable(envVar));
+    }
+
+    internal static IEnumerable<T> ApplyAllowList<T>(T value, string? only) where T : struct, Enum
+    {
         HashSet<string>? allowed = string.IsNullOrEmpty(only)
             ? null
             : new HashSet<string>(only.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries), StringComparer.OrdinalIgnoreCase);

--- a/src/tests/SOS.TestHarness/ToolPaths.cs
+++ b/src/tests/SOS.TestHarness/ToolPaths.cs
@@ -120,6 +120,21 @@ public static class ToolPaths
 
     private static string ResolveDbgEngDirectory()
     {
+        string? configuredDirectory = Environment.GetEnvironmentVariable("SOSHARNESS_DBGENG_ROOT");
+        if (!string.IsNullOrEmpty(configuredDirectory))
+        {
+            string directory = Path.GetFullPath(configuredDirectory);
+            string dbgEngPath = Path.Combine(directory, "dbgeng.dll");
+            if (File.Exists(dbgEngPath))
+            {
+                return directory;
+            }
+
+            throw new FileNotFoundException(
+                $"Could not locate dbgeng.dll in the configured SOS harness DbgEng directory '{directory}'.",
+                dbgEngPath);
+        }
+
         string relativeNative = Path.Combine("runtimes", $"win-{RepoLayout.TargetArch}", "native");
 
         foreach (string root in NuGetPackageRoots())
@@ -267,7 +282,7 @@ public static class ToolPaths
         // SOS hosts its managed extension on a .NET runtime; point it at the repo's locally-acquired
         // .dotnet shared runtime so it's deterministic. Any recent runtime works as a host (it need not
         // match the target's runtime), so pick the highest net10 present.
-        string sharedRoot = Path.Combine(RepoLayout.Root, ".dotnet", "shared", "Microsoft.NETCore.App");
+        string sharedRoot = Path.Combine(RepoLayout.DotNetRoot, "shared", "Microsoft.NETCore.App");
         if (Directory.Exists(sharedRoot))
         {
             string? best = Directory.GetDirectories(sharedRoot)

--- a/src/tests/SOS.Tests/README.md
+++ b/src/tests/SOS.Tests/README.md
@@ -220,6 +220,11 @@ Comma-separated matrix allow-lists are case-insensitive enum names:
 | `LLDB_PATH` | Override LLDB discovery. Otherwise Xcode and then `PATH` are searched. |
 | `NUGET_PACKAGES` | Override the NuGet package root used to locate runtime packs and cDAC assets. |
 
+The unprivileged Azure Linux Helix Alpine container sets
+`SOSHARNESS_ONLY_DUMPKIND=Heap,Full` to avoid an intermittent .NET 8 createdump
+`PR_SET_PTRACER` race during Mini snapshot capture. This retains Heap, Full, and
+live coverage; local Alpine test containers continue to run Mini rows.
+
 The harness sets the following implementation-owned values for child
 processes; they are not supported user controls:
 

--- a/src/tests/SOS.Tests/README.md
+++ b/src/tests/SOS.Tests/README.md
@@ -91,6 +91,12 @@ The DAC is deliberately not a capture dimension: legacy DAC and cDAC analyze
 the same dump, with DAC selection happening when the host opens it. Cached
 dumps are reused only while newer than their debuggee.
 
+Helix splits the matrix by the same capture-family key, including target,
+flavor, runtime version, GC type, dump kind, and liveness. Host and DAC are
+excluded from the key so every analysis of one dump stays in the same work
+item. `SOSHARNESS_SHARD_INDEX` and `SOSHARNESS_SHARD_COUNT` must be set
+together; hashing is stable across processes and runtimes.
+
 `Targets.GetTargetAsync` returns a cheap cursor over shared, read-only dump
 sessions. A session is memoized by host, target, stop, flavor, GC type, dump
 kind, runtime, and DAC. Live targets are never shared because command execution
@@ -188,11 +194,26 @@ Comma-separated matrix allow-lists are case-insensitive enum names:
 | `SOSHARNESS_ONLY_COREVERSIONS` | Select versions such as `Net8,Net11`; explicit selection also permits an out-of-support version. |
 | `SOSHARNESS_ONLY_DAC` | Select `Legacy` and/or `CDac`. |
 | `SOSHARNESS_TEST_OUT_OF_SUPPORT_CORE` | Set to `1` to include every installed out-of-support runtime. |
+| `SOSHARNESS_EXCLUDE_SINGLEFILE_SNAPSHOTS` | Set to `1` to omit constrained single-file snapshot rows while retaining single-file crash coverage. |
 | `SOSHARNESS_ARTIFACTS_CONFIG` | Override the build configuration embedded in the harness assembly. |
+| `SOSHARNESS_REPO_ROOT` | Override repository-root discovery, primarily for a staged correlation payload. |
+| `SOSHARNESS_DOTNET_ROOT` | Override the repository-local .NET root used for harness subprocesses. |
+| `SOSHARNESS_DOTNET_TEST_ROOT` | Override the multi-runtime test installation, including a writable executable overlay. |
+| `SOSHARNESS_NATIVE_ROOT` | Override the native SOS output directory, including a writable musl overlay. |
+| `SOSHARNESS_EXECUTABLE_ROOT` | Copy non-executable debuggee apphosts and symlink their sidecars into this writable overlay. |
+| `SOSHARNESS_SCRATCH_ROOT` | Redirect dump, target, and symbol-cache writes outside a staged payload. |
+| `SOSHARNESS_DBGENG_ROOT` | Override the directory containing the Helix payload's `dbgeng.dll`. |
+| `SOSHARNESS_HOST_RUNTIME_DIR` | Override the complete runtime layout used to host SOS's managed extension. |
+| `SOSHARNESS_USE_PREBUILT_TARGETS` | Set to `1` to require prebuilt debuggees and subprocess hosts instead of building in place. |
+| `SOSHARNESS_SHARD_INDEX` | Zero-based capture-family shard index; must be paired with `SOSHARNESS_SHARD_COUNT`. |
+| `SOSHARNESS_SHARD_COUNT` | Positive capture-family shard count; must be paired with `SOSHARNESS_SHARD_INDEX`. |
+| `SOSHARNESS_UPLOAD_ROOT` | Route replay files and debugger-host crash diagnostics to an upload directory. Helix launchers translate `HELIX_WORKITEM_UPLOAD_ROOT` to this harness-owned control. |
+| `SOSHARNESS_TEST_RUNTIME_MAJOR` | Unix launcher override selecting the installed runtime major used to run `SOS.Tests.dll`. |
 | `SOSHARNESS_MAX_LIVE` | Set the positive maximum number of concurrent live sessions. |
 | `SOSHARNESS_LIVE_TIMEOUT` | Set the positive live LLDB command timeout in seconds. |
 | `SOSHARNESS_LLDB_LOAD_TIMEOUT` | Set the positive LLDB target-load timeout in seconds. |
 | `SOSHARNESS_LLDB_TRACE` | Enable LLDB protocol tracing and record its value in replay files. |
+| `SOSHARNESS_LLDB_PATH` | Override the LLDB executable or the macOS `sos-lldb` driver. |
 | `SOSHARNESS_DAC_DIR` | Override the legacy DAC directory used by the dbgeng engine host. |
 | `SOSHARNESS_CDAC_DIR` | Override cDAC discovery with a directory containing the cDAC. |
 | `SOSHARNESS_USECDAC` | Local global DAC clamp; overrides the matrix DAC selection and is not set in CI. |
@@ -229,3 +250,19 @@ original test failure even if replay writing also fails.
 Reusable targets, dumps, symbols, and host crash artifacts live under
 `artifacts/tmp/sos-harness/<Configuration>`. Dumps can be large; remove that
 scratch subtree when a clean recapture is required.
+
+## Helix execution
+
+`eng/helix/SOS.Tests.Helix.proj` stages one immutable correlation payload per
+OS, RID, and configuration, then points every named shard work item at it. The
+payload contains `SOS.Tests`, its harness subprocesses, native SOS, the
+repository-built dotnet-dump, the test runtime and DAC closure, DbgEng on
+Windows, and all prebuilt Core, SingleFile, and Framework debuggees needed by
+that platform. Per-work-item writable overlays hold executable copies, dumps,
+logs, replays, and host crash diagnostics.
+
+The standard layout is eight dump shards and two live shards. macOS uses 32
+dump shards and two live shards, with bounded in-process parallelism, to stay
+within observed runtime and machine limits. Work-item names and commands carry
+the RID, configuration, liveness, shard index, and shard count for direct
+diagnosis and replay.

--- a/src/tests/SOS.Tests/README.md
+++ b/src/tests/SOS.Tests/README.md
@@ -221,9 +221,11 @@ Comma-separated matrix allow-lists are case-insensitive enum names:
 | `NUGET_PACKAGES` | Override the NuGet package root used to locate runtime packs and cDAC assets. |
 
 The unprivileged Azure Linux Helix Alpine container sets
-`SOSHARNESS_ONLY_DUMPKIND=Heap,Full` to avoid an intermittent .NET 8 createdump
-`PR_SET_PTRACER` race during Mini snapshot capture. This retains Heap, Full, and
-live coverage; local Alpine test containers continue to run Mini rows.
+`SOSHARNESS_ONLY_DUMPKIND=Heap,Full` and runs dump work items one test at a time
+to avoid an intermittent .NET 8 createdump `PR_SET_PTRACER` race during
+concurrent snapshot capture. This retains Heap, Full, and live coverage; live
+work items remain parallel, and local Alpine test containers continue to run
+Mini rows.
 
 The harness sets the following implementation-owned values for child
 processes; they are not supported user controls:

--- a/src/tests/SOS.Tests/SOS.Tests.csproj
+++ b/src/tests/SOS.Tests/SOS.Tests.csproj
@@ -12,11 +12,7 @@
          implicitly references xunit.v3 and the test runner; no explicit PackageReference needed.
          xunit v3 runs as an MTP executable, so OutputType must be Exe. -->
     <TestRunnerName>XUnitV3</TestRunnerName>
-  </PropertyGroup>
-
-  <!-- Temporary until SOS.Tests moves to Helix in https://github.com/dotnet/diagnostics/pull/6002. -->
-  <PropertyGroup Condition="'$(OfficialBuildId)' != ''">
-    <SkipTests>true</SkipTests>
+    <SkipTests Condition="'$(SOSHARNESS_SKIP_LOCAL_TESTS)' == 'true'">true</SkipTests>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/SOS.Tests/SosReplayAttribute.cs
+++ b/src/tests/SOS.Tests/SosReplayAttribute.cs
@@ -27,11 +27,15 @@ namespace SOS.Tests;
 public sealed class SosReplayAttribute : BeforeAfterTestAttribute
 {
     private static readonly string s_runDirectory = Path.Combine(
-        RepoLayout.Root,
-        "artifacts",
-        "TestResults",
-        "SOS.Tests",
+        ResolveReplayDirectory(
+            Environment.GetEnvironmentVariable(HostDiagnostics.UploadRootVariable),
+            RepoLayout.Root),
         $"{DateTime.UtcNow:yyyyMMdd_HHmmss}_{Environment.ProcessId}");
+
+    internal static string ResolveReplayDirectory(string? uploadRoot, string repoRoot) =>
+        string.IsNullOrEmpty(uploadRoot)
+            ? Path.Combine(repoRoot, "artifacts", "TestResults", "SOS.Tests")
+            : Path.Combine(uploadRoot, "SOS-replays");
 
     public override void After(MethodInfo methodUnderTest, IXunitTest test)
     {

--- a/src/tests/SOS.Tests/SosTheoryAttribute.cs
+++ b/src/tests/SOS.Tests/SosTheoryAttribute.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using SOS.TestHarness;
 using Xunit;
 
 namespace SOS.Tests;
@@ -22,5 +23,6 @@ public sealed class SosTheoryAttribute : TheoryAttribute
         [System.Runtime.CompilerServices.CallerLineNumber] int sourceLineNumber = -1)
         : base(sourceFilePath, sourceLineNumber)
     {
+        SkipTestWithoutData = TestConfig.AllowEmptyMatrix(Environment.GetEnvironmentVariable);
     }
 }

--- a/src/tests/SOS.Tests/TestConfigShardTests.cs
+++ b/src/tests/SOS.Tests/TestConfigShardTests.cs
@@ -1,0 +1,129 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using SOS.TestHarness;
+using Xunit;
+
+namespace SOS.Tests;
+
+public sealed class TestConfigShardTests
+{
+    [Fact]
+    public void ShardControlsCanBeUnset()
+    {
+        Assert.Null(ShardSelection.FromEnvironment(_ => null));
+    }
+
+    [Theory]
+    [InlineData("0", null)]
+    [InlineData(null, "8")]
+    public void ShardControlsMustBeSpecifiedTogether(string? index, string? count)
+    {
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(
+            () => Parse(index, count));
+
+        Assert.Contains("must either both be set or both be unset", error.Message);
+    }
+
+    [Theory]
+    [InlineData("0", "0")]
+    [InlineData("0", "-1")]
+    [InlineData("0", " 8")]
+    [InlineData("0", "eight")]
+    public void ShardCountMustBeStrictlyPositive(string index, string count)
+    {
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(
+            () => Parse(index, count));
+
+        Assert.Contains("SOSHARNESS_SHARD_COUNT", error.Message);
+    }
+
+    [Theory]
+    [InlineData("-1", "8")]
+    [InlineData("8", "8")]
+    [InlineData(" 0", "8")]
+    [InlineData("zero", "8")]
+    public void ShardIndexMustBeInRange(string index, string count)
+    {
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(
+            () => Parse(index, count));
+
+        Assert.Contains("SOSHARNESS_SHARD_INDEX", error.Message);
+    }
+
+    [Fact]
+    public void CaptureFamilyExcludesReplayOnlyAxes()
+    {
+        TestConfig first = Config(Host.Cdb, Dac.Legacy);
+        TestConfig second = Config(Host.DotnetDump, Dac.CDac);
+
+        Assert.Equal(first.CaptureFamilyKey, second.CaptureFamilyKey);
+        Assert.Equal(first.GetCaptureShard(8), second.GetCaptureShard(8));
+    }
+
+    [Fact]
+    public void CaptureFamilyIncludesEveryCaptureAxis()
+    {
+        TestConfig baseline = Config(Host.Cdb, Dac.Legacy);
+
+        Assert.NotEqual(baseline.CaptureFamilyKey, (baseline with { Target = TargetCatalog.DivZero }).CaptureFamilyKey);
+        Assert.NotEqual(baseline.CaptureFamilyKey, (baseline with { Flavor = Flavor.SingleFile }).CaptureFamilyKey);
+        Assert.NotEqual(baseline.CaptureFamilyKey, (baseline with { CoreVersion = CoreVersion.Net11 }).CaptureFamilyKey);
+        Assert.NotEqual(baseline.CaptureFamilyKey, (baseline with { GcType = GcType.Server }).CaptureFamilyKey);
+        Assert.NotEqual(baseline.CaptureFamilyKey, (baseline with { DumpKind = DumpKind.Full }).CaptureFamilyKey);
+        Assert.NotEqual(baseline.CaptureFamilyKey, (baseline with { Liveness = Liveness.Live }).CaptureFamilyKey);
+    }
+
+    [Fact]
+    public void StableHashHasFixedValue()
+    {
+        Assert.Equal(
+            0x1C7CF9C1B972727AUL,
+            TestConfig.StableHash("scenarios|Core|Net10|Workstation|Heap|Dump"));
+        Assert.Equal(2, Config(Host.Cdb, Dac.Legacy).GetCaptureShard(8));
+    }
+
+    [Fact]
+    public void ShardingUsesTransformedCaptureFamily()
+    {
+        TestConfig transformed = Config(Host.Cdb, Dac.Legacy) with { DumpKind = DumpKind.Full };
+        ShardSelection shard = new(transformed.GetCaptureShard(8), 8);
+
+        Assert.Equal(
+            [transformed],
+            TestConfig.ApplyShardFilter([transformed], shard).ToArray());
+    }
+
+    [Fact]
+    public void MatrixPartitionControlsAllowEmptyTheories()
+    {
+        Assert.False(TestConfig.AllowEmptyMatrix(_ => null));
+        Assert.True(TestConfig.AllowEmptyMatrix(name =>
+            name == "SOSHARNESS_ONLY_LIVENESS" ? "Live" : null));
+        Assert.True(TestConfig.AllowEmptyMatrix(name => name switch
+        {
+            "SOSHARNESS_SHARD_INDEX" => "31",
+            "SOSHARNESS_SHARD_COUNT" => "32",
+            _ => null,
+        }));
+    }
+
+    private static ShardSelection? Parse(string? index, string? count) =>
+        ShardSelection.FromEnvironment(name => name switch
+        {
+            "SOSHARNESS_SHARD_INDEX" => index,
+            "SOSHARNESS_SHARD_COUNT" => count,
+            _ => null,
+        });
+
+    private static TestConfig Config(Host host, Dac dac) =>
+        new(
+            TargetCatalog.Scenarios,
+            host,
+            Flavor.Core,
+            Liveness.Dump,
+            GcType.Workstation,
+            DumpKind.Heap,
+            CoreVersion.Net10,
+            dac);
+}

--- a/src/tests/SOS.Tests/TestConfigValidityTests.cs
+++ b/src/tests/SOS.Tests/TestConfigValidityTests.cs
@@ -55,6 +55,16 @@ public sealed class TestConfigValidityTests
     }
 
     [Fact]
+    public void MuslHelixDumpKindFilterPreservesHeapAndFull()
+    {
+        DumpKind[] dumpKinds = TestConfig.ApplyAllowList(
+            DumpKind.Heap | DumpKind.Mini | DumpKind.Full,
+            "Heap,Full").ToArray();
+
+        Assert.Equal([DumpKind.Heap, DumpKind.Full], dumpKinds);
+    }
+
+    [Fact]
     public void Net8LinuxArm64CreatedumpPermissionFailureIsKnown()
     {
         const string error = "open(/proc/123/mem) FAILED Permission denied (13)";

--- a/src/tests/SOS.Tests/TestMatrices.cs
+++ b/src/tests/SOS.Tests/TestMatrices.cs
@@ -38,8 +38,21 @@ internal static class TestMatrices
         CoreVersion coreVersion = CoreVersion.All,
         Dac dac = Dac.All,
         Func<TestConfig, bool>? filter = null) =>
+        TestConfig.ApplyShardFilter(
+            UnshardedStackWalkConfigs(targets, flavor, host, liveness, gcType, dumpKind, coreVersion, dac, filter));
+
+    private static IEnumerable<TestConfig> UnshardedStackWalkConfigs(
+        string[] targets,
+        Flavor flavor,
+        Host host,
+        Liveness liveness,
+        GcType gcType,
+        DumpKind dumpKind,
+        CoreVersion coreVersion,
+        Dac dac,
+        Func<TestConfig, bool>? filter) =>
         // .NET 11 cDAC supports SingleFile stack walks; TestConfig rejects cDAC on earlier runtimes.
-        TestConfig.Permutations(targets, flavor, host, liveness, gcType, dumpKind, coreVersion: coreVersion, dac: dac)
+        TestConfig.UnshardedPermutations(targets, flavor, host, liveness, gcType, dumpKind, coreVersion: coreVersion, dac: dac)
             .Where(SupportsCurrentThread)
             .Where(config => filter is null || filter(config));
 
@@ -99,16 +112,16 @@ internal static class TestMatrices
         Dac dac = Dac.All)
     {
         TheoryData<TestConfig> data = new();
-        foreach (TestConfig config in TestConfig.Permutations(targets, flavor, host, liveness, gcType, dumpKind, coreVersion, dac))
+        IEnumerable<TestConfig> configs =
+            TestConfig.UnshardedPermutations(targets, flavor, host, liveness, gcType, dumpKind, coreVersion, dac)
+                .Select(config =>
+                    OperatingSystem.IsWindows() && (config.CoreVersion & fullDumpVersions) != 0
+                        ? config with { DumpKind = DumpKind.Full }
+                        : config);
+
+        foreach (TestConfig config in TestConfig.ApplyShardFilter(configs))
         {
-            if (OperatingSystem.IsWindows() && (config.CoreVersion & fullDumpVersions) != 0)
-            {
-                data.Add(config with { DumpKind = DumpKind.Full });
-            }
-            else
-            {
-                data.Add(config);
-            }
+            data.Add(config);
         }
 
         return data;
@@ -125,18 +138,24 @@ internal static class TestMatrices
         Func<TestConfig, bool>? filter = null)
     {
         TheoryData<TestConfig> data = new();
-        foreach (TestConfig config in StackWalkConfigs(
-            targets,
-            flavor,
-            host,
-            liveness,
-            coreVersion: coreVersion,
-            dac: dac,
-            filter: filter))
+        IEnumerable<TestConfig> configs = UnshardedStackWalkConfigs(
+                targets,
+                flavor,
+                host,
+                liveness,
+                GcType.Workstation,
+                DumpKind.Heap,
+                coreVersion,
+                dac,
+                filter)
+            .Select(config =>
+                OperatingSystem.IsWindows() && (config.CoreVersion & fullDumpVersions) != 0
+                    ? config with { DumpKind = DumpKind.Full }
+                    : config);
+
+        foreach (TestConfig config in TestConfig.ApplyShardFilter(configs))
         {
-            data.Add(OperatingSystem.IsWindows() && (config.CoreVersion & fullDumpVersions) != 0
-                ? config with { DumpKind = DumpKind.Full }
-                : config);
+            data.Add(config);
         }
 
         return data;
@@ -183,9 +202,15 @@ internal static class TestMatrices
         return data;
     }
 
-    public static IEnumerable<TestConfig> CoreFrameworkConditionalFullDumpConfigs(string[] targets)
+    public static IEnumerable<TestConfig> CoreFrameworkConditionalFullDumpConfigs(string[] targets) =>
+        TestConfig.ApplyShardFilter(UnshardedCoreFrameworkConditionalFullDumpConfigs(targets));
+
+    private static IEnumerable<TestConfig> UnshardedCoreFrameworkConditionalFullDumpConfigs(string[] targets)
     {
-        foreach (TestConfig config in TestConfig.Permutations(targets, flavor: Flavor.Core | Flavor.Framework, dumpKind: DumpKind.Heap))
+        foreach (TestConfig config in TestConfig.UnshardedPermutations(
+            targets,
+            flavor: Flavor.Core | Flavor.Framework,
+            dumpKind: DumpKind.Heap))
         {
             if (!OperatingSystem.IsWindows() && config.CoreVersion == CoreVersion.Net10)
             {

--- a/src/tests/SOS.Tests/UnixPayloadTests.cs
+++ b/src/tests/SOS.Tests/UnixPayloadTests.cs
@@ -1,0 +1,91 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using SOS.TestHarness;
+using Xunit;
+
+namespace SOS.Tests;
+
+public sealed class UnixPayloadTests
+{
+    [Fact]
+    public void DirectoryOverrideUsesConfiguredPath()
+    {
+        string expected = Path.GetFullPath(Path.Combine(Path.GetTempPath(), "sos-harness-scratch"));
+        string defaultPath = Path.GetFullPath(Path.Combine(Path.GetTempPath(), "default-scratch"));
+
+        Assert.Equal(expected, RepoLayout.ResolveDirectory(expected, "/unused"));
+        Assert.Equal(defaultPath, RepoLayout.ResolveDirectory(null, defaultPath));
+    }
+
+    [Fact]
+    public void UploadRootRoutesHarnessArtifacts()
+    {
+        string repoRoot = Path.GetFullPath(Path.Combine(Path.GetTempPath(), "sos-repo"));
+        string uploadRoot = Path.GetFullPath(Path.Combine(Path.GetTempPath(), "sos-upload"));
+
+        Assert.Equal(
+            Path.Combine(uploadRoot, "failure-diagnostics", "crashdumps"),
+            HostDiagnostics.ResolveCrashDumpDirectory(uploadRoot, repoRoot));
+        Assert.Equal(
+            Path.Combine(uploadRoot, "SOS-replays"),
+            SosReplayAttribute.ResolveReplayDirectory(uploadRoot, repoRoot));
+        Assert.Equal(
+            Path.Combine(repoRoot, "artifacts", "replays", "crashdumps"),
+            HostDiagnostics.ResolveCrashDumpDirectory(null, repoRoot));
+        Assert.Equal(
+            Path.Combine(repoRoot, "artifacts", "TestResults", "SOS.Tests"),
+            SosReplayAttribute.ResolveReplayDirectory(null, repoRoot));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void TargetUsesWritableOverlay(bool sourceIsExecutable)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        string testRoot = Path.Combine(Path.GetTempPath(), $"sos-payload-{Guid.NewGuid():N}");
+        string sourceRoot = Path.Combine(testRoot, "payload");
+        string sourceDirectory = Path.Combine(sourceRoot, "artifacts", "bin", "Debuggee");
+        string overlayRoot = Path.Combine(testRoot, "overlay");
+        string sourceExecutable = Path.Combine(sourceDirectory, "Debuggee");
+        string sourceSidecar = Path.Combine(sourceDirectory, "Debuggee.dll");
+
+        try
+        {
+            Directory.CreateDirectory(sourceDirectory);
+            File.WriteAllText(sourceExecutable, "executable");
+            File.WriteAllText(sourceSidecar, "sidecar");
+            UnixFileMode sourceMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+            if (sourceIsExecutable)
+            {
+                sourceMode |= UnixFileMode.UserExecute;
+            }
+            File.SetUnixFileMode(sourceExecutable, sourceMode);
+
+            string executable = SnapshotStore.EnsureExecutable(sourceExecutable, overlayRoot, sourceRoot);
+
+            Assert.NotEqual(sourceExecutable, executable);
+            Assert.Equal("executable", File.ReadAllText(executable));
+            Assert.Equal("sidecar", File.ReadAllText(Path.Combine(Path.GetDirectoryName(executable)!, "Debuggee.dll")));
+            Assert.True((File.GetUnixFileMode(executable) & UnixFileMode.UserExecute) != 0);
+            Assert.Equal(
+                sourceIsExecutable,
+                (File.GetUnixFileMode(sourceExecutable) & UnixFileMode.UserExecute) != 0);
+
+            File.SetLastWriteTimeUtc(executable, DateTime.UtcNow.AddDays(-1));
+            DateTime overlayWriteTime = File.GetLastWriteTimeUtc(executable);
+
+            Assert.Equal(executable, SnapshotStore.EnsureExecutable(sourceExecutable, overlayRoot, sourceRoot));
+            Assert.Equal(overlayWriteTime, File.GetLastWriteTimeUtc(executable));
+        }
+        finally
+        {
+            Directory.Delete(testRoot, recursive: true);
+        }
+    }
+}

--- a/src/tests/SOS.Tests/UnixPayloadTests.cs
+++ b/src/tests/SOS.Tests/UnixPayloadTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using SOS.TestHarness;
 using Xunit;
 
@@ -82,6 +83,87 @@ public sealed class UnixPayloadTests
 
             Assert.Equal(executable, SnapshotStore.EnsureExecutable(sourceExecutable, overlayRoot, sourceRoot));
             Assert.Equal(overlayWriteTime, File.GetLastWriteTimeUtc(executable));
+        }
+        finally
+        {
+            Directory.Delete(testRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ConcurrentExecutablePreparationPublishesCompleteExecutable()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        string testRoot = Path.Combine(Path.GetTempPath(), $"sos-payload-{Guid.NewGuid():N}");
+        string sourceRoot = Path.Combine(testRoot, "payload");
+        string sourceDirectory = Path.Combine(sourceRoot, "artifacts", "bin", "Debuggee");
+        string overlayRoot = Path.Combine(testRoot, "overlay");
+        string sourceExecutable = Path.Combine(sourceDirectory, "Debuggee");
+        string content = "#!/bin/sh\nprintf 'complete\\n'\nexit 0\n" + new string('#', 8 * 1024 * 1024);
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        try
+        {
+            Directory.CreateDirectory(sourceDirectory);
+            await File.WriteAllTextAsync(sourceExecutable, content, cancellationToken);
+            File.SetUnixFileMode(sourceExecutable, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+
+            using ManualResetEventSlim start = new();
+            Task<string>[] preparations = Enumerable.Range(0, 16)
+                .Select(_ => Task.Run(() =>
+                {
+                    start.Wait(cancellationToken);
+                    return SnapshotStore.EnsureExecutable(sourceExecutable, overlayRoot, sourceRoot);
+                }, cancellationToken))
+                .ToArray();
+            Task<string[]> allPreparations = Task.WhenAll(preparations);
+            string expectedExecutable = Path.Combine(
+                overlayRoot,
+                Path.GetRelativePath(sourceRoot, sourceExecutable));
+
+            start.Set();
+            while (!File.Exists(expectedExecutable) && !allPreparations.IsCompleted)
+            {
+                await Task.Yield();
+            }
+
+            if (File.Exists(expectedExecutable))
+            {
+                Assert.Equal(content, await File.ReadAllTextAsync(expectedExecutable, cancellationToken));
+                Assert.True((File.GetUnixFileMode(expectedExecutable) & UnixFileMode.UserExecute) != 0);
+            }
+
+            string[] executables = await allPreparations;
+            string executable = Assert.Single(executables.Distinct());
+
+            Assert.Equal(content, await File.ReadAllTextAsync(executable, cancellationToken));
+            Assert.True((File.GetUnixFileMode(executable) & UnixFileMode.UserExecute) != 0);
+            Assert.Empty(Directory.EnumerateFiles(
+                Path.GetDirectoryName(executable)!,
+                $".{Path.GetFileName(executable)}.*.tmp"));
+
+            ProcessStartInfo startInfo = new(executable)
+            {
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+            };
+            using Process process = Process.Start(startInfo)!;
+            string output = await process.StandardOutput.ReadToEndAsync(cancellationToken);
+            await process.WaitForExitAsync(cancellationToken);
+
+            Assert.Equal(0, process.ExitCode);
+            Assert.Equal("complete\n", output);
+
+            await File.WriteAllTextAsync(
+                sourceExecutable,
+                "#!/bin/sh\nprintf 'replacement\\n'\n",
+                cancellationToken);
+            Assert.Equal(executable, SnapshotStore.EnsureExecutable(sourceExecutable, overlayRoot, sourceRoot));
+            Assert.Equal(content, await File.ReadAllTextAsync(executable, cancellationToken));
         }
         finally
         {

--- a/src/tests/SOS.Tests/WindowsTheoryAttribute.cs
+++ b/src/tests/SOS.Tests/WindowsTheoryAttribute.cs
@@ -3,6 +3,7 @@
 
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using SOS.TestHarness;
 using Xunit.Sdk;
 using Xunit.v3;
 using Xunit;
@@ -24,6 +25,7 @@ public sealed class WindowsTheoryAttribute : TheoryAttribute
         [CallerLineNumber] int sourceLineNumber = -1)
         : base(sourceFilePath, sourceLineNumber)
     {
+        SkipTestWithoutData = TestConfig.AllowEmptyMatrix(Environment.GetEnvironmentVariable);
     }
 }
 


### PR DESCRIPTION
## Summary

- add deterministic capture-family sharding with one shared SOS correlation payload per submission
- add Windows and Unix launchers, including the musl-safe `dotnet SOS.Tests.dll` invocation
- integrate SOS Helix execution into the pipeline with 8 dump + 2 live work items generally and 32 dump + 2 live work items on macOS
- serialize ARM64 and Alpine dump work, and restrict Alpine dump coverage to Heap and Full

Supersedes #6002, whose native stacked-PR metadata could not be repaired after its parent was squash-merged.

## Validation

- SOS.Tests Debug build
- 45 focused shard, validity, capability, and Unix payload tests
- reporter-enabled no-submit work-item graphs for Windows x64, Linux x64/ARM64, linux-musl x64, and macOS x64/ARM64
- XML, YAML, and JSON parsing; Bash syntax, LF/executable mode, diff whitespace, local-skip scope, and HELIX-to-SOSHARNESS boundary checks