### PR TITLE
Test dual runtimes in cDAC-only mode

### DIFF
--- a/src/tests/SOS.UnitTests/SOSRunner.cs
+++ b/src/tests/SOS.UnitTests/SOSRunner.cs
@@ -1636,6 +1636,10 @@ public class SOSRunner : IDisposable
                 defines.Add("UNIX_SINGLE_FILE_APP");
             }
         }
+        if (_config.DacMode == DacMode.CDac)
+        {
+            defines.Add("CDAC_ONLY");
+        }
         string setHostRuntime = _config.SetHostRuntime();
         if (!string.IsNullOrEmpty(setHostRuntime) && setHostRuntime == "-none")
         {

--- a/src/tests/SOS.UnitTests/Scripts/DualRuntimes.script
+++ b/src/tests/SOS.UnitTests/Scripts/DualRuntimes.script
@@ -71,6 +71,13 @@ ENDIF:TRIAGE_DUMP
 SOSCOMMAND:runtimes -netfx
 VERIFY:\s*Switched to desktop .NET Framework runtime successfully\s+
 
+IFDEF:CDAC_ONLY
+# Desktop .NET Framework does not support cDAC. Selecting the runtime succeeds, but data access must fail.
+SOSCOMMAND_FAIL:ClrStack -all
+VERIFY:Failed to load data access module
+ENDIF:CDAC_ONLY
+
+!IFDEF:CDAC_ONLY
 SOSCOMMAND:runtimes
 
 # Currently not on a desktop CLR thread so using the -all option to dump it.
@@ -98,3 +105,4 @@ VERIFY:\s+MT\s+Count\s+TotalSize\s+Class Name\s+
 VERIFY:\s*<HEXVAL>\s+<DECVAL>\s+<DECVAL>\s+.*
 VERIFY:\s*Total\s+<DECVAL>\s+objects.*<DECVAL>\s+bytes\s*
 !VERIFY:.*UNKNOWN.*
+ENDIF:CDAC_ONLY


### PR DESCRIPTION
## Summary

- expose standalone cDAC-only mode to SOS test scripts
- verify a dual-runtime dump can select Desktop CLR but cannot load its unsupported data-access implementation
- retain the existing Desktop CLR stack, thread, and heap assertions for non-cDAC-only modes

## Testing

- normal DualRuntimes mode: 4 passed
- cDAC-only DualRuntimes mode: .NET 11 row passed with the expected Desktop CLR data-access failure
- .NET 8-10 local rows remain unsupported by standalone cDAC and fail before reaching the new assertion