### PR TITLE
Keep wrapper build switches out of test arguments

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -3,6 +3,8 @@ Param(
     [ValidateSet("x86","x64","arm","arm64")][string][Alias('a', "platform")]$architecture = [System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant(),
     [ValidateSet("Debug","Release")][string][Alias('c')] $configuration = "Debug",
     [string][Alias('v')] $verbosity = "minimal",
+    [switch][Alias('r')] $restore,
+    [switch][Alias('b')] $build,
     [switch][Alias('t')] $test,
     [switch] $privatebuild,
     [switch] $ci,
@@ -109,7 +111,7 @@ if (-not $skipmanaged) {
     if ($privatebuild) {
         $privatebuildtesting = "true"
     }
-    Invoke-Expression "& `"$engroot\common\build.ps1`" -configuration $configuration -verbosity $verbosity $bl /p:TargetOS=$os /p:TargetArch=$architecture /p:TestArchitectures=$architecture /p:PrivateBuildTesting=$privatebuildtesting /p:LiveRuntimeDir=`"$liveRuntimeDir`" $remainingargs"
+    Invoke-Expression "& `"$engroot\common\build.ps1`" -restore:`$restore -build:`$build -configuration $configuration -verbosity $verbosity $bl /p:TargetOS=$os /p:TargetArch=$architecture /p:TestArchitectures=$architecture /p:PrivateBuildTesting=$privatebuildtesting /p:LiveRuntimeDir=`"$liveRuntimeDir`" $remainingargs"
 
     if ($lastExitCode -ne 0) {
         exit $lastExitCode


### PR DESCRIPTION
`Build.cmd -test` fails with MSB1001 because the wrapper's injected `-restore -build` switches are forwarded to the separate Arcade test invocation through array splatting. They become positional arguments passed to MSBuild rather than named PowerShell switches.

Declare `restore` and `build` as wrapper parameters with Arcade's `r` and `b` aliases, and forward their values explicitly to the managed-build invocation. This keeps the injected switches out of the test arguments while retaining the existing build/test phases and remaining-argument forwarding paths.

Addresses the Windows SOS argument-forwarding failure observed on dotnet/runtime#133774.

Validation: full Windows x64 build, plus targeted `SOSGCTests.DumpGCData` runs through both `Build.cmd -test` and `Test.cmd` against a private runtime in DAC mode; two cases passed in each run.

> [!NOTE]
> This pull request description was drafted with GitHub Copilot.